### PR TITLE
Resolve #2999: Clean up in-flight Passport bridge authentication

### DIFF
--- a/.changeset/cancel-passport-auth-shutdown.md
+++ b/.changeset/cancel-passport-auth-shutdown.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/passport': patch
+---
+
+Cancel in-flight Passport.js bridge authentication and clear its action timeout when application shutdown starts.

--- a/packages/passport/README.ko.md
+++ b/packages/passport/README.ko.md
@@ -124,6 +124,8 @@ export class AuthModule {}
 
 `actionTimeoutMs` 기본값은 `30_000`밀리초이며 0 이상인 유한한 숫자여야 합니다. `0`으로 설정하면 다음 timer turn에 timeout settlement를 예약합니다. 음수, `NaN`, 무한대 값은 settlement 제한을 비활성화하지 않고 bridge strategy 생성 시 `RangeError`를 발생시킵니다.
 
+애플리케이션 종료가 시작되면 진행 중인 모든 bridge 실행을 취소하고 action timeout을 정리한 뒤, 설정된 timeout까지 request state를 유지하지 않고 pending authentication을 reject합니다.
+
 ### 쿠키 인증 프리셋
 
 HTTP 쿠키에서 인증 정보를 읽는 애플리케이션이라면 `CookieAuthModule.forRoot(...)`를 사용합니다.

--- a/packages/passport/README.md
+++ b/packages/passport/README.md
@@ -124,6 +124,8 @@ The bridge settles each Passport.js strategy execution exactly once. A strategy 
 
 `actionTimeoutMs` defaults to `30_000` milliseconds and must be a non-negative finite number. Set it to `0` to schedule timeout settlement on the next timer turn. Negative, `NaN`, and infinite values throw `RangeError` when the bridge strategy is constructed instead of disabling the settlement bound.
 
+Application shutdown cancels every in-flight bridge execution, clears its action timeout, and rejects the pending authentication instead of retaining request state through the configured timeout.
+
 ### Cookie Auth Preset
 
 Use `CookieAuthModule.forRoot(...)` when your app authenticates requests from HTTP cookies.

--- a/packages/passport/src/adapters/passport-js.test.ts
+++ b/packages/passport/src/adapters/passport-js.test.ts
@@ -175,6 +175,26 @@ describe('PassportJsAuthStrategy action timeout', () => {
     await Promise.all([firstRejection, secondRejection]);
     expect(vi.getTimerCount()).toBe(0);
   });
