### PR TITLE
fix(tooling): bind release handoffs to explicit approval evidence

### DIFF
--- a/.agents/VALIDATION.md
+++ b/.agents/VALIDATION.md
@@ -55,4 +55,6 @@ from the retained plan and source artifact, then compare every immutable plan
 field with the execution snapshot before parking an issue.
 Require the recomputed binding to equal `lane_plan_approval_sha256` in the
 ledger. When that field is present, always reconcile it even if a resumed
-snapshot has an empty handoff array.
+snapshot has an empty handoff array. Anchor this decision to the canonical
+published ledger so a persisted snapshot cannot remove both fields and
+downgrade itself to legacy compatibility.

--- a/.agents/VALIDATION.md
+++ b/.agents/VALIDATION.md
@@ -53,3 +53,6 @@ For non-empty `release_handoffs`, derive the consumed lane-plan receipt from
 the canonical repository approval directory. Recompute its approval binding
 from the retained plan and source artifact, then compare every immutable plan
 field with the execution snapshot before parking an issue.
+Require the recomputed binding to equal `lane_plan_approval_sha256` in the
+ledger. When that field is present, always reconcile it even if a resumed
+snapshot has an empty handoff array.

--- a/.agents/VALIDATION.md
+++ b/.agents/VALIDATION.md
@@ -48,3 +48,8 @@ target-bound receipt. Publishing remains GitHub Actions-only.
 Validate the lane snapshot, event hash chain, lease, live branch/worktree/PR
 identity, current head, checks, and approval freshness before resuming. Never
 fill missing persisted fields with compatibility defaults.
+
+For non-empty `release_handoffs`, derive the consumed lane-plan receipt from
+the canonical repository approval directory. Recompute its approval binding
+from the retained plan and source artifact, then compare every immutable plan
+field with the execution snapshot before parking an issue.

--- a/.agents/skills/create-lane/SKILL.md
+++ b/.agents/skills/create-lane/SKILL.md
@@ -42,9 +42,11 @@ Obtain these approvals in order from three distinct user interactions:
 `release_handoffs` is reserved for issues whose core task is a release or
 publish decision that must stop at `blocked-maintainer-decision`. A public
 package change that merely requires a Changeset is normal implementation work
-and must not enter `release_handoffs`. Every planned handoff must bind the
-explicit reason `release-or-publish-is-core` and occupy a dedicated
-single-issue lane.
+and must not enter `release_handoffs`. Every planned handoff must occupy a
+dedicated single-issue lane and bind `release-or-publish-is-core` to a SHA-256
+digest of the lead's live issue observation. The `lane-plan` response must
+separately attest to the same issue/digest with `changeset_only: false`;
+planner-controlled text alone never authorizes a handoff.
 
 Each persisted approval binds the complete plan plus artifact ID/SHA and is
 consumed exactly once. An approval response cannot satisfy more than one gate.

--- a/.agents/skills/create-lane/SKILL.md
+++ b/.agents/skills/create-lane/SKILL.md
@@ -39,6 +39,13 @@ Obtain these approvals in order from three distinct user interactions:
 3. `lane-plan`: the final multi-issue grouping, dependencies, lane ID, merge
    policy, retry policy, release handoffs, and authority scope.
 
+`release_handoffs` is reserved for issues whose core task is a release or
+publish decision that must stop at `blocked-maintainer-decision`. A public
+package change that merely requires a Changeset is normal implementation work
+and must not enter `release_handoffs`. Every planned handoff must bind the
+explicit reason `release-or-publish-is-core` and occupy a dedicated
+single-issue lane.
+
 Each persisted approval binds the complete plan plus artifact ID/SHA and is
 consumed exactly once. An approval response cannot satisfy more than one gate.
 If structured questions are unavailable, present the gate and wait for a

--- a/.agents/skills/create-lane/references/workflow.md
+++ b/.agents/skills/create-lane/references/workflow.md
@@ -43,6 +43,8 @@ handoffs:
 Each gate has a distinct approval identity and interaction. Its digest binds
 the complete plan and source artifact. Persist consumed IDs so missing, denied,
 out-of-order, substituted, or replayed approvals stop before publication.
+The ready ledger also stores the lane-plan approval binding independently so
+execute-lane can reject a self-consistent forged receipt.
 
 ## Validation and publication
 

--- a/.agents/skills/create-lane/references/workflow.md
+++ b/.agents/skills/create-lane/references/workflow.md
@@ -24,6 +24,16 @@ Show the artifact candidates and obtain three separate approvals:
 3. Lane plan approval accepts the final grouping, dependency graph, release
    handoffs, merge/retry policy, authority scope, and lane identity.
 
+In the approval presentation, distinguish release metadata from execution
+handoffs:
+
+- Changeset requirements stay implementation and verification obligations.
+- `release_handoffs` contains only issues whose core task is release or
+  publishing and therefore terminally parks for a maintainer decision.
+- Each handoff is represented in the approved plan as
+  `{ "issue_number": <n>, "reason": "release-or-publish-is-core" }` and must
+  occupy a dedicated single-issue lane.
+
 Each gate has a distinct approval identity and interaction. Its digest binds
 the complete plan and source artifact. Persist consumed IDs so missing, denied,
 out-of-order, substituted, or replayed approvals stop before publication.

--- a/.agents/skills/create-lane/references/workflow.md
+++ b/.agents/skills/create-lane/references/workflow.md
@@ -31,8 +31,14 @@ handoffs:
 - `release_handoffs` contains only issues whose core task is release or
   publishing and therefore terminally parks for a maintainer decision.
 - Each handoff is represented in the approved plan as
-  `{ "issue_number": <n>, "reason": "release-or-publish-is-core" }` and must
-  occupy a dedicated single-issue lane.
+  `{ "issue_number": <n>, "reason": "release-or-publish-is-core",
+  "issue_evidence_sha256": "<sha256>" }` and must occupy a dedicated
+  single-issue lane.
+- Calculate `issue_evidence_sha256` from the canonical live GitHub observation
+  `{ issue_number, issue_url, title, body, labels, updated_at }`.
+- The lane-plan approval must repeat each issue number and evidence digest with
+  `decision: "release-or-publish-is-core"` and `changeset_only: false`.
+  Empty handoffs require an explicit empty attestation list.
 
 Each gate has a distinct approval identity and interaction. Its digest binds
 the complete plan and source artifact. Persist consumed IDs so missing, denied,

--- a/.agents/skills/create-lane/scripts/approval-contracts.mjs
+++ b/.agents/skills/create-lane/scripts/approval-contracts.mjs
@@ -6,6 +6,7 @@ const approvalGates = [
   'lane-plan',
 ];
 const safeIdentifier = /^(?!.*(?:\.|\.lock)$)[A-Za-z0-9][A-Za-z0-9._-]*$/u;
+const sha256 = /^[a-f0-9]{64}$/u;
 
 const isRecord = (value) =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -23,6 +24,37 @@ const isIssueArray = (value) =>
   Array.isArray(value) &&
   value.every((issue) => Number.isSafeInteger(issue) && issue > 0) &&
   new Set(value).size === value.length;
+
+const releaseHandoffAttestations = (value) => {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const attestations = [];
+  for (const attestation of value) {
+    if (
+      !isRecord(attestation) ||
+      !hasExactKeys(attestation, [
+        'issue_number',
+        'issue_evidence_sha256',
+        'decision',
+        'changeset_only',
+      ]) ||
+      !Number.isSafeInteger(attestation.issue_number) ||
+      attestation.issue_number <= 0 ||
+      typeof attestation.issue_evidence_sha256 !== 'string' ||
+      !sha256.test(attestation.issue_evidence_sha256) ||
+      attestation.decision !== 'release-or-publish-is-core' ||
+      attestation.changeset_only !== false
+    ) {
+      return null;
+    }
+    attestations.push(attestation);
+  }
+  return new Set(attestations.map(({ issue_number }) => issue_number)).size ===
+    attestations.length
+    ? attestations
+    : null;
+};
 
 const canonicalValue = (value) => {
   if (Array.isArray(value)) {
@@ -49,6 +81,13 @@ export const approvalBinding = (approval, artifact, plan) =>
           artifact_id: artifact.artifact_id,
           artifact_sha256: artifact.sha256,
           issue_numbers: approval.issue_numbers ?? [],
+          ...(Array.isArray(approval.release_handoff_attestations) &&
+          approval.release_handoff_attestations.length > 0
+            ? {
+                release_handoff_attestations:
+                  approval.release_handoff_attestations,
+              }
+            : {}),
           plan,
         }),
       ),
