### PR TITLE
Resolve #2994: Isolate nested request-scope overrides

### DIFF
--- a/.changeset/isolate-nested-request-overrides.md
+++ b/.changeset/isolate-nested-request-overrides.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/di': patch
+---
+
+Keep nested request-scope overrides owned and cached by their nearest request scope instead of leaking request-local instances into root singleton caches.

--- a/packages/di/src/container-nested-request-override-regression.test.ts
+++ b/packages/di/src/container-nested-request-override-regression.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import { Container } from './container.js';
+
+describe('Container nested request-scope override regressions', () => {
+  it('shares a nested single override with its nearest request-scope owner', async () => {
+    // Given
+    const token = Symbol('nested-single-override');
+    const root = new Container().register({
+      provide: token,
+      useFactory: () => ({ owner: 'root' }),
+    });
+    const overrideOwner = root.createRequestScope().override({
+      provide: token,
+      useFactory: () => ({ owner: 'request' }),
+    });
+    const nestedScope = overrideOwner.createRequestScope();
+
+    // When
+    const nestedInstance = await nestedScope.resolve(token);
+    const ownerInstance = await overrideOwner.resolve(token);
+
+    // Then
+    expect(nestedInstance).toBe(ownerInstance);
+  });
+
+  it('keeps a nested single override out of the root singleton cache', async () => {
+    // Given
+    const token = Symbol('nested-single-root-isolation');
+    const rootInstance = { owner: 'root' };
+    const requestInstance = { owner: 'request' };
+    const root = new Container().register({ provide: token, useValue: rootInstance });
+    const nestedScope = root
+      .createRequestScope()
+      .override({ provide: token, useValue: requestInstance })
+      .createRequestScope();
+
+    // When
+    await nestedScope.resolve(token);
+    const resolvedFromRoot = await root.resolve(token);
+
+    // Then
+    expect(resolvedFromRoot).toBe(rootInstance);
+  });
+
+  it('shares a nested multi override with its nearest request-scope owner', async () => {
+    // Given
+    const token = Symbol('nested-multi-override');
+    const root = new Container().register({
+      multi: true,
+      provide: token,
+      useFactory: () => ({ owner: 'root' }),
+    });
+    const overrideOwner = root.createRequestScope().override({
+      multi: true,
+      provide: token,
+      useFactory: () => ({ owner: 'request' }),
+    });
+    const nestedScope = overrideOwner.createRequestScope();
+
+    // When
+    const nestedInstances = await nestedScope.resolve<unknown[]>(token);
+    const ownerInstances = await overrideOwner.resolve<unknown[]>(token);
+
+    // Then
+    expect(nestedInstances[0]).toBe(ownerInstances[0]);
+  });
+});

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -922,8 +922,10 @@ export class Container {
       return await this.instantiate(provider, chain, activeTokens);
     }
 
-    if (this.shouldResolveMultiProviderFromRoot(provider)) {
-      return await this.root().resolveMultiProviderInstance(provider, chain, activeTokens);
+    const cacheOwner = this.cacheOwnerFor(provider);
+
+    if (cacheOwner !== this) {
+      return await cacheOwner.resolveMultiProviderInstance(provider, chain, activeTokens);
     }
 
     const cache = this.multiCacheFor(provider);
@@ -969,8 +971,10 @@ export class Container {
     chain: Token[],
     activeTokens: Set<Token>,
   ): Promise<unknown> {
-    if (this.shouldResolveFromRoot(provider)) {
-      return await this.root().resolveScopedOrSingletonInstance(provider, chain, activeTokens);
+    const cacheOwner = this.cacheOwnerFor(provider);
+
+    if (cacheOwner !== this) {
+      return await cacheOwner.resolveScopedOrSingletonInstance(provider, chain, activeTokens);
     }
 
     const cache = this.cacheFor(provider);
@@ -1008,19 +1012,25 @@ export class Container {
       return undefined;
     }
 
-    if (this.shouldResolveFromRoot(provider)) {
-      return this.root().getCachedScopedOrSingletonInstance(provider);
+    const cacheOwner = this.cacheOwnerFor(provider);
+
+    if (cacheOwner !== this) {
+      return cacheOwner.getCachedScopedOrSingletonInstance(provider);
     }
 
     return this.cacheFor(provider).get(provider.provide);
   }
 
-  private shouldResolveFromRoot(provider: NormalizedProvider): boolean {
-    return provider.scope === Scope.DEFAULT && this.requestScopeEnabled && !this.registrations.has(provider.provide);
-  }
+  private cacheOwnerFor(provider: NormalizedProvider): Container {
+    if (provider.scope !== Scope.DEFAULT || !this.requestScopeEnabled) {
+      return this;
+    }
 
-  private shouldResolveMultiProviderFromRoot(provider: NormalizedProvider): boolean {
-    return provider.scope === Scope.DEFAULT && this.requestScopeEnabled && !this.hasLocalMultiProvider(provider);
+    if (this.registrations.get(provider.provide) === provider || this.hasLocalMultiProvider(provider)) {
+      return this;
+    }
+
+    return this.parent?.cacheOwnerFor(provider) ?? this;
   }
 
   private async resolveDepToken(


### PR DESCRIPTION
## Summary

Resolve nested request-scope overrides through their nearest registration owner so request-local identities never enter root singleton caches.

Linked context: Closes #2994

## Changes

- Route default-scope single and multi override resolution to the nearest container that owns the exact registration.
- Add regression coverage for nested single identity, root cache isolation, and nested multi identity.
- Add a patch Changeset for `@fluojs/di`.

## Testing

- Failing-first regression: all 3 new tests failed before the implementation change for the expected identity/cache reasons.
- `pnpm --filter @fluojs/di test` — 7 files, 160 tests passed.
- `pnpm --filter @fluojs/di... build` — passed.
- `pnpm --filter @fluojs/di typecheck` — passed.
- `pnpm exec biome check packages/di/src/container.ts packages/di/src/container-nested-request-override-regression.test.ts` — passed.
- Changed-file LSP diagnostics — no diagnostics.
- `pnpm verify:platform-consistency-governance` — passed.
- `pnpm verify:release-readiness` — passed without writing draft artifacts.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch rationale: this restores documented request-scope isolation without changing the public API shape or requiring consumer migration.

## Public export documentation

Not applicable: no public exports or signatures changed. Existing `Container` documentation remains accurate.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

This is contract-preserving. `packages/di/README.md` and `README.ko.md` already require request-local overrides to avoid polluting the root cache, so no companion documentation change is needed.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests.

No governance docs, platform contracts, or README claims changed. The repository governance verifier passed.

## Risks

The change affects only default-scope providers inherited through nested request containers. The main risk is selecting the wrong ancestor when single and multi registrations coexist; exact normalized-provider identity checks and dedicated single/multi regressions constrain that path.