### PR TITLE
feat(tooling): execute lane issues through DAG supervisors

### DIFF
--- a/.agents/THREAT_MODEL.md
+++ b/.agents/THREAT_MODEL.md
@@ -2,10 +2,13 @@
 
 ## Trust boundary
 
-The authenticated top-level OMO lead and the repository owner's local
-filesystem are trusted. Search artifacts, child-task output, GitHub API
-responses, persisted state read after interruption, and live Git/GitHub state
-are untrusted until validated or reconciled.
+The authenticated top-level OMO lead, authority-bound issue-supervisor DAG
+nodes, and the repository owner's local filesystem are trusted. A supervisor is
+trusted only for its immutable lane/issue/branch/worktree/PR identity and
+`authority_scope`; its implementer and reviewer children remain untrusted.
+Search artifacts, nested child-task output, GitHub API responses, persisted
+state read after interruption, and live Git/GitHub state are untrusted until
+validated or reconciled.
 
 The workflow does not claim to resist a malicious local repository owner who
 can rewrite code, state, credentials, and history together. Event hashes detect
@@ -18,12 +21,17 @@ are not signatures against that trusted operator.
   the trusted lead. Approval-binding digests prevent accidental plan
   substitution and consumed IDs prevent replay; neither is an authentication
   signature.
-- Only the lead may execute GitHub issue/PR mutations, merge, cleanup, or root
-  synchronization after the user grants the applicable side-effect authority.
+- The parent lead owns shared lane state and root synchronization. An
+  issue-supervisor node may execute push, canonical PR create/update, merge, and
+  cleanup only for its bound issue after the user grants the applicable lane
+  authority. Nested implementers and reviewers never receive that authority.
 - Successful receipts are written only from fresh live Git/GitHub command
   output bound to lane, issue, branch, worktree, PR, and head.
-- Child tasks and caller-authored JSON can request or report work but never
-  prove approval or a completed side effect.
+- The supervisor persists target-bound observations in its issue-local atomic
+  state. The parent revalidates those receipts and live identity before
+  importing terminal evidence into the shared lane ledger.
+- Nested child tasks and unvalidated caller-authored JSON can request or report
+  work but never prove approval or a completed side effect.
 
 ## Fixture boundary
 
@@ -36,7 +44,8 @@ artifacts, receipts, and events are test evidence only.
 ## Filesystem controls
 
 Native publishers reject symlinked output directories and exclusive-write
-collisions. The lane state store rejects symlinked state files, writes a
-transaction journal before each transition, recovers incomplete transactions,
-requires exact append-only event prefixes, and atomically replaces snapshots
-and receipt sets.
+collisions. Lane and issue-supervisor state stores reject symlinked state
+paths, write transaction journals before transitions, recover incomplete
+transactions, preserve append-only event hashes, and atomically replace
+snapshots and receipt sets. DAG bindings are first-write exclusive and bind the
+lane, native run, graph definition, and snapshot event anchor.

--- a/.agents/VALIDATION.md
+++ b/.agents/VALIDATION.md
@@ -28,6 +28,7 @@ tooling/governance/create-lane-multi.test.ts
 tooling/governance/issue-to-pr-native.test.ts
 tooling/governance/pr-to-merge-native.test.ts
 tooling/governance/execute-lane-native.test.ts
+tooling/governance/execute-lane-dag-supervisor.test.ts
 tooling/governance/execute-lane-persistence.test.ts
 tooling/governance/execute-lane-resilience.test.ts
 tooling/governance/execute-lane-authority.test.ts

--- a/.agents/skills/create-lane/SKILL.md
+++ b/.agents/skills/create-lane/SKILL.md
@@ -39,6 +39,21 @@ Obtain these approvals in order from three distinct user interactions:
 3. `lane-plan`: the final multi-issue grouping, dependencies, lane ID, merge
    policy, retry policy, release handoffs, and authority scope.
 
+Unless the user explicitly chooses different bounds, propose and persist this
+retry policy in the final lane plan:
+
+```json
+{
+  "retry_count_is_terminal": true,
+  "max_same_failure_repeats": 5,
+  "max_wall_clock_minutes": 360,
+  "stop_on_child_contract_error": true
+}
+```
+
+The values are part of the approved immutable plan. Never rewrite an existing
+lane ledger to adopt a newer default.
+
 `release_handoffs` is reserved for issues whose core task is a release or
 publish decision that must stop at `blocked-maintainer-decision`. A public
 package change that merely requires a Changeset is normal implementation work

--- a/.agents/skills/create-lane/references/workflow.md
+++ b/.agents/skills/create-lane/references/workflow.md
@@ -24,6 +24,12 @@ Show the artifact candidates and obtain three separate approvals:
 3. Lane plan approval accepts the final grouping, dependency graph, release
    handoffs, merge/retry policy, authority scope, and lane identity.
 
+Present `max_same_failure_repeats: 5` and
+`max_wall_clock_minutes: 360` as the default retry bounds unless the user
+explicitly selects different values. Persist the complete approved retry
+policy in the new ledger. Existing ledgers remain immutable and continue with
+their originally approved bounds.
+
 In the approval presentation, distinguish release metadata from execution
 handoffs:
 

--- a/.agents/skills/execute-lane/SKILL.md
+++ b/.agents/skills/execute-lane/SKILL.md
@@ -8,13 +8,17 @@ description: Drain one canonical Fluo lane through implementation, same-head rev
 Consume only a strict canonical lane v2 created by `$create-lane`. Do not
 rediscover issues, regroup scope, or infer missing persisted fields.
 
-The lead is the only snapshot/event/receipt/lease writer. Child tasks return typed
-implementation or review results and never mutate the ledger. Goal, todo, and
-DAG state are projections of the persisted snapshot and event stream.
+The parent lead is the only shared lane snapshot/event/receipt/lease writer.
+It compiles the validated lane snapshot into one native DAG node per issue.
+Each issue node is a supervisor for one isolated issue lifecycle and may use
+only the Git/GitHub authority explicitly granted by the lane. Implementers and
+reviewers remain nested, separately delegated roles.
 
-Read `references/workflow.md` before execution. Use `$issue-to-pr` for new PR
-and same-PR fix-back contracts and `$pr-to-merge` for the read-only same-head
-review triad.
+Read `references/workflow.md` and `references/issue-supervisor.md` before
+execution. Compile the graph with `scripts/compile-dag.mjs`, bind the native
+run through `scripts/dag-binding.mjs`, and persist the binding at
+`.omo/lane-runs/<lane-id>/dag-binding.json`. Goal, todo, and DAG state remain
+projections of the persisted lane state and live observations.
 
 Production execution never uses `scripts/fixtures/run-replay.mjs`. The lead
 performs or observes each authorized Git/GitHub action, reads fresh raw output,
@@ -22,6 +26,9 @@ then writes the target-bound receipt and transition. Synthetic observation JSON
 is fixture evidence only.
 
 Stop only when every lane is `done` or has an explicit terminal blocker and
-cleanup/root-sync state is terminal. Exactly one contract, code, and
-verification result must bind the current head. A derived `merge` verdict is
-necessary but only a lead-owned live observation may create a merge receipt.
+cleanup/root-sync state is terminal. Before the first push, every issue must
+reach `ready-for-pr` through one same-head local contract/code/verification
+triad. A fixable CI failure returns that issue to implementation and invalidates
+all prior local review evidence. CI PASS on the exact reviewed PR head produces
+`merge-ready`; only an issue supervisor's fresh lead-authorized merge
+observation may create a merge receipt.

--- a/.agents/skills/execute-lane/references/issue-supervisor.md
+++ b/.agents/skills/execute-lane/references/issue-supervisor.md
@@ -1,0 +1,75 @@
+# Native issue supervisor
+
+One DAG node owns one issue from initial implementation through merge and
+cleanup. Nodes for independent issues run concurrently; `dependsOn` mirrors the
+canonical lane dependency graph.
+
+## Role separation
+
+The supervisor orchestrates but does not implement or review:
+
+- one implementer child edits, tests, and commits in the assigned worktree;
+- contract, code, and verification reviewers run as three independent,
+  read-only children against one captured local head;
+- the supervisor aggregates results, controls retries, and performs only the
+  issue-bound Git/GitHub actions granted by `authority_scope`;
+- the parent execute-lane lead alone mutates the shared lane ledger and performs
+  root synchronization.
+
+## Local review loop
+
+```text
+implementing -> local-review
+local-review + BLOCK -> implementing -> new head -> local-review
+local-review + NEEDS-HUMAN-CHECK -> terminal blocker
+local-review + all PASS and no PR -> ready-for-pr
+local-review + all PASS and existing PR -> ready-for-push
+```
+
+Every implementation or fix must produce a new commit head. Capture exactly one
+contract, code, and verification result against that head. A head change
+invalidates the complete triad. `ready-for-pr` and `ready-for-push` authorize
+only the next issue-bound remote observation; neither is a merge verdict.
+
+## PR and CI loop
+
+At `ready-for-pr`, push the reviewed head and create one PR. At
+`ready-for-push`, push the new reviewed head to the existing PR branch. Observe
+that the remote branch, PR `headRefOid`, and reviewed local head are identical
+before entering `ci-pending`.
+
+Classify required CI on that exact head:
+
+- `pass` -> `merge-ready`;
+- `fixable-failure` -> `ci-fix-back`, then implementation, a new head, the full
+  local triad, push, and CI again;
+- `external-failure` -> `needs-human-check-terminal` without speculative code
+  edits.
+
+Green unrelated jobs do not satisfy required CI. Pending, stale, unavailable,
+infrastructure, policy, or approval failures are not implementation defects.
+
+## Merge and cleanup
+
+`merge-ready` requires the local reviewed head, remote branch head, PR head, and
+CI head to remain identical. Under lane merge authority, perform a squash merge
+and observe the PR as `MERGED`, a non-null merge commit, and the linked issue as
+`CLOSED`.
+
+Then remove the worktree, local branch, and remote branch under cleanup
+authority. Record `done` only after all required absence checks succeed.
+Incomplete cleanup is a terminal blocker and does not silently release a
+dependent issue.
+
+## Recovery
+
+Before any remote action, re-read live Git and GitHub identity. On task restart,
+resume from the issue state and live observations rather than repeating the
+last claimed action. The node returns typed transition evidence and receipts;
+the parent validates them before updating the shared lane ledger.
+
+## Stop
+
+Stop with `done` only after observed merge and cleanup. Otherwise stop with one
+explicit terminal blocker. Never report success merely because the DAG node or
+a child task returned.

--- a/.agents/skills/execute-lane/references/workflow.md
+++ b/.agents/skills/execute-lane/references/workflow.md
@@ -7,6 +7,8 @@
 - Events: `.omo/lane-runs/<lane-id>/events.jsonl`
 - Receipts: `.omo/lane-runs/<lane-id>/receipts.json`
 - Lease: `.omo/lane-runs/<lane-id>/lease.json`
+- DAG binding: `.omo/lane-runs/<lane-id>/dag-binding.json`
+- Issue runtime: `.omo/lane-runs/<lane-id>/issues/<issue-number>/`
 
 Acquire a per-ledger lease, validate the v2 snapshot and event hash chain, and
 reconcile live branch, worktree, PR, head, checks, and issue identity before
@@ -25,18 +27,55 @@ Each receipt attestation must retain the approved issue evidence digest,
 Recompute the receipt binding and require it to equal the independent
 `lane_plan_approval_sha256` stored in the ready ledger.
 
-## Attempt loop
+## DAG projection
+
+Compile the validated lane through `scripts/compile-dag.mjs`. The definition
+contains one `issue-<number>-supervisor` node per confirmed issue, and
+`dependsOn` exactly mirrors `dependency_graph`. Every executable node owns a
+disjoint issue worktree and the complete issue lifecycle. Approval-bound
+release handoff nodes perform no implementation and park at
+`blocked-maintainer-decision`.
+
+Start the definition with the native DAG tool, then atomically persist its key,
+run ID, definition digest, and current event hash through
+`scripts/dag-binding.mjs`. On restart, reconcile Fluo state and live identities
+first, require the stored definition digest to match, and only then attach the
+recorded run. A missing or conflicting run fails closed; DAG journal state never
+overrides the lane ledger.
+
+Each node initialises `scripts/issue-supervisor-store.mjs` under its issue
+runtime directory. Every local review, remote observation, receipt, and status
+transition is transactionally persisted there. The parent imports only a
+validated terminal supervisor state through `scripts/supervisor-terminal.mjs`.
+
+## Issue supervisor loop
 
 ```text
-queued -> running -> in_review
-in_review + triad PASS -> observed squash merge -> merged
-merged -> observed cleanup -> root ff-only sync -> done
-in_review + fixable block -> running on same PR -> new head -> in_review
-in_review + human/non-fixable -> explicit terminal blocker
+queued -> implementing -> local-review
+local-review + fixable BLOCK -> implementing -> new head -> local-review
+local-review + all PASS -> ready-for-pr
+ready-for-pr -> observed push and PR creation -> ci-pending
+ci-pending + fixable failure -> ci-fix-back -> new head -> local-review
+local-review + all PASS and existing PR -> ready-for-push
+ready-for-push -> observed push -> ci-pending
+ci-pending + PASS -> merge-ready
+merge-ready -> observed squash merge -> merged
+merged -> observed cleanup -> done
+human, external CI, policy, malformed output, or exhausted budget
+  -> explicit terminal blocker
 ```
 
-Every fix must preserve issue, branch, worktree, and PR identity and produce a
-new head. Re-run every reviewer on that head; never reuse prior PASS evidence.
+Before PR creation, the local triad consists of exactly one contract, code, and
+verification result bound to the local commit head. Its successful aggregate is
+`ready-for-pr`, never `merge`. Every fix preserves issue, branch, and worktree;
+after PR creation it also preserves PR identity. Every fix produces a new head
+and reruns the complete local triad.
+
+CI must bind the same reviewed PR head. A code or test failure may enter
+`ci-fix-back`. Infrastructure, missing, stale, policy, approval, or other
+external failures enter human review without code mutation. A CI PASS on the
+same reviewed head produces `merge-ready`; a fresh issue-supervisor observation
+then performs and proves the merge.
 
 No-progress, identical blocker repetition, total attempts, elapsed time,
 malformed child output, stale approval, and ledger conflicts stop fail-closed.
@@ -50,15 +89,19 @@ INTENT event -> action -> live OBSERVED event -> candidate validation
 -> atomic snapshot replacement
 ```
 
-Issue/PR creation, push, merge, cleanup, root sync, cutover, and rollback each
-require a machine-readable target/head-bound receipt. Resume must load the
-snapshot and prove the prior event stream is an exact immutable prefix before
-appending. Local publishing is forbidden.
+Issue supervisors may perform push, PR creation/update, squash merge, and
+cleanup only when those operations are granted by the immutable lane authority.
+Each operation requires a machine-readable target/head-bound receipt and fresh
+live observation. The parent lead validates returned evidence and is the only
+shared ledger writer. Root sync, cutover, rollback, and publication remain
+parent-owned. Resume must prove the prior event stream is an exact immutable
+prefix before appending. Local publishing is forbidden.
 
 ## Production live observations
 
-The lead executes these checks directly; child output and fixture JSON are not
-live evidence:
+The issue supervisor executes issue-bound checks directly; the parent lead
+executes root-state checks. Nested child output and fixture JSON are not live
+evidence:
 
 ```bash
 gh pr view <pr> --json number,url,state,headRefName,headRefOid,mergeCommit,mergedAt