+
+  it('rejects authentication without delegation or timers after application shutdown', async () => {
+    // Given
+    vi.useFakeTimers();
+    const authenticate = vi.fn();
+    const strategy = new PassportJsAuthStrategy({ authenticate }, { actionTimeoutMs: 0 });
+    strategy.onApplicationShutdown();
+
+    // When
+    const authentication = strategy.authenticate(createGuardContext());
+    const rejection = expect(authentication).rejects.toThrow(AuthenticationRequiredError);
+    const delegationCount = authenticate.mock.calls.length;
+    const timerCount = vi.getTimerCount();
+    await vi.runAllTimersAsync();
+
+    // Then
+    await rejection;
+    expect(delegationCount).toBe(0);
+    expect(timerCount).toBe(0);
+  });
 });
 
 describe('PassportJsAuthStrategy terminal actions', () => {

--- a/packages/passport/src/adapters/passport-js.test.ts
+++ b/packages/passport/src/adapters/passport-js.test.ts
@@ -158,6 +158,23 @@ describe('PassportJsAuthStrategy action timeout', () => {
     await expect(authentication).rejects.toThrow(AuthenticationRequiredError);
     expect(vi.getTimerCount()).toBe(0);
   });
+
+  it('cancels every in-flight authentication when application shutdown starts', async () => {
+    // Given
+    vi.useFakeTimers();
+    const strategy = new PassportJsAuthStrategy(new UnsettledStrategy());
+    const firstAuthentication = strategy.authenticate(createGuardContext());
+    const secondAuthentication = strategy.authenticate(createGuardContext());
+    const firstRejection = expect(firstAuthentication).rejects.toThrow(AuthenticationRequiredError);
+    const secondRejection = expect(secondAuthentication).rejects.toThrow(AuthenticationRequiredError);
+
+    // When
+    strategy.onApplicationShutdown();
+
+    // Then
+    await Promise.all([firstRejection, secondRejection]);
+    expect(vi.getTimerCount()).toBe(0);
+  });
 });
 
 describe('PassportJsAuthStrategy terminal actions', () => {

--- a/packages/passport/src/adapters/passport-js.ts
+++ b/packages/passport/src/adapters/passport-js.ts
@@ -195,6 +195,7 @@ function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
 export class PassportJsAuthStrategy implements AuthStrategy, OnApplicationShutdown {
   private readonly actionTimeoutMs: number;
   private readonly requestState = new Map<PassportJsExecutableStrategy, PassportJsRequestState>();
+  private acceptingAuthentications = true;
 
   constructor(
     private readonly strategyTemplate: PassportJsStrategyLike,
@@ -210,6 +211,12 @@ export class PassportJsAuthStrategy implements AuthStrategy, OnApplicationShutdo
   }
 
   authenticate(context: GuardContext): Promise<Principal | AuthHandledResult> {
+    if (!this.acceptingAuthentications) {
+      return Promise.reject(
+        new AuthenticationRequiredError('Passport strategy authentication was cancelled during application shutdown.'),
+      );
+    }
+
     const response = context.requestContext.response;
     const request = context.requestContext.request.raw ?? context.requestContext.request;
     const strategy = this.createExecutableStrategy();
@@ -271,6 +278,8 @@ export class PassportJsAuthStrategy implements AuthStrategy, OnApplicationShutdo
 
   /** Cancels every unsettled Passport.js execution when application shutdown starts. */
   onApplicationShutdown(): void {
+    this.acceptingAuthentications = false;
+
     for (const strategy of this.requestState.keys()) {
       this.settle(strategy, (state) => {
         state.reject(

--- a/packages/passport/src/adapters/passport-js.ts
+++ b/packages/passport/src/adapters/passport-js.ts
@@ -2,6 +2,7 @@
 import type { Token } from '@fluojs/core';
 import type { Provider } from '@fluojs/di';
 import type { GuardContext, Principal } from '@fluojs/http';
+import type { OnApplicationShutdown } from '@fluojs/runtime';
 
 import { AuthenticationFailedError, AuthenticationRequiredError } from '../errors.js';
 import { normalizePrincipalScopes } from '../scope.js';
@@ -191,9 +192,9 @@ function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
  *
  * @throws {RangeError} When `actionTimeoutMs` is negative or non-finite.
  */
-export class PassportJsAuthStrategy implements AuthStrategy {
+export class PassportJsAuthStrategy implements AuthStrategy, OnApplicationShutdown {
   private readonly actionTimeoutMs: number;
-  private readonly requestState = new WeakMap<PassportJsExecutableStrategy, PassportJsRequestState>();
+  private readonly requestState = new Map<PassportJsExecutableStrategy, PassportJsRequestState>();
 
   constructor(
     private readonly strategyTemplate: PassportJsStrategyLike,
@@ -266,6 +267,17 @@ export class PassportJsAuthStrategy implements AuthStrategy {
         this.settle(strategy, () => reject(error));
       }
     });
+  }
+
+  /** Cancels every unsettled Passport.js execution when application shutdown starts. */
+  onApplicationShutdown(): void {
+    for (const strategy of this.requestState.keys()) {
+      this.settle(strategy, (state) => {
+        state.reject(
+          new AuthenticationRequiredError('Passport strategy authentication was cancelled during application shutdown.'),
+        );
+      });
+    }
   }
 
   private createExecutableStrategy(): PassportJsExecutableStrategy {


### PR DESCRIPTION
## Summary

Cancel in-flight Passport.js bridge authentication when application shutdown starts so request state and action timers do not remain alive until the configured timeout.

Linked context: https://github.com/fluojs/fluo/issues/2999

## Changes

- Track active `PassportJsAuthStrategy` executions in an iterable lifecycle-owned map.
- Implement `OnApplicationShutdown` to reject every unsettled authentication and clear its timeout through the existing single-settlement path.
- Add a focused two-request shutdown regression.
- Document the lifecycle guarantee in the English and Korean package READMEs.
- Add a patch Changeset for `@fluojs/passport`.

## Testing

- ✅ Changed-file LSP diagnostics: no diagnostics.
- ✅ `pnpm --dir packages/passport build`
- ✅ `pnpm --dir packages/passport typecheck`
- ✅ `pnpm --dir packages/passport test` — 11 files, 122 tests passed.
- ✅ `pnpm exec biome check packages/passport/src/adapters/passport-js.ts packages/passport/src/adapters/passport-js.test.ts`
- ✅ `pnpm docs:sync-check`
- ✅ `pnpm verify:public-export-tsdoc`
- ✅ `pnpm verify:platform-consistency-governance`
- ✅ `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`
- ⚠️ `pnpm verify` completed build, typecheck, and lint, then the workspace test phase hit an unrelated timeout in `packages/platform-bun/src/published-declaration-surface.test.ts`; that test passed alone in 1.58s.
- ⚠️ `pnpm verify:release-readiness` passed 4,356+ package tests on each attempt but hit unrelated 5s timeout flakes: two `packages/cli/src/cli.test.ts` prompt cases on the first run and the platform-bun declaration test on the second. The CLI file passed alone (222/222), and the platform-bun test passed alone.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch rationale: this is a contract-preserving lifecycle bug fix for the published `@fluojs/passport` package. It changes no configuration or authentication success semantics; it only bounds shutdown cleanup.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

The new public lifecycle hook is documented with source TSDoc. It has no parameters and returns `void`.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests.

No platform contract docs or platform conformance claims changed. The affected package README pair is synchronized, and governance verification passed.

## Risks

- During shutdown, pending bridge calls now reject immediately with the existing `AuthenticationRequiredError` family rather than waiting for `actionTimeoutMs`; this is the intended lifecycle boundary.
- Full-workspace verification is subject to the unrelated timeout flakes documented above; focused package and isolated failing-test reruns are green.

Closes #2999