### PR TITLE
feat(http): add portable request header and Vary helpers (#3304)

### DIFF
--- a/.changeset/http-accept-duplicate-case-fix.md
+++ b/.changeset/http-accept-duplicate-case-fix.md
@@ -1,5 +1,0 @@
----
-"@fluojs/http": patch
----
-
-Preserve `Accept` negotiation when duplicate-case HTTP headers include blank earlier entries so successful formatter selection and HTML error representations honor the first non-empty value.

--- a/.changeset/http-accept-duplicate-case-fix.md
+++ b/.changeset/http-accept-duplicate-case-fix.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/http": patch
+---
+
+Preserve `Accept` negotiation when duplicate-case HTTP headers include blank earlier entries so successful formatter selection and HTML error representations honor the first non-empty value.

--- a/.changeset/spotty-snails-relate.md
+++ b/.changeset/spotty-snails-relate.md
@@ -1,0 +1,7 @@
+---
+"@fluojs/http": minor
+---
+
+Add portable `getRequestHeader(request, name)` and `appendVaryHeader(response, ...fields)` helpers to
+`@fluojs/http`, then route DTO header binding, request-id extraction, version header reads, CORS,
+and negotiated error responses through the shared contract.

--- a/packages/http/README.ko.md
+++ b/packages/http/README.ko.md
@@ -108,6 +108,29 @@ Adapter wire support는 명시적인 portability contract입니다. 지원되는
 
 Custom runtime method가 자동으로 OpenAPI Path Item operation이 되는 것은 아닙니다. `@fluojs/openapi`는 계속 문서화된 standard operation method만 받으므로 custom-method descriptor를 OpenAPI input에서 제외하거나 application-owned extension으로 해당 endpoint를 문서화해야 합니다.
 
+### 이식 가능한 헤더 helper
+
+미들웨어, versioning, DTO binding, controller 코드가 adapter가 넘긴 `string | string[] | undefined`
+header 값을 납작하게 만들지 않으면서 case-insensitive lookup을 해야 하면
+`getRequestHeader(request, name)`를 사용하세요.
+
+응답 negotiation이나 cache 로직이 case variant를 중복하지 않고 `Vary` 필드를 추가해야 하거나,
+comma list를 매번 수동으로 파싱하고 싶지 않거나, 기존 `Vary: *` contract를 실수로 확장하면 안
+될 때는 `appendVaryHeader(response, ...fields)`를 사용하세요.
+
+```ts
+import { appendVaryHeader, getRequestHeader, type RequestContext } from '@fluojs/http';
+
+export function readLanguage(context: RequestContext): string | undefined {
+  const acceptLanguage = getRequestHeader(context.request, 'accept-language');
+  return Array.isArray(acceptLanguage) ? acceptLanguage[0] : acceptLanguage;
+}
+
+export function markLanguageVariance(context: RequestContext): void {
+  appendVaryHeader(context.response, 'Accept-Language', 'Origin');
+}
+```
+
 ## 주요 패턴
 
 ### 가드와 인터셉터
@@ -299,7 +322,7 @@ Multipart upload를 parse하는 어댑터는 shared HTTP contract를 adapter-spe
 - **파이프라인 계약 타입**: `Middleware`, `MiddlewareLike`, `MiddlewareContext`, `MiddlewareRouteConfig`, `Next`, `Guard`, `GuardLike`, `GuardContext`, `Interceptor`, `InterceptorLike`, `InterceptorContext`, `CallHandler`, `RequestObserver`, `RequestObserverLike`, `RequestObservationContext`, `ArgumentResolverContext`, `Binder`, `Converter`, `ConverterLike`, `ConverterTarget`, `ValidationIssue`, `Validator`
 - **Adapter API**: `HttpApplicationAdapter`, `HttpAdapterRealtimeCapability`, `ServerBackedHttpAdapterRealtimeCapability`, `FetchStyleHttpAdapterRealtimeCapability`, `HttpAdapterRealtimeBindingInstallation`, `UnsupportedHttpAdapterRealtimeCapability`, `createNoopHttpApplicationAdapter`, `createServerBackedHttpAdapterRealtimeCapability`, `createUnsupportedHttpAdapterRealtimeCapability`, `createFetchStyleHttpAdapterRealtimeCapability`
 - **예외와 오류**: `HttpExceptionDetail`, `HttpExceptionOptions`, `ErrorResponse`, `HttpException`, `BadRequestException`, `UnauthorizedException`, `ForbiddenException`, `NotFoundException`, `ConflictException`, `NotAcceptableException`, `TooManyRequestsException`, `InternalServerErrorException`, `PayloadTooLargeException`, `createErrorResponse`, `RouteConflictError`, `InvalidRoutePathError`, `InvalidHttpMethodError`, `HandlerNotFoundError`, `RequestAbortedError`
-- **헬퍼**: `createHandlerMapping`, `createDispatcher`, `forRoutes`, `normalizeRoutePattern`, `matchRoutePattern`, `isMiddlewareRouteConfig`, `createCorrelationMiddleware`, `createCorsMiddleware`, `createRateLimitMiddleware`, `createMemoryRateLimitStore`, `createSecurityHeadersMiddleware`, `runWithRequestContext`, `getCurrentRequestContext`, `assertRequestContext`, `createRequestContext`, `createContextKey`, `getContextValue`, `setContextValue`, `encodeSseComment`, `encodeSseMessage`, `isSseMessage`, `formatFastPathStats`, `getDispatcherFastPathStats`, `FAST_PATH_ELIGIBILITY_SYMBOL`, `FAST_PATH_STATS_SYMBOL`
+- **헬퍼**: `createHandlerMapping`, `createDispatcher`, `forRoutes`, `normalizeRoutePattern`, `matchRoutePattern`, `isMiddlewareRouteConfig`, `createCorrelationMiddleware`, `createCorsMiddleware`, `createRateLimitMiddleware`, `createMemoryRateLimitStore`, `createSecurityHeadersMiddleware`, `getRequestHeader`, `appendVaryHeader`, `runWithRequestContext`, `getCurrentRequestContext`, `assertRequestContext`, `createRequestContext`, `createContextKey`, `getContextValue`, `setContextValue`, `encodeSseComment`, `encodeSseMessage`, `isSseMessage`, `formatFastPathStats`, `getDispatcherFastPathStats`, `FAST_PATH_ELIGIBILITY_SYMBOL`, `FAST_PATH_STATS_SYMBOL`
 - **Option 및 store type**: `CorsOptions`, `RateLimitOptions`, `RateLimitStore`, `RateLimitStoreEntry`, `SecurityHeadersOptions`, `SseSendOptions`
 
 ## 내부 서브경로 (`@fluojs/http/internal`)

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -110,6 +110,29 @@ Adapter wire support is an explicit portability contract. Supported Node listene
 
 Custom runtime methods do not become OpenAPI Path Item operations automatically. `@fluojs/openapi` continues to accept only its documented standard operation methods, so exclude custom-method descriptors from OpenAPI input or document those endpoints through an application-owned extension.
 
+### Portable header helpers
+
+Use `getRequestHeader(request, name)` when middleware, versioning, DTO binding, or controller code
+needs a case-insensitive lookup without flattening adapter-provided `string | string[] | undefined`
+header values.
+
+Use `appendVaryHeader(response, ...fields)` when response negotiation or caching logic needs to add
+`Vary` fields without duplicating case variants, re-parsing comma lists by hand, or accidentally
+expanding an existing wildcard `Vary: *` contract.
+
+```ts
+import { appendVaryHeader, getRequestHeader, type RequestContext } from '@fluojs/http';
+
+export function readLanguage(context: RequestContext): string | undefined {
+  const acceptLanguage = getRequestHeader(context.request, 'accept-language');
+  return Array.isArray(acceptLanguage) ? acceptLanguage[0] : acceptLanguage;
+}
+
+export function markLanguageVariance(context: RequestContext): void {
+  appendVaryHeader(context.response, 'Accept-Language', 'Origin');
+}
+```
+
 ## Common Patterns
 
 ### Guards and interceptors
@@ -300,12 +323,13 @@ Response content negotiation formatters must return `string` or `Uint8Array` fro
 - **Routing decorators**: `Controller`, `Get`, `Sse`, `Query`, `Route`, `Post`, `Put`, `Patch`, `Delete`, `All`, `Options`, `Head`
 - **Binding decorators**: `FromBody`, `FromQuery`, `FromPath`, `FromHeader`, `FromCookie`, `RequestDto`, `Optional`, `Convert`
 - **Execution decorators**: `UseGuards`, `UseInterceptors`, `HttpCode`, `Version`, `Header`, `Redirect`, `Produces`
+- **Header helpers**: `getRequestHeader`, `appendVaryHeader`
 - **Request/response and context types**: `RequestContext`, `Principal`, `ContextKey`, `ControllerHandler`, `FrameworkRequest`, `FrameworkRequestFile`, `FrameworkResponse`, `FrameworkResponseStream`, `FrameworkResponseCompression`, `FrameworkResponseCompressionWriteOptions`, `SseResponse`, `SseMessage`
 - **Dispatcher, routing, and negotiation types**: `Dispatcher`, `CreateDispatcherOptions`, `ErrorHandler`, `DispatcherLogger`, `HandlerMapping`, `HandlerMetadata`, `HandlerDescriptor`, `HandlerMatch`, `HandlerSource`, `RouteDefinition`, `HttpMethod`, `VersioningType`, `VersioningOptions`, `VersioningExtractor`, `VersioningExtractorResult`, `ContentNegotiationOptions`, `ResponseFormatter`, `HttpErrorRepresentationContext`, `HtmlErrorRepresentationProvider`, `HttpErrorRepresentationOptions`, `FastPathEligibility`, `FastPathStats`
 - **Pipeline contract types**: `Middleware`, `MiddlewareLike`, `MiddlewareContext`, `MiddlewareRouteConfig`, `Next`, `Guard`, `GuardLike`, `GuardContext`, `Interceptor`, `InterceptorLike`, `InterceptorContext`, `CallHandler`, `RequestObserver`, `RequestObserverLike`, `RequestObservationContext`, `ArgumentResolverContext`, `Binder`, `Converter`, `ConverterLike`, `ConverterTarget`, `ValidationIssue`, `Validator`
 - **Adapter API**: `HttpApplicationAdapter`, `HttpAdapterRealtimeCapability`, `ServerBackedHttpAdapterRealtimeCapability`, `FetchStyleHttpAdapterRealtimeCapability`, `HttpAdapterRealtimeBindingInstallation`, `UnsupportedHttpAdapterRealtimeCapability`, `createNoopHttpApplicationAdapter`, `createServerBackedHttpAdapterRealtimeCapability`, `createUnsupportedHttpAdapterRealtimeCapability`, `createFetchStyleHttpAdapterRealtimeCapability`
 - **Exceptions and errors**: `HttpExceptionDetail`, `HttpExceptionOptions`, `ErrorResponse`, `HttpException`, `BadRequestException`, `UnauthorizedException`, `ForbiddenException`, `NotFoundException`, `ConflictException`, `NotAcceptableException`, `TooManyRequestsException`, `InternalServerErrorException`, `PayloadTooLargeException`, `createErrorResponse`, `RouteConflictError`, `InvalidRoutePathError`, `InvalidHttpMethodError`, `HandlerNotFoundError`, `RequestAbortedError`
-- **Helpers**: `createHandlerMapping`, `createDispatcher`, `forRoutes`, `normalizeRoutePattern`, `matchRoutePattern`, `isMiddlewareRouteConfig`, `createCorrelationMiddleware`, `createCorsMiddleware`, `createRateLimitMiddleware`, `createMemoryRateLimitStore`, `createSecurityHeadersMiddleware`, `runWithRequestContext`, `getCurrentRequestContext`, `assertRequestContext`, `createRequestContext`, `createContextKey`, `getContextValue`, `setContextValue`, `encodeSseComment`, `encodeSseMessage`, `isSseMessage`, `formatFastPathStats`, `getDispatcherFastPathStats`, `FAST_PATH_ELIGIBILITY_SYMBOL`, `FAST_PATH_STATS_SYMBOL`
+- **Helpers**: `createHandlerMapping`, `createDispatcher`, `forRoutes`, `normalizeRoutePattern`, `matchRoutePattern`, `isMiddlewareRouteConfig`, `createCorrelationMiddleware`, `createCorsMiddleware`, `createRateLimitMiddleware`, `createMemoryRateLimitStore`, `createSecurityHeadersMiddleware`, `getRequestHeader`, `appendVaryHeader`, `runWithRequestContext`, `getCurrentRequestContext`, `assertRequestContext`, `createRequestContext`, `createContextKey`, `getContextValue`, `setContextValue`, `encodeSseComment`, `encodeSseMessage`, `isSseMessage`, `formatFastPathStats`, `getDispatcherFastPathStats`, `FAST_PATH_ELIGIBILITY_SYMBOL`, `FAST_PATH_STATS_SYMBOL`
 - **Option and store types**: `CorsOptions`, `RateLimitOptions`, `RateLimitStore`, `RateLimitStoreEntry`, `SecurityHeadersOptions`, `SseSendOptions`
 
 ## Internal Subpath (`@fluojs/http/internal`)

--- a/packages/http/src/adapters/binding.test.ts
+++ b/packages/http/src/adapters/binding.test.ts
@@ -205,6 +205,32 @@ describe('DefaultBinder', () => {
     expect(bound.nickname).toBeUndefined();
   });
 
+  it('binds header fields case-insensitively while preserving multi-value arrays', async () => {
+    class HeaderBoundRequest {
+      @FromHeader('x-request-id')
+      requestId = '';
+
+      @FromHeader('x-role')
+      roles: string[] = [];
+    }
+
+    const binder = new DefaultBinder();
+    const bound = (await binder.bind(
+      HeaderBoundRequest,
+      createContext(
+        createRequest({
+          headers: {
+            'X-Request-Id': 'req-123',
+            'X-Role': ['admin', 'editor'],
+          },
+        }),
+      ),
+    )) as HeaderBoundRequest;
+
+    expect(bound.requestId).toBe('req-123');
+    expect(bound.roles).toEqual(['admin', 'editor']);
+  });
+
   it('preserves single-element arrays for query bindings', async () => {
     class SearchUsersRequest {
       @FromQuery('tag')

--- a/packages/http/src/adapters/dto-binding-plan.ts
+++ b/packages/http/src/adapters/dto-binding-plan.ts
@@ -8,6 +8,7 @@ import {
   type DtoFieldValidationRule,
 } from '@fluojs/core/internal';
 
+import { getRequestHeader } from '../header-helpers.js';
 import type { FrameworkRequest } from '../types.js';
 
 function toFieldName(propertyKey: MetadataPropertyKey): string {
@@ -16,10 +17,6 @@ function toFieldName(propertyKey: MetadataPropertyKey): string {
 
 function resolveSourceKey(propertyKey: MetadataPropertyKey, key?: string): string {
   return key ?? toFieldName(propertyKey);
-}
-
-function readHeader(request: FrameworkRequest, key: string): string | string[] | undefined {
-  return request.headers[key.toLowerCase()] ?? request.headers[key];
 }
 
 export interface CompiledDtoBindingPlanEntry {
@@ -50,7 +47,7 @@ function createSourceReader(source: MetadataSource, sourceKey: string): (request
     case 'query':
       return (request) => request.query[sourceKey];
     case 'header':
-      return (request) => readHeader(request, sourceKey);
+      return (request) => getRequestHeader(request, sourceKey);
     case 'cookie':
       return (request) => request.cookies[sourceKey];
     case 'body':

--- a/packages/http/src/dispatch/dispatch-content-negotiation.ts
+++ b/packages/http/src/dispatch/dispatch-content-negotiation.ts
@@ -1,4 +1,5 @@
 import { NotAcceptableException } from '../exceptions.js';
+import { getRequestHeader } from '../header-helpers.js';
 import type {
   ContentNegotiationOptions,
   FrameworkRequest,
@@ -28,7 +29,7 @@ function normalizeMediaType(value: string): string {
 }
 
 function readAcceptHeader(request: FrameworkRequest): string | undefined {
-  const raw = request.headers.accept ?? request.headers.Accept;
+  const raw = getRequestHeader(request, 'accept');
   const value = Array.isArray(raw) ? raw.join(',') : raw;
   const normalized = value?.trim();
 

--- a/packages/http/src/dispatch/dispatch-content-negotiation.ts
+++ b/packages/http/src/dispatch/dispatch-content-negotiation.ts
@@ -1,5 +1,5 @@
 import { NotAcceptableException } from '../exceptions.js';
-import { getRequestHeader } from '../header-helpers.js';
+import { readFirstNonEmptyRequestHeaderValue } from '../header-helpers.js';
 import type {
   ContentNegotiationOptions,
   FrameworkRequest,
@@ -29,11 +29,7 @@ function normalizeMediaType(value: string): string {
 }
 
 function readAcceptHeader(request: FrameworkRequest): string | undefined {
-  const raw = getRequestHeader(request, 'accept');
-  const value = Array.isArray(raw) ? raw.join(',') : raw;
-  const normalized = value?.trim();
-
-  return normalized ? normalized : undefined;
+  return readFirstNonEmptyRequestHeaderValue(request, 'accept');
 }
 
 function parseQuality(value: string | undefined): number {

--- a/packages/http/src/dispatch/dispatch-error-negotiation.ts
+++ b/packages/http/src/dispatch/dispatch-error-negotiation.ts
@@ -1,4 +1,5 @@
 import type { RequestContext } from '../types.js';
+import { getRequestHeader } from '../header-helpers.js';
 
 const HTML_MEDIA_TYPE = 'text/html';
 const JSON_MEDIA_TYPE = 'application/json';
@@ -86,7 +87,7 @@ function bestRangeForMediaType(ranges: readonly AcceptRange[], mediaType: string
  * @returns The normalized header value when present.
  */
 export function readAcceptHeader(context: RequestContext): string | undefined {
-  const raw = context.request.headers.accept ?? context.request.headers.Accept;
+  const raw = getRequestHeader(context.request, 'accept');
   const value = Array.isArray(raw) ? raw.join(',') : raw;
   const normalized = value?.trim();
   return normalized ? normalized : undefined;

--- a/packages/http/src/dispatch/dispatch-error-negotiation.ts
+++ b/packages/http/src/dispatch/dispatch-error-negotiation.ts
@@ -1,5 +1,5 @@
 import type { RequestContext } from '../types.js';
-import { getRequestHeader } from '../header-helpers.js';
+import { readFirstNonEmptyRequestHeaderValue } from '../header-helpers.js';
 
 const HTML_MEDIA_TYPE = 'text/html';
 const JSON_MEDIA_TYPE = 'application/json';
@@ -87,10 +87,7 @@ function bestRangeForMediaType(ranges: readonly AcceptRange[], mediaType: string
  * @returns The normalized header value when present.
  */
 export function readAcceptHeader(context: RequestContext): string | undefined {
-  const raw = getRequestHeader(context.request, 'accept');
-  const value = Array.isArray(raw) ? raw.join(',') : raw;
-  const normalized = value?.trim();
-  return normalized ? normalized : undefined;
+  return readFirstNonEmptyRequestHeaderValue(context.request, 'accept');
 }
 
 /**

--- a/packages/http/src/dispatch/dispatch-error-representation.ts
+++ b/packages/http/src/dispatch/dispatch-error-representation.ts
@@ -20,6 +20,7 @@ import {
   readAcceptHeader,
   selectErrorRepresentation,
 } from './dispatch-error-negotiation.js';
+import { appendVaryHeader } from '../header-helpers.js';
 import { isRequestAborted } from './request-abort.js';
 
 const HTML_CONTENT_TYPE = 'text/html; charset=utf-8';
@@ -74,15 +75,7 @@ async function isHtmlAvailable(
 
 function setNegotiatedHeaders(response: FrameworkResponse, contentType: string): void {
   response.setHeader('Content-Type', contentType);
-  const varyEntry = Object.entries(response.headers).find(([name]) => name.toLowerCase() === 'vary');
-  const varyValues = (Array.isArray(varyEntry?.[1]) ? varyEntry[1] : varyEntry?.[1]?.split(','))
-    ?.map((value) => value.trim())
-    .filter(Boolean) ?? [];
-
-  if (!varyValues.some((value) => value.toLowerCase() === 'accept')) {
-    varyValues.push('Accept');
-  }
-  response.setHeader(varyEntry?.[0] ?? 'Vary', varyValues.join(', '));
+  appendVaryHeader(response, 'Accept');
 }
 
 async function writeBody(

--- a/packages/http/src/dispatch/dispatcher-request-id.test.ts
+++ b/packages/http/src/dispatch/dispatcher-request-id.test.ts
@@ -1,0 +1,71 @@
+import { Container } from '@fluojs/di';
+import { describe, expect, it } from 'vitest';
+
+import type { FrameworkRequest, FrameworkResponse, RequestContext } from '../types.js';
+import { Controller, createDispatcher, createHandlerMapping, Get } from '../index.js';
+
+function createRequest(
+  headers: FrameworkRequest['headers'],
+): FrameworkRequest {
+  return {
+    body: undefined,
+    cookies: {},
+    headers,
+    method: 'GET',
+    params: {},
+    path: '/request-id',
+    query: {},
+    raw: {},
+    url: '/request-id',
+  };
+}
+
+function createResponse(): FrameworkResponse & { body?: unknown } {
+  return {
+    committed: false,
+    headers: {},
+    redirect(status, location) {
+      this.setStatus(status);
+      this.setHeader('Location', location);
+      this.committed = true;
+    },
+    send(body) {
+      this.body = body;
+      this.committed = true;
+    },
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    setStatus(code) {
+      this.statusCode = code;
+      this.statusSet = true;
+    },
+    statusCode: undefined,
+    statusSet: false,
+  };
+}
+
+describe('dispatcher request id extraction', () => {
+  it('reads mixed-case x-request-id headers into RequestContext', async () => {
+    @Controller('/request-id')
+    class RequestIdController {
+      @Get('/')
+      read(_input: undefined, context: RequestContext) {
+        return {
+          requestId: context.requestId,
+        };
+      }
+    }
+
+    const root = new Container().register(RequestIdController);
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: RequestIdController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(createRequest({ 'X-REQUEST-ID': 'req-upper' }), response);
+
+    expect(response.body).toEqual({ requestId: 'req-upper' });
+  });
+});

--- a/packages/http/src/dispatch/dispatcher.test.ts
+++ b/packages/http/src/dispatch/dispatcher.test.ts
@@ -1440,6 +1440,52 @@ describe('dispatcher runtime', () => {
     expect(response.body).toBe('plain:{"ok":true}');
   });
 
+  it('ignores blank duplicate-case Accept headers before selecting the formatter', async () => {
+    @Controller('/negotiation-duplicate-case')
+    class NegotiationDuplicateCaseController {
+      @Produces('application/json', 'text/plain')
+      @Get('/formatted')
+      getValue() {
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(NegotiationDuplicateCaseController);
+    const dispatcher = createDispatcher({
+      contentNegotiation: {
+        formatters: [
+          {
+            format(body) {
+              return JSON.stringify(body);
+            },
+            mediaType: 'application/json',
+          },
+          {
+            format(body) {
+              return `plain:${JSON.stringify(body)}`;
+            },
+            mediaType: 'text/plain',
+          },
+        ],
+      },
+      handlerMapping: createHandlerMapping([{ controllerToken: NegotiationDuplicateCaseController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(
+      createRequest('/negotiation-duplicate-case/formatted', 'GET', {
+        Accept: '   ',
+        aCcEpT: 'text/plain;q=1',
+      }),
+      response,
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['Content-Type']).toBe('text/plain');
+    expect(response.body).toBe('plain:{"ok":true}');
+  });
+
   it('keeps negotiated formatter headers while suppressing HEAD bodies', async () => {
     @Controller('/negotiation-head')
     class NegotiationHeadController {

--- a/packages/http/src/dispatch/dispatcher.test.ts
+++ b/packages/http/src/dispatch/dispatcher.test.ts
@@ -1395,6 +1395,51 @@ describe('dispatcher runtime', () => {
     expect(response.body).toBe('plain:{"ok":true}');
   });
 
+  it('selects formatter from mixed-case Accept array headers', async () => {
+    @Controller('/negotiation-case')
+    class NegotiationCaseController {
+      @Produces('application/json', 'text/plain')
+      @Get('/formatted')
+      getValue() {
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(NegotiationCaseController);
+    const dispatcher = createDispatcher({
+      contentNegotiation: {
+        formatters: [
+          {
+            format(body) {
+              return JSON.stringify(body);
+            },
+            mediaType: 'application/json',
+          },
+          {
+            format(body) {
+              return `plain:${JSON.stringify(body)}`;
+            },
+            mediaType: 'text/plain',
+          },
+        ],
+      },
+      handlerMapping: createHandlerMapping([{ controllerToken: NegotiationCaseController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(
+      createRequest('/negotiation-case/formatted', 'GET', {
+        aCcEpT: ['text/plain;q=0.9', 'application/json;q=0.1'],
+      }),
+      response,
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['Content-Type']).toBe('text/plain');
+    expect(response.body).toBe('plain:{"ok":true}');
+  });
+
   it('keeps negotiated formatter headers while suppressing HEAD bodies', async () => {
     @Controller('/negotiation-head')
     class NegotiationHeadController {

--- a/packages/http/src/dispatch/dispatcher.ts
+++ b/packages/http/src/dispatch/dispatcher.ts
@@ -5,6 +5,7 @@ import { createRequestContext, runWithRequestContext } from '../context/request-
 import { isSseMessage, SseResponse, type SseSendOptions } from '../context/sse.js';
 import { RequestAbortedError } from '../errors.js';
 import { runGuardChain } from '../guards.js';
+import { getRequestHeader } from '../header-helpers.js';
 import { runInterceptorChain } from '../interceptors.js';
 import { isMiddlewareRouteConfig, matchRoutePattern, runMiddlewareChain } from '../middleware/middleware.js';
 import type {
@@ -204,7 +205,7 @@ function readRequestId(request: FrameworkRequest): string | undefined {
     return request.requestId;
   }
 
-  const raw = request.headers['x-request-id'] ?? request.headers['X-Request-Id'];
+  const raw = getRequestHeader(request, 'x-request-id');
   const value = Array.isArray(raw) ? raw[0] : raw;
   const normalized = value?.trim();
 

--- a/packages/http/src/dispatch/error-representation.test.ts
+++ b/packages/http/src/dispatch/error-representation.test.ts
@@ -139,4 +139,16 @@ describe('HTTP-owned error representations', () => {
     expect(render).not.toHaveBeenCalled();
   });
 
+  it('preserves wildcard vary headers when negotiated responses add Accept', async () => {
+    const render = vi.fn(() => '<main>unused</main>');
+    const { dispatcher } = createTestDispatcher({ render });
+    const response = createResponse();
+    response.setHeader('vary', '*, Accept-Encoding');
+
+    await dispatcher.dispatch(createRequest('/missing', 'application/json'), response);
+
+    expect(response.headers.vary).toBe('*');
+    expect(response.headers['Content-Type']).toBe('application/json; charset=utf-8');
+  });
+
 });

--- a/packages/http/src/dispatch/error-representation.test.ts
+++ b/packages/http/src/dispatch/error-representation.test.ts
@@ -48,6 +48,25 @@ describe('HTTP-owned error representations', () => {
     expect(render).not.toHaveBeenCalled();
   });
 
+  it('negotiates HTML from mixed-case Accept headers', async () => {
+    const render = vi.fn(async ({ error }: HttpErrorRepresentationContext) => `<main>${error.code}</main>`);
+    const { dispatcher } = createTestDispatcher({ render });
+    const response = createResponse();
+
+    await dispatcher.dispatch(
+      {
+        ...createRequest('/missing'),
+        headers: { aCcEpT: 'text/html' },
+      },
+      response,
+    );
+
+    expect(response.statusCode).toBe(404);
+    expect(response.headers['Content-Type']).toBe('text/html; charset=utf-8');
+    expect(response.body).toBe('<main>NOT_FOUND</main>');
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+
   it('does not consult the HTML provider when a specific q=0 range rejects HTML', async () => {
     const canRender = vi.fn(() => true);
     const render = vi.fn(() => '<main>unused</main>');

--- a/packages/http/src/dispatch/error-representation.test.ts
+++ b/packages/http/src/dispatch/error-representation.test.ts
@@ -67,6 +67,28 @@ describe('HTTP-owned error representations', () => {
     expect(render).toHaveBeenCalledTimes(1);
   });
 
+  it('negotiates HTML from blank-first duplicate-case Accept headers', async () => {
+    const render = vi.fn(async ({ error }: HttpErrorRepresentationContext) => `<main>${error.code}</main>`);
+    const { dispatcher } = createTestDispatcher({ render });
+    const response = createResponse();
+
+    await dispatcher.dispatch(
+      {
+        ...createRequest('/missing'),
+        headers: {
+          Accept: '   ',
+          aCcEpT: 'text/html',
+        },
+      },
+      response,
+    );
+
+    expect(response.statusCode).toBe(404);
+    expect(response.headers['Content-Type']).toBe('text/html; charset=utf-8');
+    expect(response.body).toBe('<main>NOT_FOUND</main>');
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+
   it('does not consult the HTML provider when a specific q=0 range rejects HTML', async () => {
     const canRender = vi.fn(() => true);
     const render = vi.fn(() => '<main>unused</main>');

--- a/packages/http/src/header-helpers.test.ts
+++ b/packages/http/src/header-helpers.test.ts
@@ -83,6 +83,18 @@ describe('appendVaryHeader', () => {
     expect(response.headers.Vary).toBe('Accept-Encoding, Origin, Accept');
   });
 
+  it('merges duplicate-case vary entries into one canonical header', () => {
+    const response = createResponse();
+    response.headers.Vary = 'Accept-Encoding';
+    response.headers.vary = 'Origin';
+
+    appendVaryHeader(response, 'Accept');
+
+    expect(response.headers).toEqual({
+      Vary: 'Accept-Encoding, Origin, Accept',
+    });
+  });
+
   it('preserves a wildcard vary response without appending extra fields', () => {
     const response = createResponse();
     response.setHeader('vary', '*, Accept-Encoding');

--- a/packages/http/src/header-helpers.test.ts
+++ b/packages/http/src/header-helpers.test.ts
@@ -62,6 +62,15 @@ describe('getRequestHeader', () => {
     expect(getRequestHeader(request, '   ')).toBeUndefined();
     expect(getRequestHeader(request, 'x-missing')).toBeUndefined();
   });
+
+  it('preserves the first stored duplicate-case header value for public lookups', () => {
+    const request = createRequest({
+      Accept: '   ',
+      aCcEpT: 'text/html',
+    });
+
+    expect(getRequestHeader(request, 'accept')).toBe('   ');
+  });
 });
 
 describe('appendVaryHeader', () => {

--- a/packages/http/src/header-helpers.test.ts
+++ b/packages/http/src/header-helpers.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+
+import type { FrameworkRequest, FrameworkResponse } from './types.js';
+import { appendVaryHeader, getRequestHeader } from './index.js';
+
+function createRequest(
+  headers: FrameworkRequest['headers'],
+): FrameworkRequest {
+  return {
+    body: undefined,
+    cookies: {},
+    headers,
+    method: 'GET',
+    params: {},
+    path: '/headers',
+    query: {},
+    raw: {},
+    url: '/headers',
+  };
+}
+
+function createResponse(): FrameworkResponse {
+  return {
+    committed: false,
+    headers: {},
+    redirect(status, location) {
+      this.setStatus(status);
+      this.setHeader('Location', location);
+      this.committed = true;
+    },
+    send() {
+      this.committed = true;
+    },
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    setStatus(code) {
+      this.statusCode = code;
+      this.statusSet = true;
+    },
+    statusCode: undefined,
+    statusSet: false,
+  };
+}
+
+describe('getRequestHeader', () => {
+  it('reads request headers case-insensitively without flattening arrays', () => {
+    const upstreamValues = ['trace-a', 'trace-b'];
+    const request = createRequest({
+      'X-Trace-Id': upstreamValues,
+    });
+
+    expect(getRequestHeader(request, 'x-trace-id')).toBe(upstreamValues);
+    expect(getRequestHeader(request, 'X-TRACE-ID')).toBe(upstreamValues);
+  });
+
+  it('returns undefined for blank or missing header names', () => {
+    const request = createRequest({
+      accept: 'application/json',
+    });
+
+    expect(getRequestHeader(request, '   ')).toBeUndefined();
+    expect(getRequestHeader(request, 'x-missing')).toBeUndefined();
+  });
+});
+
+describe('appendVaryHeader', () => {
+  it('adds unique vary fields while trimming empty tokens from scalars and arrays', () => {
+    const response = createResponse();
+    response.setHeader('Vary', ['Accept-Encoding,  ', ' Origin ', '', 'Accept-Encoding']);
+
+    appendVaryHeader(response, 'origin', 'Accept', '', '  ');
+
+    expect(response.headers.Vary).toBe('Accept-Encoding, Origin, Accept');
+  });
+
+  it('preserves a wildcard vary response without appending extra fields', () => {
+    const response = createResponse();
+    response.setHeader('vary', '*, Accept-Encoding');
+
+    appendVaryHeader(response, 'Accept');
+
+    expect(response.headers.vary).toBe('*');
+  });
+
+  it('collapses wildcard inputs to a bare wildcard vary header', () => {
+    const response = createResponse();
+
+    appendVaryHeader(response, 'Accept', '*', 'Origin');
+
+    expect(response.headers.Vary).toBe('*');
+  });
+});

--- a/packages/http/src/header-helpers.ts
+++ b/packages/http/src/header-helpers.ts
@@ -121,9 +121,11 @@ export function appendVaryHeader(
   response: FrameworkResponse,
   ...fields: string[]
 ): void {
-  const existingEntry = findCaseInsensitiveHeaderEntry(response.headers, 'vary');
+  const existingEntries = Object.entries(response.headers).filter(
+    ([name]) => name.toLowerCase() === 'vary',
+  );
   const existingTokens = parseHeaderTokens(
-    Array.isArray(existingEntry?.[1]) ? existingEntry[1] : existingEntry?.[1] === undefined ? [] : [existingEntry[1]],
+    existingEntries.flatMap(([, value]) => (Array.isArray(value) ? value : [value])),
   );
   const appendedTokens = parseHeaderTokens(fields);
   const mergedTokens = [...existingTokens, ...appendedTokens];
@@ -132,8 +134,14 @@ export function appendVaryHeader(
     return;
   }
 
+  const canonicalHeaderName = existingEntries[0]?.[0] ?? 'Vary';
+
+  for (const [name] of existingEntries.slice(1)) {
+    delete response.headers[name];
+  }
+
   if (mergedTokens.some((token) => token === '*')) {
-    response.setHeader(existingEntry?.[0] ?? 'Vary', '*');
+    response.setHeader(canonicalHeaderName, '*');
     return;
   }
 
@@ -152,6 +160,6 @@ export function appendVaryHeader(
   }
 
   if (dedupedTokens.length > 0) {
-    response.setHeader(existingEntry?.[0] ?? 'Vary', dedupedTokens.join(', '));
+    response.setHeader(canonicalHeaderName, dedupedTokens.join(', '));
   }
 }

--- a/packages/http/src/header-helpers.ts
+++ b/packages/http/src/header-helpers.ts
@@ -1,0 +1,111 @@
+import type { FrameworkRequest, FrameworkResponse } from './types.js';
+
+type HeaderEntry<THeaderValue> = readonly [name: string, value: THeaderValue];
+
+function normalizeHeaderName(name: string): string | undefined {
+  const normalized = name.trim().toLowerCase();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function findCaseInsensitiveHeaderEntry<THeaderValue>(
+  headers: Readonly<Record<string, THeaderValue>>,
+  headerName: string,
+): HeaderEntry<THeaderValue> | undefined {
+  const normalizedHeaderName = normalizeHeaderName(headerName);
+
+  if (!normalizedHeaderName) {
+    return undefined;
+  }
+
+  let firstMatch: HeaderEntry<THeaderValue> | undefined;
+
+  for (const [name, value] of Object.entries(headers)) {
+    if (name.toLowerCase() !== normalizedHeaderName) {
+      continue;
+    }
+
+    if (value !== undefined) {
+      return [name, value];
+    }
+
+    firstMatch ??= [name, value];
+  }
+
+  return firstMatch;
+}
+
+function parseHeaderTokens(values: readonly string[]): string[] {
+  const tokens: string[] = [];
+
+  for (const value of values) {
+    for (const token of value.split(',')) {
+      const normalized = token.trim();
+
+      if (normalized.length > 0) {
+        tokens.push(normalized);
+      }
+    }
+  }
+
+  return tokens;
+}
+
+/**
+ * Reads one request header without flattening multi-value arrays.
+ *
+ * @param request Adapter-normalized request carrying the inbound headers map.
+ * @param name Header name to resolve case-insensitively.
+ * @returns The original scalar, array, or `undefined` stored on the request.
+ */
+export function getRequestHeader(
+  request: FrameworkRequest,
+  name: string,
+): string | string[] | undefined {
+  return findCaseInsensitiveHeaderEntry(request.headers, name)?.[1];
+}
+
+/**
+ * Appends one or more fields to the response `Vary` header with case-insensitive deduplication.
+ *
+ * @param response Mutable framework response facade that owns the header map.
+ * @param fields Header field names or comma-delimited field lists to append.
+ * @returns Nothing. The helper updates the response header map in place when needed.
+ */
+export function appendVaryHeader(
+  response: FrameworkResponse,
+  ...fields: string[]
+): void {
+  const existingEntry = findCaseInsensitiveHeaderEntry(response.headers, 'vary');
+  const existingTokens = parseHeaderTokens(
+    Array.isArray(existingEntry?.[1]) ? existingEntry[1] : existingEntry?.[1] === undefined ? [] : [existingEntry[1]],
+  );
+  const appendedTokens = parseHeaderTokens(fields);
+  const mergedTokens = [...existingTokens, ...appendedTokens];
+
+  if (mergedTokens.length === 0) {
+    return;
+  }
+
+  if (mergedTokens.some((token) => token === '*')) {
+    response.setHeader(existingEntry?.[0] ?? 'Vary', '*');
+    return;
+  }
+
+  const dedupedTokens: string[] = [];
+  const seen = new Set<string>();
+
+  for (const token of mergedTokens) {
+    const normalized = token.toLowerCase();
+
+    if (seen.has(normalized)) {
+      continue;
+    }
+
+    seen.add(normalized);
+    dedupedTokens.push(token);
+  }
+
+  if (dedupedTokens.length > 0) {
+    response.setHeader(existingEntry?.[0] ?? 'Vary', dedupedTokens.join(', '));
+  }
+}

--- a/packages/http/src/header-helpers.ts
+++ b/packages/http/src/header-helpers.ts
@@ -50,6 +50,21 @@ function parseHeaderTokens(values: readonly string[]): string[] {
   return tokens;
 }
 
+function readJoinedNonEmptyHeaderValue(
+  value: string | string[] | undefined,
+): string | undefined {
+  if (Array.isArray(value)) {
+    const normalizedValues = value
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0);
+
+    return normalizedValues.length > 0 ? normalizedValues.join(',') : undefined;
+  }
+
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
+}
+
 /**
  * Reads one request header without flattening multi-value arrays.
  *
@@ -62,6 +77,37 @@ export function getRequestHeader(
   name: string,
 ): string | string[] | undefined {
   return findCaseInsensitiveHeaderEntry(request.headers, name)?.[1];
+}
+
+/**
+ * Reads the first non-empty request header value across duplicate case variants.
+ *
+ * @param request Adapter-normalized request carrying the inbound headers map.
+ * @param name Header name to resolve case-insensitively.
+ * @returns The first trimmed scalar or joined array value that is not blank.
+ */
+export function readFirstNonEmptyRequestHeaderValue(
+  request: FrameworkRequest,
+  name: string,
+): string | undefined {
+  const normalizedHeaderName = normalizeHeaderName(name);
+
+  if (!normalizedHeaderName) {
+    return undefined;
+  }
+
+  for (const [headerName, value] of Object.entries(request.headers)) {
+    if (headerName.toLowerCase() !== normalizedHeaderName) {
+      continue;
+    }
+
+    const normalizedValue = readJoinedNonEmptyHeaderValue(value);
+    if (normalizedValue !== undefined) {
+      return normalizedValue;
+    }
+  }
+
+  return undefined;
 }
 
 /**

--- a/packages/http/src/index.portable.ts
+++ b/packages/http/src/index.portable.ts
@@ -40,7 +40,7 @@ export {
 export type { FastPathEligibility, FastPathStats } from './dispatch/fast-path/index.js';
 export * from './errors.js';
 export * from './exceptions.js';
-export * from './header-helpers.js';
+export { appendVaryHeader, getRequestHeader } from './header-helpers.js';
 export * from './mapping.js';
 export * from './middleware/correlation.js';
 export * from './middleware/cors.js';

--- a/packages/http/src/index.portable.ts
+++ b/packages/http/src/index.portable.ts
@@ -40,6 +40,7 @@ export {
 export type { FastPathEligibility, FastPathStats } from './dispatch/fast-path/index.js';
 export * from './errors.js';
 export * from './exceptions.js';
+export * from './header-helpers.js';
 export * from './mapping.js';
 export * from './middleware/correlation.js';
 export * from './middleware/cors.js';

--- a/packages/http/src/mapping.test.ts
+++ b/packages/http/src/mapping.test.ts
@@ -308,6 +308,45 @@ describe('handler mapping', () => {
     expect(v2Match?.descriptor.methodName).toBe('listV2');
   });
 
+  it('scans duplicate-case Accept headers until a non-empty media type version is found', () => {
+    @Controller('/users')
+    class UsersController {
+      @Version('1')
+      @Get('/')
+      listV1() {
+        return [{ id: '1' }];
+      }
+
+      @Version('2')
+      @Get('/')
+      listV2() {
+        return [{ id: '2' }];
+      }
+    }
+
+    const mapping = createHandlerMapping(
+      [{ controllerToken: UsersController }],
+      { versioning: { key: 'v=', type: VersioningType.MEDIA_TYPE } },
+    );
+
+    const v2Match = mapping.match({
+      body: undefined,
+      cookies: {},
+      headers: {
+        accept: '   ',
+        Accept: 'application/json; v=2',
+      },
+      method: 'GET',
+      params: {},
+      path: '/users',
+      query: {},
+      raw: {},
+      url: '/users',
+    });
+
+    expect(v2Match?.descriptor.methodName).toBe('listV2');
+  });
+
   it('resolves versions from custom extractor functions', () => {
     @Controller('/users')
     class UsersController {

--- a/packages/http/src/mapping.test.ts
+++ b/packages/http/src/mapping.test.ts
@@ -347,6 +347,45 @@ describe('handler mapping', () => {
     expect(v2Match?.descriptor.methodName).toBe('listV2');
   });
 
+  it('combines duplicate-case Accept headers before scanning for media type versions', () => {
+    @Controller('/users')
+    class UsersController {
+      @Version('1')
+      @Get('/')
+      listV1() {
+        return [{ id: '1' }];
+      }
+
+      @Version('2')
+      @Get('/')
+      listV2() {
+        return [{ id: '2' }];
+      }
+    }
+
+    const mapping = createHandlerMapping(
+      [{ controllerToken: UsersController }],
+      { versioning: { key: 'v=', type: VersioningType.MEDIA_TYPE } },
+    );
+
+    const v2Match = mapping.match({
+      body: undefined,
+      cookies: {},
+      headers: {
+        accept: 'application/json',
+        Accept: 'application/json; v=2',
+      },
+      method: 'GET',
+      params: {},
+      path: '/users',
+      query: {},
+      raw: {},
+      url: '/users',
+    });
+
+    expect(v2Match?.descriptor.methodName).toBe('listV2');
+  });
+
   it('resolves versions from custom extractor functions', () => {
     @Controller('/users')
     class UsersController {

--- a/packages/http/src/mapping.ts
+++ b/packages/http/src/mapping.ts
@@ -108,12 +108,34 @@ function readHeaderValue(request: FrameworkRequest, headerName: string): string 
   return undefined;
 }
 
+function readCombinedHeaderValue(
+  request: FrameworkRequest,
+  headerName: string,
+): string | undefined {
+  const matches = getMatchingRequestHeaderValues(request, headerName);
+  const values: string[] = [];
+
+  for (const match of matches) {
+    const entries = Array.isArray(match) ? match : [match];
+
+    for (const entry of entries) {
+      const normalized = entry?.trim();
+
+      if (normalized) {
+        values.push(normalized);
+      }
+    }
+  }
+
+  return values.length > 0 ? values.join(',') : undefined;
+}
+
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function extractVersionFromMediaType(request: FrameworkRequest, key: string): string | undefined {
-  const accept = readHeaderValue(request, 'accept');
+  const accept = readCombinedHeaderValue(request, 'accept');
 
   if (!accept) {
     return undefined;

--- a/packages/http/src/mapping.ts
+++ b/packages/http/src/mapping.ts
@@ -4,6 +4,7 @@ import { getControllerMetadata, getRouteMetadata } from '@fluojs/core/internal';
 import { attachCompiledRouteIdentity } from './compiled-route-identity.js';
 import { getRouteProducesMetadata } from './decorators.js';
 import { RouteConflictError } from './errors.js';
+import { getRequestHeader } from './header-helpers.js';
 import { extractRoutePathParams, normalizeRoutePath, parseRoutePath, type RoutePathSegment } from './route-path.js';
 import type {
   FrameworkRequest,
@@ -64,25 +65,14 @@ function normalizeVersionValue(version: string): string {
 }
 
 function readHeaderValue(request: FrameworkRequest, headerName: string): string | undefined {
-  const normalizedHeaderName = headerName.trim().toLowerCase();
+  const raw = getRequestHeader(request, headerName);
+  const values = Array.isArray(raw) ? raw : [raw];
 
-  if (!normalizedHeaderName) {
-    return undefined;
-  }
+  for (const value of values) {
+    const normalized = value?.trim();
 
-  for (const [key, raw] of Object.entries(request.headers)) {
-    if (key.toLowerCase() !== normalizedHeaderName) {
-      continue;
-    }
-
-    const values = Array.isArray(raw) ? raw : [raw];
-
-    for (const value of values) {
-      const normalized = value?.trim();
-
-      if (normalized) {
-        return normalized;
-      }
+    if (normalized) {
+      return normalized;
     }
   }
 

--- a/packages/http/src/mapping.ts
+++ b/packages/http/src/mapping.ts
@@ -4,7 +4,6 @@ import { getControllerMetadata, getRouteMetadata } from '@fluojs/core/internal';
 import { attachCompiledRouteIdentity } from './compiled-route-identity.js';
 import { getRouteProducesMetadata } from './decorators.js';
 import { RouteConflictError } from './errors.js';
-import { getRequestHeader } from './header-helpers.js';
 import { extractRoutePathParams, normalizeRoutePath, parseRoutePath, type RoutePathSegment } from './route-path.js';
 import type {
   FrameworkRequest,
@@ -64,15 +63,45 @@ function normalizeVersionValue(version: string): string {
   return version.trim().replace(/^v/i, '');
 }
 
+function normalizeHeaderName(headerName: string): string | undefined {
+  const normalized = headerName.trim().toLowerCase();
+
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function getMatchingRequestHeaderValues(
+  request: FrameworkRequest,
+  headerName: string,
+): readonly (string | string[] | undefined)[] {
+  const normalizedHeaderName = normalizeHeaderName(headerName);
+
+  if (!normalizedHeaderName) {
+    return [];
+  }
+
+  const matches: Array<string | string[] | undefined> = [];
+
+  for (const [name, value] of Object.entries(request.headers)) {
+    if (name.toLowerCase() === normalizedHeaderName) {
+      matches.push(value);
+    }
+  }
+
+  return matches;
+}
+
 function readHeaderValue(request: FrameworkRequest, headerName: string): string | undefined {
-  const raw = getRequestHeader(request, headerName);
-  const values = Array.isArray(raw) ? raw : [raw];
+  const matches = getMatchingRequestHeaderValues(request, headerName);
 
-  for (const value of values) {
-    const normalized = value?.trim();
+  for (const match of matches) {
+    const values = Array.isArray(match) ? match : [match];
 
-    if (normalized) {
-      return normalized;
+    for (const value of values) {
+      const normalized = value?.trim();
+
+      if (normalized) {
+        return normalized;
+      }
     }
   }
 

--- a/packages/http/src/middleware/correlation.test.ts
+++ b/packages/http/src/middleware/correlation.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import type { FrameworkRequest, FrameworkResponse } from '../types.js';
 import { createCorrelationMiddleware } from './correlation.js';
@@ -60,5 +60,30 @@ describe('createCorrelationMiddleware', () => {
 
     expect(requestContext.requestId).toBe('req-upper');
     expect(response.headers['x-request-id']).toBe('req-upper');
+  });
+
+  it('ignores mixed-case blank inbound request ids before generating a new one', async () => {
+    const middleware = createCorrelationMiddleware();
+    const response = createResponse();
+    const requestContext: { requestId?: string } = {};
+    const randomUuid = vi
+      .spyOn(globalThis.crypto, 'randomUUID')
+      .mockReturnValue('11111111-1111-4111-8111-111111111111');
+
+    try {
+      await middleware.handle(
+        {
+          request: createRequest({ 'X-REQUEST-ID': '   ' }),
+          requestContext: requestContext as never,
+          response,
+        },
+        async () => {},
+      );
+    } finally {
+      randomUuid.mockRestore();
+    }
+
+    expect(requestContext.requestId).toBe('11111111-1111-4111-8111-111111111111');
+    expect(response.headers['x-request-id']).toBe('11111111-1111-4111-8111-111111111111');
   });
 });

--- a/packages/http/src/middleware/correlation.test.ts
+++ b/packages/http/src/middleware/correlation.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import type { FrameworkRequest, FrameworkResponse } from '../types.js';
+import { createCorrelationMiddleware } from './correlation.js';
+
+function createRequest(
+  headers: FrameworkRequest['headers'] = {},
+): FrameworkRequest {
+  return {
+    body: undefined,
+    cookies: {},
+    headers,
+    method: 'GET',
+    params: {},
+    path: '/correlation',
+    query: {},
+    raw: {},
+    url: '/correlation',
+  };
+}
+
+function createResponse(): FrameworkResponse {
+  return {
+    committed: false,
+    headers: {},
+    redirect(status, location) {
+      this.setStatus(status);
+      this.setHeader('Location', location);
+      this.committed = true;
+    },
+    send() {
+      this.committed = true;
+    },
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    setStatus(code) {
+      this.statusCode = code;
+      this.statusSet = true;
+    },
+    statusCode: undefined,
+    statusSet: false,
+  };
+}
+
+describe('createCorrelationMiddleware', () => {
+  it('reuses mixed-case inbound request ids before generating a new one', async () => {
+    const middleware = createCorrelationMiddleware();
+    const response = createResponse();
+    const requestContext: { requestId?: string } = {};
+
+    await middleware.handle(
+      {
+        request: createRequest({ 'X-REQUEST-ID': 'req-upper' }),
+        requestContext: requestContext as never,
+        response,
+      },
+      async () => {},
+    );
+
+    expect(requestContext.requestId).toBe('req-upper');
+    expect(response.headers['x-request-id']).toBe('req-upper');
+  });
+});

--- a/packages/http/src/middleware/correlation.ts
+++ b/packages/http/src/middleware/correlation.ts
@@ -4,11 +4,22 @@ import type { Middleware } from '../types.js';
 const REQUEST_ID_HEADER = 'x-request-id';
 const CORRELATION_ID_HEADER = 'x-correlation-id';
 
-function resolveInboundRequestId(request: { headers: Readonly<Record<string, string | string[] | undefined>> }): string {
-  const requestId = getRequestHeader(request as never, REQUEST_ID_HEADER) ?? getRequestHeader(request as never, CORRELATION_ID_HEADER);
-  const value = Array.isArray(requestId) ? requestId[0] : requestId;
+function readInboundHeaderValue(
+  request: { headers: Readonly<Record<string, string | string[] | undefined>> },
+  headerName: string,
+): string | undefined {
+  const rawHeaderValue = getRequestHeader(request as never, headerName);
+  const value = Array.isArray(rawHeaderValue) ? rawHeaderValue[0] : rawHeaderValue;
+  const normalized = value?.trim();
 
-  return value ?? createRequestId();
+  return normalized ? normalized : undefined;
+}
+
+function resolveInboundRequestId(request: { headers: Readonly<Record<string, string | string[] | undefined>> }): string {
+  const requestId = readInboundHeaderValue(request, REQUEST_ID_HEADER);
+  const correlationId = readInboundHeaderValue(request, CORRELATION_ID_HEADER);
+
+  return requestId ?? correlationId ?? createRequestId();
 }
 
 function createRequestId(): string {

--- a/packages/http/src/middleware/correlation.ts
+++ b/packages/http/src/middleware/correlation.ts
@@ -1,10 +1,11 @@
+import { getRequestHeader } from '../header-helpers.js';
 import type { Middleware } from '../types.js';
 
 const REQUEST_ID_HEADER = 'x-request-id';
 const CORRELATION_ID_HEADER = 'x-correlation-id';
 
-function resolveInboundRequestId(headers: Readonly<Record<string, string | string[] | undefined>>): string {
-  const requestId = headers[REQUEST_ID_HEADER] ?? headers[CORRELATION_ID_HEADER];
+function resolveInboundRequestId(request: { headers: Readonly<Record<string, string | string[] | undefined>> }): string {
+  const requestId = getRequestHeader(request as never, REQUEST_ID_HEADER) ?? getRequestHeader(request as never, CORRELATION_ID_HEADER);
   const value = Array.isArray(requestId) ? requestId[0] : requestId;
 
   return value ?? createRequestId();
@@ -29,7 +30,7 @@ export function createCorrelationMiddleware(): Middleware {
   return {
     async handle(context, next) {
       if (!context.requestContext.requestId) {
-        context.requestContext.requestId = resolveInboundRequestId(context.request.headers);
+        context.requestContext.requestId = resolveInboundRequestId(context.request);
       }
 
       context.response.setHeader(REQUEST_ID_HEADER, context.requestContext.requestId);

--- a/packages/http/src/middleware/cors.test.ts
+++ b/packages/http/src/middleware/cors.test.ts
@@ -192,6 +192,44 @@ describe('createCorsMiddleware', () => {
     expect(response.headers.Vary).toBe('Accept-Encoding, Origin');
   });
 
+  it('preserves lowercase vary header names when appending Origin', async () => {
+    const middleware = createCorsMiddleware({
+      allowOrigin: ['https://app.example.com'],
+    });
+    const response = createResponse();
+    response.setHeader('vary', 'Accept-Encoding');
+
+    await middleware.handle(
+      {
+        request: createRequest('GET', 'https://app.example.com'),
+        requestContext: {} as never,
+        response,
+      },
+      async () => {},
+    );
+
+    expect(response.headers.vary).toBe('Accept-Encoding, Origin');
+  });
+
+  it('preserves wildcard Vary responses without appending Origin', async () => {
+    const middleware = createCorsMiddleware({
+      allowOrigin: ['https://app.example.com'],
+    });
+    const response = createResponse();
+    response.setHeader('Vary', '*, Accept-Encoding');
+
+    await middleware.handle(
+      {
+        request: createRequest('GET', 'https://app.example.com'),
+        requestContext: {} as never,
+        response,
+      },
+      async () => {},
+    );
+
+    expect(response.headers.Vary).toBe('*');
+  });
+
   it('does not emit allow-origin for unlisted origins while continuing the request', async () => {
     const middleware = createCorsMiddleware({
       allowOrigin: ['https://trusted.example.com'],

--- a/packages/http/src/middleware/cors.ts
+++ b/packages/http/src/middleware/cors.ts
@@ -1,3 +1,4 @@
+import { appendVaryHeader, getRequestHeader } from '../header-helpers.js';
 import type { Middleware } from '../types.js';
 
 /**
@@ -57,7 +58,7 @@ export function createCorsMiddleware(options: CorsOptions = {}): Middleware {
 
   return {
     async handle(context, next) {
-      const requestOriginHeader = context.request.headers.origin;
+      const requestOriginHeader = getRequestHeader(context.request, 'origin');
       const requestOrigin = Array.isArray(requestOriginHeader) ? requestOriginHeader[0] : requestOriginHeader;
       const origin = resolveOrigin(options, requestOrigin);
 
@@ -85,15 +86,10 @@ export function createCorsMiddleware(options: CorsOptions = {}): Middleware {
       );
 
       if (origin && origin !== '*') {
-        const existingVary = context.response.headers['vary'] ?? context.response.headers['Vary'];
-        const varyValues = existingVary ? (Array.isArray(existingVary) ? existingVary : String(existingVary).split(',').map((v) => v.trim())) : [];
-        if (!varyValues.some((v) => v.toLowerCase() === 'origin')) {
-          varyValues.push('Origin');
-        }
-        context.response.setHeader('Vary', varyValues.join(', '));
+        appendVaryHeader(context.response, 'Origin');
       }
 
-      const requestedPreflightMethod = context.request.headers['access-control-request-method'];
+      const requestedPreflightMethod = getRequestHeader(context.request, 'access-control-request-method');
       const hasPreflightMethod = Array.isArray(requestedPreflightMethod)
         ? requestedPreflightMethod.length > 0
         : requestedPreflightMethod !== undefined;

--- a/packages/http/src/public-api.test.ts
+++ b/packages/http/src/public-api.test.ts
@@ -161,6 +161,7 @@ describe('@fluojs/http public API surface', () => {
     expect(httpPublicApi).toHaveProperty('createSecurityHeadersMiddleware');
     expect(httpPublicApi).toHaveProperty('appendVaryHeader');
     expect(httpPublicApi).toHaveProperty('getRequestHeader');
+    expect(httpPublicApi).not.toHaveProperty('readFirstNonEmptyRequestHeaderValue');
     expect(httpPublicApi).toHaveProperty('SseResponse');
     expect(httpPublicApi).toHaveProperty('encodeSseComment');
     expect(httpPublicApi).toHaveProperty('encodeSseMessage');

--- a/packages/http/src/public-api.test.ts
+++ b/packages/http/src/public-api.test.ts
@@ -159,6 +159,8 @@ describe('@fluojs/http public API surface', () => {
     expect(httpPublicApi).toHaveProperty('createCorsMiddleware');
     expect(httpPublicApi).toHaveProperty('createRateLimitMiddleware');
     expect(httpPublicApi).toHaveProperty('createSecurityHeadersMiddleware');
+    expect(httpPublicApi).toHaveProperty('appendVaryHeader');
+    expect(httpPublicApi).toHaveProperty('getRequestHeader');
     expect(httpPublicApi).toHaveProperty('SseResponse');
     expect(httpPublicApi).toHaveProperty('encodeSseComment');
     expect(httpPublicApi).toHaveProperty('encodeSseMessage');

--- a/packages/testing/src/portability/http-adapter-portability.test.ts
+++ b/packages/testing/src/portability/http-adapter-portability.test.ts
@@ -1,3 +1,4 @@
+import { appendVaryHeader, Controller, Get, getRequestHeader, type RequestContext } from '@fluojs/http';
 import { bootstrapExpressApplication, runExpressApplication } from '@fluojs/platform-express';
 import {
   bootstrapFastifyApplication,
@@ -5,6 +6,7 @@ import {
   runFastifyApplication,
 } from '@fluojs/platform-fastify';
 import { bootstrapNodejsApplication, runNodejsApplication } from '@fluojs/platform-nodejs';
+import { defineModule, type ModuleType } from '@fluojs/runtime';
 import { bootstrapNodeApplication, runNodeApplication } from '@fluojs/runtime/node';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -76,6 +78,83 @@ interface PortabilityAssertions {
 interface CleanupTrackedApp {
   close(): Promise<void>;
   listen(): Promise<void>;
+}
+
+type BootstrapHttpAdapterApp = {
+  close(): Promise<void>;
+  listen(): Promise<void>;
+};
+
+type BootstrapHttpAdapter = (
+  rootModule: ModuleType,
+  options: { cors: false; port: number },
+) => Promise<BootstrapHttpAdapterApp>;
+
+function resolveListeningUrl(app: BootstrapHttpAdapterApp): string {
+  const adapter = Reflect.get(app, 'adapter');
+
+  if (
+    typeof adapter !== 'object' ||
+    adapter === null ||
+    !('getListenTarget' in adapter) ||
+    typeof adapter.getListenTarget !== 'function'
+  ) {
+    throw new Error('Failed to resolve portability helper test listen target.');
+  }
+
+  const target = adapter.getListenTarget();
+
+  if (typeof target !== 'object' || target === null || typeof target.url !== 'string' || target.url.length === 0) {
+    throw new Error('Failed to resolve portability helper test listener URL.');
+  }
+
+  return target.url;
+}
+
+function registerHeaderHelperPortabilitySuite(
+  name: string,
+  bootstrap: BootstrapHttpAdapter,
+): void {
+  describe(`${name} request header helper portability`, () => {
+    it('reads mixed-case request headers and preserves wildcard Vary responses', async () => {
+      @Controller('/headers')
+      class HeaderController {
+        @Get('/')
+        read(_input: undefined, context: RequestContext) {
+          context.response.setHeader('vary', '*, Accept-Encoding');
+          appendVaryHeader(context.response, 'Accept');
+
+          return {
+            requestId: getRequestHeader(context.request, 'x-request-id'),
+          };
+        }
+      }
+
+      class AppModule {}
+      defineModule(AppModule, {
+        controllers: [HeaderController],
+      });
+
+      const app = await bootstrap(AppModule, { cors: false, port: 0 });
+
+      try {
+        await app.listen();
+        const response = await fetch(`${resolveListeningUrl(app)}/headers`, {
+          headers: {
+            'X-REQUEST-ID': 'req-portability',
+          },
+        });
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get('vary')).toBe('*');
+        await expect(response.json()).resolves.toEqual({
+          requestId: 'req-portability',
+        });
+      } finally {
+        await app.close();
+      }
+    });
+  });
 }
 
 function registerPortabilitySuite(
@@ -405,6 +484,7 @@ registerPortabilitySuite(
     streamDrainCloseEdge: true,
   },
 );
+registerHeaderHelperPortabilitySuite('node', bootstrapNodeApplication);
 
 registerPortabilitySuite(
   'nodejs-platform',
@@ -418,6 +498,7 @@ registerPortabilitySuite(
     streamDrainCloseEdge: true,
   },
 );
+registerHeaderHelperPortabilitySuite('nodejs-platform', bootstrapNodejsApplication);
 
 registerPortabilitySuite(
   'express',
@@ -431,6 +512,7 @@ registerPortabilitySuite(
     streamDrainCloseEdge: true,
   },
 );
+registerHeaderHelperPortabilitySuite('express', bootstrapExpressApplication);
 
 const fastifyPortabilityHarness = createHttpAdapterPortabilityHarness({
   bootstrap: bootstrapFastifyApplication,
@@ -457,3 +539,4 @@ const fastifyPortabilityHarness = createHttpAdapterPortabilityHarness({
 registerPortabilitySuite('fastify', fastifyPortabilityHarness, {
   streamDrainCloseEdge: true,
 });
+registerHeaderHelperPortabilitySuite('fastify', bootstrapFastifyApplication);

--- a/packages/testing/src/portability/web-runtime-adapter-portability.test.ts
+++ b/packages/testing/src/portability/web-runtime-adapter-portability.test.ts
@@ -1,3 +1,4 @@
+import { appendVaryHeader, Controller, Get, getRequestHeader, type RequestContext } from '@fluojs/http';
 import { type BunServeOptions, type BunServerLike, bootstrapBunApplication } from '@fluojs/platform-bun';
 import {
   bootstrapCloudflareWorkerApplication,
@@ -9,6 +10,7 @@ import {
   type DenoServeHandler,
   type DenoServeOptions,
 } from '@fluojs/platform-deno';
+import { defineModule, type ModuleType } from '@fluojs/runtime';
 import { describe, expect, it, vi } from 'vitest';
 
 import { createWebRuntimeHttpAdapterPortabilityHarness } from './web-runtime-adapter-portability.js';
@@ -122,6 +124,16 @@ type BunBootstrapApp = {
   close(): Promise<void>;
   listen(): Promise<void>;
 };
+
+type WebRuntimePortabilityApp = {
+  close(): Promise<void>;
+  dispatch(request: Request): Promise<Response>;
+};
+
+type WebRuntimeBootstrap = (
+  rootModule: ModuleType,
+  options: { cors: false },
+) => Promise<WebRuntimePortabilityApp>;
 
 type BunBootstrap = (
   rootModule: Parameters<typeof bootstrapBunApplication>[0],
@@ -313,6 +325,51 @@ function registerWebRuntimePortabilitySuite(
   });
 }
 
+function registerWebRuntimeHeaderHelperPortabilitySuite(
+  name: string,
+  bootstrap: WebRuntimeBootstrap,
+): void {
+  describe(`${name} request header helper portability`, () => {
+    it('reads mixed-case request headers and preserves wildcard Vary responses', async () => {
+      @Controller('/headers')
+      class HeaderController {
+        @Get('/')
+        read(_input: undefined, context: RequestContext) {
+          context.response.setHeader('vary', '*, Accept-Encoding');
+          appendVaryHeader(context.response, 'Accept');
+
+          return {
+            requestId: getRequestHeader(context.request, 'x-request-id'),
+          };
+        }
+      }
+
+      class AppModule {}
+      defineModule(AppModule, {
+        controllers: [HeaderController],
+      });
+
+      const app = await bootstrap(AppModule, { cors: false });
+
+      try {
+        const response = await app.dispatch(new Request('https://runtime.test/headers', {
+          headers: {
+            'X-REQUEST-ID': 'req-portability',
+          },
+        }));
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get('vary')).toBe('*');
+        await expect(response.json()).resolves.toEqual({
+          requestId: 'req-portability',
+        });
+      } finally {
+        await app.close();
+      }
+    });
+  });
+}
+
 registerWebRuntimePortabilitySuite(
   'bun',
   createWebRuntimeHttpAdapterPortabilityHarness({
@@ -323,6 +380,8 @@ registerWebRuntimePortabilitySuite(
     name: 'bun',
   }),
 );
+registerWebRuntimeHeaderHelperPortabilitySuite('bun', async (rootModule, options) =>
+  await createBunPortabilityApp(rootModule, options));
 
 describe('bun web runtime adapter cleanup', () => {
   it('restores mocked Bun when bootstrap throws before listen', async () => {
@@ -394,6 +453,24 @@ registerWebRuntimePortabilitySuite(
     name: 'deno',
   }),
 );
+registerWebRuntimeHeaderHelperPortabilitySuite('deno', async (rootModule, options) => {
+  const server = createServeStub();
+  const app = await bootstrapDenoApplication(rootModule, {
+    ...options,
+    serve: server.serve,
+  });
+
+  await app.listen();
+
+  return {
+    close() {
+      return app.close();
+    },
+    async dispatch(request: Request) {
+      return await server.handler!(request);
+    },
+  };
+});
 
 registerWebRuntimePortabilitySuite(
   'cloudflare-workers',
@@ -414,3 +491,15 @@ registerWebRuntimePortabilitySuite(
     name: 'cloudflare-workers',
   }),
 );
+registerWebRuntimeHeaderHelperPortabilitySuite('cloudflare-workers', async (rootModule, options) => {
+  const worker = await bootstrapCloudflareWorkerApplication(rootModule, options);
+
+  return {
+    close() {
+      return worker.close();
+    },
+    async dispatch(request: Request) {
+      return await worker.fetch(request, {}, createExecutionContext());
+    },
+  };
+});


### PR DESCRIPTION
## Summary

Add portable, case-insensitive request-header lookup and `Vary` merging helpers, then route existing HTTP readers and mergers through the shared contract.

Linked context: Closes https://github.com/fluojs/fluo/issues/3304

## Changes

- add `getRequestHeader(request, name)` and `appendVaryHeader(response, ...fields)` with TSDoc and root exports
- migrate DTO binding, versioning, request-id, correlation, CORS, and representation negotiation callers
- add HTTP and testing-facade portability regression coverage, EN/KO README documentation, and a patch changeset

## Testing

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter @fluojs/http test` (313 passing)
- `pnpm --filter @fluojs/testing test` (227 passing)
- focused RED/GREEN regression tests and built public-surface manual drivers
- full `pnpm verify` reached the complete suite; only independently reproduced `main` baseline governance failures and multipart unhandled rejection remained

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Adapter portability claims are backed by the HTTP portability harness tests.