@@ -72,11 +115,14 @@ git rev-parse HEAD
 git rev-parse origin/<base-branch>
 ```
 
-Before merge, the lead verifies the triad against `headRefOid`. After merge, it
+Before first push and every update, the issue supervisor verifies the complete
+local triad against the commit head. Before merge, it verifies the reviewed
+head, remote branch, `headRefOid`, and CI head are identical. After merge, it
 requires `state: MERGED`, a non-null merge commit, and the linked issue
 `state: CLOSED`. Cleanup receipts require the worktree and local/remote branch
-queries to prove absence. Root-sync receipts require a clean primary checkout,
-successful `pull --ff-only`, and equal local/remote base-branch SHAs.
+queries to prove absence. The parent performs root sync only after all DAG nodes
+are terminal; its receipt requires a clean primary checkout, successful
+`pull --ff-only`, and equal local/remote base-branch SHAs.
 
 `scripts/fixtures/run-replay.mjs --fixture-only` is a deterministic transition
 exerciser and never grants or observes production side-effect authority.

--- a/.agents/skills/execute-lane/scripts/compile-dag.mjs
+++ b/.agents/skills/execute-lane/scripts/compile-dag.mjs
@@ -1,0 +1,95 @@
+import { assertContract } from '../../../workflow-contracts/contracts.mjs';
+import { validateLedger } from '../../../../tooling/governance/lane-ledger-state.mjs';
+
+const nodeId = (issueNumber) => `issue-${String(issueNumber)}-supervisor`;
+
+const supervisorPrompt = (lane, issueNumber) => `TASK:
+Execute the complete Fluo lifecycle for issue ${String(issueNumber)} as an issue supervisor.
+
+DELIVERABLE:
+Return one typed terminal report for lane ${lane.lane_id} and issue ${String(issueNumber)}.
+
+SCOPE:
+- Consume the canonical lane ledger at .omo/lanes/${lane.lane_id}.json.
+- Use one isolated issue branch and worktree.
+- Delegate implementation and each contract/code/verification review to separate children.
+- Reach READY_FOR_PR locally before the lead pushes or creates the PR.
+- After PR creation, observe required CI on the exact reviewed head.
+- On a fixable CI failure, return to implementation, create a new head, rerun the full local triad, push, and observe CI again.
+- The issue supervisor owns issue-bound push, PR mutation, merge, cleanup, and
+  issue-local evidence only under immutable lane authority.
+- The parent lead alone owns the shared lane ledger and root synchronization.
+
+VERIFY:
+- Bind every local review, PR observation, CI result, merge, and cleanup action to the current head.
+- Persist every transition and receipt through issue-supervisor-store.mjs.
+- Treat node completion as a claim until the parent validates persisted evidence and live Git/GitHub state.
+- Never reuse a reviewer PASS after the head changes.
+
+STOP WHEN:
+The issue is merged, cleanup is observed, and its issue runtime state is done, or one explicit terminal blocker is persisted.`;
+
+const releaseHandoffPrompt = (lane, issueNumber) => `TASK:
+Represent approved release handoff issue ${String(issueNumber)} in lane ${lane.lane_id}.
+
+DELIVERABLE:
+Return one typed blocked-maintainer-decision result bound to the approved lane-plan receipt.
+
+SCOPE:
+- Do not dispatch implementation.
+- Do not create or mutate a PR.
+- Do not publish or run a local publish path.
+- Preserve the release handoff for maintainer-controlled GitHub Actions execution.
+
+VERIFY:
+Validate the issue number, release-handoff approval digest, and changeset_only=false evidence from the canonical lane ledger.
+
+STOP WHEN:
+The release handoff is persisted as blocked-maintainer-decision, or the approval binding is rejected.`;
+
+export const compileLaneSupervisorDag = (lane) => {
+  assertContract('lane-ledger-v2', lane);
+  validateLedger('lane-ledger-v2', lane);
+  const releaseHandoffs = new Set(lane.release_handoffs);
+  const confirmedIssues = new Set(lane.confirmed_issues);
+  const nodes = lane.confirmed_issues.map((issueNumber) => {
+    const dependencies = lane.dependency_graph[String(issueNumber)] ?? [];
+    if (dependencies.some((dependency) => !confirmedIssues.has(dependency))) {
+      throw new TypeError(
+        `issue ${String(issueNumber)} has a dependency outside confirmed issues.`,
+      );
+    }
+    const releaseHandoff = releaseHandoffs.has(issueNumber);
+    if (
+      !releaseHandoff &&
+      dependencies.some((dependency) => releaseHandoffs.has(dependency))
+    ) {
+      throw new TypeError(
+        `issue ${String(issueNumber)} has a release handoff dependency that cannot execute in the DAG.`,
+      );
+    }
+    return {
+      id: nodeId(issueNumber),
+      label: releaseHandoff
+        ? `Issue #${String(issueNumber)} release handoff`
+        : `Issue #${String(issueNumber)} supervisor`,
+      description: releaseHandoff
+        ? `Park approved release handoff issue #${String(issueNumber)} for maintainer action.`
+        : `Run issue #${String(issueNumber)} through local review, PR, CI, merge, and cleanup.`,
+      task_summary: releaseHandoff
+        ? `Issue #${String(issueNumber)} release handoff 보존`
+        : `Issue #${String(issueNumber)} 전체 lifecycle 실행`,
+      category: releaseHandoff ? 'quick' : 'deep',
+      load_skills: ['execute-lane'],
+      dependsOn: dependencies.map(nodeId),
+      prompt: releaseHandoff
+        ? releaseHandoffPrompt(lane, issueNumber)
+        : supervisorPrompt(lane, issueNumber),
+    };
+  });
+  return {
+    key: `fluo:lane:${lane.lane_id}:issue-supervisors:v1`,
+    name: `Fluo lane ${lane.lane_id} issue supervisors`,
+    nodes,
+  };
+};

--- a/.agents/skills/execute-lane/scripts/dag-binding.mjs
+++ b/.agents/skills/execute-lane/scripts/dag-binding.mjs
@@ -1,0 +1,151 @@
+import { randomUUID } from 'node:crypto';
+import {
+  existsSync,
+  lstatSync,
+  linkSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { resolve, sep } from 'node:path';
+
+import {
+  assertContract,
+  payloadDigest,
+} from '../../../workflow-contracts/contracts.mjs';
+
+const bindingPath = (runtimeRoot, laneId) =>
+  resolve(runtimeRoot, laneId, 'dag-binding.json');
+
+const assertRealFile = (path) => {
+  if (!existsSync(path)) {
+    return;
+  }
+  const stat = lstatSync(path);
+  if (stat.isSymbolicLink() || !stat.isFile()) {
+    throw new TypeError(`${path} must be a real regular file.`);
+  }
+};
+
+const ensureRealDirectory = (directory) => {
+  if (!existsSync(directory)) {
+    mkdirSync(directory);
+  }
+  const stat = lstatSync(directory);
+  if (
+    stat.isSymbolicLink() ||
+    !stat.isDirectory() ||
+    realpathSync(directory) !== resolve(directory)
+  ) {
+    throw new TypeError('DAG binding directory must be a real directory.');
+  }
+};
+
+const laneDirectory = (runtimeRoot, laneId) => {
+  ensureRealDirectory(runtimeRoot);
+  const directory = resolve(runtimeRoot, laneId);
+  if (!directory.startsWith(`${resolve(runtimeRoot)}${sep}`)) {
+    throw new TypeError('DAG binding lane path must stay under runtime root.');
+  }
+  ensureRealDirectory(directory);
+  return directory;
+};
+
+export const createDagBinding = ({
+  definition,
+  lane_id,
+  run_id,
+  snapshot_event_hash,
+}) => {
+  const canonicalKey = `fluo:lane:${lane_id}:issue-supervisors:v1`;
+  if (definition.key !== canonicalKey) {
+    throw new TypeError('DAG definition key must be canonical for its lane.');
+  }
+  const binding = {
+    version: 1,
+    lane_id,
+    dag_key: definition.key,
+    run_id,
+    definition_sha256: payloadDigest(definition),
+    snapshot_event_hash,
+    status: 'attached',
+  };
+  assertContract('lane-dag-binding', binding);
+  return binding;
+};
+
+export const assertDagBindingMatches = (
+  binding,
+  { definition, lane_id, run_id, snapshot_event_hash },
+) => {
+  assertContract('lane-dag-binding', binding);
+  if (binding.definition_sha256 !== payloadDigest(definition)) {
+    throw new TypeError('DAG binding definition digest does not match.');
+  }
+  if (
+    binding.dag_key !==
+    `fluo:lane:${binding.lane_id}:issue-supervisors:v1`
+  ) {
+    throw new TypeError('DAG binding key is not canonical for its lane.');
+  }
+  if (
+    binding.lane_id !== lane_id ||
+    binding.dag_key !== definition.key ||
+    binding.run_id !== run_id ||
+    binding.snapshot_event_hash !== snapshot_event_hash
+  ) {
+    throw new TypeError('DAG binding identity does not match the persisted run.');
+  }
+};
+
+export const persistDagBinding = (runtimeRoot, binding) => {
+  assertContract('lane-dag-binding', binding);
+  laneDirectory(runtimeRoot, binding.lane_id);
+  const target = bindingPath(runtimeRoot, binding.lane_id);
+  assertRealFile(target);
+  const acceptPersisted = () => {
+    assertRealFile(target);
+    const persisted = JSON.parse(readFileSync(target, 'utf8'));
+    assertContract('lane-dag-binding', persisted);
+    if (JSON.stringify(persisted) === JSON.stringify(binding)) {
+      return;
+    }
+    throw new TypeError('DAG binding conflicts with the persisted run.');
+  };
+  if (existsSync(target)) {
+    return acceptPersisted();
+  }
+  const candidate = `${target}.${randomUUID()}.tmp`;
+  writeFileSync(candidate, `${JSON.stringify(binding, null, 2)}\n`, {
+    encoding: 'utf8',
+    flag: 'wx',
+  });
+  try {
+    try {
+      linkSync(candidate, target);
+    } catch (error) {
+      if (error?.code !== 'EEXIST') {
+        throw error;
+      }
+      return acceptPersisted();
+    }
+  } finally {
+    if (existsSync(candidate)) {
+      unlinkSync(candidate);
+    }
+  }
+};
+
+export const loadDagBinding = (runtimeRoot, laneId) => {
+  laneDirectory(runtimeRoot, laneId);
+  const target = bindingPath(runtimeRoot, laneId);
+  assertRealFile(target);
+  if (!existsSync(target)) {
+    return null;
+  }
+  const binding = JSON.parse(readFileSync(target, 'utf8'));
+  assertContract('lane-dag-binding', binding);
+  return binding;
+};

--- a/.agents/skills/execute-lane/scripts/issue-supervisor-contracts.mjs
+++ b/.agents/skills/execute-lane/scripts/issue-supervisor-contracts.mjs
@@ -1,0 +1,238 @@
+import { assertContract } from '../../../workflow-contracts/contracts.mjs';
+import {
+  requireRecord,
+  requireSha,
+  requireString,
+} from './transition-contracts.mjs';
+import {
+  requirePrIdentity,
+  requireTargetReceipt,
+} from './issue-supervisor-receipts.mjs';
+
+const statuses = new Set([
+  'implementing',
+  'local-review',
+  'ready-for-pr',
+  'ready-for-push',
+  'ci-pending',
+  'ci-fix-back',
+  'merge-ready',
+  'merged',
+  'done',
+  'needs-human-check-terminal',
+  'blocked-terminal',
+  'blocked-budget-exhausted',
+  'blocked-maintainer-decision',
+]);
+
+const prStatuses = new Set([
+  'ready-for-push',
+  'ci-pending',
+  'ci-fix-back',
+  'merge-ready',
+  'merged',
+  'done',
+]);
+
+const localReviewStatuses = new Set([
+  'ready-for-pr',
+  'ready-for-push',
+  'ci-pending',
+  'merge-ready',
+  'merged',
+  'done',
+]);
+
+export const requirePositiveInteger = (value, name) => {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new TypeError(`${name} must be a positive integer.`);
+  }
+  return value;
+};
+
+export const requireTimestamp = (value, name) => {
+  const timestamp = requireString(value, name);
+  if (
+    !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(timestamp) ||
+    Number.isNaN(Date.parse(timestamp))
+  ) {
+    throw new TypeError(`${name} must be an ISO timestamp.`);
+  }
+  return timestamp;
+};
+
+export const requireAuthorityScope = (value) => {
+  const scope = requireRecord(value, 'issue supervisor authority_scope');
+  for (const key of [
+    'pr_creation',
+    'pr_merge',
+    'cleanup_command_worktrees',
+  ]) {
+    if (typeof scope[key] !== 'boolean') {
+      throw new TypeError(`authority_scope.${key} must be boolean.`);
+    }
+  }
+  return {
+    pr_creation: scope.pr_creation,
+    pr_merge: scope.pr_merge,
+    cleanup_command_worktrees: scope.cleanup_command_worktrees,
+  };
+};
+
+export const requireRetryPolicy = (value) => {
+  const policy = requireRecord(value, 'issue supervisor retry_policy');
+  if (
+    policy.retry_count_is_terminal !== true ||
+    policy.stop_on_child_contract_error !== true
+  ) {
+    throw new TypeError(
+      'retry policy requires terminal retry count and child contract errors.',
+    );
+  }
+  return {
+    retry_count_is_terminal: true,
+    max_same_failure_repeats: requirePositiveInteger(
+      policy.max_same_failure_repeats,
+      'retry_policy.max_same_failure_repeats',
+    ),
+    max_wall_clock_minutes: requirePositiveInteger(
+      policy.max_wall_clock_minutes,
+      'retry_policy.max_wall_clock_minutes',
+    ),
+    stop_on_child_contract_error: true,
+  };
+};
+
+const requireCanonicalIdentity = (state) => {
+  const issueNumber = requirePositiveInteger(
+    state.issue_number,
+    'issue supervisor issue_number',
+  );
+  const branch = requireString(state.branch, 'issue supervisor branch');
+  const branchPattern = new RegExp(
+    `^issue-${String(issueNumber)}-[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$`,
+    'u',
+  );
+  if (!branchPattern.test(branch)) {
+    throw new TypeError('issue supervisor branch must use the canonical issue branch.');
+  }
+  if (state.worktree !== `.worktrees/${branch}`) {
+    throw new TypeError('issue supervisor worktree must match its branch.');
+  }
+};
+
+export const assertIssueSupervisorState = (input) => {
+  const state = requireRecord(input, 'issue supervisor state');
+  if (state.version !== 1 || !statuses.has(state.status)) {
+    throw new TypeError('issue supervisor state invariant failed: version or status.');
+  }
+  requireString(state.lane_id, 'issue supervisor lane_id');
+  requireCanonicalIdentity(state);
+  requireSha(state.starting_head_sha, 'issue supervisor starting_head_sha');
+  requireSha(state.head_sha, 'issue supervisor head_sha');
+  requireTimestamp(state.started_at, 'issue supervisor started_at');
+  if (typeof state.release_handoff !== 'boolean') {
+    throw new TypeError(
+      'issue supervisor state invariant failed: release_handoff.',
+    );
+  }
+  const authority = requireAuthorityScope(state.authority_scope);
+  const retryPolicy = requireRetryPolicy(state.retry_policy);
+  if (
+    !Number.isSafeInteger(state.attempt) ||
+    state.attempt < 0 ||
+    state.attempt > retryPolicy.max_same_failure_repeats
+  ) {
+    throw new TypeError('issue supervisor state invariant failed: attempt.');
+  }
+  if (!Array.isArray(state.blockers)) {
+    throw new TypeError('issue supervisor state invariant failed: blockers.');
+  }
+  if (state.local_review !== null) {
+    assertContract('local-review-verdict', state.local_review);
+    if (state.local_review.head_sha !== state.head_sha) {
+      throw new TypeError('issue supervisor state invariant failed: local review head.');
+    }
+  } else if (localReviewStatuses.has(state.status)) {
+    throw new TypeError('issue supervisor state invariant failed: local review required.');
+  }
+  if (prStatuses.has(state.status) && state.pr === null) {
+    throw new TypeError('issue supervisor state invariant failed: PR required.');
+  }
+  if (state.pr !== null) {
+    const prReceipt = requireTargetReceipt(
+      { ...state, head_sha: state.pr.receipt?.head_sha },
+      state.pr.receipt,
+      state.pr.receipt?.kind,
+    );
+    requirePrIdentity(prReceipt, state.pr);
+    if (
+      !['pr-create', 'pr-update'].includes(prReceipt.kind) ||
+      (['ci-pending', 'ci-fix-back', 'merge-ready', 'merged', 'done'].includes(
+        state.status,
+      ) &&
+        (prReceipt.remote_head_sha !== state.head_sha ||
+          prReceipt.pr_head_sha !== state.head_sha))
+    ) {
+      throw new TypeError('issue supervisor state invariant failed: PR receipt.');
+    }
+  }
+  if (state.ci !== null) {
+    const ciReceipt = requireTargetReceipt(state, state.ci, 'ci');
+    requirePrIdentity(ciReceipt, state.pr);
+    if (!['pass', 'fixable-failure', 'external-failure'].includes(ciReceipt.result)) {
+      throw new TypeError('issue supervisor state invariant failed: CI receipt.');
+    }
+  }
+  if (
+    ['merge-ready', 'merged', 'done'].includes(state.status) &&
+    (state.ci === null ||
+      state.ci.result !== 'pass' ||
+      state.ci.head_sha !== state.head_sha)
+  ) {
+    throw new TypeError('issue supervisor state invariant failed: passing CI required.');
+  }
+  if (['merged', 'done'].includes(state.status) && state.merge === null) {
+    throw new TypeError('issue supervisor state invariant failed: merge required.');
+  }
+  if (state.merge !== null) {
+    const mergeReceipt = requireTargetReceipt(
+      state,
+      state.merge.receipt,
+      'merge',
+    );
+    requirePrIdentity(mergeReceipt, state.pr);
+    if (
+      mergeReceipt.merge_commit_sha !== state.merge.commit_sha ||
+      [
+        mergeReceipt.reviewed_head_sha,
+        mergeReceipt.remote_head_sha,
+        mergeReceipt.pr_head_sha,
+        mergeReceipt.ci_head_sha,
+      ].some((head) => head !== state.head_sha)
+    ) {
+      throw new TypeError('issue supervisor state invariant failed: merge receipt.');
+    }
+  }
+  if (state.cleanup !== null) {
+    const cleanupReceipt = requireTargetReceipt(
+      state,
+      state.cleanup.receipt,
+      'cleanup',
+    );
+    requirePrIdentity(cleanupReceipt, state.pr);
+  }
+  if (
+    state.status === 'done' &&
+    (state.cleanup === null ||
+      (authority.cleanup_command_worktrees
+        ? state.cleanup.status !== 'done' ||
+          !state.cleanup.worktree_removed ||
+          !state.cleanup.local_branch_deleted ||
+          !state.cleanup.remote_branch_deleted
+        : state.cleanup.status !== 'skipped-authority'))
+  ) {
+    throw new TypeError('issue supervisor state invariant failed: cleanup required.');
+  }
+  return { state, authority, retryPolicy };
+};