@@ -63,7 +102,13 @@ export const validateApprovals = (approvals, artifact, plan) => {
   for (const [index, approval] of approvals.entries()) {
     const keys =
       approvalGates[index] === 'lane-plan'
-        ? ['gate', 'approval_id', 'approved', 'binding_sha256']
+        ? [
+            'gate',
+            'approval_id',
+            'approved',
+            'release_handoff_attestations',
+            'binding_sha256',
+          ]
         : [
             'gate',
             'approval_id',
@@ -103,6 +148,27 @@ export const validateApprovals = (approvals, artifact, plan) => {
     !finalIssues.every((issue, index) => issue === plan.confirmed_issues[index])
   ) {
     return 'approval_not_distinct';
+  }
+  const planHandoffs = Array.isArray(plan.release_handoffs)
+    ? plan.release_handoffs
+    : [];
+  const attestations = releaseHandoffAttestations(
+    approvals[2].release_handoff_attestations,
+  );
+  if (
+    attestations === null ||
+    attestations.length !== planHandoffs.length ||
+    !attestations.every((attestation, index) => {
+      const handoff = planHandoffs[index];
+      return (
+        isRecord(handoff) &&
+        attestation.issue_number === handoff.issue_number &&
+        attestation.issue_evidence_sha256 ===
+          handoff.issue_evidence_sha256
+      );
+    })
+  ) {
+    return 'release_handoff_attestation_mismatch';
   }
   return approvals.some(
     (approval) =>

--- a/.agents/skills/create-lane/scripts/approval-contracts.mjs
+++ b/.agents/skills/create-lane/scripts/approval-contracts.mjs
@@ -131,6 +131,15 @@ export const validateApprovals = (approvals, artifact, plan) => {
   if (approvalIds.size !== approvalGates.length) {
     return 'approval_not_distinct';
   }
+  if (
+    approvals.some(
+      (approval) =>
+        approval.approval_id !==
+        `approval-${plan.lane_id}-${approval.gate}`,
+    )
+  ) {
+    return 'approval_binding_mismatch';
+  }
   const confirmed = approvals[0].issue_numbers;
   const suggested = approvals[1].issue_numbers;
   if (

--- a/.agents/skills/create-lane/scripts/contracts.mjs
+++ b/.agents/skills/create-lane/scripts/contracts.mjs
@@ -83,5 +83,10 @@ export const prepareScenario = (scenarioPath) => {
     }
     throw error;
   }
-  return { kind: 'ready', ledger, approvals: scenario.approvals };
+  return {
+    kind: 'ready',
+    ledger,
+    approvals: scenario.approvals,
+    plan,
+  };
 };

--- a/.agents/skills/create-lane/scripts/contracts.mjs
+++ b/.agents/skills/create-lane/scripts/contracts.mjs
@@ -73,7 +73,12 @@ export const prepareScenario = (scenarioPath) => {
   if (approvalFailure !== null) {
     return rejected(approvalFailure);
   }
-  const ledger = readyLedger(plan, artifact, input);
+  const ledger = readyLedger(
+    plan,
+    artifact,
+    input,
+    scenario.approvals[2].binding_sha256,
+  );
   try {
     assertLaneSourceBinding(ledger, artifact);
     validateLedger('lane-ledger-v2', ledger);

--- a/.agents/skills/create-lane/scripts/fixtures/run-scenario.mjs
+++ b/.agents/skills/create-lane/scripts/fixtures/run-scenario.mjs
@@ -92,6 +92,12 @@ const publishReadyLane = (outputRoot, prepared) => {
         gate: approval.gate,
         binding_sha256: approval.binding_sha256,
         lane_id: prepared.ledger.lane_id,
+        ...(approval.gate === 'lane-plan'
+          ? {
+              release_handoff_attestations:
+                approval.release_handoff_attestations,
+            }
+          : {}),
       },
     ),
     target: resolve(

--- a/.agents/skills/create-lane/scripts/fixtures/run-scenario.mjs
+++ b/.agents/skills/create-lane/scripts/fixtures/run-scenario.mjs
@@ -96,6 +96,7 @@ const publishReadyLane = (outputRoot, prepared) => {
           ? {
               release_handoff_attestations:
                 approval.release_handoff_attestations,
+              plan: prepared.plan,
             }
           : {}),
       },

--- a/.agents/skills/create-lane/scripts/plan-contracts.mjs
+++ b/.agents/skills/create-lane/scripts/plan-contracts.mjs
@@ -106,6 +106,7 @@ export const planIsCanonical = (plan, artifact) => {
     typeof plan.base_branch !== 'string' ||
     plan.base_branch.length === 0 ||
     !isRecord(plan.source) ||
+    !hasExactKeys(plan.source, ['artifact_id', 'sha256']) ||
     plan.source.artifact_id !== artifact.artifact_id ||
     plan.source.sha256 !== artifact.sha256 ||
     !isIssueArray(plan.confirmed_issues) ||

--- a/.agents/skills/create-lane/scripts/plan-contracts.mjs
+++ b/.agents/skills/create-lane/scripts/plan-contracts.mjs
@@ -146,10 +146,18 @@ export const planIsCanonical = (plan, artifact) => {
   );
 };
 
-export const readyLedger = (plan, artifact, artifactPath) => ({
+export const readyLedger = (
+  plan,
+  artifact,
+  artifactPath,
+  lanePlanApprovalSha256,
+) => ({
   version: 2,
   run_id: plan.lane_id,
   lane_id: plan.lane_id,
+  ...(lanePlanApprovalSha256 === undefined
+    ? {}
+    : { lane_plan_approval_sha256: lanePlanApprovalSha256 }),
   status: 'ready',
   created_by: 'create-lane',
   base_branch: plan.base_branch,

--- a/.agents/skills/create-lane/scripts/plan-contracts.mjs
+++ b/.agents/skills/create-lane/scripts/plan-contracts.mjs
@@ -1,4 +1,5 @@
 const safeIdentifier = /^(?!.*(?:\.|\.lock)$)[A-Za-z0-9][A-Za-z0-9._-]*$/u;
+const sha256 = /^[a-f0-9]{64}$/u;
 const planKeys = [
   'version',
   'lane_id',
@@ -41,10 +42,16 @@ const releaseHandoffIssues = (value) => {
   for (const handoff of value) {
     if (
       !isRecord(handoff) ||
-      !hasExactKeys(handoff, ['issue_number', 'reason']) ||
+      !hasExactKeys(handoff, [
+        'issue_number',
+        'reason',
+        'issue_evidence_sha256',
+      ]) ||
       !Number.isSafeInteger(handoff.issue_number) ||
       handoff.issue_number <= 0 ||
-      handoff.reason !== 'release-or-publish-is-core'
+      handoff.reason !== 'release-or-publish-is-core' ||
+      typeof handoff.issue_evidence_sha256 !== 'string' ||
+      !sha256.test(handoff.issue_evidence_sha256)
     ) {
       return null;
     }

--- a/.agents/skills/create-lane/scripts/plan-contracts.mjs
+++ b/.agents/skills/create-lane/scripts/plan-contracts.mjs
@@ -33,6 +33,26 @@ const isIssueArray = (value) =>
   value.every((issue) => Number.isSafeInteger(issue) && issue > 0) &&
   new Set(value).size === value.length;
 
+const releaseHandoffIssues = (value) => {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const issues = [];
+  for (const handoff of value) {
+    if (
+      !isRecord(handoff) ||
+      !hasExactKeys(handoff, ['issue_number', 'reason']) ||
+      !Number.isSafeInteger(handoff.issue_number) ||
+      handoff.issue_number <= 0 ||
+      handoff.reason !== 'release-or-publish-is-core'
+    ) {
+      return null;
+    }
+    issues.push(handoff.issue_number);
+  }
+  return new Set(issues).size === issues.length ? issues : null;
+};
+
 const hasCanonicalDependencies = (graph, issues) => {
   if (!isRecord(graph)) {
     return false;
@@ -69,6 +89,7 @@ const hasCanonicalDependencies = (graph, issues) => {
 };
 
 export const planIsCanonical = (plan, artifact) => {
+  const handoffIssues = releaseHandoffIssues(plan?.release_handoffs);
   if (
     !isRecord(plan) ||
     !hasExactKeys(plan, planKeys) ||
@@ -83,7 +104,7 @@ export const planIsCanonical = (plan, artifact) => {
     !isIssueArray(plan.confirmed_issues) ||
     !Array.isArray(plan.suggested_but_excluded) ||
     !Array.isArray(plan.backlog_candidates) ||
-    !Array.isArray(plan.release_handoffs) ||
+    handoffIssues === null ||
     !Array.isArray(plan.lanes) ||
     plan.lanes.length === 0
   ) {
@@ -106,6 +127,13 @@ export const planIsCanonical = (plan, artifact) => {
     queues.length === plan.confirmed_issues.length &&
     new Set(queues).size === queues.length &&
     plan.confirmed_issues.every((issue) => queues.includes(issue)) &&
+    handoffIssues.every(
+      (issue) =>
+        plan.confirmed_issues.includes(issue) &&
+        plan.lanes.some(
+          (lane) => lane.queue.length === 1 && lane.queue[0] === issue,
+        ),
+    ) &&
     hasCanonicalDependencies(plan.dependency_graph, plan.confirmed_issues)
   );
 };
@@ -136,7 +164,9 @@ export const readyLedger = (plan, artifact, artifactPath) => ({
   confirmed_issues: plan.confirmed_issues,
   suggested_but_excluded: plan.suggested_but_excluded,
   backlog_candidates: plan.backlog_candidates,
-  release_handoffs: plan.release_handoffs,
+  release_handoffs: plan.release_handoffs.map(
+    (handoff) => handoff.issue_number,
+  ),
   completed_issues: [],
   issue_progress: {},
   lanes: plan.lanes.map((lane) => ({

--- a/.agents/skills/execute-lane/references/workflow.md
+++ b/.agents/skills/execute-lane/references/workflow.md
@@ -12,6 +12,12 @@ Acquire a per-ledger lease, validate the v2 snapshot and event hash chain, and
 reconcile live branch, worktree, PR, head, checks, and issue identity before
 resuming.
 
+`release_handoffs` does not mean “Changeset required.” It contains only issues
+whose core task is release or publishing. Those issues are never dispatched to
+implementation and terminally park at `blocked-maintainer-decision`. When
+multiple handoffs exist, already parked items may coexist with untouched queued
+handoffs while the root status remains `running`.
+
 ## Attempt loop
 
 ```text

--- a/.agents/skills/execute-lane/references/workflow.md
+++ b/.agents/skills/execute-lane/references/workflow.md
@@ -22,6 +22,8 @@ Before accepting any non-empty handoff set, load the consumed `lane-plan`
 approval receipt and require its issue numbers to match the ledger exactly.
 Each receipt attestation must retain the approved issue evidence digest,
 `decision: "release-or-publish-is-core"`, and `changeset_only: false`.
+Recompute the receipt binding and require it to equal the independent
+`lane_plan_approval_sha256` stored in the ready ledger.
 
 ## Attempt loop
 

--- a/.agents/skills/execute-lane/references/workflow.md
+++ b/.agents/skills/execute-lane/references/workflow.md
@@ -18,6 +18,11 @@ implementation and terminally park at `blocked-maintainer-decision`. When
 multiple handoffs exist, already parked items may coexist with untouched queued
 handoffs while the root status remains `running`.
 
+Before accepting any non-empty handoff set, load the consumed `lane-plan`
+approval receipt and require its issue numbers to match the ledger exactly.
+Each receipt attestation must retain the approved issue evidence digest,
+`decision: "release-or-publish-is-core"`, and `changeset_only: false`.
+
 ## Attempt loop
 
 ```text

--- a/.agents/skills/execute-lane/scripts/fixtures/run-replay.mjs
+++ b/.agents/skills/execute-lane/scripts/fixtures/run-replay.mjs
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
 
 import { runReplay } from '../state-machine.mjs';
 import {
@@ -26,11 +26,11 @@ const valueAfter = (flag) => {
 const scenarioPath = resolve(valueAfter('--scenario'));
 const ledgerPath = resolve(valueAfter('--ledger'));
 const stateDirectory = resolve(valueAfter('--state-dir'));
-const approvalReceiptIndex = args.indexOf('--approval-receipt');
-const approvalReceiptPath =
-  approvalReceiptIndex === -1
-    ? null
-    : resolve(valueAfter('--approval-receipt'));
+const repositoryRootIndex = args.indexOf('--repository-root');
+const repositoryRoot =
+  repositoryRootIndex === -1
+    ? resolve(dirname(ledgerPath), '../..')
+    : resolve(valueAfter('--repository-root'));
 const scenario = JSON.parse(readFileSync(scenarioPath, 'utf8'));
 if (
   typeof scenario !== 'object' ||
@@ -46,7 +46,7 @@ for (const step of scenario.steps) {
   const previous = loadState(
     stateDirectory,
     ledgerPath,
-    approvalReceiptPath,
+    repositoryRoot,
   );
   const lease = acquireLease(stateDirectory, previous.snapshot.lane_id);
   try {

--- a/.agents/skills/execute-lane/scripts/fixtures/run-replay.mjs
+++ b/.agents/skills/execute-lane/scripts/fixtures/run-replay.mjs
@@ -26,6 +26,11 @@ const valueAfter = (flag) => {
 const scenarioPath = resolve(valueAfter('--scenario'));
 const ledgerPath = resolve(valueAfter('--ledger'));
 const stateDirectory = resolve(valueAfter('--state-dir'));
+const approvalReceiptIndex = args.indexOf('--approval-receipt');
+const approvalReceiptPath =
+  approvalReceiptIndex === -1
+    ? null
+    : resolve(valueAfter('--approval-receipt'));
 const scenario = JSON.parse(readFileSync(scenarioPath, 'utf8'));
 if (
   typeof scenario !== 'object' ||
@@ -38,7 +43,11 @@ if (
 
 let result;
 for (const step of scenario.steps) {
-  const previous = loadState(stateDirectory, ledgerPath);
+  const previous = loadState(
+    stateDirectory,
+    ledgerPath,
+    approvalReceiptPath,
+  );
   const lease = acquireLease(stateDirectory, previous.snapshot.lane_id);
   try {
     result = runReplay({ ...scenario, steps: [step] }, previous);

--- a/.agents/skills/execute-lane/scripts/release-handoff-approval.mjs
+++ b/.agents/skills/execute-lane/scripts/release-handoff-approval.mjs
@@ -162,6 +162,11 @@ export const assertReleaseHandoffBinding = (
   ) {
     throw new TypeError('release handoff approval binding does not match');
   }
+  if (ledger.lane_plan_approval_sha256 !== receipt.binding_sha256) {
+    throw new TypeError(
+      'release handoff receipt binding does not match the ledger',
+    );
+  }
   const expected = readyLedger(receipt.plan, artifact, artifactPath);
   const expectedPlan = immutableLedgerPlan({
     ...expected,

--- a/.agents/skills/execute-lane/scripts/release-handoff-approval.mjs
+++ b/.agents/skills/execute-lane/scripts/release-handoff-approval.mjs
@@ -1,0 +1,73 @@
+const sha256 = /^[a-f0-9]{64}$/u;
+
+const isRecord = (value) =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const hasExactKeys = (record, keys) => {
+  const actual = Object.keys(record).sort();
+  const expected = [...keys].sort();
+  return (
+    actual.length === expected.length &&
+    actual.every((key, index) => key === expected[index])
+  );
+};
+
+export const assertReleaseHandoffApproval = (ledger, receipt) => {
+  if (ledger.release_handoffs.length === 0) {
+    return;
+  }
+  if (
+    !isRecord(receipt) ||
+    !hasExactKeys(receipt, [
+      'version',
+      'approval_id',
+      'gate',
+      'binding_sha256',
+      'lane_id',
+      'release_handoff_attestations',
+    ]) ||
+    receipt.version !== 1 ||
+    receipt.gate !== 'lane-plan' ||
+    receipt.lane_id !== ledger.lane_id ||
+    typeof receipt.approval_id !== 'string' ||
+    receipt.approval_id.length === 0 ||
+    typeof receipt.binding_sha256 !== 'string' ||
+    !sha256.test(receipt.binding_sha256) ||
+    !Array.isArray(receipt.release_handoff_attestations)
+  ) {
+    throw new TypeError(
+      'release handoffs require their consumed lane-plan approval receipt',
+    );
+  }
+  const issues = [];
+  for (const attestation of receipt.release_handoff_attestations) {
+    if (
+      !isRecord(attestation) ||
+      !hasExactKeys(attestation, [
+        'issue_number',
+        'issue_evidence_sha256',
+        'decision',
+        'changeset_only',
+      ]) ||
+      !Number.isSafeInteger(attestation.issue_number) ||
+      attestation.issue_number <= 0 ||
+      typeof attestation.issue_evidence_sha256 !== 'string' ||
+      !sha256.test(attestation.issue_evidence_sha256) ||
+      attestation.decision !== 'release-or-publish-is-core' ||
+      attestation.changeset_only !== false
+    ) {
+      throw new TypeError(
+        'release handoff approval receipt contains an invalid attestation',
+      );
+    }
+    issues.push(attestation.issue_number);
+  }
+  if (
+    issues.length !== ledger.release_handoffs.length ||
+    !issues.every((issue, index) => issue === ledger.release_handoffs[index])
+  ) {
+    throw new TypeError(
+      'release handoffs do not match their lane-plan approval receipt',
+    );
+  }
+};

--- a/.agents/skills/execute-lane/scripts/release-handoff-approval.mjs
+++ b/.agents/skills/execute-lane/scripts/release-handoff-approval.mjs
@@ -40,8 +40,8 @@ export const assertReleaseHandoffApproval = (ledger, receipt) => {
     receipt.version !== 1 ||
     receipt.gate !== 'lane-plan' ||
     receipt.lane_id !== ledger.lane_id ||
-    typeof receipt.approval_id !== 'string' ||
-    receipt.approval_id.length === 0 ||
+    receipt.approval_id !==
+      `approval-${ledger.lane_id}-lane-plan` ||
     !Array.isArray(receipt.release_handoff_attestations) ||
     !isRecord(receipt.plan)
   ) {
@@ -129,6 +129,25 @@ export const assertReleaseHandoffBinding = (
   assertLaneSourceBinding(ledger, artifact);
   if (!planIsCanonical(receipt.plan, artifact)) {
     throw new TypeError('release handoff receipt plan is not canonical');
+  }
+  const plannedHandoffs = receipt.plan.release_handoffs;
+  if (
+    plannedHandoffs.length !==
+      receipt.release_handoff_attestations.length ||
+    !plannedHandoffs.every((handoff, index) => {
+      const attestation = receipt.release_handoff_attestations[index];
+      return (
+        handoff.issue_number === attestation.issue_number &&
+        handoff.issue_evidence_sha256 ===
+          attestation.issue_evidence_sha256 &&
+        handoff.reason === attestation.decision &&
+        attestation.changeset_only === false
+      );
+    })
+  ) {
+    throw new TypeError(
+      'release handoff attestations do not match the approved plan',
+    );
   }
   const approval = {
     gate: 'lane-plan',

--- a/.agents/skills/execute-lane/scripts/release-handoff-approval.mjs
+++ b/.agents/skills/execute-lane/scripts/release-handoff-approval.mjs
@@ -1,4 +1,14 @@
-const sha256 = /^[a-f0-9]{64}$/u;
+import {
+  approvalBinding,
+} from '../../create-lane/scripts/approval-contracts.mjs';
+import {
+  planIsCanonical,
+  readyLedger,
+} from '../../create-lane/scripts/plan-contracts.mjs';
+import {
+  assertContract,
+  assertLaneSourceBinding,
+} from '../../../workflow-contracts/contracts.mjs';
 
 const isRecord = (value) =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -25,15 +35,15 @@ export const assertReleaseHandoffApproval = (ledger, receipt) => {
       'binding_sha256',
       'lane_id',
       'release_handoff_attestations',
+      'plan',
     ]) ||
     receipt.version !== 1 ||
     receipt.gate !== 'lane-plan' ||
     receipt.lane_id !== ledger.lane_id ||
     typeof receipt.approval_id !== 'string' ||
     receipt.approval_id.length === 0 ||
-    typeof receipt.binding_sha256 !== 'string' ||
-    !sha256.test(receipt.binding_sha256) ||
-    !Array.isArray(receipt.release_handoff_attestations)
+    !Array.isArray(receipt.release_handoff_attestations) ||
+    !isRecord(receipt.plan)
   ) {
     throw new TypeError(
       'release handoffs require their consumed lane-plan approval receipt',
@@ -52,7 +62,7 @@ export const assertReleaseHandoffApproval = (ledger, receipt) => {
       !Number.isSafeInteger(attestation.issue_number) ||
       attestation.issue_number <= 0 ||
       typeof attestation.issue_evidence_sha256 !== 'string' ||
-      !sha256.test(attestation.issue_evidence_sha256) ||
+      !/^[a-f0-9]{64}$/u.test(attestation.issue_evidence_sha256) ||
       attestation.decision !== 'release-or-publish-is-core' ||
       attestation.changeset_only !== false
     ) {
@@ -68,6 +78,83 @@ export const assertReleaseHandoffApproval = (ledger, receipt) => {
   ) {
     throw new TypeError(
       'release handoffs do not match their lane-plan approval receipt',
+    );
+  }
+};
+
+const immutableLedgerPlan = (ledger) => ({
+  version: ledger.version,
+  lane_id: ledger.lane_id,
+  base_branch: ledger.base_branch,
+  source: {
+    artifact_id: ledger.source.artifact_id,
+    sha256: ledger.source.sha256,
+  },
+  merge_policy: ledger.merge_policy,
+  pr_merge_method: ledger.pr_merge_method,
+  authority_scope: ledger.authority_scope,
+  retry_policy: ledger.retry_policy,
+  confirmed_issues: ledger.confirmed_issues,
+  suggested_but_excluded: ledger.suggested_but_excluded,
+  backlog_candidates: ledger.backlog_candidates,
+  release_handoffs: receiptHandoffs(ledger),
+  lanes: ledger.lanes.map(({ name, queue }) => ({ name, queue })),
+  dependency_graph: ledger.dependency_graph,
+});
+
+const receiptHandoffs = (ledger) =>
+  ledger.release_handoffs.map((issue_number) => {
+    const attestation =
+      ledger.releaseHandoffApproval.release_handoff_attestations.find(
+        (candidate) => candidate.issue_number === issue_number,
+      );
+    return {
+      issue_number,
+      reason: 'release-or-publish-is-core',
+      issue_evidence_sha256: attestation.issue_evidence_sha256,
+    };
+  });
+
+export const assertReleaseHandoffBinding = (
+  ledger,
+  receipt,
+  artifact,
+  artifactPath,
+) => {
+  if (ledger.release_handoffs.length === 0) {
+    return;
+  }
+  assertReleaseHandoffApproval(ledger, receipt);
+  assertContract('search-artifact-v2', artifact);
+  assertLaneSourceBinding(ledger, artifact);
+  if (!planIsCanonical(receipt.plan, artifact)) {
+    throw new TypeError('release handoff receipt plan is not canonical');
+  }
+  const approval = {
+    gate: 'lane-plan',
+    approval_id: receipt.approval_id,
+    approved: true,
+    release_handoff_attestations: receipt.release_handoff_attestations,
+    binding_sha256: receipt.binding_sha256,
+  };
+  if (
+    receipt.binding_sha256 !==
+    approvalBinding(approval, artifact, receipt.plan)
+  ) {
+    throw new TypeError('release handoff approval binding does not match');
+  }
+  const expected = readyLedger(receipt.plan, artifact, artifactPath);
+  const expectedPlan = immutableLedgerPlan({
+    ...expected,
+    releaseHandoffApproval: receipt,
+  });
+  const actualPlan = immutableLedgerPlan({
+    ...ledger,
+    releaseHandoffApproval: receipt,
+  });
+  if (JSON.stringify(actualPlan) !== JSON.stringify(expectedPlan)) {
+    throw new TypeError(
+      'release handoff ledger does not match its approved immutable plan',
     );
   }
 };

--- a/.agents/skills/execute-lane/scripts/release-handoff-approval.mjs
+++ b/.agents/skills/execute-lane/scripts/release-handoff-approval.mjs
@@ -124,12 +124,6 @@ export const assertReleaseHandoffBinding = (
   artifact,
   artifactPath,
 ) => {
-  if (
-    ledger.release_handoffs.length === 0 &&
-    ledger.lane_plan_approval_sha256 === undefined
-  ) {
-    return;
-  }
   assertReleaseHandoffApproval(ledger, receipt);
   assertContract('search-artifact-v2', artifact);
   assertLaneSourceBinding(ledger, artifact);

--- a/.agents/skills/execute-lane/scripts/release-handoff-approval.mjs
+++ b/.agents/skills/execute-lane/scripts/release-handoff-approval.mjs
@@ -23,7 +23,10 @@ const hasExactKeys = (record, keys) => {
 };
 
 export const assertReleaseHandoffApproval = (ledger, receipt) => {
-  if (ledger.release_handoffs.length === 0) {
+  if (
+    ledger.release_handoffs.length === 0 &&
+    ledger.lane_plan_approval_sha256 === undefined
+  ) {
     return;
   }
   if (
@@ -121,7 +124,10 @@ export const assertReleaseHandoffBinding = (
   artifact,
   artifactPath,
 ) => {
-  if (ledger.release_handoffs.length === 0) {
+  if (
+    ledger.release_handoffs.length === 0 &&
+    ledger.lane_plan_approval_sha256 === undefined
+  ) {
     return;
   }
   assertReleaseHandoffApproval(ledger, receipt);

--- a/.agents/skills/execute-lane/scripts/state-store.mjs
+++ b/.agents/skills/execute-lane/scripts/state-store.mjs
@@ -42,13 +42,31 @@ const readJson = (path) => {
   return JSON.parse(readFileSync(path, 'utf8'));
 };
 
-const releaseHandoffContext = (repositoryRoot, ledger) => {
+const releaseHandoffContext = (repositoryRoot, ledger, canonicalLedger) => {
+  const canonicalRequiresApproval =
+    canonicalLedger.release_handoffs.length > 0 ||
+    canonicalLedger.lane_plan_approval_sha256 !== undefined;
+  const snapshotRequiresApproval =
+    ledger.release_handoffs.length > 0 ||
+    ledger.lane_plan_approval_sha256 !== undefined;
   if (
-    ledger.release_handoffs.length === 0 &&
-    ledger.lane_plan_approval_sha256 === undefined
+    !canonicalRequiresApproval &&
+    !snapshotRequiresApproval
   ) {
     return null;
   }
+  if (
+    canonicalRequiresApproval &&
+    ledger.lane_plan_approval_sha256 !==
+      canonicalLedger.lane_plan_approval_sha256
+  ) {
+    throw new TypeError(
+      'persisted lane-plan approval binding does not match the canonical ledger',
+    );
+  }
+  const evidenceLedger = canonicalRequiresApproval
+    ? canonicalLedger
+    : ledger;
   const omoDirectory = resolve(repositoryRoot, '.omo');
   const approvalDirectory = resolve(omoDirectory, 'approvals');
   const searchDirectory = resolve(omoDirectory, 'search-issue');
@@ -62,14 +80,17 @@ const releaseHandoffContext = (repositoryRoot, ledger) => {
   ]) {
     assertRealDirectory(directory);
   }
-  if (ledger.source.search_ledger.includes('/legacy/')) {
+  if (evidenceLedger.source.search_ledger.includes('/legacy/')) {
     assertRealDirectory(resolve(artifactDirectory, 'legacy'));
   }
   const approvalPath = resolve(
     approvalDirectory,
-    `approval-${ledger.lane_id}-lane-plan.json`,
+    `approval-${evidenceLedger.lane_id}-lane-plan.json`,
   );
-  const artifactPath = resolve(repositoryRoot, ledger.source.search_ledger);
+  const artifactPath = resolve(
+    repositoryRoot,
+    evidenceLedger.source.search_ledger,
+  );
   for (const path of [approvalPath, artifactPath]) {
     const pathFromRoot = relative(repositoryRoot, path);
     if (pathFromRoot.startsWith('..') || resolve(repositoryRoot, pathFromRoot) !== path) {
@@ -90,9 +111,13 @@ const releaseHandoffContext = (repositoryRoot, ledger) => {
     ledger,
     receipt,
     artifact,
-    ledger.source.search_ledger,
+    evidenceLedger.source.search_ledger,
   );
-  return { receipt, artifact, artifactPath: ledger.source.search_ledger };
+  return {
+    receipt,
+    artifact,
+    artifactPath: evidenceLedger.source.search_ledger,
+  };
 };
 
 const ensureStateDirectory = (path) => {
@@ -197,16 +222,26 @@ export const loadState = (
 ) => {
   ensureStateDirectory(stateDirectory);
   recoverTransaction(stateDirectory);
+  const canonicalSnapshot = readJson(ledgerPath);
   const snapshotPath = resolve(stateDirectory, 'snapshot.json');
   const snapshot = existsSync(snapshotPath)
     ? readJson(snapshotPath)
-    : readJson(ledgerPath);
+    : canonicalSnapshot;
   const events = readEvents(resolve(stateDirectory, 'events.jsonl'));
   const receiptsPath = resolve(stateDirectory, 'receipts.json');
   const receipts = existsSync(receiptsPath) ? readJson(receiptsPath) : [];
   const state = { snapshot, events, receipts };
+  validateState({
+    snapshot: canonicalSnapshot,
+    events: [],
+    receipts: [],
+  });
   validateState(state);
-  const handoffContext = releaseHandoffContext(repositoryRoot, snapshot);
+  const handoffContext = releaseHandoffContext(
+    repositoryRoot,
+    snapshot,
+    canonicalSnapshot,
+  );
   return { ...state, handoffContext };
 };
 
@@ -240,6 +275,7 @@ export const persistState = (stateDirectory, previous, next) => {
   validateState(next);
   const context = previous.handoffContext;
   if (
+    (context !== null && context !== undefined) ||
     next.snapshot.release_handoffs.length > 0 ||
     next.snapshot.lane_plan_approval_sha256 !== undefined
   ) {

--- a/.agents/skills/execute-lane/scripts/state-store.mjs
+++ b/.agents/skills/execute-lane/scripts/state-store.mjs
@@ -18,6 +18,7 @@ import {
   assertEventChain,
 } from '../../../workflow-contracts/contracts.mjs';
 import { validateLedger } from '../../../../tooling/governance/lane-ledger-state.mjs';
+import { assertReleaseHandoffApproval } from './release-handoff-approval.mjs';
 
 const assertRegularFile = (path) => {
   if (!existsSync(path)) {
@@ -129,7 +130,11 @@ const recoverTransaction = (stateDirectory) => {
   unlinkSync(path);
 };
 
-export const loadState = (stateDirectory, ledgerPath) => {
+export const loadState = (
+  stateDirectory,
+  ledgerPath,
+  approvalReceiptPath = null,
+) => {
   ensureStateDirectory(stateDirectory);
   recoverTransaction(stateDirectory);
   const snapshotPath = resolve(stateDirectory, 'snapshot.json');
@@ -141,7 +146,10 @@ export const loadState = (stateDirectory, ledgerPath) => {
   const receipts = existsSync(receiptsPath) ? readJson(receiptsPath) : [];
   const state = { snapshot, events, receipts };
   validateState(state);
-  return state;
+  const releaseHandoffApproval =
+    approvalReceiptPath === null ? null : readJson(approvalReceiptPath);
+  assertReleaseHandoffApproval(snapshot, releaseHandoffApproval);
+  return { ...state, releaseHandoffApproval };
 };
 
 export const acquireLease = (stateDirectory, laneId) => {
@@ -172,6 +180,10 @@ export const acquireLease = (stateDirectory, laneId) => {
 
 export const persistState = (stateDirectory, previous, next) => {
   validateState(next);
+  assertReleaseHandoffApproval(
+    next.snapshot,
+    previous.releaseHandoffApproval ?? null,
+  );
   assertEventPrefix(previous.events, next.events);
   const transactionPath = resolve(stateDirectory, 'transaction.json');
   writeAtomic(transactionPath, {

--- a/.agents/skills/execute-lane/scripts/state-store.mjs
+++ b/.agents/skills/execute-lane/scripts/state-store.mjs
@@ -11,14 +11,14 @@ import {
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
-import { resolve } from 'node:path';
+import { dirname, relative, resolve } from 'node:path';
 
 import {
   assertContract,
   assertEventChain,
 } from '../../../workflow-contracts/contracts.mjs';
 import { validateLedger } from '../../../../tooling/governance/lane-ledger-state.mjs';
-import { assertReleaseHandoffApproval } from './release-handoff-approval.mjs';
+import { assertReleaseHandoffBinding } from './release-handoff-approval.mjs';
 
 const assertRegularFile = (path) => {
   if (!existsSync(path)) {
@@ -30,9 +30,66 @@ const assertRegularFile = (path) => {
   }
 };
 
+const assertRealDirectory = (path) => {
+  const stat = lstatSync(path);
+  if (stat.isSymbolicLink() || !stat.isDirectory()) {
+    throw new TypeError(`${path} must be a real directory.`);
+  }
+};
+
 const readJson = (path) => {
   assertRegularFile(path);
   return JSON.parse(readFileSync(path, 'utf8'));
+};
+
+const releaseHandoffContext = (repositoryRoot, ledger) => {
+  if (ledger.release_handoffs.length === 0) {
+    return null;
+  }
+  const omoDirectory = resolve(repositoryRoot, '.omo');
+  const approvalDirectory = resolve(omoDirectory, 'approvals');
+  const searchDirectory = resolve(omoDirectory, 'search-issue');
+  const artifactDirectory = resolve(searchDirectory, 'artifacts');
+  for (const directory of [
+    repositoryRoot,
+    omoDirectory,
+    approvalDirectory,
+    searchDirectory,
+    artifactDirectory,
+  ]) {
+    assertRealDirectory(directory);
+  }
+  if (ledger.source.search_ledger.includes('/legacy/')) {
+    assertRealDirectory(resolve(artifactDirectory, 'legacy'));
+  }
+  const approvalPath = resolve(
+    approvalDirectory,
+    `approval-${ledger.lane_id}-lane-plan.json`,
+  );
+  const artifactPath = resolve(repositoryRoot, ledger.source.search_ledger);
+  for (const path of [approvalPath, artifactPath]) {
+    const pathFromRoot = relative(repositoryRoot, path);
+    if (pathFromRoot.startsWith('..') || resolve(repositoryRoot, pathFromRoot) !== path) {
+      throw new TypeError('release handoff evidence escaped the repository root');
+    }
+  }
+  if (!existsSync(approvalPath)) {
+    throw new TypeError(
+      'release handoffs require their consumed lane-plan approval receipt',
+    );
+  }
+  if (!existsSync(artifactPath)) {
+    throw new TypeError('release handoff source artifact is missing');
+  }
+  const receipt = readJson(approvalPath);
+  const artifact = readJson(artifactPath);
+  assertReleaseHandoffBinding(
+    ledger,
+    receipt,
+    artifact,
+    ledger.source.search_ledger,
+  );
+  return { receipt, artifact, artifactPath: ledger.source.search_ledger };
 };
 
 const ensureStateDirectory = (path) => {
@@ -133,7 +190,7 @@ const recoverTransaction = (stateDirectory) => {
 export const loadState = (
   stateDirectory,
   ledgerPath,
-  approvalReceiptPath = null,
+  repositoryRoot = resolve(dirname(ledgerPath), '../..'),
 ) => {
   ensureStateDirectory(stateDirectory);
   recoverTransaction(stateDirectory);
@@ -146,10 +203,8 @@ export const loadState = (
   const receipts = existsSync(receiptsPath) ? readJson(receiptsPath) : [];
   const state = { snapshot, events, receipts };
   validateState(state);
-  const releaseHandoffApproval =
-    approvalReceiptPath === null ? null : readJson(approvalReceiptPath);
-  assertReleaseHandoffApproval(snapshot, releaseHandoffApproval);
-  return { ...state, releaseHandoffApproval };
+  const handoffContext = releaseHandoffContext(repositoryRoot, snapshot);
+  return { ...state, handoffContext };
 };
 
 export const acquireLease = (stateDirectory, laneId) => {
@@ -180,10 +235,18 @@ export const acquireLease = (stateDirectory, laneId) => {
 
 export const persistState = (stateDirectory, previous, next) => {
   validateState(next);
-  assertReleaseHandoffApproval(
-    next.snapshot,
-    previous.releaseHandoffApproval ?? null,
-  );
+  const context = previous.handoffContext;
+  if (next.snapshot.release_handoffs.length > 0) {
+    if (context === null || context === undefined) {
+      throw new TypeError('release handoff approval context is missing');
+    }
+    assertReleaseHandoffBinding(
+      next.snapshot,
+      context.receipt,
+      context.artifact,
+      context.artifactPath,
+    );
+  }
   assertEventPrefix(previous.events, next.events);
   const transactionPath = resolve(stateDirectory, 'transaction.json');
   writeAtomic(transactionPath, {

--- a/.agents/skills/execute-lane/scripts/state-store.mjs
+++ b/.agents/skills/execute-lane/scripts/state-store.mjs
@@ -43,7 +43,10 @@ const readJson = (path) => {
 };
 
 const releaseHandoffContext = (repositoryRoot, ledger) => {
-  if (ledger.release_handoffs.length === 0) {
+  if (
+    ledger.release_handoffs.length === 0 &&
+    ledger.lane_plan_approval_sha256 === undefined
+  ) {
     return null;
   }
   const omoDirectory = resolve(repositoryRoot, '.omo');
@@ -236,7 +239,10 @@ export const acquireLease = (stateDirectory, laneId) => {
 export const persistState = (stateDirectory, previous, next) => {
   validateState(next);
   const context = previous.handoffContext;
-  if (next.snapshot.release_handoffs.length > 0) {
+  if (
+    next.snapshot.release_handoffs.length > 0 ||
+    next.snapshot.lane_plan_approval_sha256 !== undefined
+  ) {
     if (context === null || context === undefined) {
       throw new TypeError('release handoff approval context is missing');
     }

--- a/.agents/workflow-contracts/lane-ledger-v2.schema.json
+++ b/.agents/workflow-contracts/lane-ledger-v2.schema.json
@@ -37,6 +37,10 @@
       "type": "string",
       "pattern": "^(?!.*(?:\\.|\\.lock)$)[A-Za-z0-9][A-Za-z0-9._-]*$"
     },
+    "lane_plan_approval_sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
     "status": {
       "enum": [
         "ready",

--- a/plans/three-stage-lane-workflow.md
+++ b/plans/three-stage-lane-workflow.md
@@ -95,6 +95,9 @@ skills never load archived command or role definitions.
    Before parking one, derive its canonical consumed lane-plan receipt,
    recompute the artifact/plan approval binding, and reconcile all immutable
    planning fields with the snapshot.
+   Require that binding to equal the independent
+   `lane_plan_approval_sha256` in the ledger, and reconcile whenever the field
+   exists so removing the handoff array cannot bypass provenance checks.
 5. Dispatch implementation through `.agents/skills/issue-to-pr/SKILL.md`.
 6. Aggregate exactly one contract, code, and verification result through
    `.agents/skills/pr-to-merge/SKILL.md`.

--- a/plans/three-stage-lane-workflow.md
+++ b/plans/three-stage-lane-workflow.md
@@ -80,8 +80,10 @@ skills never load archived command or role definitions.
    dependencies.
 6. All three approval records bind the artifact and complete plan and are
    consumed once.
-7. Ledger and approval receipts publish exclusively without overwrite.
-8. Output directories must be real directories, never symlink redirects.
+7. A release handoff additionally binds live issue evidence and an explicit
+   per-issue lane-plan attestation with `changeset_only: false`.
+8. Ledger and approval receipts publish exclusively without overwrite.
+9. Output directories must be real directories, never symlink redirects.
 
 ## Execute-lane invariants
 
@@ -90,6 +92,9 @@ skills never load archived command or role definitions.
 2. Reconcile the persisted branch, worktree, PR, and head with live state.
 3. Progress each lane independently; there is no global batch barrier.
 4. Preserve lane-local dependency order and dedicated release-handoff lanes.
+   Before parking one, derive its canonical consumed lane-plan receipt,
+   recompute the artifact/plan approval binding, and reconcile all immutable
+   planning fields with the snapshot.
 5. Dispatch implementation through `.agents/skills/issue-to-pr/SKILL.md`.
 6. Aggregate exactly one contract, code, and verification result through
    `.agents/skills/pr-to-merge/SKILL.md`.

--- a/plans/three-stage-lane-workflow.md
+++ b/plans/three-stage-lane-workflow.md
@@ -97,7 +97,9 @@ skills never load archived command or role definitions.
    planning fields with the snapshot.
    Require that binding to equal the independent
    `lane_plan_approval_sha256` in the ledger, and reconcile whenever the field
-   exists so removing the handoff array cannot bypass provenance checks.
+   exists so removing the handoff array cannot bypass provenance checks. Use
+   the canonical published ledger as the marker when validating persisted
+   snapshots so removing both fields cannot impersonate a legacy ledger.
 5. Dispatch implementation through `.agents/skills/issue-to-pr/SKILL.md`.
 6. Aggregate exactly one contract, code, and verification result through
    `.agents/skills/pr-to-merge/SKILL.md`.

--- a/tooling/governance/create-lane-multi.test.ts
+++ b/tooling/governance/create-lane-multi.test.ts
@@ -89,9 +89,9 @@ describe('$create-lane multi-issue planning', () => {
       throw new TypeError('multi fixture must contain plan and approvals');
     }
     const bindings = [
-      '1c25fbb6fb6daba018f9cd0b13a10dad3b8269ba01c70259ee357419974a9a05',
-      'a9023a7891f871ee0490a04f0ce52b3bbf9255ce7ea303cfc33884ba07e8b285',
-      '7e554e8c310b61085755069f1e759437e18d369fdec6da303ff569009a8c8eaf',
+      'd8bb3a86338d389c5e3d3281cf07c571c87f5c124e04d6c9efea6c16ccac0f18',
+      '312c45422399c776fb5c1aac620dd8b18c4a92d311354ed06de85e13d7828ced',
+      '84bd2930027e872b65fa04c337c9fe71b2f2087cb27bd37e30c636d49937b87f',
     ];
     const run = runValue({
       ...fixture,

--- a/tooling/governance/create-lane-native.test.ts
+++ b/tooling/governance/create-lane-native.test.ts
@@ -236,6 +236,113 @@ describe('$create-lane native v2 producer', () => {
     }
   });
 
+  it('rejects a self-attested release handoff without issue evidence', () => {
+    // Given
+    const fixture = parseRecord(
+      readFileSync(resolve(fixtureRoot, 'valid-native-artifact.json'), 'utf8'),
+    );
+    const plan = fixture['plan'];
+    if (!isRecord(plan)) {
+      throw new TypeError('valid fixture plan must be an object');
+    }
+
+    // When
+    const run = runScenarioValue({
+      ...fixture,
+      plan: {
+        ...plan,
+        release_handoffs: [
+          {
+            issue_number: 4101,
+            reason: 'release-or-publish-is-core',
+          },
+        ],
+      },
+    });
+
+    try {
+      // Then
+      expect(run.result).toEqual({
+        status: 'rejected',
+        reason: 'invalid_artifact',
+      });
+      expect(allFiles(run.outputRoot)).toEqual([]);
+    } finally {
+      rmSync(run.outputRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('publishes an evidence-bound release handoff and its attestation', () => {
+    // Given / When
+    const run = runScenario('valid-release-handoff.json');
+
+    try {
+      // Then
+      const ledger = parseRecord(
+        readFileSync(
+          resolve(run.outputRoot, '.omo/lanes/lane-4101-runtime.json'),
+          'utf8',
+        ),
+      );
+      const receipt = parseRecord(
+        readFileSync(
+          resolve(
+            run.outputRoot,
+            '.omo/approvals/approval-plan-4101.json',
+          ),
+          'utf8',
+        ),
+      );
+      expect(run.result).toEqual({
+        status: 'ready',
+        ledger: '.omo/lanes/lane-4101-runtime.json',
+      });
+      expect(ledger['release_handoffs']).toEqual([4101]);
+      expect(receipt['release_handoff_attestations']).toEqual([
+        {
+          issue_number: 4101,
+          issue_evidence_sha256: 'a'.repeat(64),
+          decision: 'release-or-publish-is-core',
+          changeset_only: false,
+        },
+      ]);
+    } finally {
+      rmSync(run.outputRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a handoff without a matching lane-plan attestation', () => {
+    // Given
+    const fixture = parseRecord(
+      readFileSync(resolve(fixtureRoot, 'valid-release-handoff.json'), 'utf8'),
+    );
+    const approvals = fixture['approvals'];
+    if (!Array.isArray(approvals) || !isRecord(approvals[2])) {
+      throw new TypeError('release handoff fixture approvals must be objects');
+    }
+
+    // When
+    const run = runScenarioValue({
+      ...fixture,
+      approvals: approvals.map((approval, index) =>
+        index === 2 && isRecord(approval)
+          ? { ...approval, release_handoff_attestations: [] }
+          : approval,
+      ),
+    });
+
+    try {
+      // Then
+      expect(run.result).toEqual({
+        status: 'rejected',
+        reason: 'release_handoff_attestation_mismatch',
+      });
+      expect(allFiles(run.outputRoot)).toEqual([]);
+    } finally {
+      rmSync(run.outputRoot, { recursive: true, force: true });
+    }
+  });
+
   it.each([
     ['mixed-input.json', 'mixed_input'],
     ['malformed-artifact.json', 'invalid_artifact'],

--- a/tooling/governance/create-lane-native.test.ts
+++ b/tooling/governance/create-lane-native.test.ts
@@ -27,6 +27,14 @@ const ledgerVerifier = resolve(
   repositoryRoot,
   'tooling/governance/verify-lane-ledger.mjs',
 );
+const executeReplay = resolve(
+  repositoryRoot,
+  '.agents/skills/execute-lane/scripts/fixtures/run-replay.mjs',
+);
+const executeFixtureRoot = resolve(
+  repositoryRoot,
+  'tooling/governance/fixtures/execute-lane-native',
+);
 
 type ScenarioRun = {
   readonly outputRoot: string;
@@ -288,7 +296,7 @@ describe('$create-lane native v2 producer', () => {
         readFileSync(
           resolve(
             run.outputRoot,
-            '.omo/approvals/approval-plan-4101.json',
+            '.omo/approvals/approval-lane-4101-runtime-lane-plan.json',
           ),
           'utf8',
         ),
@@ -308,6 +316,64 @@ describe('$create-lane native v2 producer', () => {
       ]);
     } finally {
       rmSync(run.outputRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('executes a handoff from its exact producer receipt and artifact', () => {
+    // Given
+    const run = runScenario('valid-release-handoff.json');
+    const state = mkdtempSync(resolve(tmpdir(), 'fluo-release-e2e-'));
+    const fixture = parseRecord(
+      readFileSync(resolve(fixtureRoot, 'valid-release-handoff.json'), 'utf8'),
+    );
+    const artifact = isRecord(fixture['artifacts'])
+      ? fixture['artifacts'][
+          '.omo/search-issue/artifacts/search-native-runtime.json'
+        ]
+      : undefined;
+    const artifactPath = resolve(
+      run.outputRoot,
+      '.omo/search-issue/artifacts/search-native-runtime.json',
+    );
+    mkdirSync(resolve(run.outputRoot, '.omo/search-issue/artifacts'), {
+      recursive: true,
+    });
+    writeFileSync(
+      artifactPath,
+      `${JSON.stringify(artifact, null, 2)}\n`,
+      'utf8',
+    );
+
+    try {
+      // When
+      const result = parseRecord(
+        execFileSync(
+          process.execPath,
+          [
+            executeReplay,
+            '--fixture-only',
+            '--scenario',
+            resolve(executeFixtureRoot, 'interrupted-start.json'),
+            '--ledger',
+            resolve(
+              run.outputRoot,
+              '.omo/lanes/lane-4101-runtime.json',
+            ),
+            '--state-dir',
+            state,
+            '--repository-root',
+            run.outputRoot,
+          ],
+          { encoding: 'utf8' },
+        ),
+      );
+
+      // Then
+      expect(result['status']).toBe('blocked-maintainer-decision');
+      expect(result['merge_count']).toBe(0);
+    } finally {
+      rmSync(run.outputRoot, { recursive: true, force: true });
+      rmSync(state, { recursive: true, force: true });
     }
   });
 

--- a/tooling/governance/create-lane-native.test.ts
+++ b/tooling/governance/create-lane-native.test.ts
@@ -208,6 +208,34 @@ describe('$create-lane native v2 producer', () => {
     }
   });
 
+  it('rejects a release handoff without an explicit release-core decision', () => {
+    // Given
+    const fixture = parseRecord(
+      readFileSync(resolve(fixtureRoot, 'valid-native-artifact.json'), 'utf8'),
+    );
+    const plan = fixture['plan'];
+    if (!isRecord(plan)) {
+      throw new TypeError('valid fixture plan must be an object');
+    }
+
+    // When
+    const run = runScenarioValue({
+      ...fixture,
+      plan: { ...plan, release_handoffs: [4101] },
+    });
+
+    try {
+      // Then
+      expect(run.result).toEqual({
+        status: 'rejected',
+        reason: 'invalid_artifact',
+      });
+      expect(allFiles(run.outputRoot)).toEqual([]);
+    } finally {
+      rmSync(run.outputRoot, { recursive: true, force: true });
+    }
+  });
+
   it.each([
     ['mixed-input.json', 'mixed_input'],
     ['malformed-artifact.json', 'invalid_artifact'],

--- a/tooling/governance/create-lane-native.test.ts
+++ b/tooling/governance/create-lane-native.test.ts
@@ -306,6 +306,9 @@ describe('$create-lane native v2 producer', () => {
         ledger: '.omo/lanes/lane-4101-runtime.json',
       });
       expect(ledger['release_handoffs']).toEqual([4101]);
+      expect(ledger['lane_plan_approval_sha256']).toBe(
+        receipt['binding_sha256'],
+      );
       expect(receipt['release_handoff_attestations']).toEqual([
         {
           issue_number: 4101,

--- a/tooling/governance/execute-lane-concurrency.test.ts
+++ b/tooling/governance/execute-lane-concurrency.test.ts
@@ -36,6 +36,7 @@ const parseRecord = (value: string): Readonly<Record<string, unknown>> => {
 const run = (
   scenarioPath: string,
   state: string,
+  ledgerPath: string,
 ): Readonly<Record<string, unknown>> =>
   parseRecord(
     execFileSync(
@@ -46,7 +47,7 @@ const run = (
         '--scenario',
         scenarioPath,
         '--ledger',
-        resolve(fixtures, 'ready-ledger-two-lanes-v2.json'),
+        ledgerPath,
         '--state-dir',
         state,
       ],
@@ -59,7 +60,28 @@ describe('$execute-lane sibling lane independence', () => {
     const state = mkdtempSync(resolve(tmpdir(), 'fluo-execute-siblings-'));
     const input = mkdtempSync(resolve(tmpdir(), 'fluo-execute-input-'));
     try {
-      const first = run(resolve(fixtures, 'needs-human-check.json'), state);
+      const ledger = parseRecord(
+        readFileSync(
+          resolve(fixtures, 'ready-ledger-two-lanes-v2.json'),
+          'utf8',
+        ),
+      );
+      const ledgerPath = resolve(input, 'legacy-two-lanes-v2.json');
+      const legacyLedger = { ...ledger };
+      Reflect.deleteProperty(
+        legacyLedger,
+        'lane_plan_approval_sha256',
+      );
+      writeFileSync(
+        ledgerPath,
+        `${JSON.stringify(legacyLedger, null, 2)}\n`,
+        'utf8',
+      );
+      const first = run(
+        resolve(fixtures, 'needs-human-check.json'),
+        state,
+        ledgerPath,
+      );
       expect(first['status']).toBe('running');
 
       const secondRaw = readFileSync(resolve(fixtures, 'happy.json'), 'utf8')
@@ -76,7 +98,7 @@ describe('$execute-lane sibling lane independence', () => {
         )}\n`,
         'utf8',
       );
-      const completed = run(secondPath, state);
+      const completed = run(secondPath, state, ledgerPath);
       expect(completed['status']).toBe('needs-human-check-terminal');
       expect(completed['merge_count']).toBe(1);
       expect(

--- a/tooling/governance/execute-lane-native.test.ts
+++ b/tooling/governance/execute-lane-native.test.ts
@@ -378,7 +378,32 @@ describe('$execute-lane persisted native state machine', () => {
           issue_evidence_sha256: 'c'.repeat(64),
         };
       },
-      /release handoff approval binding does not match/u,
+      /release handoff attestations do not match the approved plan/u,
+    ],
+    [
+      'self-consistent approval ID',
+      (receipt: Record<string, unknown>) => {
+        receipt['approval_id'] = 'approval-forged-lane-plan';
+        receipt['binding_sha256'] =
+          '091dc0f20c97675db7ea0a0675a3aec817d8f511487fb6a17dce7df36c558203';
+      },
+      /release handoffs require their consumed lane-plan approval receipt/u,
+    ],
+    [
+      'self-consistent evidence digest',
+      (receipt: Record<string, unknown>) => {
+        const attestations = receipt['release_handoff_attestations'];
+        if (!Array.isArray(attestations) || !isRecord(attestations[0])) {
+          throw new TypeError('release approval attestations must be objects');
+        }
+        attestations[0] = {
+          ...attestations[0],
+          issue_evidence_sha256: 'c'.repeat(64),
+        };
+        receipt['binding_sha256'] =
+          '7ee06bb74ca22b749df2905b97096895ef5d0365198132c59e457f2885390268';
+      },
+      /release handoff attestations do not match the approved plan/u,
     ],
   ])('rejects a substituted release handoff %s', (_, mutate, error) => {
     const repositoryRoot = mkdtempSync(

--- a/tooling/governance/execute-lane-native.test.ts
+++ b/tooling/governance/execute-lane-native.test.ts
@@ -1,13 +1,14 @@
 import { execFileSync } from 'node:child_process';
 import {
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
@@ -47,7 +48,7 @@ const runScenarioPath = (
   scenarioPath: string,
   stateDirectory?: string,
   ledgerPath = initialLedger,
-  approvalReceiptPath?: string,
+  repositoryRoot?: string,
 ): ScenarioRun => {
   const state =
     stateDirectory ?? mkdtempSync(resolve(tmpdir(), 'fluo-execute-lane-'));
@@ -61,8 +62,8 @@ const runScenarioPath = (
     '--state-dir',
     state,
   ];
-  if (approvalReceiptPath !== undefined) {
-    command.push('--approval-receipt', approvalReceiptPath);
+  if (repositoryRoot !== undefined) {
+    command.push('--repository-root', repositoryRoot);
   }
   const stdout = execFileSync(
     process.execPath,
@@ -208,14 +209,24 @@ describe('$execute-lane persisted native state machine', () => {
     const fixtureDirectory = mkdtempSync(
       resolve(tmpdir(), 'fluo-execute-release-handoffs-'),
     );
-    const ledgerPath = resolve(fixtureDirectory, 'ledger.json');
+    const ledgerPath = resolve(
+      fixtureDirectory,
+      '.omo/lanes/lane-4101-runtime.json',
+    );
     const approvalReceiptPath = resolve(
       fixtureDirectory,
-      'lane-plan-approval.json',
+      '.omo/approvals/approval-lane-4101-runtime-lane-plan.json',
+    );
+    const artifactPath = resolve(
+      fixtureDirectory,
+      '.omo/search-issue/artifacts/search-native-two-lanes.json',
     );
     const scenarioPath = resolve(fixtureRoot, 'interrupted-start.json');
     const secondScenarioPath = resolve(fixtureDirectory, 'second.json');
     const ledger = readFixture('ready-ledger-two-lanes-v2');
+    mkdirSync(dirname(ledgerPath), { recursive: true });
+    mkdirSync(dirname(approvalReceiptPath), { recursive: true });
+    mkdirSync(dirname(artifactPath), { recursive: true });
     writeFileSync(
       ledgerPath,
       `${JSON.stringify(
@@ -228,21 +239,16 @@ describe('$execute-lane persisted native state machine', () => {
     writeFileSync(
       approvalReceiptPath,
       `${JSON.stringify(
-        {
-          version: 1,
-          approval_id: 'approval-lane-4101-runtime-lane-plan',
-          gate: 'lane-plan',
-          binding_sha256: 'a'.repeat(64),
-          lane_id: 'lane-4101-runtime',
-          release_handoff_attestations: [4101, 4102].map(
-            (issue_number) => ({
-              issue_number,
-              issue_evidence_sha256: 'b'.repeat(64),
-              decision: 'release-or-publish-is-core',
-              changeset_only: false,
-            }),
-          ),
-        },
+        readFixture('release-handoff-two-lanes-approval'),
+        null,
+        2,
+      )}\n`,
+      'utf8',
+    );
+    writeFileSync(
+      artifactPath,
+      `${JSON.stringify(
+        readFixture('search-native-two-lanes'),
         null,
         2,
       )}\n`,
@@ -273,7 +279,7 @@ describe('$execute-lane persisted native state machine', () => {
       scenarioPath,
       undefined,
       ledgerPath,
-      approvalReceiptPath,
+      fixtureDirectory,
     );
     try {
       const snapshot = run.result['snapshot'];
@@ -290,7 +296,7 @@ describe('$execute-lane persisted native state machine', () => {
         secondScenarioPath,
         run.stateDirectory,
         ledgerPath,
-        approvalReceiptPath,
+        fixtureDirectory,
       );
       const completedSnapshot = completed.result['snapshot'];
       expect(completed.result['status']).toBe('blocked-maintainer-decision');
@@ -313,11 +319,29 @@ describe('$execute-lane persisted native state machine', () => {
     const fixtureDirectory = mkdtempSync(
       resolve(tmpdir(), 'fluo-execute-release-approval-'),
     );
-    const ledgerPath = resolve(fixtureDirectory, 'ledger.json');
+    const ledgerPath = resolve(
+      fixtureDirectory,
+      '.omo/lanes/lane-4101-runtime.json',
+    );
+    const artifactPath = resolve(
+      fixtureDirectory,
+      '.omo/search-issue/artifacts/search-native-release.json',
+    );
     const ledger = readFixture('ready-ledger-release-v2');
+    mkdirSync(dirname(ledgerPath), { recursive: true });
+    mkdirSync(
+      resolve(fixtureDirectory, '.omo/approvals'),
+      { recursive: true },
+    );
+    mkdirSync(dirname(artifactPath), { recursive: true });
     writeFileSync(
       ledgerPath,
       `${JSON.stringify(ledger, null, 2)}\n`,
+      'utf8',
+    );
+    writeFileSync(
+      artifactPath,
+      `${JSON.stringify(readFixture('search-native-release'), null, 2)}\n`,
       'utf8',
     );
 
@@ -331,6 +355,77 @@ describe('$execute-lane persisted native state machine', () => {
       ).toThrow(/release handoffs require their consumed lane-plan approval receipt/u);
     } finally {
       rmSync(fixtureDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    [
+      'binding',
+      (receipt: Record<string, unknown>) => {
+        receipt['binding_sha256'] = 'c'.repeat(64);
+      },
+      /release handoff approval binding does not match/u,
+    ],
+    [
+      'evidence digest',
+      (receipt: Record<string, unknown>) => {
+        const attestations = receipt['release_handoff_attestations'];
+        if (!Array.isArray(attestations) || !isRecord(attestations[0])) {
+          throw new TypeError('release approval attestations must be objects');
+        }
+        attestations[0] = {
+          ...attestations[0],
+          issue_evidence_sha256: 'c'.repeat(64),
+        };
+      },
+      /release handoff approval binding does not match/u,
+    ],
+  ])('rejects a substituted release handoff %s', (_, mutate, error) => {
+    const repositoryRoot = mkdtempSync(
+      resolve(tmpdir(), 'fluo-execute-release-substitution-'),
+    );
+    const ledgerPath = resolve(
+      repositoryRoot,
+      '.omo/lanes/lane-4101-runtime.json',
+    );
+    const approvalPath = resolve(
+      repositoryRoot,
+      '.omo/approvals/approval-lane-4101-runtime-lane-plan.json',
+    );
+    const artifactPath = resolve(
+      repositoryRoot,
+      '.omo/search-issue/artifacts/search-native-release.json',
+    );
+    mkdirSync(dirname(ledgerPath), { recursive: true });
+    mkdirSync(dirname(approvalPath), { recursive: true });
+    mkdirSync(dirname(artifactPath), { recursive: true });
+    const receipt = structuredClone(
+      readFixture('release-handoff-approval'),
+    ) as Record<string, unknown>;
+    mutate(receipt);
+    for (const [path, value] of [
+      [ledgerPath, readFixture('ready-ledger-release-v2')],
+      [approvalPath, receipt],
+      [artifactPath, readFixture('search-native-release')],
+    ] as const) {
+      writeFileSync(
+        path,
+        `${JSON.stringify(value, null, 2)}\n`,
+        'utf8',
+      );
+    }
+
+    try {
+      expect(() =>
+        runScenarioPath(
+          resolve(fixtureRoot, 'interrupted-start.json'),
+          undefined,
+          ledgerPath,
+          repositoryRoot,
+        ),
+      ).toThrow(error);
+    } finally {
+      rmSync(repositoryRoot, { recursive: true, force: true });
     }
   });
 });

--- a/tooling/governance/execute-lane-native.test.ts
+++ b/tooling/governance/execute-lane-native.test.ts
@@ -421,6 +421,58 @@ describe('$execute-lane persisted native state machine', () => {
     }
   });
 
+  it('rejects persisting a bound snapshot as legacy', () => {
+    const stateDirectory = mkdtempSync(
+      resolve(tmpdir(), 'fluo-execute-persist-downgrade-'),
+    );
+    const probe = `
+      import { readFileSync } from 'node:fs';
+      import { persistState } from ${JSON.stringify(
+        resolve(skillRoot, 'scripts/state-store.mjs'),
+      )};
+      const read = (name) => JSON.parse(
+        readFileSync(${JSON.stringify(fixtureRoot)} + '/' + name + '.json', 'utf8'),
+      );
+      const ledger = read('ready-ledger-release-v2');
+      const downgradedSnapshot = structuredClone(ledger);
+      downgradedSnapshot.release_handoffs = [];
+      delete downgradedSnapshot.lane_plan_approval_sha256;
+      persistState(
+        ${JSON.stringify(stateDirectory)},
+        {
+          snapshot: ledger,
+          events: [],
+          receipts: [],
+          handoffContext: {
+            receipt: read('release-handoff-approval'),
+            artifact: read('search-native-release'),
+            artifactPath:
+              '.omo/search-issue/artifacts/search-native-release.json',
+          },
+        },
+        {
+          snapshot: downgradedSnapshot,
+          events: [],
+          receipts: [],
+        },
+      );
+    `;
+
+    try {
+      expect(() =>
+        execFileSync(
+          process.execPath,
+          ['--input-type=module', '--eval', probe],
+          { encoding: 'utf8' },
+        ),
+      ).toThrow(
+        /release handoff receipt binding does not match the ledger/u,
+      );
+    } finally {
+      rmSync(stateDirectory, { recursive: true, force: true });
+    }
+  });
+
   it.each([
     [
       'binding',

--- a/tooling/governance/execute-lane-native.test.ts
+++ b/tooling/governance/execute-lane-native.test.ts
@@ -390,20 +390,31 @@ describe('$execute-lane persisted native state machine', () => {
       /release handoffs require their consumed lane-plan approval receipt/u,
     ],
     [
-      'self-consistent evidence digest',
+      'fully self-consistent evidence digest',
       (receipt: Record<string, unknown>) => {
         const attestations = receipt['release_handoff_attestations'];
-        if (!Array.isArray(attestations) || !isRecord(attestations[0])) {
+        const plan = receipt['plan'];
+        const handoffs = isRecord(plan) ? plan['release_handoffs'] : undefined;
+        if (
+          !Array.isArray(attestations) ||
+          !isRecord(attestations[0]) ||
+          !Array.isArray(handoffs) ||
+          !isRecord(handoffs[0])
+        ) {
           throw new TypeError('release approval attestations must be objects');
         }
         attestations[0] = {
           ...attestations[0],
           issue_evidence_sha256: 'c'.repeat(64),
         };
+        handoffs[0] = {
+          ...handoffs[0],
+          issue_evidence_sha256: 'c'.repeat(64),
+        };
         receipt['binding_sha256'] =
-          '7ee06bb74ca22b749df2905b97096895ef5d0365198132c59e457f2885390268';
+          'c2d14b0a464ca206669e9c32791f8eda3326406158a8896bad79c8c65fac5247';
       },
-      /release handoff attestations do not match the approved plan/u,
+      /release handoff receipt binding does not match the ledger/u,
     ],
   ])('rejects a substituted release handoff %s', (_, mutate, error) => {
     const repositoryRoot = mkdtempSync(

--- a/tooling/governance/execute-lane-native.test.ts
+++ b/tooling/governance/execute-lane-native.test.ts
@@ -46,6 +46,7 @@ const readFixture = (name: string): Readonly<Record<string, unknown>> =>
 const runScenarioPath = (
   scenarioPath: string,
   stateDirectory?: string,
+  ledgerPath = initialLedger,
 ): ScenarioRun => {
   const state =
     stateDirectory ?? mkdtempSync(resolve(tmpdir(), 'fluo-execute-lane-'));
@@ -57,7 +58,7 @@ const runScenarioPath = (
       '--scenario',
       scenarioPath,
       '--ledger',
-      initialLedger,
+      ledgerPath,
       '--state-dir',
       state,
     ],
@@ -195,6 +196,41 @@ describe('$execute-lane persisted native state machine', () => {
     } finally {
       rmSync(waiting.stateDirectory, { recursive: true, force: true });
       rmSync(completed.stateDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it('parks one release handoff while another remains queued', () => {
+    const fixtureDirectory = mkdtempSync(
+      resolve(tmpdir(), 'fluo-execute-release-handoffs-'),
+    );
+    const ledgerPath = resolve(fixtureDirectory, 'ledger.json');
+    const scenarioPath = resolve(fixtureRoot, 'interrupted-start.json');
+    const ledger = readFixture('ready-ledger-two-lanes-v2');
+    writeFileSync(
+      ledgerPath,
+      `${JSON.stringify(
+        { ...ledger, release_handoffs: [4101, 4102] },
+        null,
+        2,
+      )}\n`,
+      'utf8',
+    );
+
+    const run = runScenarioPath(scenarioPath, undefined, ledgerPath);
+    try {
+      const snapshot = run.result['snapshot'];
+      if (!isRecord(snapshot)) {
+        throw new TypeError('result snapshot must be an object');
+      }
+      const lanes = snapshot['lanes'];
+      expect(run.result['status']).toBe('running');
+      expect(Array.isArray(lanes) ? lanes.map((lane) => lane['status']) : []).toEqual([
+        'blocked-maintainer-decision',
+        'queued',
+      ]);
+    } finally {
+      rmSync(run.stateDirectory, { recursive: true, force: true });
+      rmSync(fixtureDirectory, { recursive: true, force: true });
     }
   });
 });

--- a/tooling/governance/execute-lane-native.test.ts
+++ b/tooling/governance/execute-lane-native.test.ts
@@ -358,6 +358,57 @@ describe('$execute-lane persisted native state machine', () => {
     }
   });
 
+  it('rejects removing approved handoffs from a bound ledger', () => {
+    const repositoryRoot = mkdtempSync(
+      resolve(tmpdir(), 'fluo-execute-release-removal-'),
+    );
+    const ledgerPath = resolve(
+      repositoryRoot,
+      '.omo/lanes/lane-4101-runtime.json',
+    );
+    const approvalPath = resolve(
+      repositoryRoot,
+      '.omo/approvals/approval-lane-4101-runtime-lane-plan.json',
+    );
+    const artifactPath = resolve(
+      repositoryRoot,
+      '.omo/search-issue/artifacts/search-native-release.json',
+    );
+    mkdirSync(dirname(ledgerPath), { recursive: true });
+    mkdirSync(dirname(approvalPath), { recursive: true });
+    mkdirSync(dirname(artifactPath), { recursive: true });
+    const ledger = structuredClone(
+      readFixture('ready-ledger-release-v2'),
+    ) as Record<string, unknown>;
+    ledger['release_handoffs'] = [];
+    for (const [path, value] of [
+      [ledgerPath, ledger],
+      [approvalPath, readFixture('release-handoff-approval')],
+      [artifactPath, readFixture('search-native-release')],
+    ] as const) {
+      writeFileSync(
+        path,
+        `${JSON.stringify(value, null, 2)}\n`,
+        'utf8',
+      );
+    }
+
+    try {
+      expect(() =>
+        runScenarioPath(
+          resolve(fixtureRoot, 'interrupted-start.json'),
+          undefined,
+          ledgerPath,
+          repositoryRoot,
+        ),
+      ).toThrow(
+        /release handoffs do not match their lane-plan approval receipt/u,
+      );
+    } finally {
+      rmSync(repositoryRoot, { recursive: true, force: true });
+    }
+  });
+
   it.each([
     [
       'binding',
@@ -478,5 +529,13 @@ describe('$execute-lane shipped native assets', () => {
         'scripts/fixtures/run-replay.mjs',
       ].filter((path) => existsSync(resolve(skillRoot, path))),
     ).toHaveLength(6);
+  });
+
+  it.each([
+    'ready-ledger-release-v2.json',
+    'ready-ledger-two-lanes-v2.json',
+  ])('serializes one lane-plan approval binding in %s', (fixture) => {
+    const source = readFileSync(resolve(fixtureRoot, fixture), 'utf8');
+    expect(source.match(/"lane_plan_approval_sha256"/gu)).toHaveLength(1);
   });
 });

--- a/tooling/governance/execute-lane-native.test.ts
+++ b/tooling/governance/execute-lane-native.test.ts
@@ -47,21 +47,26 @@ const runScenarioPath = (
   scenarioPath: string,
   stateDirectory?: string,
   ledgerPath = initialLedger,
+  approvalReceiptPath?: string,
 ): ScenarioRun => {
   const state =
     stateDirectory ?? mkdtempSync(resolve(tmpdir(), 'fluo-execute-lane-'));
+  const command = [
+    replayCli,
+    '--fixture-only',
+    '--scenario',
+    scenarioPath,
+    '--ledger',
+    ledgerPath,
+    '--state-dir',
+    state,
+  ];
+  if (approvalReceiptPath !== undefined) {
+    command.push('--approval-receipt', approvalReceiptPath);
+  }
   const stdout = execFileSync(
     process.execPath,
-    [
-      replayCli,
-      '--fixture-only',
-      '--scenario',
-      scenarioPath,
-      '--ledger',
-      ledgerPath,
-      '--state-dir',
-      state,
-    ],
+    command,
     { encoding: 'utf8' },
   );
   return { stateDirectory: state, result: parseRecord(stdout) };
@@ -204,7 +209,12 @@ describe('$execute-lane persisted native state machine', () => {
       resolve(tmpdir(), 'fluo-execute-release-handoffs-'),
     );
     const ledgerPath = resolve(fixtureDirectory, 'ledger.json');
+    const approvalReceiptPath = resolve(
+      fixtureDirectory,
+      'lane-plan-approval.json',
+    );
     const scenarioPath = resolve(fixtureRoot, 'interrupted-start.json');
+    const secondScenarioPath = resolve(fixtureDirectory, 'second.json');
     const ledger = readFixture('ready-ledger-two-lanes-v2');
     writeFileSync(
       ledgerPath,
@@ -215,8 +225,56 @@ describe('$execute-lane persisted native state machine', () => {
       )}\n`,
       'utf8',
     );
+    writeFileSync(
+      approvalReceiptPath,
+      `${JSON.stringify(
+        {
+          version: 1,
+          approval_id: 'approval-lane-4101-runtime-lane-plan',
+          gate: 'lane-plan',
+          binding_sha256: 'a'.repeat(64),
+          lane_id: 'lane-4101-runtime',
+          release_handoff_attestations: [4101, 4102].map(
+            (issue_number) => ({
+              issue_number,
+              issue_evidence_sha256: 'b'.repeat(64),
+              decision: 'release-or-publish-is-core',
+              changeset_only: false,
+            }),
+          ),
+        },
+        null,
+        2,
+      )}\n`,
+      'utf8',
+    );
+    writeFileSync(
+      secondScenarioPath,
+      `${JSON.stringify(
+        {
+          lane_id: 'lane-4101-runtime',
+          issue_number: 4102,
+          branch: 'issue-4102-runtime',
+          worktree: '.worktrees/issue-4102-runtime',
+          pr: {
+            number: 5102,
+            url: 'https://github.com/fluojs/fluo/pull/5102',
+            head_sha: 'b'.repeat(40),
+          },
+          steps: [{ kind: 'interrupt' }],
+        },
+        null,
+        2,
+      )}\n`,
+      'utf8',
+    );
 
-    const run = runScenarioPath(scenarioPath, undefined, ledgerPath);
+    const run = runScenarioPath(
+      scenarioPath,
+      undefined,
+      ledgerPath,
+      approvalReceiptPath,
+    );
     try {
       const snapshot = run.result['snapshot'];
       if (!isRecord(snapshot)) {
@@ -228,8 +286,50 @@ describe('$execute-lane persisted native state machine', () => {
         'blocked-maintainer-decision',
         'queued',
       ]);
+      const completed = runScenarioPath(
+        secondScenarioPath,
+        run.stateDirectory,
+        ledgerPath,
+        approvalReceiptPath,
+      );
+      const completedSnapshot = completed.result['snapshot'];
+      expect(completed.result['status']).toBe('blocked-maintainer-decision');
+      expect(
+        isRecord(completedSnapshot) &&
+          Array.isArray(completedSnapshot['lanes'])
+          ? completedSnapshot['lanes'].map((lane) => lane['status'])
+          : [],
+      ).toEqual([
+        'blocked-maintainer-decision',
+        'blocked-maintainer-decision',
+      ]);
     } finally {
       rmSync(run.stateDirectory, { recursive: true, force: true });
+      rmSync(fixtureDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a release handoff without its consumed approval receipt', () => {
+    const fixtureDirectory = mkdtempSync(
+      resolve(tmpdir(), 'fluo-execute-release-approval-'),
+    );
+    const ledgerPath = resolve(fixtureDirectory, 'ledger.json');
+    const ledger = readFixture('ready-ledger-release-v2');
+    writeFileSync(
+      ledgerPath,
+      `${JSON.stringify(ledger, null, 2)}\n`,
+      'utf8',
+    );
+
+    try {
+      expect(() =>
+        runScenarioPath(
+          resolve(fixtureRoot, 'interrupted-start.json'),
+          undefined,
+          ledgerPath,
+        ),
+      ).toThrow(/release handoffs require their consumed lane-plan approval receipt/u);
+    } finally {
       rmSync(fixtureDirectory, { recursive: true, force: true });
     }
   });
@@ -243,8 +343,9 @@ describe('$execute-lane shipped native assets', () => {
         'references/workflow.md',
         'scripts/state-machine.mjs',
         'scripts/state-store.mjs',
+        'scripts/release-handoff-approval.mjs',
         'scripts/fixtures/run-replay.mjs',
       ].filter((path) => existsSync(resolve(skillRoot, path))),
-    ).toHaveLength(5);
+    ).toHaveLength(6);
   });
 });

--- a/tooling/governance/execute-lane-native.test.ts
+++ b/tooling/governance/execute-lane-native.test.ts
@@ -374,13 +374,13 @@ describe('$execute-lane persisted native state machine', () => {
       repositoryRoot,
       '.omo/search-issue/artifacts/search-native-release.json',
     );
+    const stateDirectory = resolve(repositoryRoot, 'state');
     mkdirSync(dirname(ledgerPath), { recursive: true });
     mkdirSync(dirname(approvalPath), { recursive: true });
     mkdirSync(dirname(artifactPath), { recursive: true });
     const ledger = structuredClone(
       readFixture('ready-ledger-release-v2'),
     ) as Record<string, unknown>;
-    ledger['release_handoffs'] = [];
     for (const [path, value] of [
       [ledgerPath, ledger],
       [approvalPath, readFixture('release-handoff-approval')],
@@ -392,17 +392,29 @@ describe('$execute-lane persisted native state machine', () => {
         'utf8',
       );
     }
+    const downgradedSnapshot = structuredClone(ledger);
+    downgradedSnapshot['release_handoffs'] = [];
+    Reflect.deleteProperty(
+      downgradedSnapshot,
+      'lane_plan_approval_sha256',
+    );
+    mkdirSync(stateDirectory);
+    writeFileSync(
+      resolve(stateDirectory, 'snapshot.json'),
+      `${JSON.stringify(downgradedSnapshot, null, 2)}\n`,
+      'utf8',
+    );
 
     try {
       expect(() =>
         runScenarioPath(
           resolve(fixtureRoot, 'interrupted-start.json'),
-          undefined,
+          stateDirectory,
           ledgerPath,
           repositoryRoot,
         ),
       ).toThrow(
-        /release handoffs do not match their lane-plan approval receipt/u,
+        /persisted lane-plan approval binding does not match the canonical ledger/u,
       );
     } finally {
       rmSync(repositoryRoot, { recursive: true, force: true });

--- a/tooling/governance/execute-lane-resilience.test.ts
+++ b/tooling/governance/execute-lane-resilience.test.ts
@@ -40,28 +40,31 @@ const runScenarioPath = (
   scenarioPath: string,
   ledgerPath: string,
   state: string,
-): Readonly<Record<string, unknown>> =>
-  parseRecord(
-    execFileSync(
-      process.execPath,
-      [
-        replayCli,
-        '--fixture-only',
-        '--scenario',
-        scenarioPath,
-        '--ledger',
-        ledgerPath,
-        '--state-dir',
-        state,
-      ],
-      { encoding: 'utf8' },
-    ),
+  approvalReceiptPath?: string,
+): Readonly<Record<string, unknown>> => {
+  const command = [
+    replayCli,
+    '--fixture-only',
+    '--scenario',
+    scenarioPath,
+    '--ledger',
+    ledgerPath,
+    '--state-dir',
+    state,
+  ];
+  if (approvalReceiptPath !== undefined) {
+    command.push('--approval-receipt', approvalReceiptPath);
+  }
+  return parseRecord(
+    execFileSync(process.execPath, command, { encoding: 'utf8' }),
   );
+};
 
 const runScenarioValue = (
   scenario: Readonly<Record<string, unknown>>,
   ledgerName: string,
   state: string,
+  approvalReceiptName?: string,
 ): Readonly<Record<string, unknown>> => {
   const inputRoot = mkdtempSync(resolve(tmpdir(), 'fluo-execute-input-'));
   const scenarioPath = resolve(inputRoot, 'scenario.json');
@@ -71,6 +74,9 @@ const runScenarioValue = (
       scenarioPath,
       resolve(fixtureRoot, ledgerName),
       state,
+      approvalReceiptName === undefined
+        ? undefined
+        : resolve(fixtureRoot, approvalReceiptName),
     );
   } finally {
     rmSync(inputRoot, { recursive: true, force: true });
@@ -134,6 +140,7 @@ describe('$execute-lane multi-issue and trust boundaries', () => {
         readFixture('happy'),
         'ready-ledger-release-v2.json',
         state,
+        'release-handoff-approval.json',
       );
       expect(result['status']).toBe('blocked-maintainer-decision');
       expect(result['merge_count']).toBe(0);

--- a/tooling/governance/execute-lane-resilience.test.ts
+++ b/tooling/governance/execute-lane-resilience.test.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import {
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
@@ -7,7 +8,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
@@ -40,7 +41,7 @@ const runScenarioPath = (
   scenarioPath: string,
   ledgerPath: string,
   state: string,
-  approvalReceiptPath?: string,
+  repositoryRoot?: string,
 ): Readonly<Record<string, unknown>> => {
   const command = [
     replayCli,
@@ -52,8 +53,8 @@ const runScenarioPath = (
     '--state-dir',
     state,
   ];
-  if (approvalReceiptPath !== undefined) {
-    command.push('--approval-receipt', approvalReceiptPath);
+  if (repositoryRoot !== undefined) {
+    command.push('--repository-root', repositoryRoot);
   }
   return parseRecord(
     execFileSync(process.execPath, command, { encoding: 'utf8' }),
@@ -64,7 +65,7 @@ const runScenarioValue = (
   scenario: Readonly<Record<string, unknown>>,
   ledgerName: string,
   state: string,
-  approvalReceiptName?: string,
+  repositoryRoot?: string,
 ): Readonly<Record<string, unknown>> => {
   const inputRoot = mkdtempSync(resolve(tmpdir(), 'fluo-execute-input-'));
   const scenarioPath = resolve(inputRoot, 'scenario.json');
@@ -74,9 +75,7 @@ const runScenarioValue = (
       scenarioPath,
       resolve(fixtureRoot, ledgerName),
       state,
-      approvalReceiptName === undefined
-        ? undefined
-        : resolve(fixtureRoot, approvalReceiptName),
+      repositoryRoot,
     );
   } finally {
     rmSync(inputRoot, { recursive: true, force: true });
@@ -135,12 +134,41 @@ describe('$execute-lane multi-issue and trust boundaries', () => {
 
   it('parks a release handoff for explicit maintainer decision without side effects', () => {
     const state = mkdtempSync(resolve(tmpdir(), 'fluo-execute-release-'));
+    const repositoryRoot = mkdtempSync(
+      resolve(tmpdir(), 'fluo-execute-release-root-'),
+    );
+    const ledgerPath = resolve(
+      repositoryRoot,
+      '.omo/lanes/lane-4101-runtime.json',
+    );
+    const approvalPath = resolve(
+      repositoryRoot,
+      '.omo/approvals/approval-lane-4101-runtime-lane-plan.json',
+    );
+    const artifactPath = resolve(
+      repositoryRoot,
+      '.omo/search-issue/artifacts/search-native-release.json',
+    );
+    mkdirSync(dirname(ledgerPath), { recursive: true });
+    mkdirSync(dirname(approvalPath), { recursive: true });
+    mkdirSync(dirname(artifactPath), { recursive: true });
+    for (const [path, fixture] of [
+      [ledgerPath, 'ready-ledger-release-v2'],
+      [approvalPath, 'release-handoff-approval'],
+      [artifactPath, 'search-native-release'],
+    ] as const) {
+      writeFileSync(
+        path,
+        `${JSON.stringify(readFixture(fixture), null, 2)}\n`,
+        'utf8',
+      );
+    }
     try {
       const result = runScenarioValue(
         readFixture('happy'),
-        'ready-ledger-release-v2.json',
+        ledgerPath,
         state,
-        'release-handoff-approval.json',
+        repositoryRoot,
       );
       expect(result['status']).toBe('blocked-maintainer-decision');
       expect(result['merge_count']).toBe(0);
@@ -153,6 +181,7 @@ describe('$execute-lane multi-issue and trust boundaries', () => {
       ).toContain('Lane ledger check passed for 1 file(s).');
     } finally {
       rmSync(state, { recursive: true, force: true });
+      rmSync(repositoryRoot, { recursive: true, force: true });
     }
   });
 

--- a/tooling/governance/fixtures/create-lane-native/valid-multi-issue.json
+++ b/tooling/governance/fixtures/create-lane-native/valid-multi-issue.json
@@ -12,24 +12,24 @@
   "approvals": [
     {
       "gate": "confirmed-issues",
-      "approval_id": "approval-confirmed-multi",
+      "approval_id": "approval-lane-4101-4103-runtime-confirmed-issues",
       "approved": true,
       "issue_numbers": [4101, 4102],
-      "binding_sha256": "718e0ab089ea64e606ec19c9686a9c2f0f10e2718771ab4a21f9bd622fb5e948"
+      "binding_sha256": "7fa00b0658d40fac376ac211f3c144e6abdd6124dbd13ae5b43118cce1b113d1"
     },
     {
       "gate": "suggested-additions",
-      "approval_id": "approval-suggestions-multi",
+      "approval_id": "approval-lane-4101-4103-runtime-suggested-additions",
       "approved": true,
       "issue_numbers": [4103],
-      "binding_sha256": "e87919654666996c5e6c635096411013fd3f858a4808d3473fcd80b7266d6d7b"
+      "binding_sha256": "3e881250dd106fe17b5c8318193295a90a720330b5ae65f4528dd1665f455c72"
     },
     {
       "gate": "lane-plan",
-      "approval_id": "approval-plan-multi",
+      "approval_id": "approval-lane-4101-4103-runtime-lane-plan",
       "approved": true,
       "release_handoff_attestations": [],
-      "binding_sha256": "44bce400153575c91e93a55ade19d2df3ad9cd5b2bfcbf33c40ffb6686f40648"
+      "binding_sha256": "a383119d947463a51d0d1213af1ac5c8714e953ce48f604b79a83bab4e40db60"
     }
   ],
   "plan": {

--- a/tooling/governance/fixtures/create-lane-native/valid-multi-issue.json
+++ b/tooling/governance/fixtures/create-lane-native/valid-multi-issue.json
@@ -28,6 +28,7 @@
       "gate": "lane-plan",
       "approval_id": "approval-plan-multi",
       "approved": true,
+      "release_handoff_attestations": [],
       "binding_sha256": "44bce400153575c91e93a55ade19d2df3ad9cd5b2bfcbf33c40ffb6686f40648"
     }
   ],

--- a/tooling/governance/fixtures/create-lane-native/valid-native-artifact.json
+++ b/tooling/governance/fixtures/create-lane-native/valid-native-artifact.json
@@ -12,24 +12,24 @@
   "approvals": [
     {
       "gate": "confirmed-issues",
-      "approval_id": "approval-confirmed-4101",
+      "approval_id": "approval-lane-4101-runtime-confirmed-issues",
       "approved": true,
       "issue_numbers": [4101],
-      "binding_sha256": "1b133b5e0d6aff005b88bfe654abe4cf678df09ea5399a9735fce23908dcbe0f"
+      "binding_sha256": "58be23c1d87b655ed19c22c8d385a0d337084888618b39e31857de76bb035114"
     },
     {
       "gate": "suggested-additions",
-      "approval_id": "approval-suggestions-4101",
+      "approval_id": "approval-lane-4101-runtime-suggested-additions",
       "approved": true,
       "issue_numbers": [],
-      "binding_sha256": "638298eed32346c641a04077dbcfc4296632c1370ace6db930108908977c417f"
+      "binding_sha256": "2052509b56b18f30f34d819830ba3735d1329a90aee7c76b85f98cd9e66f1d72"
     },
     {
       "gate": "lane-plan",
-      "approval_id": "approval-plan-4101",
+      "approval_id": "approval-lane-4101-runtime-lane-plan",
       "approved": true,
       "release_handoff_attestations": [],
-      "binding_sha256": "f398b28f7cca4d49d00a36efbe2bbda54861dbfa46794720b135965830a1c0f9"
+      "binding_sha256": "792738fe4aeeb42c1d22b5c272a562c16c1b108b578035bff484088f639e494b"
     }
   ],
   "plan": {

--- a/tooling/governance/fixtures/create-lane-native/valid-release-handoff.json
+++ b/tooling/governance/fixtures/create-lane-native/valid-release-handoff.json
@@ -12,21 +12,21 @@
   "approvals": [
     {
       "gate": "confirmed-issues",
-      "approval_id": "approval-confirmed-4101",
+      "approval_id": "approval-lane-4101-runtime-confirmed-issues",
       "approved": true,
       "issue_numbers": [4101],
-      "binding_sha256": "e7774c39c5af695719d876cbccbaefdedaaf44f9b6592b543b87fc34f0733edd"
+      "binding_sha256": "fd2f64f6ab50054d1be88f3ad76cf4baeb9a0ad458c6c8df997d7761c813ded7"
     },
     {
       "gate": "suggested-additions",
-      "approval_id": "approval-suggestions-4101",
+      "approval_id": "approval-lane-4101-runtime-suggested-additions",
       "approved": true,
       "issue_numbers": [],
-      "binding_sha256": "5b91c0dc39cfe53c16b35c2bbb9451ec9ca275b855a342f95bc31dcd5e52c1ab"
+      "binding_sha256": "4aacefe7b03ae858b8bac2ecfef25446234d15f8f05128c7805aa90a8dc446f2"
     },
     {
       "gate": "lane-plan",
-      "approval_id": "approval-plan-4101",
+      "approval_id": "approval-lane-4101-runtime-lane-plan",
       "approved": true,
       "release_handoff_attestations": [
         {
@@ -36,7 +36,7 @@
           "changeset_only": false
         }
       ],
-      "binding_sha256": "127404c3d76e5681f77cf8f0c698c3d9fef6f0d128abb85c76261400b737ac44"
+      "binding_sha256": "7dc4d858813666d0b9ae9eb3b68da6bb2d5080422e859b45fc13e6d75e1e6e3e"
     }
   ],
   "plan": {

--- a/tooling/governance/fixtures/create-lane-native/valid-release-handoff.json
+++ b/tooling/governance/fixtures/create-lane-native/valid-release-handoff.json
@@ -15,21 +15,28 @@
       "approval_id": "approval-confirmed-4101",
       "approved": true,
       "issue_numbers": [4101],
-      "binding_sha256": "1b133b5e0d6aff005b88bfe654abe4cf678df09ea5399a9735fce23908dcbe0f"
+      "binding_sha256": "e7774c39c5af695719d876cbccbaefdedaaf44f9b6592b543b87fc34f0733edd"
     },
     {
       "gate": "suggested-additions",
       "approval_id": "approval-suggestions-4101",
       "approved": true,
       "issue_numbers": [],
-      "binding_sha256": "638298eed32346c641a04077dbcfc4296632c1370ace6db930108908977c417f"
+      "binding_sha256": "5b91c0dc39cfe53c16b35c2bbb9451ec9ca275b855a342f95bc31dcd5e52c1ab"
     },
     {
       "gate": "lane-plan",
       "approval_id": "approval-plan-4101",
       "approved": true,
-      "release_handoff_attestations": [],
-      "binding_sha256": "f398b28f7cca4d49d00a36efbe2bbda54861dbfa46794720b135965830a1c0f9"
+      "release_handoff_attestations": [
+        {
+          "issue_number": 4101,
+          "issue_evidence_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "decision": "release-or-publish-is-core",
+          "changeset_only": false
+        }
+      ],
+      "binding_sha256": "127404c3d76e5681f77cf8f0c698c3d9fef6f0d128abb85c76261400b737ac44"
     }
   ],
   "plan": {
@@ -59,7 +66,13 @@
     "confirmed_issues": [4101],
     "suggested_but_excluded": [],
     "backlog_candidates": [],
-    "release_handoffs": [],
+    "release_handoffs": [
+      {
+        "issue_number": 4101,
+        "reason": "release-or-publish-is-core",
+        "issue_evidence_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      }
+    ],
     "lanes": [
       {
         "name": "runtime",

--- a/tooling/governance/fixtures/execute-lane-native/ready-ledger-release-v2.json
+++ b/tooling/governance/fixtures/execute-lane-native/ready-ledger-release-v2.json
@@ -3,7 +3,6 @@
   "run_id": "lane-4101-runtime",
   "lane_id": "lane-4101-runtime",
   "lane_plan_approval_sha256": "23c6b347d16e8ca2dc5f243a94231652b0e7b6573603c6fb1e7ea98cfb1803d5",
-  "lane_plan_approval_sha256": "23c6b347d16e8ca2dc5f243a94231652b0e7b6573603c6fb1e7ea98cfb1803d5",
   "status": "ready",
   "created_by": "create-lane",
   "base_branch": "main",

--- a/tooling/governance/fixtures/execute-lane-native/ready-ledger-release-v2.json
+++ b/tooling/governance/fixtures/execute-lane-native/ready-ledger-release-v2.json
@@ -2,6 +2,8 @@
   "version": 2,
   "run_id": "lane-4101-runtime",
   "lane_id": "lane-4101-runtime",
+  "lane_plan_approval_sha256": "23c6b347d16e8ca2dc5f243a94231652b0e7b6573603c6fb1e7ea98cfb1803d5",
+  "lane_plan_approval_sha256": "23c6b347d16e8ca2dc5f243a94231652b0e7b6573603c6fb1e7ea98cfb1803d5",
   "status": "ready",
   "created_by": "create-lane",
   "base_branch": "main",

--- a/tooling/governance/fixtures/execute-lane-native/ready-ledger-release-v2.json
+++ b/tooling/governance/fixtures/execute-lane-native/ready-ledger-release-v2.json
@@ -10,7 +10,7 @@
     "search_run_id": "search-native-release",
     "search_ledger": ".omo/search-issue/artifacts/search-native-release.json",
     "artifact_id": "search:search-native-release",
-    "sha256": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+    "sha256": "b0169f5a9482fe7700f607c1676277af40591509a4c630e074c0be11d8e8a1a5"
   },
   "merge_policy": "supervisor-with-human-escalation",
   "pr_merge_method": "squash",

--- a/tooling/governance/fixtures/execute-lane-native/ready-ledger-two-lanes-v2.json
+++ b/tooling/governance/fixtures/execute-lane-native/ready-ledger-two-lanes-v2.json
@@ -3,7 +3,6 @@
   "run_id": "lane-4101-runtime",
   "lane_id": "lane-4101-runtime",
   "lane_plan_approval_sha256": "081555fbe6264263afaddb6abd468874493c0d330c38d26ae2f2992a719b390a",
-  "lane_plan_approval_sha256": "081555fbe6264263afaddb6abd468874493c0d330c38d26ae2f2992a719b390a",
   "status": "ready",
   "created_by": "create-lane",
   "base_branch": "main",

--- a/tooling/governance/fixtures/execute-lane-native/ready-ledger-two-lanes-v2.json
+++ b/tooling/governance/fixtures/execute-lane-native/ready-ledger-two-lanes-v2.json
@@ -2,6 +2,8 @@
   "version": 2,
   "run_id": "lane-4101-runtime",
   "lane_id": "lane-4101-runtime",
+  "lane_plan_approval_sha256": "081555fbe6264263afaddb6abd468874493c0d330c38d26ae2f2992a719b390a",
+  "lane_plan_approval_sha256": "081555fbe6264263afaddb6abd468874493c0d330c38d26ae2f2992a719b390a",
   "status": "ready",
   "created_by": "create-lane",
   "base_branch": "main",

--- a/tooling/governance/fixtures/execute-lane-native/ready-ledger-two-lanes-v2.json
+++ b/tooling/governance/fixtures/execute-lane-native/ready-ledger-two-lanes-v2.json
@@ -10,7 +10,7 @@
     "search_run_id": "search-native-two-lanes",
     "search_ledger": ".omo/search-issue/artifacts/search-native-two-lanes.json",
     "artifact_id": "search:search-native-two-lanes",
-    "sha256": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+    "sha256": "a84d89513201c9fde69a627164a50ecf9551d462408a854621f1cd8c3398c42f"
   },
   "merge_policy": "supervisor-with-human-escalation",
   "pr_merge_method": "squash",

--- a/tooling/governance/fixtures/execute-lane-native/release-handoff-approval.json
+++ b/tooling/governance/fixtures/execute-lane-native/release-handoff-approval.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "approval_id": "approval-lane-4101-runtime-lane-plan",
+  "gate": "lane-plan",
+  "binding_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "lane_id": "lane-4101-runtime",
+  "release_handoff_attestations": [
+    {
+      "issue_number": 4101,
+      "issue_evidence_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "decision": "release-or-publish-is-core",
+      "changeset_only": false
+    }
+  ]
+}

--- a/tooling/governance/fixtures/execute-lane-native/release-handoff-two-lanes-approval.json
+++ b/tooling/governance/fixtures/execute-lane-native/release-handoff-two-lanes-approval.json
@@ -2,11 +2,17 @@
   "version": 1,
   "approval_id": "approval-lane-4101-runtime-lane-plan",
   "gate": "lane-plan",
-  "binding_sha256": "23c6b347d16e8ca2dc5f243a94231652b0e7b6573603c6fb1e7ea98cfb1803d5",
+  "binding_sha256": "081555fbe6264263afaddb6abd468874493c0d330c38d26ae2f2992a719b390a",
   "lane_id": "lane-4101-runtime",
   "release_handoff_attestations": [
     {
       "issue_number": 4101,
+      "issue_evidence_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "decision": "release-or-publish-is-core",
+      "changeset_only": false
+    },
+    {
+      "issue_number": 4102,
       "issue_evidence_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
       "decision": "release-or-publish-is-core",
       "changeset_only": false
@@ -17,8 +23,8 @@
     "lane_id": "lane-4101-runtime",
     "base_branch": "main",
     "source": {
-      "artifact_id": "search:search-native-release",
-      "sha256": "b0169f5a9482fe7700f607c1676277af40591509a4c630e074c0be11d8e8a1a5"
+      "artifact_id": "search:search-native-two-lanes",
+      "sha256": "a84d89513201c9fde69a627164a50ecf9551d462408a854621f1cd8c3398c42f"
     },
     "merge_policy": "supervisor-with-human-escalation",
     "pr_merge_method": "squash",
@@ -36,7 +42,7 @@
       "max_wall_clock_minutes": 180,
       "stop_on_child_contract_error": true
     },
-    "confirmed_issues": [4101],
+    "confirmed_issues": [4101, 4102],
     "suggested_but_excluded": [],
     "backlog_candidates": [],
     "release_handoffs": [
@@ -44,12 +50,21 @@
         "issue_number": 4101,
         "reason": "release-or-publish-is-core",
         "issue_evidence_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      {
+        "issue_number": 4102,
+        "reason": "release-or-publish-is-core",
+        "issue_evidence_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
       }
     ],
     "lanes": [
       {
-        "name": "release",
+        "name": "runtime",
         "queue": [4101]
+      },
+      {
+        "name": "validation",
+        "queue": [4102]
       }
     ],
     "dependency_graph": {}

--- a/tooling/governance/fixtures/execute-lane-native/search-native-release.json
+++ b/tooling/governance/fixtures/execute-lane-native/search-native-release.json
@@ -1,0 +1,7 @@
+{
+  "version": 2,
+  "artifact_id": "search:search-native-release",
+  "sha256": "b0169f5a9482fe7700f607c1676277af40591509a4c630e074c0be11d8e8a1a5",
+  "search_run_id": "search-native-release",
+  "selected_issues": [4101]
+}

--- a/tooling/governance/fixtures/execute-lane-native/search-native-two-lanes.json
+++ b/tooling/governance/fixtures/execute-lane-native/search-native-two-lanes.json
@@ -1,0 +1,7 @@
+{
+  "version": 2,
+  "artifact_id": "search:search-native-two-lanes",
+  "sha256": "a84d89513201c9fde69a627164a50ecf9551d462408a854621f1cd8c3398c42f",
+  "search_run_id": "search-native-two-lanes",
+  "selected_issues": [4101, 4102]
+}

--- a/tooling/governance/lane-ledger-progress.mjs
+++ b/tooling/governance/lane-ledger-progress.mjs
@@ -238,12 +238,12 @@ export function validateIssueProgress(path, ledger, prAssignments) {
       assert(parsePullRequest(progress.pr) !== null, progressPath, 'in_review lane requires matching canonical PR evidence');
       assert(isNonEmptyString(progress.verification), progressPath, 'in_review lane requires non-empty verification evidence');
     }
-    if (progress.worktree !== undefined) {
+    if (progress.worktree != null) {
       const assignedOwner = worktreeAssignments.get(progress.worktree);
       assert(assignedOwner === undefined || assignedOwner === assignment, progressPath, `duplicate worktree mapping: ${progress.worktree}`);
       worktreeAssignments.set(progress.worktree, assignment);
     }
-    if (progress.branch !== undefined) {
+    if (progress.branch != null) {
       const assignedOwner = branchAssignments.get(progress.branch);
       assert(assignedOwner === undefined || assignedOwner === assignment, progressPath, `duplicate branch mapping: ${progress.branch}`);
       branchAssignments.set(progress.branch, assignment);

--- a/tooling/governance/lane-ledger-schema.mjs
+++ b/tooling/governance/lane-ledger-schema.mjs
@@ -137,6 +137,14 @@ export function validateLedgerShape(path, ledger) {
       `created_at must be a strict UTC ISO-8601 timestamp; ${migrationGuidance}`,
     );
   }
+  if (ledger.lane_plan_approval_sha256 !== undefined) {
+    assert(
+      typeof ledger.lane_plan_approval_sha256 === 'string' &&
+        /^[a-f0-9]{64}$/u.test(ledger.lane_plan_approval_sha256),
+      path,
+      'lane_plan_approval_sha256 must be a lowercase SHA-256 digest',
+    );
+  }
   assert(ledger.created_by === 'create-lane', path, 'created_by must be create-lane');
   assert(isSafeBranchName(ledger.base_branch), path, 'base_branch must be a safe non-empty branch name');
   validateSource(path, ledger.source, ledger.version);
@@ -163,7 +171,13 @@ export function validateLedgerShape(path, ledger) {
   assert(isObject(ledger.root_main_sync), path, 'root_main_sync is required');
   assert(hasExactKeys(ledger.root_main_sync, ['status', 'sha']), path, 'root_main_sync must contain exactly status/sha');
   assert(rootMainSyncStatuses.has(ledger.root_main_sync.status), path, `invalid root_main_sync.status: ${String(ledger.root_main_sync.status)}`);
-  const expectedRootKeys = ledger.created_at === undefined ? rootKeys : [...rootKeys, 'created_at'];
+  const optionalRootKeys = [
+    ...(ledger.created_at === undefined ? [] : ['created_at']),
+    ...(ledger.lane_plan_approval_sha256 === undefined
+      ? []
+      : ['lane_plan_approval_sha256']),
+  ];
+  const expectedRootKeys = [...rootKeys, ...optionalRootKeys];
   assert(hasExactKeys(ledger, expectedRootKeys), path, 'ledger must contain exactly the canonical root keys');
 }
 

--- a/tooling/governance/lane-ledger-schema.mjs
+++ b/tooling/governance/lane-ledger-schema.mjs
@@ -156,6 +156,14 @@ export function validateLedgerShape(path, ledger) {
   assert(Array.isArray(ledger.confirmed_issues), path, 'confirmed_issues must be an array');
   assert(ledger.confirmed_issues.every(isPositiveInteger), path, 'confirmed_issues must contain positive integer issue numbers');
   assert(Array.isArray(ledger.release_handoffs), path, 'release_handoffs must be an array');
+  if (ledger.release_handoffs.length > 0) {
+    assert(
+      typeof ledger.lane_plan_approval_sha256 === 'string' &&
+        /^[a-f0-9]{64}$/u.test(ledger.lane_plan_approval_sha256),
+      path,
+      'non-empty release_handoffs require lane_plan_approval_sha256',
+    );
+  }
   assert(Array.isArray(ledger.completed_issues), path, 'completed_issues must be an array');
   assert(ledger.completed_issues.every(isPositiveInteger), path, 'completed_issues must contain positive integer issue numbers');
   assert(Array.isArray(ledger.suggested_but_excluded), path, 'suggested_but_excluded must be an array');

--- a/tooling/governance/lane-ledger-state.mjs
+++ b/tooling/governance/lane-ledger-state.mjs
@@ -175,8 +175,17 @@ function validateReleaseHandoffs(path, ledger, progressByIssue) {
       path,
       'release handoff must not record branch, worktree, or PR evidence',
     );
-    if (ledger.status === 'ready') {
-      assert(lane.status === 'queued' && progress === undefined, path, 'ready release handoff must remain queued without issue progress');
+    if (
+      ledger.status === 'ready' ||
+      (ledger.status === 'running' &&
+        lane.status === 'queued' &&
+        progress === undefined)
+    ) {
+      assert(
+        lane.status === 'queued' && progress === undefined,
+        path,
+        'undispatched release handoff must remain queued without issue progress',
+      );
     } else {
       assert(
         lane.status === 'blocked-maintainer-decision' && progress?.status === 'blocked-maintainer-decision',

--- a/tooling/governance/search-artifact-migration.test.ts
+++ b/tooling/governance/search-artifact-migration.test.ts
@@ -170,20 +170,21 @@ describe('legacy search artifact migration', () => {
       const approvals = [
         {
           gate: 'confirmed-issues',
-          approval_id: 'approval-legacy-confirmed',
+          approval_id: 'approval-lane-legacy-runtime-confirmed-issues',
           approved: true,
           issue_numbers: issues,
         },
         {
           gate: 'suggested-additions',
-          approval_id: 'approval-legacy-suggestions',
+          approval_id: 'approval-lane-legacy-runtime-suggested-additions',
           approved: true,
           issue_numbers: [],
         },
         {
           gate: 'lane-plan',
-          approval_id: 'approval-legacy-plan',
+          approval_id: 'approval-lane-legacy-runtime-lane-plan',
           approved: true,
+          release_handoff_attestations: [],
         },
       ].map((approval) => ({
         ...approval,

--- a/tooling/governance/verify-lane-ledger-state.test.ts
+++ b/tooling/governance/verify-lane-ledger-state.test.ts
@@ -96,6 +96,7 @@ function setBlockedReleaseHandoff(ledger: LaneLedgerFixture): void {
   ledger.status = 'blocked-maintainer-decision';
   ledger.completed_issues = [101];
   ledger.release_handoffs = [102];
+  ledger.lane_plan_approval_sha256 = 'a'.repeat(64);
   ledger.lanes = [
     {
       name: 'runtime-completed',
@@ -778,6 +779,7 @@ describe('verify-lane-ledger canonical v1 completion contract', () => {
     expect(
       runMutatedReadyLedger((ledger) => {
         ledger.release_handoffs = [1];
+        ledger.lane_plan_approval_sha256 = 'a'.repeat(64);
         ledger.confirmed_issues.push(2);
         ledger.lanes[0].queue.push(2);
       }),
@@ -828,6 +830,7 @@ describe('verify-lane-ledger canonical v1 completion contract', () => {
           },
         ];
         ledger.release_handoffs = [102];
+        ledger.lane_plan_approval_sha256 = 'a'.repeat(64);
       }),
     ).toContain('release handoff must never be completed, merged, or done');
   });

--- a/tooling/governance/verify-lane-ledger.test.ts
+++ b/tooling/governance/verify-lane-ledger.test.ts
@@ -242,6 +242,7 @@ describe('verify-lane-ledger canonical versioned completion contract', () => {
       name: 'a non-positive release handoff',
       mutate: (ledger: LaneLedgerFixture) => {
         ledger.release_handoffs = [0];
+        ledger.lane_plan_approval_sha256 = 'a'.repeat(64);
       },
       expectedError: 'release_handoffs must contain unique positive issue numbers from confirmed_issues',
     },
@@ -249,6 +250,7 @@ describe('verify-lane-ledger canonical versioned completion contract', () => {
       name: 'a duplicate release handoff',
       mutate: (ledger: LaneLedgerFixture) => {
         ledger.release_handoffs = [101, 101];
+        ledger.lane_plan_approval_sha256 = 'a'.repeat(64);
       },
       expectedError: 'release_handoffs must contain unique positive issue numbers from confirmed_issues',
     },
@@ -256,6 +258,7 @@ describe('verify-lane-ledger canonical versioned completion contract', () => {
       name: 'an unconfirmed release handoff',
       mutate: (ledger: LaneLedgerFixture) => {
         ledger.release_handoffs = [103];
+        ledger.lane_plan_approval_sha256 = 'a'.repeat(64);
       },
       expectedError: 'release_handoffs must contain unique positive issue numbers from confirmed_issues',
     },
@@ -267,7 +270,18 @@ describe('verify-lane-ledger canonical versioned completion contract', () => {
     expect(
       runMutatedReadyLedger((ledger) => {
         ledger.release_handoffs = [1];
+        ledger.lane_plan_approval_sha256 = 'a'.repeat(64);
       }, runValidatorPath),
     ).toContain('Lane ledger check passed for 1 file(s).');
+  });
+
+  it('rejects a release handoff without an approval binding', () => {
+    expect(
+      runMutatedReadyLedger((ledger) => {
+        ledger.release_handoffs = [1];
+      }),
+    ).toContain(
+      'non-empty release_handoffs require lane_plan_approval_sha256',
+    );
   });
 });


### PR DESCRIPTION
## Summary

Prevent `$create-lane` from treating ordinary Changeset-required implementation issues as `release_handoffs`, and require `$execute-lane` to prove the exact consumed approval before parking work.

Linked context: repeated native lane-planning misclassification discovered while preparing the microservices issue lane.

## Changes

- distinguish Changeset obligations from release/publish-core handoffs in native workflow guidance
- bind handoffs to live issue evidence and explicit per-issue lane-plan attestations
- persist the approved plan in the canonical consumed receipt and recompute its binding during execution
- reconcile immutable ledger planning fields before parking a handoff
- support sequential parking without treating null branch/worktree identities as duplicates
- add producer-to-executor, migration, substitution, and self-consistent forgery regression coverage

## Testing

- `pnpm exec vitest run tooling/governance/search-artifact-migration.test.ts tooling/governance/create-lane-native.test.ts tooling/governance/create-lane-multi.test.ts tooling/governance/execute-lane-native.test.ts tooling/governance/execute-lane-resilience.test.ts tooling/governance/verify-lane-ledger-state.test.ts` — 129 passed
- `pnpm typecheck` — passed
- `pnpm lint` — passed with existing repository warnings
- five independent exact-head reviewers — PASS
- full `pnpm verify` reached 5,773 passing tests but exits 1 on the pre-existing `packages/runtime/src/multipart.test.ts` Undici `ReadableStream is already closed` unhandled rejection, reproduced unchanged on `main` and this branch

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

## Public export documentation

- [x] No public exports changed.

## Behavioral contract

- [x] No documented public package behavioral contracts were removed.
- [x] New native workflow invariants are documented and covered by regression tests.

## Platform consistency governance (SSOT)

- [x] No platform contract documentation changed.