--- a/.agents/skills/execute-lane/scripts/issue-supervisor-files.mjs
+++ b/.agents/skills/execute-lane/scripts/issue-supervisor-files.mjs
@@ -1,0 +1,94 @@
+import { randomUUID } from 'node:crypto';
+import {
+  closeSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  realpathSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { resolve, sep } from 'node:path';
+
+import { requirePositiveInteger } from './issue-supervisor-contracts.mjs';
+
+export const assertRealFile = (path) => {
+  if (!existsSync(path)) {
+    return;
+  }
+  const stat = lstatSync(path);
+  if (stat.isSymbolicLink() || !stat.isFile()) {
+    throw new TypeError(`${path} must be a real regular file.`);
+  }
+};
+
+const ensureDirectory = (path) => {
+  if (!existsSync(path)) {
+    mkdirSync(path);
+  }
+  const stat = lstatSync(path);
+  if (
+    stat.isSymbolicLink() ||
+    !stat.isDirectory() ||
+    realpathSync(path) !== resolve(path)
+  ) {
+    throw new TypeError(`${path} must be a real directory.`);
+  }
+};
+
+export const issueDirectory = (runtimeRoot, laneId, issueNumber) => {
+  if (
+    !/^(?!.*(?:\.|\.lock)$)[A-Za-z0-9][A-Za-z0-9._-]*$/u.test(laneId)
+  ) {
+    throw new TypeError('issue supervisor lane ID is not canonical.');
+  }
+  requirePositiveInteger(issueNumber, 'issue supervisor store issue number');
+  ensureDirectory(runtimeRoot);
+  const laneDirectory = resolve(runtimeRoot, laneId);
+  if (!laneDirectory.startsWith(`${resolve(runtimeRoot)}${sep}`)) {
+    throw new TypeError('issue supervisor lane path escaped runtime root.');
+  }
+  ensureDirectory(laneDirectory);
+  const issuesDirectory = resolve(laneDirectory, 'issues');
+  ensureDirectory(issuesDirectory);
+  const directory = resolve(issuesDirectory, String(issueNumber));
+  if (!directory.startsWith(`${realpathSync(issuesDirectory)}${sep}`)) {
+    throw new TypeError('issue supervisor path escaped the issues directory.');
+  }
+  ensureDirectory(directory);
+  return directory;
+};
+
+export const withIssueLease = (directory, operation) => {
+  const leasePath = resolve(directory, 'lease.lock');
+  let descriptor;
+  try {
+    descriptor = openSync(leasePath, 'wx');
+  } catch (error) {
+    if (error?.code === 'EEXIST') {
+      throw new TypeError('issue supervisor store lease is already held.');
+    }
+    throw error;
+  }
+  try {
+    return operation();
+  } finally {
+    closeSync(descriptor);
+    unlinkSync(leasePath);
+  }
+};
+
+export const atomicWrite = (path, value) => {
+  assertRealFile(path);
+  const candidate = `${path}.${randomUUID()}.tmp`;
+  writeFileSync(candidate, value, { encoding: 'utf8', flag: 'wx' });
+  try {
+    renameSync(candidate, path);
+  } finally {
+    if (existsSync(candidate)) {
+      unlinkSync(candidate);
+    }
+  }
+};

--- a/.agents/skills/execute-lane/scripts/issue-supervisor-history.mjs
+++ b/.agents/skills/execute-lane/scripts/issue-supervisor-history.mjs
@@ -1,0 +1,133 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { payloadDigest } from '../../../workflow-contracts/contracts.mjs';
+import { assertRealFile } from './issue-supervisor-files.mjs';
+
+const assertEventChain = (events) => {
+  if (!Array.isArray(events)) {
+    throw new TypeError('issue supervisor events must be an array.');
+  }
+  events.forEach((event, index) => {
+    const { event_hash: eventHash, ...base } = event;
+    if (
+      event.sequence !== index + 1 ||
+      event.previous_hash !== (events[index - 1]?.event_hash ?? null) ||
+      eventHash !== payloadDigest(base)
+    ) {
+      throw new TypeError('issue supervisor event hash chain is invalid.');
+    }
+  });
+};
+
+const containsInOrder = (kinds, required) => {
+  let index = 0;
+  for (const kind of kinds) {
+    if (kind === required[index]) {
+      index += 1;
+    }
+  }
+  return index === required.length;
+};
+
+export const assertSupervisorHistory = (snapshot, events) => {
+  assertEventChain(events);
+  const first = events[0];
+  if (
+    first?.kind !== 'initialised' ||
+    first.status !== 'implementing' ||
+    first.head_sha !== snapshot.starting_head_sha
+  ) {
+    throw new TypeError('issue supervisor history must start with initialisation.');
+  }
+  if (
+    events.some(
+      (event) =>
+        event.lane_id !== snapshot.lane_id ||
+        event.issue_number !== snapshot.issue_number,
+    )
+  ) {
+    throw new TypeError('issue supervisor history identity is inconsistent.');
+  }
+  const last = events.at(-1);
+  if (
+    last.status !== snapshot.status ||
+    last.head_sha !== snapshot.head_sha
+  ) {
+    throw new TypeError(
+      'issue supervisor event history does not match its snapshot.',
+    );
+  }
+  const required =
+    snapshot.status === 'done' || snapshot.status === 'blocked-terminal'
+      ? [
+          'initialised',
+          'implementation-completed',
+          'local-review',
+          'pr-observed',
+          'ci-observed',
+          'merge-observed',
+          'cleanup-observed',
+        ]
+      : snapshot.status === 'blocked-maintainer-decision'
+        ? ['initialised', 'release-handoff']
+        : snapshot.status === 'blocked-budget-exhausted'
+          ? [
+              'initialised',
+              'implementation-completed',
+              'local-review',
+              'fix-completed',
+            ]
+          : snapshot.status === 'needs-human-check-terminal' &&
+              snapshot.pr !== null
+            ? [
+                'initialised',
+                'implementation-completed',
+                'local-review',
+                'pr-observed',
+                'ci-observed',
+              ]
+            : ['initialised', 'implementation-completed', 'local-review'];
+  if (
+    [
+      'done',
+      'needs-human-check-terminal',
+      'blocked-terminal',
+      'blocked-budget-exhausted',
+      'blocked-maintainer-decision',
+    ].includes(snapshot.status) &&
+    !containsInOrder(
+      events.map((event) => event.kind),
+      required,
+    )
+  ) {
+    throw new TypeError(
+      'issue supervisor history does not prove its terminal lifecycle.',
+    );
+  }
+};
+
+export const eventFor = (previous, transition, snapshot) => {
+  const base = {
+    version: 1,
+    sequence: previous.length + 1,
+    previous_hash: previous.at(-1)?.event_hash ?? null,
+    kind: transition.kind,
+    lane_id: snapshot.lane_id,
+    issue_number: snapshot.issue_number,
+    status: snapshot.status,
+    head_sha: snapshot.head_sha,
+    transition_sha256: payloadDigest(transition),
+  };
+  return { ...base, event_hash: payloadDigest(base) };
+};
+
+export const persistedEventHash = (directory, filename) => {
+  const path = resolve(directory, filename);
+  if (!existsSync(path)) {
+    return null;
+  }
+  assertRealFile(path);
+  const lines = readFileSync(path, 'utf8').trim().split('\n').filter(Boolean);
+  return lines.length === 0 ? null : JSON.parse(lines.at(-1)).event_hash;
+};

--- a/.agents/skills/execute-lane/scripts/issue-supervisor-receipts.mjs
+++ b/.agents/skills/execute-lane/scripts/issue-supervisor-receipts.mjs
@@ -1,0 +1,105 @@
+import {
+  requireRecord,
+  requireString,
+} from './transition-contracts.mjs';
+
+const requirePositiveInteger = (value, name) => {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new TypeError(`${name} must be a positive integer.`);
+  }
+  return value;
+};
+
+const requireTimestamp = (value, name) => {
+  const timestamp = requireString(value, name);
+  if (
+    !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(timestamp) ||
+    Number.isNaN(Date.parse(timestamp))
+  ) {
+    throw new TypeError(`${name} must be an ISO timestamp.`);
+  }
+  return timestamp;
+};
+
+export const requireTargetReceipt = (state, value, kind) => {
+  const receipt = requireRecord(value, `${kind} receipt`);
+  if (
+    receipt.kind !== kind ||
+    receipt.authority !== 'issue-supervisor' ||
+    receipt.lane_id !== state.lane_id ||
+    receipt.issue_number !== state.issue_number ||
+    receipt.branch !== state.branch ||
+    receipt.worktree !== state.worktree ||
+    receipt.head_sha !== state.head_sha
+  ) {
+    throw new TypeError(
+      `${kind} receipt must bind supervisor identity and current head.`,
+    );
+  }
+  requireTimestamp(receipt.observed_at, `${kind} receipt observed_at`);
+  return receipt;
+};
+
+export const requirePrIdentity = (receipt, existingPr = null) => {
+  const number = requirePositiveInteger(receipt.pr_number, 'receipt pr_number');
+  const url = requireString(receipt.pr_url, 'receipt pr_url');
+  const match =
+    /^https:\/\/github\.com\/fluojs\/fluo\/pull\/([1-9]\d*)$/u.exec(url);
+  if (
+    match === null ||
+    Number(match[1]) !== number ||
+    (existingPr !== null &&
+      (existingPr.number !== number || existingPr.url !== url))
+  ) {
+    throw new TypeError('receipt must preserve canonical PR identity.');
+  }
+  return { number, url };
+};
+
+export const assertPersistedReceipt = (supervisor, value) => {
+  const receipt = requireRecord(value, 'persisted supervisor receipt');
+  const historicalState = { ...supervisor, head_sha: receipt.head_sha };
+  requireTargetReceipt(historicalState, receipt, receipt.kind);
+  if (
+    !['pr-create', 'pr-update', 'ci', 'merge', 'cleanup'].includes(receipt.kind)
+  ) {
+    throw new TypeError('persisted supervisor receipt kind is invalid.');
+  }
+  requirePrIdentity(receipt);
+  if (
+    ['pr-create', 'pr-update'].includes(receipt.kind) &&
+    (receipt.remote_head_sha !== receipt.head_sha ||
+      receipt.pr_head_sha !== receipt.head_sha)
+  ) {
+    throw new TypeError('persisted PR receipt heads must match.');
+  }
+  if (
+    receipt.kind === 'merge' &&
+    [
+      receipt.reviewed_head_sha,
+      receipt.remote_head_sha,
+      receipt.pr_head_sha,
+      receipt.ci_head_sha,
+    ].some((head) => head !== receipt.head_sha)
+  ) {
+    throw new TypeError('persisted merge receipt heads must match.');
+  }
+  if (
+    receipt.kind === 'merge' &&
+    (receipt.merge_method !== 'squash' ||
+      receipt.pr_state !== 'MERGED' ||
+      receipt.issue_state !== 'CLOSED' ||
+      !/^[a-f0-9]{40}$/u.test(receipt.merge_commit_sha))
+  ) {
+    throw new TypeError('persisted merge receipt outcome is invalid.');
+  }
+  if (
+    receipt.kind === 'cleanup' &&
+    receipt.status !== 'skipped-authority' &&
+    (receipt.worktree_removed !== true ||
+      receipt.local_branch_deleted !== true ||
+      receipt.remote_branch_deleted !== true)
+  ) {
+    throw new TypeError('persisted cleanup receipt is incomplete.');
+  }
+};

--- a/.agents/skills/execute-lane/scripts/issue-supervisor-remote.mjs
+++ b/.agents/skills/execute-lane/scripts/issue-supervisor-remote.mjs
@@ -1,0 +1,143 @@
+import {
+  requirePrIdentity,
+  requireTargetReceipt,
+} from './issue-supervisor-receipts.mjs';
+import { requireSha, requireString } from './transition-contracts.mjs';
+
+const requireStatus = (state, ...allowed) => {
+  if (!allowed.includes(state.status)) {
+    throw new TypeError(
+      `${state.status} cannot accept this transition; expected ${allowed.join(' or ')}.`,
+    );
+  }
+};
+
+const observePr = (state, step) => {
+  requireStatus(state, 'ready-for-pr', 'ready-for-push');
+  if (!state.authority_scope.pr_creation) {
+    throw new TypeError('authority_scope.pr_creation is required.');
+  }
+  const expectedKind =
+    state.status === 'ready-for-pr' ? 'pr-create' : 'pr-update';
+  const receipt = requireTargetReceipt(state, step.receipt, expectedKind);
+  if (
+    (state.status === 'ready-for-pr' && step.action !== 'create') ||
+    (state.status === 'ready-for-push' && step.action !== 'update')
+  ) {
+    throw new TypeError('PR observation action does not match local readiness.');
+  }
+  if (
+    receipt.remote_head_sha !== state.head_sha ||
+    receipt.pr_head_sha !== state.head_sha
+  ) {
+    throw new TypeError('PR receipt must bind local, remote, and PR heads.');
+  }
+  state.pr = requirePrIdentity(receipt, state.pr);
+  state.pr.receipt = receipt;
+  state.status = 'ci-pending';
+};
+
+const observeCi = (state, step) => {
+  requireStatus(state, 'ci-pending');
+  const receipt = requireTargetReceipt(state, step.receipt, 'ci');
+  requirePrIdentity(receipt, state.pr);
+  const evidence = requireString(receipt.evidence, 'ci receipt evidence');
+  state.ci = { ...receipt, evidence };
+  if (receipt.result === 'pass') {
+    state.status = 'merge-ready';
+    return;
+  }
+  const fixable = receipt.result === 'fixable-failure';
+  if (!fixable && receipt.result !== 'external-failure') {
+    throw new TypeError(
+      'CI result must be pass, fixable-failure, or external-failure.',
+    );
+  }
+  state.status = fixable ? 'ci-fix-back' : 'needs-human-check-terminal';
+  state.blockers = [
+    {
+      reviewer: 'verification',
+      signature: fixable
+        ? 'ci:required-check:failed'
+        : 'ci:external:blocked',
+      evidence,
+      fix_back_eligible: fixable,
+      status: 'unresolved',
+    },
+  ];
+};
+
+const observeMerge = (state, step) => {
+  requireStatus(state, 'merge-ready');
+  if (!state.authority_scope.pr_merge) {
+    throw new TypeError('authority_scope.pr_merge is required.');
+  }
+  const receipt = requireTargetReceipt(state, step.receipt, 'merge');
+  requirePrIdentity(receipt, state.pr);
+  if (
+    [
+      receipt.reviewed_head_sha,
+      receipt.remote_head_sha,
+      receipt.pr_head_sha,
+      receipt.ci_head_sha,
+    ].some((head) => head !== state.head_sha) ||
+    receipt.merge_method !== 'squash' ||
+    receipt.pr_state !== 'MERGED' ||
+    receipt.issue_state !== 'CLOSED'
+  ) {
+    throw new TypeError(
+      'merge receipt must bind reviewed, remote, PR, and CI heads.',
+    );
+  }
+  state.merge = {
+    commit_sha: requireSha(
+      receipt.merge_commit_sha,
+      'merge-observed.merge_commit_sha',
+    ),
+    head_sha: state.head_sha,
+    receipt,
+  };
+  state.status = 'merged';
+};
+
+const observeCleanup = (state, step) => {
+  requireStatus(state, 'merged');
+  const receipt = requireTargetReceipt(state, step.receipt, 'cleanup');
+  requirePrIdentity(receipt, state.pr);
+  const authorized = state.authority_scope.cleanup_command_worktrees;
+  const complete = authorized
+    ?
+    receipt.worktree_removed === true &&
+    receipt.local_branch_deleted === true &&
+      receipt.remote_branch_deleted === true
+    : receipt.status === 'skipped-authority';
+  state.cleanup = authorized
+    ? {
+        status: 'done',
+        worktree_removed: receipt.worktree_removed === true,
+        local_branch_deleted: receipt.local_branch_deleted === true,
+        remote_branch_deleted: receipt.remote_branch_deleted === true,
+        receipt,
+      }
+    : { status: 'skipped-authority', receipt };
+  state.status = complete ? 'done' : 'blocked-terminal';
+};
+
+export const applyRemoteTransition = (state, step) => {
+  switch (step.kind) {
+    case 'pr-observed':
+      observePr(state, step);
+      return true;
+    case 'ci-observed':
+      observeCi(state, step);
+      return true;
+    case 'merge-observed':
+      observeMerge(state, step);
+      return true;
+    case 'cleanup-observed':
+      observeCleanup(state, step);
+      return true;
+    default:
+      return false;
+  }
+};

--- a/.agents/skills/execute-lane/scripts/issue-supervisor-store.mjs
+++ b/.agents/skills/execute-lane/scripts/issue-supervisor-store.mjs
@@ -1,0 +1,205 @@
+import {
+  existsSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { resolve } from 'node:path';
+
+import {
+  createIssueSupervisor,
+  transitionIssueSupervisor,
+} from './issue-supervisor.mjs';
+import { assertIssueSupervisorState } from './issue-supervisor-contracts.mjs';
+import {
+  assertRealFile,
+  atomicWrite,
+  issueDirectory,
+  withIssueLease,
+} from './issue-supervisor-files.mjs';
+import {
+  assertSupervisorHistory,
+  eventFor,
+  persistedEventHash,
+} from './issue-supervisor-history.mjs';
+import { assertPersistedReceipt } from './issue-supervisor-receipts.mjs';
+
+const filenames = {
+  snapshot: 'snapshot.json',
+  events: 'events.jsonl',
+  receipts: 'receipts.json',
+  transaction: 'transaction.json',
+};
+
+const assertBundle = (bundle) => {
+  assertIssueSupervisorState(bundle.snapshot);
+  assertSupervisorHistory(bundle.snapshot, bundle.events);
+  if (!Array.isArray(bundle.receipts)) {
+    throw new TypeError('issue supervisor receipts must be an array.');
+  }
+  bundle.receipts.forEach((receipt) =>
+    assertPersistedReceipt(bundle.snapshot, receipt),
+  );
+};
+
+export const assertIssueSupervisorBundle = assertBundle;
+
+const applyTransaction = (directory, transaction) => {
+  assertBundle(transaction);
+  atomicWrite(
+    resolve(directory, filenames.snapshot),
+    `${JSON.stringify(transaction.snapshot, null, 2)}\n`,
+  );
+  atomicWrite(
+    resolve(directory, filenames.events),
+    `${transaction.events.map((event) => JSON.stringify(event)).join('\n')}\n`,
+  );
+  atomicWrite(
+    resolve(directory, filenames.receipts),
+    `${JSON.stringify(transaction.receipts, null, 2)}\n`,
+  );
+  const path = resolve(directory, filenames.transaction);
+  if (existsSync(path)) {
+    unlinkSync(path);
+  }
+};
+
+const recoverTransaction = (directory) => {
+  const path = resolve(directory, filenames.transaction);
+  assertRealFile(path);
+  if (existsSync(path)) {
+    applyTransaction(directory, JSON.parse(readFileSync(path, 'utf8')));
+  }
+};
+
+const readBundle = (directory) => {
+  recoverTransaction(directory);
+  const snapshotPath = resolve(directory, filenames.snapshot);
+  if (!existsSync(snapshotPath)) {
+    return null;
+  }
+  for (const name of ['snapshot', 'events', 'receipts']) {
+    assertRealFile(resolve(directory, filenames[name]));
+  }
+  const eventText = readFileSync(resolve(directory, filenames.events), 'utf8');
+  const bundle = {
+    snapshot: JSON.parse(readFileSync(snapshotPath, 'utf8')),
+    events: eventText
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line)),
+    receipts: JSON.parse(
+      readFileSync(resolve(directory, filenames.receipts), 'utf8'),
+    ),
+  };
+  assertBundle(bundle);
+  return bundle;
+};
+
+const persistBundle = (directory, bundle, expectedPreviousHash) => {
+  const transactionPath = resolve(directory, filenames.transaction);
+  assertRealFile(transactionPath);
+  if (existsSync(transactionPath)) {
+    throw new TypeError('issue supervisor transaction already exists.');
+  }
+  if (
+    persistedEventHash(directory, filenames.events) !== expectedPreviousHash
+  ) {
+    throw new TypeError('issue supervisor event CAS conflict.');
+  }
+  writeFileSync(
+    transactionPath,
+    `${JSON.stringify({ version: 1, ...bundle }, null, 2)}\n`,
+    { encoding: 'utf8', flag: 'wx' },
+  );
+  applyTransaction(directory, bundle);
+};
+
+export const initialiseIssueSupervisorStore = (runtimeRoot, identity) => {
+  const initial = createIssueSupervisor(identity);
+  const directory = issueDirectory(
+    runtimeRoot,
+    initial.lane_id,
+    initial.issue_number,
+  );
+  return withIssueLease(directory, () => {
+    const existing = readBundle(directory);
+    if (existing !== null) {
+      for (const key of [
+        'lane_id',
+        'issue_number',
+        'branch',
+        'worktree',
+        'starting_head_sha',
+        'started_at',
+        'authority_scope',
+        'retry_policy',
+        'lane_plan_approval_sha256',
+        'release_handoff',
+      ]) {
+        if (
+          JSON.stringify(existing.snapshot[key]) !==
+          JSON.stringify(initial[key])
+        ) {
+          throw new TypeError(
+            `issue supervisor store identity conflict: ${key}.`,
+          );
+        }
+      }
+      return existing;
+    }
+    const transition = { kind: 'initialised' };
+    const bundle = {
+      snapshot: initial,
+      events: [eventFor([], transition, initial)],
+      receipts: [],
+    };
+    persistBundle(directory, bundle, null);
+    return bundle;
+  });
+};
+
+export const applyIssueSupervisorTransition = (
+  runtimeRoot,
+  laneId,
+  issueNumber,
+  transition,
+) => {
+  const directory = issueDirectory(runtimeRoot, laneId, issueNumber);
+  return withIssueLease(directory, () => {
+    const current = readBundle(directory);
+    if (current === null) {
+      throw new TypeError('issue supervisor store must be initialised.');
+    }
+    const snapshot = transitionIssueSupervisor(current.snapshot, transition);
+    const receipt =
+      typeof transition.receipt === 'object' && transition.receipt !== null
+        ? transition.receipt
+        : null;
+    const bundle = {
+      snapshot,
+      events: [
+        ...current.events,
+        eventFor(current.events, transition, snapshot),
+      ],
+      receipts:
+        receipt === null ? current.receipts : [...current.receipts, receipt],
+    };
+    persistBundle(
+      directory,
+      bundle,
+      current.events.at(-1)?.event_hash ?? null,
+    );
+    return bundle;
+  });
+};
+
+export const loadIssueSupervisorStore = (
+  runtimeRoot,
+  laneId,
+  issueNumber,
+) => {
+  const directory = issueDirectory(runtimeRoot, laneId, issueNumber);
+  return withIssueLease(directory, () => readBundle(directory));
+};

--- a/.agents/skills/execute-lane/scripts/issue-supervisor.mjs
+++ b/.agents/skills/execute-lane/scripts/issue-supervisor.mjs
@@ -1,0 +1,179 @@
+import { assertBlockerReconciliation } from '../../issue-to-pr/scripts/contracts.mjs';
+import { aggregateReviewerGate } from '../../pr-to-merge/scripts/contracts.mjs';
+import { assertContract } from '../../../workflow-contracts/contracts.mjs';
+import {
+  assertIssueSupervisorState,
+  requireAuthorityScope,
+  requirePositiveInteger,
+  requireRetryPolicy,
+  requireTimestamp,
+} from './issue-supervisor-contracts.mjs';
+import { applyRemoteTransition } from './issue-supervisor-remote.mjs';
+import {
+  requireRecord,
+  requireSha,
+  requireString,
+} from './transition-contracts.mjs';
+
+const requireStatus = (state, ...allowed) => {
+  if (!allowed.includes(state.status)) {
+    throw new TypeError(
+      `${state.status} cannot accept this transition; expected ${allowed.join(' or ')}.`,
+    );
+  }
+};
+
+const reviewerSignals = (reviews) =>
+  Object.fromEntries(
+    reviews.map((review) => [review.reviewer, review.verdict_signal]),
+  );
+
+const localReview = (state, step) => {
+  requireStatus(state, 'local-review');
+  const outcome = aggregateReviewerGate({
+    head_sha: state.head_sha,
+    reviews: step.reviews,
+  });
+  const readyVerdict = state.pr === null ? 'ready-for-pr' : 'ready-for-push';
+  const verdict = {
+    version: 1,
+    lane_id: state.lane_id,
+    issue_number: state.issue_number,
+    verdict:
+      outcome.verdict === 'merge' ? readyVerdict : outcome.verdict,
+    head_sha: state.head_sha,
+    reviewers: reviewerSignals(step.reviews),
+    blockers: outcome.blockers,
+  };
+  assertContract('local-review-verdict', verdict);
+  state.local_review = verdict;
+  if (outcome.verdict === 'merge') {
+    state.status = readyVerdict;
+    state.blockers = [];
+  } else if (outcome.verdict === 'block') {
+    state.status = 'implementing';
+    state.blockers = outcome.blockers;
+  } else {
+    state.status = 'needs-human-check-terminal';
+    state.blockers = [];
+  }
+};
+
+const completeImplementation = (state, step) => {
+  if (step.kind === 'implementation-completed') {
+    requireStatus(state, 'implementing');
+    if (state.attempt !== 0 || state.blockers.length !== 0 || state.pr !== null) {
+      throw new TypeError(
+        'blocked implementation requires fix-completed reconciliation.',
+      );
+    }
+  } else {
+    requireStatus(state, 'implementing', 'ci-fix-back');
+    if (state.blockers.length === 0) {
+      throw new TypeError('fix-completed requires unresolved blockers.');
+    }
+    const observedAt = requireTimestamp(
+      step.observed_at,
+      'fix-completed.observed_at',
+    );
+    const elapsed = Date.parse(observedAt) - Date.parse(state.started_at);
+    if (
+      state.attempt >= state.retry_policy.max_same_failure_repeats ||
+      elapsed > state.retry_policy.max_wall_clock_minutes * 60_000
+    ) {
+      state.status = 'blocked-budget-exhausted';
+      return;
+    }
+    assertBlockerReconciliation(state.blockers, step.addressed_blockers, []);
+    state.attempt += 1;
+  }
+  const newHead = requireSha(step.new_head, `${step.kind}.new_head`);
+  if (newHead === state.head_sha) {
+    throw new TypeError(`${step.kind} must produce a new head.`);
+  }
+  state.head_sha = newHead;
+  state.verification = requireString(
+    step.verification,
+    `${step.kind}.verification`,
+  );
+  state.status = 'local-review';
+  state.blockers = [];
+  state.local_review = null;
+  state.ci = null;
+};
+
+const parkReleaseHandoff = (state, step) => {
+  requireStatus(state, 'implementing');
+  if (
+    state.release_handoff !== true ||
+    state.lane_plan_approval_sha256 === null ||
+    step.approval_sha256 !== state.lane_plan_approval_sha256
+  ) {
+    throw new TypeError('release handoff approval does not match the lane binding.');
+  }
+  state.status = 'blocked-maintainer-decision';
+  state.blockers = [
+    {
+      reviewer: 'verification',
+      signature: 'release-handoff:maintainer:required',
+      evidence: step.approval_sha256,
+      fix_back_eligible: false,
+      status: 'unresolved',
+    },
+  ];
+};
+
+export const createIssueSupervisor = (input) => {
+  const value = requireRecord(input, 'issue supervisor identity');
+  const issueNumber = requirePositiveInteger(
+    value.issue_number,
+    'issue supervisor issue_number',
+  );
+  const state = {
+    version: 1,
+    lane_id: requireString(value.lane_id, 'issue supervisor lane_id'),
+    issue_number: issueNumber,
+    branch: requireString(value.branch, 'issue supervisor branch'),
+    worktree: requireString(value.worktree, 'issue supervisor worktree'),
+    starting_head_sha: requireSha(
+      value.starting_head_sha,
+      'issue supervisor starting_head_sha',
+    ),
+    head_sha: value.starting_head_sha,
+    started_at: requireTimestamp(value.started_at, 'issue supervisor started_at'),
+    authority_scope: requireAuthorityScope(value.authority_scope),
+    retry_policy: requireRetryPolicy(value.retry_policy),
+    lane_plan_approval_sha256: value.lane_plan_approval_sha256 ?? null,
+    release_handoff: value.release_handoff === true,
+    status: 'implementing',
+    attempt: 0,
+    verification: null,
+    blockers: [],
+    local_review: null,
+    pr: null,
+    ci: null,
+    merge: null,
+    cleanup: null,
+  };
+  assertIssueSupervisorState(state);
+  return state;
+};
+
+export const transitionIssueSupervisor = (current, transition) => {
+  assertIssueSupervisorState(current);
+  const state = structuredClone(current);
+  const step = requireRecord(transition, 'issue supervisor transition');
+  if (step.kind === 'implementation-completed' || step.kind === 'fix-completed') {
+    completeImplementation(state, step);
+  } else if (step.kind === 'local-review') {
+    localReview(state, step);
+  } else if (step.kind === 'release-handoff') {
+    parkReleaseHandoff(state, step);
+  } else if (!applyRemoteTransition(state, step)) {
+    throw new TypeError(
+      `unknown issue supervisor transition: ${String(step.kind)}`,
+    );
+  }
+  assertIssueSupervisorState(state);
+  return state;
+};

--- a/.agents/skills/execute-lane/scripts/supervisor-terminal.mjs
+++ b/.agents/skills/execute-lane/scripts/supervisor-terminal.mjs
@@ -1,0 +1,277 @@
+import { assertContract } from '../../../workflow-contracts/contracts.mjs';
+import { validateLedger } from '../../../../tooling/governance/lane-ledger-state.mjs';
+import {
+  appendEvent,
+  cleanupReceipts,
+  mergeReceipt,
+  setRootStatus,
+  terminalize,
+} from './transition-application.mjs';
+import { assertIssueSupervisorState } from './issue-supervisor-contracts.mjs';
+import { assertIssueSupervisorBundle } from './issue-supervisor-store.mjs';
+import { parkReleaseHandoff } from './lane-progression.mjs';
+import { assertReleaseHandoffBinding } from './release-handoff-approval.mjs';
+
+const terminalStatuses = new Set([
+  'done',
+  'needs-human-check-terminal',
+  'blocked-terminal',
+  'blocked-budget-exhausted',
+  'blocked-maintainer-decision',
+]);
+
+const laneFor = (snapshot, issueNumber) => {
+  const laneIndex = snapshot.lanes.findIndex((lane) =>
+    lane.queue.includes(issueNumber),
+  );
+  if (laneIndex === -1) {
+    throw new TypeError('supervisor issue is not assigned to a lane.');
+  }
+  return { lane: snapshot.lanes[laneIndex], laneIndex };
+};
+
+const advanceLane = (snapshot, lane) => {
+  const nextIssue = lane.queue.find(
+    (issue) => !snapshot.completed_issues.includes(issue),
+  );
+  Object.assign(lane, {
+    status: nextIssue === undefined ? 'done' : 'queued',
+    current_issue: nextIssue ?? null,
+    branch: null,
+    worktree: null,
+    pr: null,
+    retry_count: 0,
+  });
+};
+
+const identityFromSupervisor = (snapshot, supervisor, laneIndex) => ({
+  lane_id: snapshot.lane_id,
+  lane_index: laneIndex,
+  issue_number: supervisor.issue_number,
+  branch: supervisor.branch,
+  worktree: supervisor.worktree,
+  pr_number: supervisor.pr?.number ?? null,
+  pr_url: supervisor.pr?.url ?? null,
+  head_sha: supervisor.head_sha,
+});
+
+const completedProgress = (supervisor) => ({
+  status: 'done',
+  branch: supervisor.branch,
+  worktree: supervisor.worktree,
+  pr: supervisor.pr.url,
+  head_sha: supervisor.head_sha,
+  verification: supervisor.verification,
+  retry_count: supervisor.attempt,
+  blockers: supervisor.blockers,
+  review_verdict: 'merge',
+  checks: 'PASS',
+  reviewers: supervisor.local_review.reviewers,
+  reviewed_head: supervisor.local_review.head_sha,
+  commits: [supervisor.head_sha],
+  merge_commit: supervisor.merge.commit_sha,
+  issue_state: 'CLOSED',
+  cleanup: supervisor.authority_scope.cleanup_command_worktrees
+    ? {
+        status: 'done',
+        worktree_removed: true,
+        local_branch_deleted: true,
+        remote_branch_deleted: true,
+      }
+    : { status: 'skipped-authority' },
+});
+
+const blockedProgress = (supervisor) => ({
+  status: supervisor.status,
+  branch: supervisor.branch,
+  worktree: supervisor.worktree,
+  pr: supervisor.pr?.url ?? null,
+  head_sha: supervisor.head_sha,
+  verification: supervisor.verification,
+  retry_count: supervisor.attempt,
+  blockers: supervisor.blockers,
+});
+
+const assertLiveCompletion = (supervisor, live) => {
+  const expected = {
+    issue_number: supervisor.issue_number,
+    issue_url: `https://github.com/fluojs/fluo/issues/${String(supervisor.issue_number)}`,
+    pr_number: supervisor.pr.number,
+    pr_url: supervisor.pr.url,
+    branch: supervisor.branch,
+    worktree: supervisor.worktree,
+    reviewed_head_sha: supervisor.head_sha,
+    remote_head_sha: supervisor.head_sha,
+    pr_head_sha: supervisor.head_sha,
+    ci_head_sha: supervisor.head_sha,
+    merge_commit_sha: supervisor.merge.commit_sha,
+    merge_method: 'squash',
+    pr_state: 'MERGED',
+    issue_state: 'CLOSED',
+    cleanup_status: supervisor.authority_scope.cleanup_command_worktrees
+      ? 'done'
+      : 'skipped-authority',
+  };
+  if (supervisor.authority_scope.cleanup_command_worktrees) {
+    Object.assign(expected, {
+      worktree_removed: true,
+      local_branch_deleted: true,
+      remote_branch_deleted: true,
+    });
+  }
+  const actualKeys = Object.keys(live ?? {}).sort();
+  const expectedKeys = Object.keys(expected).sort();
+  if (
+    actualKeys.length !== expectedKeys.length ||
+    actualKeys.some((key, index) => key !== expectedKeys[index])
+  ) {
+    throw new TypeError('supervisor live completion contains unexpected fields.');
+  }
+  for (const [key, value] of Object.entries(expected)) {
+    if (live?.[key] !== value) {
+      throw new TypeError(`supervisor live completion mismatch: ${key}.`);
+    }
+  }
+};
+
+export const importSupervisorTerminal = (
+  persisted,
+  supervisorBundle,
+  liveCompletion = null,
+  releaseHandoffContext = null,
+) => {
+  assertIssueSupervisorBundle(supervisorBundle);
+  const { state: supervisor } = assertIssueSupervisorState(
+    supervisorBundle.snapshot,
+  );
+  if (!terminalStatuses.has(supervisor.status)) {
+    throw new TypeError('shared lane import requires a terminal supervisor state.');
+  }
+  const snapshot = structuredClone(persisted.snapshot);
+  const events = structuredClone(persisted.events);
+  const receipts = structuredClone(persisted.receipts);
+  assertContract('lane-ledger-v2', snapshot);
+  validateLedger('lane-ledger-v2', snapshot);
+  if (supervisor.lane_id !== snapshot.lane_id) {
+    throw new TypeError('supervisor lane identity does not match the ledger.');
+  }
+  for (const key of [
+    'pr_creation',
+    'pr_merge',
+    'cleanup_command_worktrees',
+  ]) {
+    if (supervisor.authority_scope[key] !== snapshot.authority_scope[key]) {
+      throw new TypeError(`supervisor authority does not match ledger: ${key}.`);
+    }
+  }
+  if (
+    supervisor.retry_policy.retry_count_is_terminal !==
+      snapshot.retry_policy.retry_count_is_terminal ||
+    supervisor.retry_policy.max_same_failure_repeats !==
+      snapshot.retry_policy.max_same_failure_repeats ||
+    supervisor.retry_policy.max_wall_clock_minutes !==
+      snapshot.retry_policy.max_wall_clock_minutes ||
+    supervisor.retry_policy.stop_on_child_contract_error !==
+      snapshot.retry_policy.stop_on_child_contract_error
+  ) {
+    throw new TypeError('supervisor retry policy does not match the ledger.');
+  }
+
+  const { lane, laneIndex } = laneFor(snapshot, supervisor.issue_number);
+  const unmet = (
+    snapshot.dependency_graph[String(supervisor.issue_number)] ?? []
+  ).filter((issue) => !snapshot.completed_issues.includes(issue));
+  if (unmet.length > 0) {
+    throw new TypeError('supervisor terminal import has unmet dependencies.');
+  }
+  const identity = identityFromSupervisor(snapshot, supervisor, laneIndex);
+  const existingProgress =
+    snapshot.issue_progress[String(supervisor.issue_number)];
+
+  if (supervisor.status === 'done') {
+    assertLiveCompletion(supervisor, liveCompletion);
+    const progress = completedProgress(supervisor);
+    if (snapshot.completed_issues.includes(supervisor.issue_number)) {
+      if (
+        JSON.stringify(
+          snapshot.issue_progress[String(supervisor.issue_number)],
+        ) !== JSON.stringify(progress)
+      ) {
+        throw new TypeError(
+          'completed supervisor import conflicts with shared lane evidence.',
+        );
+      }
+      return { snapshot, events, receipts };
+    }
+    snapshot.issue_progress[String(supervisor.issue_number)] = progress;
+    if (!snapshot.completed_issues.includes(supervisor.issue_number)) {
+      snapshot.completed_issues.push(supervisor.issue_number);
+    }
+    receipts.push(
+      mergeReceipt(identity),
+      ...cleanupReceipts(
+        identity,
+        supervisor.authority_scope.cleanup_command_worktrees
+          ? 'succeeded'
+          : 'skipped',
+      ),
+    );
+    appendEvent(
+      events,
+      snapshot.lane_id,
+      'supervisor.completed',
+      String(supervisor.issue_number),
+      {
+        head_sha: supervisor.head_sha,
+        merge_commit_sha: supervisor.merge.commit_sha,
+      },
+    );
+    advanceLane(snapshot, lane);
+    setRootStatus(snapshot, 'running');
+  } else if (supervisor.status === 'blocked-maintainer-decision') {
+    if (
+      supervisor.release_handoff !== true ||
+      !snapshot.release_handoffs.includes(supervisor.issue_number) ||
+      supervisor.lane_plan_approval_sha256 === null ||
+      supervisor.lane_plan_approval_sha256 !==
+        snapshot.lane_plan_approval_sha256
+    ) {
+      throw new TypeError('release handoff approval does not match the ledger.');
+    }
+    assertReleaseHandoffBinding(
+      snapshot,
+      releaseHandoffContext?.receipt,
+      releaseHandoffContext?.artifact,
+      releaseHandoffContext?.artifact_path,
+    );
+    if (
+      lane.status === 'blocked-maintainer-decision' &&
+      existingProgress?.status === 'blocked-maintainer-decision'
+    ) {
+      return { snapshot, events, receipts };
+    }
+    parkReleaseHandoff(snapshot, identity, events);
+  } else {
+    const progress = blockedProgress(supervisor);
+    if (lane.status === supervisor.status && existingProgress !== undefined) {
+      if (JSON.stringify(existingProgress) !== JSON.stringify(progress)) {
+        throw new TypeError(
+          'blocked supervisor import conflicts with shared lane evidence.',
+        );
+      }
+      return { snapshot, events, receipts };
+    }
+    snapshot.issue_progress[String(supervisor.issue_number)] = progress;
+    terminalize(snapshot, identity, supervisor.status, supervisor.blockers);
+    appendEvent(
+      events,
+      snapshot.lane_id,
+      'supervisor.blocked',
+      String(supervisor.issue_number),
+      { status: supervisor.status },
+    );
+  }
+  assertContract('lane-ledger-v2', snapshot);
+  validateLedger('lane-ledger-v2', snapshot);
+  return { snapshot, events, receipts };
+};

--- a/.agents/skills/execute-lane/scripts/transition-application.mjs
+++ b/.agents/skills/execute-lane/scripts/transition-application.mjs
@@ -101,7 +101,7 @@ export const terminalize = (
   progress.blockers = blockers;
 };
 
-const mergeReceipt = (identity) =>
+export const mergeReceipt = (identity) =>
   receipt({
     identity,
     receiptId: `${identity.lane_id}:pr.merge:${identity.head_sha}`,

--- a/.agents/skills/issue-to-pr/SKILL.md
+++ b/.agents/skills/issue-to-pr/SKILL.md
@@ -16,6 +16,9 @@ Accept one typed input defined by `scripts/contracts.mjs`:
 - `mode: new-pr` starts from an issue with no existing PR or blockers.
 - `mode: fix-back` requires the existing PR identity, one or more canonical
   unresolved blockers, and `fix_back_attempt` from 1 through 3.
+- `mode: local-new` returns the first verified local head before PR creation.
+- `mode: local-fix-back` remediates local reviewer blockers without PR identity.
+- `mode: ci-fix-back` remediates CI blockers while preserving the existing PR.
 - Both modes bind `lane_id`, issue identity, base branch,
   `issue-<number>-<short-title>`, `.worktrees/<branch>`, and the starting head.
 
@@ -50,11 +53,19 @@ Follow `references/workflow.md` end to end:
    `references/implementer.md`.
 5. Validate the child report and repository identity. Completion requires a
    commit that advances the assigned branch to a new head.
-6. The lead runs or confirms the closest canonical verification, pushes the new
-   head, then creates a PR for `new-pr` or confirms the existing PR received the
-   fix-back head.
-7. Validate the final typed output with `assertIssueToPrResult` before reporting
+6. The lead runs or confirms the closest canonical verification.
+7. For a direct `$issue-to-pr` invocation, the lead pushes the new head, then
+   creates a PR for `new-pr` or confirms the existing PR received the fix-back
+   head.
+8. Validate the final typed output with `assertIssueToPrResult` before reporting
    completion.
+
+When called by an `$execute-lane` issue supervisor, use `local-new`,
+`local-fix-back`, or `ci-fix-back` and stop the local phase after step 6. The
+supervisor must run one same-head contract/code/verification triad and reach
+`ready-for-pr` or `ready-for-push` before the supervisor-owned remote phase.
+A local reviewer or CI blocker reuses the implementation child contract but
+never skips the fresh local triad.
 
 Use one native task, not a persistent team. A missing task result may be
 re-requested once from the same child session. Missing, malformed, unchanged-

--- a/.agents/skills/issue-to-pr/references/implementer.md
+++ b/.agents/skills/issue-to-pr/references/implementer.md
@@ -1,30 +1,33 @@
 # Native issue implementer
 
-This is the detailed task contract for the single implementation child used by
-`$issue-to-pr` and reused by `$execute-lane`. The child owns scoped
-edit-test-commit work inside one assigned worktree. The lead owns branch,
-worktree, push, PR, merge, and cleanup orchestration.
+This is the detailed task contract for an implementation child used by
+`$issue-to-pr` and by an `$execute-lane` issue supervisor. The child owns scoped
+edit-test-commit work inside one assigned worktree. It never reviews or
+publishes its own result. The caller owns orchestration and remote authority.
 
 ## Required task input
 
 The lead must supply:
 
-- validated mode: `new-pr` or `fix-back`
+- validated mode: `new-pr`, `local-new`, `fix-back`, `local-fix-back`, or
+  `ci-fix-back`
 - lane ID and issue number, URL, title, and body
 - absolute `WORKTREE_PATH`
 - branch and base branch
 - `starting_head_sha`
 - applicable governance and package contract paths
 
-For `fix-back`, the lead must also supply:
+For `fix-back` or `ci-fix-back`, the caller must also supply:
 
 - existing PR identity and expected head branch
-- canonical unresolved blockers from the same-head merge gate
+- canonical unresolved blockers from the same-head local or CI gate
 - fix-back attempt number
 
-Missing identity, a mismatched branch or worktree, an absent starting head, or
-missing fix-back blockers is a child contract error. Do not repair orchestration
-identity by creating a replacement branch, worktree, PR, or issue.
+`local-fix-back` occurs before a PR exists and requires local reviewer blockers
+instead of PR identity. Missing required identity, a mismatched branch or
+worktree, an absent starting head, or missing fix-back blockers is a child
+contract error. Do not repair orchestration identity by creating a replacement
+branch, worktree, PR, or issue.
 
 ## Worktree boundary
 
@@ -33,7 +36,7 @@ identity by creating a replacement branch, worktree, PR, or issue.
   to that path and the checked-out branch equals the supplied branch.
 - Never edit `main`, the repository root outside the assigned worktree, another
   lane, or another agent's worktree.
-- In `fix-back`, verify the existing PR head branch, supplied branch, worktree
+- When a PR exists, verify its head branch, the supplied branch, worktree
   branch, and starting head describe the same identity.
 - On mismatch, stop with contract-error evidence. Do not switch identity,
   merge, rebase, reset, or copy changes across worktrees.
@@ -129,18 +132,18 @@ do not invent command names.
 
 ## Fix-back mode
 
-`fix-back` is remediation, not a fresh implementation pass.
+Every fix-back mode is remediation, not a fresh implementation pass.
 
-- Modify only supplied unresolved blockers and directly necessary tests, docs,
+- Modify only supplied local-review or CI blockers and directly necessary tests, docs,
   contract companions, migration guidance, or release metadata.
-- Preserve the existing branch, worktree, PR, and commit history.
+- Preserve the existing branch, worktree, optional PR, and commit history.
 - Append one new commit; never amend, squash, rebase, or rewrite prior work.
 - Mark a blocker addressed only when its exact evidence is corrected and a
   relevant verifier passes.
 - If a blocker requires product, policy, security, or release authority, do not
   guess. Return it as `needs-human-check`.
-- If evidence cannot be reproduced or identity differs from the supplied PR
-  head, return it as still blocked with exact evidence.
+- If evidence cannot be reproduced or identity differs from the supplied local
+  or PR head, return it as still blocked with exact evidence.
 - Do not expand into unrelated findings discovered during remediation; report
   them separately without modifying their scope.
 
@@ -160,9 +163,10 @@ Return one machine-readable report containing:
   `needs-human-check`
 - child contract errors, baseline failures, and unresolved decisions
 
-The report is evidence for the lead. It does not authorize push, PR creation,
-merge, cleanup, release, or publication and must not claim the overall workflow
-is complete.
+The report is evidence for the caller. The issue supervisor must run a fresh
+three-axis local review against `new head` before any push. The report does not
+authorize push, PR creation, merge, cleanup, release, or publication and must
+not claim the overall workflow is complete.
 
 ## Communication policy
 

--- a/.agents/skills/issue-to-pr/references/workflow.md
+++ b/.agents/skills/issue-to-pr/references/workflow.md
@@ -82,7 +82,13 @@ cannot be established, stop as `blocked-child-contract-error`.
 
 ## Lead remote phase
 
-Only after the child result gate passes may the lead push.
+For a direct `$issue-to-pr` invocation, only after the child result gate passes
+may the lead push.
+
+For an `$execute-lane` issue supervisor, return the validated local head before
+this phase. The supervisor runs a fresh local contract/code/verification triad.
+Only `ready-for-pr` or `ready-for-push` on that exact head may re-enter this
+remote phase.
 
 For `new-pr`:
 
@@ -97,8 +103,10 @@ For `fix-back`:
 2. do not create or edit a PR
 3. query the existing PR and confirm it now observes the new head
 
-The lead may push and create a new PR; the implementer may not. Neither actor
-may merge, close, clean up, or publish in this workflow.
+The lead or authority-bound issue supervisor may push and create/update the
+single canonical PR; the implementer may not. Direct `$issue-to-pr` does not
+merge, close, clean up, or publish. The issue supervisor performs merge and
+cleanup only after exact-head CI PASS under `$execute-lane`.
 
 ## Typed completion
 

--- a/.agents/skills/issue-to-pr/scripts/contracts.mjs
+++ b/.agents/skills/issue-to-pr/scripts/contracts.mjs
@@ -123,18 +123,30 @@ export const assertIssueToPrInput = (value) => {
   assertSha(value.starting_head_sha, 'issue-to-pr input.starting_head_sha');
   assertUnresolvedInputBlockers(value.blockers, 'issue-to-pr input.blockers');
 
-  if (value.mode === 'new-pr') {
+  if (value.mode === 'new-pr' || value.mode === 'local-new') {
     if (value.existing_pr !== null || value.blockers.length !== 0 || value.fix_back_attempt !== null) {
-      fail('issue-to-pr input', 'new-pr must not carry PR, blockers, or fix-back attempt');
+      fail('issue-to-pr input', 'new modes must not carry PR, blockers, or fix-back attempt');
     }
     return;
   }
-  if (value.mode !== 'fix-back') {
-    fail('issue-to-pr input.mode', 'must be new-pr or fix-back');
+  if (!['fix-back', 'local-fix-back', 'ci-fix-back'].includes(value.mode)) {
+    fail(
+      'issue-to-pr input.mode',
+      'must be new-pr, local-new, fix-back, local-fix-back, or ci-fix-back',
+    );
   }
-  assertPr(value.existing_pr, 'issue-to-pr input.existing_pr');
-  if (value.existing_pr.head_branch !== value.branch || value.blockers.length === 0) {
-    fail('issue-to-pr input', 'fix-back PR identity and at least one blocker are required');
+  if (value.mode === 'local-fix-back') {
+    if (value.existing_pr !== null || value.blockers.length === 0) {
+      fail(
+        'issue-to-pr input',
+        'local-fix-back requires blockers and must not carry PR identity',
+      );
+    }
+  } else {
+    assertPr(value.existing_pr, 'issue-to-pr input.existing_pr');
+    if (value.existing_pr.head_branch !== value.branch || value.blockers.length === 0) {
+      fail('issue-to-pr input', 'remote fix-back PR identity and blockers are required');
+    }
   }
   if (value.blockers.some((blocker) => blocker.fix_back_eligible !== true)) {
     fail(
@@ -154,9 +166,9 @@ export const assertIssueToPrIdentity = (input, identity) => {
   if (identity.branch !== input.branch || identity.worktree !== input.worktree || identity.checked_out_branch !== input.branch) {
     fail('issue-to-pr identity', 'branch, worktree, and checked-out branch must match input');
   }
-  if (input.mode === 'new-pr') {
+  if (['new-pr', 'local-new', 'local-fix-back'].includes(input.mode)) {
     if (identity.pr !== null) {
-      fail('issue-to-pr identity.PR', 'new-pr must not reuse a PR');
+      fail('issue-to-pr identity.PR', 'local or new implementation must not reuse a PR');
     }
     return;
   }
@@ -184,12 +196,23 @@ export const assertIssueToPrResult = (input, result) => {
   ) {
     fail('issue-to-pr typed output identity', 'lane, issue, branch, and worktree must match input');
   }
-  assertPr(result.pr, 'issue-to-pr typed output.pr');
-  if (result.pr.head_branch !== input.branch) {
-    fail('issue-to-pr typed output identity', 'PR head branch must match input branch');
-  }
-  if (input.mode === 'fix-back' && (result.pr.number !== input.existing_pr.number || result.pr.url !== input.existing_pr.url)) {
-    fail('issue-to-pr typed output identity', 'fix-back must retain the existing PR');
+  const localMode = ['local-new', 'local-fix-back'].includes(input.mode);
+  if (localMode) {
+    if (result.pr !== null) {
+      fail('issue-to-pr typed output.pr', 'local modes must return before PR creation');
+    }
+  } else {
+    assertPr(result.pr, 'issue-to-pr typed output.pr');
+    if (result.pr.head_branch !== input.branch) {
+      fail('issue-to-pr typed output identity', 'PR head branch must match input branch');
+    }
+    if (
+      ['fix-back', 'ci-fix-back'].includes(input.mode) &&
+      (result.pr.number !== input.existing_pr.number ||
+        result.pr.url !== input.existing_pr.url)
+    ) {
+      fail('issue-to-pr typed output identity', 'remote fix-back must retain the existing PR');
+    }
   }
   assertSha(result.previous_head_sha, 'issue-to-pr typed output.previous_head_sha');
   assertSha(result.head_sha, 'issue-to-pr typed output.head_sha');
@@ -220,7 +243,13 @@ export const assertIssueToPrResult = (input, result) => {
     result.addressed_blockers,
     result.remaining_blockers,
   );
-  const expectedFixBackResult = input.mode === 'fix-back' ? 'remediated' : 'not-applicable';
+  const expectedFixBackResult = [
+    'fix-back',
+    'local-fix-back',
+    'ci-fix-back',
+  ].includes(input.mode)
+    ? 'remediated'
+    : 'not-applicable';
   if (result.fix_back_result !== expectedFixBackResult) {
     fail('issue-to-pr typed output', 'completion requires the canonical mode result');
   }

--- a/.agents/skills/pr-to-merge/references/reviewers/code.md
+++ b/.agents/skills/pr-to-merge/references/reviewers/code.md
@@ -1,8 +1,8 @@
 # Code reviewer
 
-You are the read-only `code` member of the `$pr-to-merge` triad. Review every
+You are the read-only `code` member of a Fluo three-axis triad. Review every
 changed file and enough surrounding callers, dependencies, and tests to detect
-concrete merge risks at one immutable PR head.
+concrete risks at one immutable local or PR head.
 
 ## Review scope
 
@@ -13,7 +13,7 @@ concrete merge risks at one immutable PR head.
 - runtime, adapter, and environment isolation
 - input boundaries and typed error handling
 - regression tests and whether they can fail for the claimed behavior
-- scope discipline and unrelated changes introduced by the PR
+- scope discipline and unrelated changes introduced by the local or PR diff
 
 ## Key questions
 
@@ -59,10 +59,11 @@ concrete merge risks at one immutable PR head.
 
 ## Same-head and authority rules
 
-Review only the supplied 40-character head SHA. If the observed PR head differs,
-stop rather than mixing revisions. Use only read-only repository, `gh`, and
-`git` inspection. Do not edit, merge, approve, comment, push, publish, rerun
-checks, clean up, or change repository or GitHub state.
+Review only the supplied 40-character head SHA. In `local-pre-pr`, inspect the
+worktree commit against its captured base. In `remote-pr`, stop if the observed
+PR head differs. Use only read-only repository, `gh`, and `git` inspection. Do
+not edit, merge, approve, comment, push, publish, rerun checks, clean up, or
+change repository or GitHub state.
 
 ## Result
 

--- a/.agents/skills/pr-to-merge/references/reviewers/contract.md
+++ b/.agents/skills/pr-to-merge/references/reviewers/contract.md
@@ -1,13 +1,15 @@
 # Contract reviewer
 
-You are the read-only `contract` member of the `$pr-to-merge` triad. Decide
-whether one PR at one immutable head satisfies issue intent, documented
-behavior, companion-surface obligations, and release governance.
+You are the read-only `contract` member of a Fluo three-axis triad. The supplied
+surface is either `local-pre-pr` or `remote-pr`. Decide whether one immutable
+head satisfies issue intent, documented behavior, companion-surface
+obligations, and release governance.
 
 ## Review scope
 
 - linked issue acceptance criteria and explicit non-goals
-- PR title, body, template axes, and claimed verification
+- linked issue plus the local diff for `local-pre-pr`
+- PR title, body, template axes, and claimed verification for `remote-pr`
 - changed package README and README.ko.md contracts
 - affected public exports, defaults, errors, lifecycle, and adapter behavior
 - relevant `docs/contracts/*`, `docs/reference/*`, book, and examples
@@ -50,7 +52,8 @@ Use a more specific package contract when it governs the changed behavior.
   `BLOCK` when the remediation is concrete.
 - A public package change without a Changeset and without a valid no-release
   rationale is `BLOCK`.
-- Missing linked intent that the PR body and contracts cannot reconstruct is
+- Missing linked intent that the supplied issue, PR body when present, and
+  contracts cannot reconstruct is
   `NEEDS-HUMAN-CHECK`, not a speculative blocker.
 - Ambiguous security, privacy, legal, release-policy, or cross-lane ownership
   decisions are `NEEDS-HUMAN-CHECK`.
@@ -61,10 +64,11 @@ Use a more specific package contract when it governs the changed behavior.
 
 ## Same-head and authority rules
 
-Review only the supplied 40-character head SHA. If the observed PR head differs,
-stop rather than reviewing mixed evidence. Use only read-only repository, `gh`,
-and `git` inspection. Do not edit, merge, approve, comment, push, publish,
-rerun checks, clean up, or change repository or GitHub state.
+Review only the supplied 40-character head SHA. In `local-pre-pr`, compare the
+worktree head and base diff; a PR must not be required. In `remote-pr`, stop if
+the observed PR head differs. Use only read-only repository, `gh`, and `git`
+inspection. Do not edit, merge, approve, comment, push, publish, rerun checks,
+clean up, or change repository or GitHub state.
 
 ## Result
 

--- a/.agents/skills/pr-to-merge/references/reviewers/verification.md
+++ b/.agents/skills/pr-to-merge/references/reviewers/verification.md
@@ -1,12 +1,13 @@
 # Verification reviewer
 
-You are the read-only `verification` member of the `$pr-to-merge` triad. Decide
-whether the exact PR head has current, relevant, and sufficient evidence for
-the behavior and scope it changes.
+You are the read-only `verification` member of a Fluo three-axis triad. Decide
+whether the exact local or PR head has current, relevant, and sufficient
+evidence for the behavior and scope it changes.
 
 ## Review scope
 
-- current required and optional PR checks for the supplied head
+- local canonical verifier evidence for `local-pre-pr`
+- current required and optional PR checks for `remote-pr`
 - canonical verifier use for the affected packages and tooling
 - build, typecheck, lint, test, and package-specific diagnostics
 - regression evidence for behavioral changes and bug fixes
@@ -29,7 +30,7 @@ the behavior and scope it changes.
 
 ## Verification rules
 
-- A relevant failed or missing required check is `BLOCK`.
+- A relevant failed local verifier or remote required check is `BLOCK`.
 - Missing regression evidence for a behavioral change is `BLOCK`.
 - A noncanonical, narrowed, or unrelated substitute for required verification
   is `BLOCK`.
@@ -53,11 +54,12 @@ the behavior and scope it changes.
 
 ## Same-head and authority rules
 
-Review only the supplied 40-character head SHA and current checks attached to
-that head. If the observed PR head differs, stop rather than mixing revisions.
-Use existing evidence and read-only repository, `gh`, and `git` inspection.
-Do not edit, merge, approve, comment, push, publish, rerun or cancel checks,
-clean up, or change repository or GitHub state.
+Review only the supplied 40-character head SHA. For `local-pre-pr`, require
+captured local verifier output against that head. For `remote-pr`, require
+current checks attached to that head and stop if the observed PR head differs.
+Use existing evidence and read-only repository, `gh`, and `git` inspection. Do
+not edit, merge, approve, comment, push, publish, rerun or cancel checks, clean
+up, or change repository or GitHub state.
 
 ## Result
 

--- a/.agents/workflow-contracts/contracts.mjs
+++ b/.agents/workflow-contracts/contracts.mjs
@@ -7,6 +7,8 @@ import { isRecord, schemaFailure } from './schema-validator.mjs';
 export const contractNames = [
   'search-artifact-v2',
   'lane-ledger-v2',
+  'lane-dag-binding',
+  'local-review-verdict',
   'review-verdict',
   'blocker',
   'receipt',
@@ -131,6 +133,32 @@ const assertSemanticContract = (name, value) => {
     case 'lane-ledger-v2':
       assertSafeBranch(value.base_branch);
       assertLaneLedgerSemantics(value);
+      return;
+    case 'lane-dag-binding':
+      if (
+        value.dag_key !==
+        `fluo:lane:${value.lane_id}:issue-supervisors:v1`
+      ) {
+        fail(name, 'dag_key must be canonical for lane_id');
+      }
+      return;
+    case 'local-review-verdict':
+      if (
+        ['ready-for-pr', 'ready-for-push'].includes(value.verdict) &&
+        (value.blockers.length !== 0 ||
+          Object.values(value.reviewers).some((signal) => signal !== 'PASS'))
+      ) {
+        fail(name, 'ready verdict requires all reviewers PASS and no blockers');
+      }
+      if (value.verdict === 'block' && value.blockers.length === 0) {
+        fail(name, 'block verdict must contain at least one blocker');
+      }
+      if (
+        value.verdict === 'needs-human-check' &&
+        !Object.values(value.reviewers).includes('NEEDS-HUMAN-CHECK')
+      ) {
+        fail(name, 'needs-human-check requires one reviewer escalation');
+      }
       return;
     case 'review-verdict':
       if (value.verdict === 'pass' && value.blockers.length !== 0) {

--- a/.agents/workflow-contracts/lane-dag-binding.schema.json
+++ b/.agents/workflow-contracts/lane-dag-binding.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://fluo.dev/schemas/omo/lane-dag-binding.schema.json",
+  "title": "OMO lane DAG run binding",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "lane_id",
+    "dag_key",
+    "run_id",
+    "definition_sha256",
+    "snapshot_event_hash",
+    "status"
+  ],
+  "properties": {
+    "version": { "const": 1 },
+    "lane_id": {
+      "type": "string",
+      "pattern": "^(?!.*(?:\\.|\\.lock)$)[A-Za-z0-9][A-Za-z0-9._-]*$"
+    },
+    "dag_key": { "type": "string", "minLength": 1 },
+    "run_id": { "type": "string", "minLength": 1 },
+    "definition_sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "snapshot_event_hash": {
+      "oneOf": [
+        { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+        { "type": "null" }
+      ]
+    },
+    "status": { "const": "attached" }
+  }
+}

--- a/.agents/workflow-contracts/local-review-verdict.schema.json
+++ b/.agents/workflow-contracts/local-review-verdict.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://fluo.dev/schemas/omo/local-review-verdict.schema.json",
+  "title": "OMO local pre-PR review verdict",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "lane_id",
+    "issue_number",
+    "verdict",
+    "head_sha",
+    "reviewers",
+    "blockers"
+  ],
+  "properties": {
+    "version": { "const": 1 },
+    "lane_id": { "type": "string", "minLength": 1 },
+    "issue_number": { "type": "integer", "minimum": 1 },
+    "verdict": {
+      "enum": ["ready-for-pr", "ready-for-push", "block", "needs-human-check"]
+    },
+    "head_sha": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{40}$"
+    },
+    "reviewers": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["contract", "code", "verification"],
+      "properties": {
+        "contract": { "enum": ["PASS", "BLOCK", "NEEDS-HUMAN-CHECK"] },
+        "code": { "enum": ["PASS", "BLOCK", "NEEDS-HUMAN-CHECK"] },
+        "verification": {
+          "enum": ["PASS", "BLOCK", "NEEDS-HUMAN-CHECK"]
+        }
+      }
+    },
+    "blockers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "reviewer",
+          "signature",
+          "evidence",
+          "fix_back_eligible",
+          "status"
+        ],
+        "properties": {
+          "reviewer": { "enum": ["contract", "code", "verification"] },
+          "signature": { "type": "string", "minLength": 1 },
+          "evidence": { "type": "string", "minLength": 1 },
+          "fix_back_eligible": { "type": "boolean" },
+          "status": { "const": "unresolved" }
+        }
+      }
+    }
+  }
+}

--- a/plans/three-stage-lane-workflow.md
+++ b/plans/three-stage-lane-workflow.md
@@ -33,6 +33,8 @@ The shared source of truth is `.agents/workflow-contracts/`:
 
 - `search-artifact-v2.schema.json`
 - `lane-ledger-v2.schema.json`
+- `lane-dag-binding.schema.json`
+- `local-review-verdict.schema.json`
 - `review-verdict.schema.json`
 - `blocker.schema.json`
 - `receipt.schema.json`
@@ -100,19 +102,25 @@ skills never load archived command or role definitions.
    exists so removing the handoff array cannot bypass provenance checks. Use
    the canonical published ledger as the marker when validating persisted
    snapshots so removing both fields cannot impersonate a legacy ledger.
-5. Dispatch implementation through `.agents/skills/issue-to-pr/SKILL.md`.
-6. Aggregate exactly one contract, code, and verification result through
-   `.agents/skills/pr-to-merge/SKILL.md`.
-7. Fix eligible blockers on the same branch, worktree, and PR, and require a
-   new head plus exact blocker reconciliation.
-8. Record merge success only from a lead-owned observed squash merge bound to
-   the current PR and head, with the linked issue observed `CLOSED`.
-9. Cleanup only after merge observation; retain a terminal blocker when any
+5. Compile one native DAG issue-supervisor node per approved issue and mirror
+   the canonical dependency graph through `dependsOn`.
+6. Implement and locally verify one commit head, then aggregate exactly one
+   contract, code, and verification result before any push or PR creation.
+7. Treat the successful local verdict as `ready-for-pr`, not `merge`. Fix local
+   blockers on the same branch and worktree, requiring a new head and a fresh
+   complete triad.
+8. After PR creation, bind required CI to the reviewed PR head. A fixable CI
+   failure returns to implementation and the local triad before the next push.
+9. Record merge success only after CI PASS and an issue-supervisor-owned live
+   squash merge observation bound to the reviewed PR head, with the linked
+   issue observed `CLOSED`.
+10. Cleanup only after merge observation; retain a terminal blocker when any
    worktree/local-branch/remote-branch removal is incomplete.
-10. Sync the clean root with a lead-owned `git pull --ff-only` observation.
-11. Append events, atomically replace the snapshot, record target-bound
-    receipts, and release the lease after every transition.
-12. Run the canonical ledger verifier before final reporting.
+11. Sync the clean root with a parent-lead `git pull --ff-only` observation
+    only after every issue-supervisor DAG node is terminal.
+12. Append events, atomically replace the snapshot, record target-bound
+   receipts, and release the lease after every transition.
+13. Run the canonical ledger verifier before final reporting.
 
 ## Verification
 
@@ -125,6 +133,7 @@ pnpm exec vitest run \
   tooling/governance/create-lane-native.test.ts \
   tooling/governance/create-lane-multi.test.ts \
   tooling/governance/execute-lane-native.test.ts \
+  tooling/governance/execute-lane-dag-supervisor.test.ts \
   tooling/governance/execute-lane-persistence.test.ts \
   tooling/governance/execute-lane-resilience.test.ts \
   tooling/governance/execute-lane-authority.test.ts \

--- a/tooling/governance/execute-lane-dag-supervisor.test.ts
+++ b/tooling/governance/execute-lane-dag-supervisor.test.ts
@@ -1,0 +1,1111 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+type DagNode = Readonly<{
+  id: string;
+  category: string;
+  dependsOn: readonly string[];
+  load_skills: readonly string[];
+  prompt: string;
+}>;
+type DagDefinition = Readonly<{
+  key: string;
+  name: string;
+  nodes: readonly DagNode[];
+}>;
+type DagBinding = Readonly<{
+  version: number;
+  lane_id: string;
+  dag_key: string;
+  run_id: string;
+  definition_sha256: string;
+  snapshot_event_hash: string | null;
+  status: string;
+}>;
+type SupervisorState = Readonly<{
+  lane_id: string;
+  issue_number: number;
+  head_sha: string;
+  status: string;
+  blockers: readonly Blocker[];
+  pr: null | Readonly<Record<string, unknown>>;
+  ci: null | Readonly<Record<string, unknown>>;
+  local_review: null | {
+    verdict: string;
+    head_sha: string;
+    reviewers: Readonly<Record<string, string>>;
+  };
+}>;
+
+const {
+  createIssueSupervisor,
+  transitionIssueSupervisor,
+} = (await import(
+  resolve(
+    process.cwd(),
+    '.agents/skills/execute-lane/scripts/issue-supervisor.mjs',
+  )
+)) as {
+  createIssueSupervisor: (identity: unknown) => SupervisorState;
+  transitionIssueSupervisor: (
+    state: SupervisorState,
+    transition: unknown,
+  ) => SupervisorState;
+};
+const { compileLaneSupervisorDag } = (await import(
+  resolve(
+    process.cwd(),
+    '.agents/skills/execute-lane/scripts/compile-dag.mjs',
+  )
+)) as {
+  compileLaneSupervisorDag: (ledger: unknown) => DagDefinition;
+};
+const {
+  assertDagBindingMatches,
+  createDagBinding,
+  loadDagBinding,
+  persistDagBinding,
+} = (await import(
+  resolve(
+    process.cwd(),
+    '.agents/skills/execute-lane/scripts/dag-binding.mjs',
+  )
+)) as {
+  assertDagBindingMatches: (
+    binding: DagBinding,
+    expected: {
+      definition: DagDefinition;
+      lane_id: string;
+      run_id: string;
+      snapshot_event_hash: string | null;
+    },
+  ) => void;
+  createDagBinding: (input: {
+    definition: DagDefinition;
+    lane_id: string;
+    run_id: string;
+    snapshot_event_hash: string | null;
+  }) => DagBinding;
+  loadDagBinding: (runtimeRoot: string, laneId: string) => DagBinding | null;
+  persistDagBinding: (runtimeRoot: string, binding: DagBinding) => void;
+};
+const {
+  applyIssueSupervisorTransition,
+  initialiseIssueSupervisorStore,
+  loadIssueSupervisorStore,
+} = (await import(
+  resolve(
+    process.cwd(),
+    '.agents/skills/execute-lane/scripts/issue-supervisor-store.mjs',
+  )
+)) as {
+  applyIssueSupervisorTransition: (
+    runtimeRoot: string,
+    laneId: string,
+    issueNumber: number,
+    transition: unknown,
+  ) => {
+    snapshot: SupervisorState;
+    events: readonly Readonly<Record<string, unknown>>[];
+    receipts: readonly Readonly<Record<string, unknown>>[];
+  };
+  initialiseIssueSupervisorStore: (
+    runtimeRoot: string,
+    identity: unknown,
+  ) => {
+    snapshot: SupervisorState;
+    events: readonly Readonly<Record<string, unknown>>[];
+    receipts: readonly Readonly<Record<string, unknown>>[];
+  };
+  loadIssueSupervisorStore: (
+    runtimeRoot: string,
+    laneId: string,
+    issueNumber: number,
+  ) => {
+    snapshot: SupervisorState;
+    events: readonly Readonly<Record<string, unknown>>[];
+    receipts: readonly Readonly<Record<string, unknown>>[];
+  } | null;
+};
+const { importSupervisorTerminal } = (await import(
+  resolve(
+    process.cwd(),
+    '.agents/skills/execute-lane/scripts/supervisor-terminal.mjs',
+  )
+)) as {
+  importSupervisorTerminal: (
+    persisted: {
+      snapshot: unknown;
+      events: readonly unknown[];
+      receipts: readonly unknown[];
+    },
+    supervisorBundle: {
+      snapshot: SupervisorState;
+      events: readonly Readonly<Record<string, unknown>>[];
+      receipts: readonly Readonly<Record<string, unknown>>[];
+    },
+    liveCompletion?: Readonly<Record<string, unknown>> | null,
+    releaseHandoffContext?: {
+      receipt: Readonly<Record<string, unknown>>;
+      artifact: Readonly<Record<string, unknown>>;
+      artifact_path: string;
+    } | null,
+  ) => {
+    snapshot: Readonly<Record<string, unknown>>;
+    events: readonly unknown[];
+    receipts: readonly unknown[];
+  };
+};
+
+const headA = 'a'.repeat(40);
+const headB = 'b'.repeat(40);
+const headC = 'c'.repeat(40);
+const observedAt = '2026-08-25T00:00:00.000Z';
+
+type Blocker = Readonly<{
+  reviewer: string;
+  signature: string;
+  evidence: string;
+  fix_back_eligible: boolean;
+  status: string;
+}>;
+
+const remediate = (blockers: readonly Blocker[]) =>
+  blockers.map((blocker) => ({
+    reviewer: blocker.reviewer,
+    signature: blocker.signature,
+    evidence: blocker.evidence,
+    fix_back_eligible: blocker.fix_back_eligible,
+    status: 'remediated',
+  }));
+
+const persistedLifecycle = (
+  identityValue: unknown,
+  transitions: readonly unknown[],
+) => {
+  const directory = mkdtempSync(
+    join(realpathSync(tmpdir()), 'fluo-terminal-bundle-'),
+  );
+  const runtimeRoot = join(directory, 'lane-runs');
+  try {
+    let bundle = initialiseIssueSupervisorStore(runtimeRoot, identityValue);
+    for (const transition of transitions) {
+      bundle = applyIssueSupervisorTransition(
+        runtimeRoot,
+        bundle.snapshot.lane_id,
+        bundle.snapshot.issue_number,
+        transition,
+      );
+    }
+    return bundle;
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+};
+
+const identity = {
+  lane_id: 'lane-4101-runtime',
+  issue_number: 4101,
+  branch: 'issue-4101-runtime',
+  worktree: '.worktrees/issue-4101-runtime',
+  starting_head_sha: '0'.repeat(40),
+  started_at: observedAt,
+  release_handoff: false,
+  authority_scope: {
+    pr_creation: true,
+    pr_merge: true,
+    cleanup_command_worktrees: true,
+  },
+  retry_policy: {
+    retry_count_is_terminal: true,
+    max_same_failure_repeats: 3,
+    max_wall_clock_minutes: 180,
+    stop_on_child_contract_error: true,
+  },
+} as const;
+
+const observationBase = (head: string) => ({
+  authority: 'issue-supervisor',
+  lane_id: identity.lane_id,
+  issue_number: identity.issue_number,
+  branch: identity.branch,
+  worktree: identity.worktree,
+  head_sha: head,
+  observed_at: observedAt,
+});
+
+const prReceipt = (kind: 'pr-create' | 'pr-update', head: string) => ({
+  ...observationBase(head),
+  kind,
+  pr_number: 5101,
+  pr_url: 'https://github.com/fluojs/fluo/pull/5101',
+  remote_head_sha: head,
+  pr_head_sha: head,
+});
+
+const passReviews = (head: string) =>
+  ['contract', 'code', 'verification'].map((reviewer) => ({
+    reviewer,
+    reviewed_head_sha: head,
+    verdict_signal: 'PASS',
+    blockers: [],
+  }));
+
+describe('execute-lane issue supervisor lifecycle', () => {
+  it('rejects non-canonical issue branch and worktree identity', () => {
+    expect(() =>
+      createIssueSupervisor({
+        ...identity,
+        branch: '../../main',
+        worktree: '.worktrees/../../main',
+      }),
+    ).toThrow(/canonical issue branch/u);
+    expect(() =>
+      createIssueSupervisor({
+        ...identity,
+        branch: 'issue-99-wrong',
+        worktree: '.worktrees/issue-99-wrong',
+      }),
+    ).toThrow(/canonical issue branch/u);
+  });
+
+  it('requires a same-head local triad before becoming ready for PR', () => {
+    let state = createIssueSupervisor(identity);
+
+    state = transitionIssueSupervisor(state, {
+      kind: 'implementation-completed',
+      new_head: headA,
+      verification: 'pnpm test --filter runtime passed',
+    });
+    expect(state.status).toBe('local-review');
+
+    state = transitionIssueSupervisor(state, {
+      kind: 'local-review',
+      reviews: [
+        passReviews(headA)[0],
+        {
+          reviewer: 'code',
+          reviewed_head_sha: headA,
+          verdict_signal: 'BLOCK',
+          blockers: [
+            {
+              reviewer: 'code',
+              signature: 'runtime:worker:abort-path',
+              evidence: 'packages/runtime/src/worker.ts:42',
+              fix_back_eligible: true,
+              status: 'unresolved',
+            },
+          ],
+        },
+        passReviews(headA)[2],
+      ],
+    });
+    expect(state.status).toBe('implementing');
+
+    state = transitionIssueSupervisor(state, {
+      kind: 'fix-completed',
+      new_head: headB,
+      observed_at: observedAt,
+      verification: 'pnpm test --filter runtime passed',
+      addressed_blockers: remediate(state.blockers as readonly Blocker[]),
+    });
+    expect(state.status).toBe('local-review');
+
+    state = transitionIssueSupervisor(state, {
+      kind: 'local-review',
+      reviews: passReviews(headB),
+    });
+
+    expect(state.status).toBe('ready-for-pr');
+    expect(state.local_review).toMatchObject({
+      verdict: 'ready-for-pr',
+      head_sha: headB,
+      reviewers: {
+        contract: 'PASS',
+        code: 'PASS',
+        verification: 'PASS',
+      },
+    });
+  });
+
+  it('returns a failed PR check through local fix-back before merge', () => {
+    let state = createIssueSupervisor(identity);
+    state = transitionIssueSupervisor(state, {
+      kind: 'implementation-completed',
+      new_head: headA,
+      verification: 'pnpm test --filter runtime passed',
+    });
+    state = transitionIssueSupervisor(state, {
+      kind: 'local-review',
+      reviews: passReviews(headA),
+    });
+    state = transitionIssueSupervisor(state, {
+      kind: 'pr-observed',
+      action: 'create',
+      receipt: prReceipt('pr-create', headA),
+    });
+    expect(state.status).toBe('ci-pending');
+
+    state = transitionIssueSupervisor(state, {
+      kind: 'ci-observed',
+      receipt: {
+        ...observationBase(headA),
+        kind: 'ci',
+        pr_number: 5101,
+        pr_url: 'https://github.com/fluojs/fluo/pull/5101',
+        result: 'fixable-failure',
+        evidence: 'runtime test failed on the reviewed head',
+      },
+    });
+    expect(state.status).toBe('ci-fix-back');
+
+    state = transitionIssueSupervisor(state, {
+      kind: 'fix-completed',
+      new_head: headB,
+      observed_at: observedAt,
+      verification: 'pnpm test --filter runtime passed',
+      addressed_blockers: remediate(state.blockers as readonly Blocker[]),
+    });
+    state = transitionIssueSupervisor(state, {
+      kind: 'local-review',
+      reviews: passReviews(headB),
+    });
+    expect(state.status).toBe('ready-for-push');
+
+    state = transitionIssueSupervisor(state, {
+      kind: 'pr-observed',
+      action: 'update',
+      receipt: prReceipt('pr-update', headB),
+    });
+    state = transitionIssueSupervisor(state, {
+      kind: 'ci-observed',
+      receipt: {
+        ...observationBase(headB),
+        kind: 'ci',
+        pr_number: 5101,
+        pr_url: 'https://github.com/fluojs/fluo/pull/5101',
+        result: 'pass',
+        evidence: 'all required checks passed',
+      },
+    });
+    expect(state.status).toBe('merge-ready');
+
+    state = transitionIssueSupervisor(state, {
+      kind: 'merge-observed',
+      receipt: {
+        ...observationBase(headB),
+        kind: 'merge',
+        pr_number: 5101,
+        pr_url: 'https://github.com/fluojs/fluo/pull/5101',
+        reviewed_head_sha: headB,
+        remote_head_sha: headB,
+        pr_head_sha: headB,
+        ci_head_sha: headB,
+        merge_method: 'squash',
+        pr_state: 'MERGED',
+        issue_state: 'CLOSED',
+        merge_commit_sha: 'c'.repeat(40),
+      },
+    });
+    state = transitionIssueSupervisor(state, {
+      kind: 'cleanup-observed',
+      receipt: {
+        ...observationBase(headB),
+        kind: 'cleanup',
+        pr_number: 5101,
+        pr_url: 'https://github.com/fluojs/fluo/pull/5101',
+        worktree_removed: true,
+        local_branch_deleted: true,
+        remote_branch_deleted: true,
+      },
+    });
+
+    expect(state.status).toBe('done');
+  });
+
+  it('fails closed on forged state, missing authority, and exhausted retries', () => {
+    let state = createIssueSupervisor({
+      ...identity,
+      authority_scope: {
+        ...identity.authority_scope,
+        pr_creation: false,
+      },
+      retry_policy: {
+        ...identity.retry_policy,
+        max_same_failure_repeats: 1,
+      },
+    });
+    state = transitionIssueSupervisor(state, {
+      kind: 'implementation-completed',
+      new_head: headA,
+      verification: 'focused tests passed',
+    });
+    const blockingReviews = [
+      passReviews(headA)[0],
+      {
+        reviewer: 'code',
+        reviewed_head_sha: headA,
+        verdict_signal: 'BLOCK',
+        blockers: [
+          {
+            reviewer: 'code',
+            signature: 'runtime:worker:abort-path',
+            evidence: 'packages/runtime/src/worker.ts:42',
+            fix_back_eligible: true,
+            status: 'unresolved',
+          },
+        ],
+      },
+      passReviews(headA)[2],
+    ];
+    state = transitionIssueSupervisor(state, {
+      kind: 'local-review',
+      reviews: blockingReviews,
+    });
+    expect(() =>
+      transitionIssueSupervisor(state, {
+        kind: 'implementation-completed',
+        new_head: headB,
+        verification: 'bypass attempt',
+      }),
+    ).toThrow(/fix-completed/u);
+
+    state = transitionIssueSupervisor(state, {
+      kind: 'fix-completed',
+      new_head: headB,
+      observed_at: observedAt,
+      verification: 'focused tests passed',
+      addressed_blockers: remediate(state.blockers as readonly Blocker[]),
+    });
+    state = transitionIssueSupervisor(state, {
+      kind: 'local-review',
+      reviews: blockingReviews.map((review) => ({
+        ...review,
+        reviewed_head_sha: headB,
+      })),
+    });
+    state = transitionIssueSupervisor(state, {
+      kind: 'fix-completed',
+      new_head: headC,
+      observed_at: observedAt,
+      verification: 'focused tests passed',
+      addressed_blockers: remediate(state.blockers as readonly Blocker[]),
+    });
+    expect(state.status).toBe('blocked-budget-exhausted');
+
+    let ready = createIssueSupervisor({
+      ...identity,
+      authority_scope: {
+        ...identity.authority_scope,
+        pr_creation: false,
+      },
+    });
+    ready = transitionIssueSupervisor(ready, {
+      kind: 'implementation-completed',
+      new_head: headA,
+      verification: 'focused tests passed',
+    });
+    ready = transitionIssueSupervisor(ready, {
+      kind: 'local-review',
+      reviews: passReviews(headA),
+    });
+    expect(() =>
+      transitionIssueSupervisor(ready, {
+        kind: 'pr-observed',
+        action: 'create',
+        receipt: prReceipt('pr-create', headA),
+      }),
+    ).toThrow(/pr_creation/u);
+
+    expect(() =>
+      transitionIssueSupervisor(
+        {
+          ...ready,
+          status: 'merge-ready',
+          pr: null,
+          ci: null,
+        },
+        {
+          kind: 'merge-observed',
+          receipt: {
+            ...observationBase(headA),
+            kind: 'merge',
+            pr_number: 5101,
+            pr_url: 'https://github.com/fluojs/fluo/pull/5101',
+            reviewed_head_sha: headA,
+            remote_head_sha: headA,
+            pr_head_sha: headA,
+            ci_head_sha: headA,
+            merge_method: 'squash',
+            pr_state: 'MERGED',
+            issue_state: 'CLOSED',
+            merge_commit_sha: headC,
+          },
+        },
+      ),
+    ).toThrow(/state invariant/u);
+  });
+
+  it('persists each supervisor transition and target-bound receipt', () => {
+    const directory = mkdtempSync(
+      join(realpathSync(tmpdir()), 'fluo-issue-supervisor-'),
+    );
+    const runtimeRoot = join(directory, 'lane-runs');
+    try {
+      let stored = initialiseIssueSupervisorStore(runtimeRoot, identity);
+      expect(stored.events).toHaveLength(1);
+      const leasePath = resolve(
+        runtimeRoot,
+        identity.lane_id,
+        'issues',
+        String(identity.issue_number),
+        'lease.lock',
+      );
+      writeFileSync(leasePath, 'held\n', { encoding: 'utf8', flag: 'wx' });
+      expect(() =>
+        applyIssueSupervisorTransition(
+          runtimeRoot,
+          identity.lane_id,
+          identity.issue_number,
+          {
+            kind: 'implementation-completed',
+            new_head: headA,
+            verification: 'focused tests passed',
+          },
+        ),
+      ).toThrow(/lease is already held/u);
+      unlinkSync(leasePath);
+      expect(() =>
+        loadIssueSupervisorStore(
+          runtimeRoot,
+          identity.lane_id,
+          '../../4102' as unknown as number,
+        ),
+      ).toThrow(/positive integer/u);
+      stored = applyIssueSupervisorTransition(
+        runtimeRoot,
+        identity.lane_id,
+        identity.issue_number,
+        {
+          kind: 'implementation-completed',
+          new_head: headA,
+          verification: 'focused tests passed',
+        },
+      );
+      stored = applyIssueSupervisorTransition(
+        runtimeRoot,
+        identity.lane_id,
+        identity.issue_number,
+        {
+          kind: 'local-review',
+          reviews: passReviews(headA),
+        },
+      );
+      stored = applyIssueSupervisorTransition(
+        runtimeRoot,
+        identity.lane_id,
+        identity.issue_number,
+        {
+          kind: 'pr-observed',
+          action: 'create',
+          receipt: prReceipt('pr-create', headA),
+        },
+      );
+
+      expect(stored.snapshot.status).toBe('ci-pending');
+      expect(stored.events).toHaveLength(4);
+      expect(stored.receipts).toEqual([prReceipt('pr-create', headA)]);
+      expect(
+        loadIssueSupervisorStore(
+          runtimeRoot,
+          identity.lane_id,
+          identity.issue_number,
+        ),
+      ).toEqual(stored);
+      expect(() =>
+        initialiseIssueSupervisorStore(runtimeRoot, {
+          ...identity,
+          starting_head_sha: headB,
+        }),
+      ).toThrow(/identity conflict/u);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('imports only terminal supervisor evidence into the shared lane', () => {
+    let state = createIssueSupervisor(identity);
+    state = transitionIssueSupervisor(state, {
+      kind: 'implementation-completed',
+      new_head: headA,
+      verification: 'focused tests passed',
+    });
+    state = transitionIssueSupervisor(state, {
+      kind: 'local-review',
+      reviews: passReviews(headA),
+    });
+    state = transitionIssueSupervisor(state, {
+      kind: 'pr-observed',
+      action: 'create',
+      receipt: prReceipt('pr-create', headA),
+    });
+    state = transitionIssueSupervisor(state, {
+      kind: 'ci-observed',
+      receipt: {
+        ...observationBase(headA),
+        kind: 'ci',
+        pr_number: 5101,
+        pr_url: 'https://github.com/fluojs/fluo/pull/5101',
+        result: 'pass',
+        evidence: 'all required checks passed',
+      },
+    });
+    state = transitionIssueSupervisor(state, {
+      kind: 'merge-observed',
+      receipt: {
+        ...observationBase(headA),
+        kind: 'merge',
+        pr_number: 5101,
+        pr_url: 'https://github.com/fluojs/fluo/pull/5101',
+        reviewed_head_sha: headA,
+        remote_head_sha: headA,
+        pr_head_sha: headA,
+        ci_head_sha: headA,
+        merge_method: 'squash',
+        pr_state: 'MERGED',
+        issue_state: 'CLOSED',
+        merge_commit_sha: headC,
+      },
+    });
+    state = transitionIssueSupervisor(state, {
+      kind: 'cleanup-observed',
+      receipt: {
+        ...observationBase(headA),
+        kind: 'cleanup',
+        pr_number: 5101,
+        pr_url: 'https://github.com/fluojs/fluo/pull/5101',
+        worktree_removed: true,
+        local_branch_deleted: true,
+        remote_branch_deleted: true,
+      },
+    });
+    const ledger = JSON.parse(
+      readFileSync(
+        resolve(
+          process.cwd(),
+          'tooling/governance/fixtures/execute-lane-native/ready-ledger-multi-v2.json',
+        ),
+        'utf8',
+      ),
+    );
+
+    const ciReceipt = {
+      ...observationBase(headA),
+      kind: 'ci',
+      pr_number: 5101,
+      pr_url: 'https://github.com/fluojs/fluo/pull/5101',
+      result: 'pass',
+      evidence: 'all required checks passed',
+    };
+    const mergeReceipt = {
+      ...observationBase(headA),
+      kind: 'merge',
+      pr_number: 5101,
+      pr_url: 'https://github.com/fluojs/fluo/pull/5101',
+      reviewed_head_sha: headA,
+      remote_head_sha: headA,
+      pr_head_sha: headA,
+      ci_head_sha: headA,
+      merge_method: 'squash',
+      pr_state: 'MERGED',
+      issue_state: 'CLOSED',
+      merge_commit_sha: headC,
+    };
+    const cleanupReceipt = {
+      ...observationBase(headA),
+      kind: 'cleanup',
+      pr_number: 5101,
+      pr_url: 'https://github.com/fluojs/fluo/pull/5101',
+      worktree_removed: true,
+      local_branch_deleted: true,
+      remote_branch_deleted: true,
+    };
+    const terminalBundle = persistedLifecycle(identity, [
+        {
+          kind: 'implementation-completed',
+          new_head: headA,
+          verification: 'focused tests passed',
+        },
+        { kind: 'local-review', reviews: passReviews(headA) },
+        {
+          kind: 'pr-observed',
+          action: 'create',
+          receipt: prReceipt('pr-create', headA),
+        },
+        { kind: 'ci-observed', receipt: ciReceipt },
+        { kind: 'merge-observed', receipt: mergeReceipt },
+        { kind: 'cleanup-observed', receipt: cleanupReceipt },
+      ]);
+    const liveCompletion = {
+        issue_number: identity.issue_number,
+        issue_url: `https://github.com/fluojs/fluo/issues/${String(identity.issue_number)}`,
+        pr_number: 5101,
+        pr_url: 'https://github.com/fluojs/fluo/pull/5101',
+        branch: identity.branch,
+        worktree: identity.worktree,
+        reviewed_head_sha: headA,
+        remote_head_sha: headA,
+        pr_head_sha: headA,
+        ci_head_sha: headA,
+        merge_commit_sha: headC,
+        merge_method: 'squash',
+        pr_state: 'MERGED',
+        issue_state: 'CLOSED',
+        cleanup_status: 'done',
+        worktree_removed: true,
+        local_branch_deleted: true,
+        remote_branch_deleted: true,
+      };
+    const imported = importSupervisorTerminal(
+      { snapshot: ledger, events: [], receipts: [] },
+      terminalBundle,
+      liveCompletion,
+    );
+    expect(imported.snapshot.completed_issues).toEqual([4101]);
+    expect(imported.snapshot.issue_progress).toMatchObject({
+      '4101': {
+        status: 'done',
+        reviewed_head: headA,
+        merge_commit: headC,
+        checks: 'PASS',
+      },
+    });
+    expect(imported.snapshot.lanes).toMatchObject([
+      { status: 'queued', current_issue: 4102 },
+    ]);
+    expect(imported.receipts).toHaveLength(4);
+    expect(
+      importSupervisorTerminal(imported, terminalBundle, liveCompletion),
+    ).toEqual(imported);
+  });
+
+  it('imports blocked and release-handoff supervisor terminals', () => {
+    let blocked = createIssueSupervisor(identity);
+    blocked = transitionIssueSupervisor(blocked, {
+      kind: 'implementation-completed',
+      new_head: headA,
+      verification: 'focused tests passed',
+    });
+    blocked = transitionIssueSupervisor(blocked, {
+      kind: 'local-review',
+      reviews: [
+        passReviews(headA)[0],
+        {
+          reviewer: 'code',
+          reviewed_head_sha: headA,
+          verdict_signal: 'NEEDS-HUMAN-CHECK',
+          blockers: [],
+        },
+        passReviews(headA)[2],
+      ],
+    });
+    const ledger = JSON.parse(
+      readFileSync(
+        resolve(
+          process.cwd(),
+          'tooling/governance/fixtures/execute-lane-native/ready-ledger-multi-v2.json',
+        ),
+        'utf8',
+      ),
+    );
+    const blockedImport = importSupervisorTerminal(
+      { snapshot: ledger, events: [], receipts: [] },
+      persistedLifecycle(identity, [
+        {
+          kind: 'implementation-completed',
+          new_head: headA,
+          verification: 'focused tests passed',
+        },
+        {
+          kind: 'local-review',
+          reviews: [
+            passReviews(headA)[0],
+            {
+              reviewer: 'code',
+              reviewed_head_sha: headA,
+              verdict_signal: 'NEEDS-HUMAN-CHECK',
+              blockers: [],
+            },
+            passReviews(headA)[2],
+          ],
+        },
+      ]),
+    );
+    expect(blockedImport.snapshot.lanes).toMatchObject([
+      { status: 'needs-human-check-terminal' },
+    ]);
+    expect(
+      importSupervisorTerminal(
+        blockedImport,
+        persistedLifecycle(identity, [
+          {
+            kind: 'implementation-completed',
+            new_head: headA,
+            verification: 'focused tests passed',
+          },
+          {
+            kind: 'local-review',
+            reviews: [
+              passReviews(headA)[0],
+              {
+                reviewer: 'code',
+                reviewed_head_sha: headA,
+                verdict_signal: 'NEEDS-HUMAN-CHECK',
+                blockers: [],
+              },
+              passReviews(headA)[2],
+            ],
+          },
+        ]),
+      ),
+    ).toEqual(blockedImport);
+
+    const releaseLedger = JSON.parse(
+      readFileSync(
+        resolve(
+          process.cwd(),
+          'tooling/governance/fixtures/execute-lane-native/ready-ledger-release-v2.json',
+        ),
+        'utf8',
+      ),
+    );
+    const releaseIssue = releaseLedger.confirmed_issues[0];
+    const releaseIdentity = {
+      lane_id: releaseLedger.lane_id,
+      issue_number: releaseIssue,
+      branch: `issue-${String(releaseIssue)}-release-handoff`,
+      worktree: `.worktrees/issue-${String(releaseIssue)}-release-handoff`,
+      starting_head_sha: headA,
+      started_at: observedAt,
+      authority_scope: {
+        pr_creation: releaseLedger.authority_scope.pr_creation,
+        pr_merge: releaseLedger.authority_scope.pr_merge,
+        cleanup_command_worktrees:
+          releaseLedger.authority_scope.cleanup_command_worktrees,
+      },
+      retry_policy: {
+        retry_count_is_terminal:
+          releaseLedger.retry_policy.retry_count_is_terminal,
+        max_same_failure_repeats:
+          releaseLedger.retry_policy.max_same_failure_repeats,
+        max_wall_clock_minutes:
+          releaseLedger.retry_policy.max_wall_clock_minutes,
+        stop_on_child_contract_error:
+          releaseLedger.retry_policy.stop_on_child_contract_error,
+      },
+      lane_plan_approval_sha256: releaseLedger.lane_plan_approval_sha256,
+      release_handoff: true,
+    };
+    let release = createIssueSupervisor(releaseIdentity);
+    release = transitionIssueSupervisor(release, {
+      kind: 'release-handoff',
+      approval_sha256: releaseLedger.lane_plan_approval_sha256,
+    });
+    const releaseImport = importSupervisorTerminal(
+      { snapshot: releaseLedger, events: [], receipts: [] },
+      persistedLifecycle(releaseIdentity, [
+        {
+          kind: 'release-handoff',
+          approval_sha256: releaseLedger.lane_plan_approval_sha256,
+        },
+      ]),
+      null,
+      {
+        receipt: JSON.parse(
+          readFileSync(
+            resolve(
+              process.cwd(),
+              'tooling/governance/fixtures/execute-lane-native/release-handoff-approval.json',
+            ),
+            'utf8',
+          ),
+        ),
+        artifact: JSON.parse(
+          readFileSync(
+            resolve(
+              process.cwd(),
+              'tooling/governance/fixtures/execute-lane-native/search-native-release.json',
+            ),
+            'utf8',
+          ),
+        ),
+        artifact_path: releaseLedger.source.search_ledger,
+      },
+    );
+    expect(releaseImport.snapshot.lanes).toMatchObject([
+      { status: 'blocked-maintainer-decision' },
+    ]);
+    expect(
+      importSupervisorTerminal(
+        releaseImport,
+        persistedLifecycle(releaseIdentity, [
+          {
+            kind: 'release-handoff',
+            approval_sha256: releaseLedger.lane_plan_approval_sha256,
+          },
+        ]),
+        null,
+        {
+          receipt: JSON.parse(
+            readFileSync(
+              resolve(
+                process.cwd(),
+                'tooling/governance/fixtures/execute-lane-native/release-handoff-approval.json',
+              ),
+              'utf8',
+            ),
+          ),
+          artifact: JSON.parse(
+            readFileSync(
+              resolve(
+                process.cwd(),
+                'tooling/governance/fixtures/execute-lane-native/search-native-release.json',
+              ),
+              'utf8',
+            ),
+          ),
+          artifact_path: releaseLedger.source.search_ledger,
+        },
+      ),
+    ).toEqual(releaseImport);
+  });
+
+  it('compiles issue dependencies and persists one idempotent DAG binding', () => {
+    const ledger = JSON.parse(
+      readFileSync(
+        resolve(
+          process.cwd(),
+          'tooling/governance/fixtures/execute-lane-native/ready-ledger-multi-v2.json',
+        ),
+        'utf8',
+      ),
+    );
+    const definition = compileLaneSupervisorDag(ledger);
+
+    expect(definition.key).toBe('fluo:lane:lane-4101-runtime:issue-supervisors:v1');
+    expect(definition.nodes).toHaveLength(2);
+    expect(definition.nodes[0]).toMatchObject({
+      id: 'issue-4101-supervisor',
+      dependsOn: [],
+      load_skills: ['execute-lane'],
+    });
+    expect(definition.nodes[1]).toMatchObject({
+      id: 'issue-4102-supervisor',
+      dependsOn: ['issue-4101-supervisor'],
+      load_skills: ['execute-lane'],
+    });
+    expect(definition.nodes[0].prompt).toContain('STOP WHEN:');
+    expect(() =>
+      compileLaneSupervisorDag({
+        ...ledger,
+        dependency_graph: { 4102: [9999] },
+      }),
+    ).toThrow(/dependency|confirmed issue/u);
+    expect(() =>
+      compileLaneSupervisorDag({
+        ...ledger,
+        dependency_graph: { 4101: [4102], 4102: [4101] },
+      }),
+    ).toThrow(/cycle|dependency/u);
+    const releaseLedger = JSON.parse(
+      readFileSync(
+        resolve(
+          process.cwd(),
+          'tooling/governance/fixtures/execute-lane-native/ready-ledger-release-v2.json',
+        ),
+        'utf8',
+      ),
+    );
+    const releaseDefinition = compileLaneSupervisorDag(releaseLedger);
+    expect(releaseDefinition.nodes).toHaveLength(1);
+    expect(releaseDefinition.nodes[0]).toMatchObject({
+      category: 'quick',
+      dependsOn: [],
+    });
+    expect(releaseDefinition.nodes[0].prompt).toContain(
+      'blocked-maintainer-decision',
+    );
+
+    const binding = createDagBinding({
+      definition,
+      lane_id: ledger.lane_id,
+      run_id: 'run_lane_4101',
+      snapshot_event_hash: null,
+    });
+    expect(() =>
+      createDagBinding({
+        definition: { ...definition, key: 'fluo:lane:other:issue-supervisors:v1' },
+        lane_id: ledger.lane_id,
+        run_id: 'run_lane_4101',
+        snapshot_event_hash: null,
+      }),
+    ).toThrow(/canonical for its lane/u);
+    const directory = mkdtempSync(
+      join(realpathSync(tmpdir()), 'fluo-dag-binding-'),
+    );
+    const runtimeRoot = join(directory, 'lane-runs');
+    try {
+      persistDagBinding(runtimeRoot, binding);
+      persistDagBinding(runtimeRoot, binding);
+      expect(loadDagBinding(runtimeRoot, binding.lane_id)).toEqual(binding);
+      expect(() =>
+        assertDagBindingMatches(binding, {
+          definition,
+          lane_id: binding.lane_id,
+          run_id: binding.run_id,
+          snapshot_event_hash: binding.snapshot_event_hash,
+        }),
+      ).not.toThrow();
+      expect(() =>
+        assertDagBindingMatches(binding, {
+          definition: { ...definition, name: 'tampered definition' },
+          lane_id: binding.lane_id,
+          run_id: binding.run_id,
+          snapshot_event_hash: binding.snapshot_event_hash,
+        }),
+      ).toThrow(/definition digest/u);
+      expect(() =>
+        persistDagBinding(runtimeRoot, {
+          ...binding,
+          run_id: 'run_substituted',
+        }),
+      ).toThrow(/conflicts with the persisted run/u);
+
+      const redirectedRoot = join(directory, 'redirected-root');
+      const outside = join(directory, 'outside');
+      mkdirSync(outside);
+      symlinkSync(outside, redirectedRoot);
+      expect(() =>
+        persistDagBinding(redirectedRoot, {
+          ...binding,
+          lane_id: 'lane-symlink',
+          dag_key: 'fluo:lane:lane-symlink:issue-supervisors:v1',
+        }),
+      ).toThrow(/real directory/u);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/tooling/governance/execute-lane-dag-supervisor.test.ts
+++ b/tooling/governance/execute-lane-dag-supervisor.test.ts
@@ -230,8 +230,8 @@ const identity = {
   },
   retry_policy: {
     retry_count_is_terminal: true,
-    max_same_failure_repeats: 3,
-    max_wall_clock_minutes: 180,
+    max_same_failure_repeats: 5,
+    max_wall_clock_minutes: 360,
     stop_on_child_contract_error: true,
   },
 } as const;

--- a/tooling/governance/execute-lane-native.test.ts
+++ b/tooling/governance/execute-lane-native.test.ts
@@ -582,17 +582,28 @@ describe('$execute-lane persisted native state machine', () => {
 });
 
 describe('$execute-lane shipped native assets', () => {
-  it('ships the skill, workflow, state machine, store, and replay CLI', () => {
+  it('ships the workflow, issue supervisor, DAG projection, store, and replay CLI', () => {
     expect(
       [
         'SKILL.md',
         'references/workflow.md',
+        'references/issue-supervisor.md',
+        'scripts/compile-dag.mjs',
+        'scripts/dag-binding.mjs',
+        'scripts/issue-supervisor.mjs',
+        'scripts/issue-supervisor-contracts.mjs',
+        'scripts/issue-supervisor-files.mjs',
+        'scripts/issue-supervisor-history.mjs',
+        'scripts/issue-supervisor-receipts.mjs',
+        'scripts/issue-supervisor-remote.mjs',
+        'scripts/issue-supervisor-store.mjs',
+        'scripts/supervisor-terminal.mjs',
         'scripts/state-machine.mjs',
         'scripts/state-store.mjs',
         'scripts/release-handoff-approval.mjs',
         'scripts/fixtures/run-replay.mjs',
       ].filter((path) => existsSync(resolve(skillRoot, path))),
-    ).toHaveLength(6);
+    ).toHaveLength(17);
   });
 
   it.each([

--- a/tooling/governance/issue-to-pr-native.test.ts
+++ b/tooling/governance/issue-to-pr-native.test.ts
@@ -44,6 +44,19 @@ const fixBackInput = {
   blockers: [blocker],
   fix_back_attempt: 1,
 };
+const localNewInput = {
+  ...newPrInput,
+  mode: 'local-new',
+};
+const localFixBackInput = {
+  ...fixBackInput,
+  mode: 'local-fix-back',
+  existing_pr: null,
+};
+const ciFixBackInput = {
+  ...fixBackInput,
+  mode: 'ci-fix-back',
+};
 const identity = {
   branch: baseInput.branch,
   worktree: baseInput.worktree,
@@ -104,6 +117,9 @@ describe('$issue-to-pr native input and identity contract', () => {
     // When / Then
     expect(() => api.assertIssueToPrInput(newPrInput)).not.toThrow();
     expect(() => api.assertIssueToPrInput(fixBackInput)).not.toThrow();
+    expect(() => api.assertIssueToPrInput(localNewInput)).not.toThrow();
+    expect(() => api.assertIssueToPrInput(localFixBackInput)).not.toThrow();
+    expect(() => api.assertIssueToPrInput(ciFixBackInput)).not.toThrow();
     expect(source).toMatch(
       /from ['"]\.\.\/\.\.\/\.\.\/workflow-contracts\/contracts\.mjs['"]/u,
     );
@@ -183,6 +199,19 @@ describe('$issue-to-pr authority and typed output contract', () => {
 
     // When / Then
     expect(() => api.assertIssueToPrResult(fixBackInput, completedResult)).not.toThrow();
+    expect(() =>
+      api.assertIssueToPrResult(localFixBackInput, {
+        ...completedResult,
+        mode: 'local-fix-back',
+        pr: null,
+      }),
+    ).not.toThrow();
+    expect(() =>
+      api.assertIssueToPrResult(ciFixBackInput, {
+        ...completedResult,
+        mode: 'ci-fix-back',
+      }),
+    ).not.toThrow();
     expect(() =>
       api.assertIssueToPrResult(fixBackInput, {
         ...completedResult,

--- a/tooling/governance/omo-native-contracts.test.ts
+++ b/tooling/governance/omo-native-contracts.test.ts
@@ -8,6 +8,8 @@ const contractRoot = resolve(process.cwd(), '.agents/workflow-contracts');
 const contractNames = [
   'search-artifact-v2',
   'lane-ledger-v2',
+  'lane-dag-binding',
+  'local-review-verdict',
   'review-verdict',
   'blocker',
   'receipt',
@@ -104,6 +106,28 @@ const lane = {
   dependency_graph: {},
   root_main_sync: { status: 'not-started', sha: null },
 };
+const laneDagBinding = {
+  version: 1,
+  lane_id: lane.lane_id,
+  dag_key: `fluo:lane:${lane.lane_id}:issue-supervisors:v1`,
+  run_id: 'run_lane_4101',
+  definition_sha256: 'd'.repeat(64),
+  snapshot_event_hash: null,
+  status: 'attached',
+};
+const localReviewVerdict = {
+  version: 1,
+  lane_id: lane.lane_id,
+  issue_number: issueNumber,
+  verdict: 'ready-for-pr',
+  head_sha: headSha,
+  reviewers: {
+    contract: 'PASS',
+    code: 'PASS',
+    verification: 'PASS',
+  },
+  blockers: [],
+};
 const blocker = {
   reviewer: 'code',
   signature: 'missing-abort-path',
@@ -174,6 +198,8 @@ describe('OMO native workflow JSON schemas', () => {
   it.each([
     ['search-artifact-v2', artifact],
     ['lane-ledger-v2', lane],
+    ['lane-dag-binding', laneDagBinding],
+    ['local-review-verdict', localReviewVerdict],
     ['review-verdict', reviewVerdict],
     ['blocker', blocker],
     ['receipt', receipt],


### PR DESCRIPTION
## Summary

Execute each confirmed lane issue through an independently resumable supervisor DAG node while preserving canonical lane evidence and authority boundaries.

Linked context: Internal Fluo native workflow hardening for issue-scoped implementation, local review, PR/CI observation, merge, and cleanup.

## Changes

- compile canonical lane snapshots into issue supervisor DAG definitions with dependency ordering
- persist exclusive DAG bindings, issue lifecycle event chains, receipts, retry identity, and terminal imports
- require same-head local contract/code/verification review before PR and CI, then bounded fix-back on failures
- bind release handoffs to approved issue membership and full lane-plan approval provenance
- document supervisor authority, persistence, recovery, and security invariants

## Testing

- governance suite: 20 files, 470 tests passed
- final QA governance run: 1,116 tests passed
- `pnpm typecheck` passed
- `pnpm lint` passed (26 existing warnings, 210 infos; no errors)
- goal, quality, security, hands-on QA, and context review gates: PASS

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

## Public export documentation

- [x] No public package exports changed.
- [x] No exported functions requiring new `@param` / `@returns` documentation changed.
- [x] README examples and source examples are unaffected.

## Behavioral contract

- [x] No documented public behavioral contracts were removed.
- [x] Internal workflow contracts are documented in the affected native workflow references.
- [x] Intentional authority and retry limitations are explicitly stated.
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] No EN/KO package documentation mirror was changed.
- [x] Workflow contract changes include discoverability, tooling enforcement, and regression-test evidence.
- [x] No package README alignment or platform conformance claim changed.