### PR TITLE
fix(tooling): gate dependent issue dispatch

### DIFF
--- a/.agents/MIGRATION.md
+++ b/.agents/MIGRATION.md
@@ -13,8 +13,8 @@ $search-issue -> $create-lane -> $execute-lane
 - Skills define inputs, procedure, outputs, authority, and stop conditions.
 - The top-level lead is the only canonical ledger writer.
 - Background tasks implement or review one typed assignment.
-- DAG nodes schedule acyclic attempts; the persisted ledger remains resume
-  truth.
+- The parent dispatches eligible issues as independent single-node DAG runs;
+  the persisted ledger remains dependency and resume truth.
 - Goal and todo state are user-facing projections.
 - Memory stores durable preferences and decisions, never issue/PR/retry state.
 
@@ -62,3 +62,7 @@ provenance mandatory.
 
 Rollback restores the control plane only. Remote GitHub issues, PRs, and merges
 are reconciled into the restored ledger; they are never silently undone.
+
+Legacy lane-wide v1 DAG bindings are not upgraded in place. Quiesce their run,
+reconcile terminal issue stores and live state, and carry unfinished issues
+through a newly approved lane identity before using per-issue v2 dispatch.

--- a/.agents/THREAT_MODEL.md
+++ b/.agents/THREAT_MODEL.md
@@ -24,7 +24,10 @@ are not signatures against that trusted operator.
 - The parent lead owns shared lane state and root synchronization. An
   issue-supervisor node may execute push, canonical PR create/update, merge, and
   cleanup only for its bound issue after the user grants the applicable lane
-  authority. Nested implementers and reviewers never receive that authority.
+  authority. The parent persists a dispatch intent, starts one issue run, then
+  immediately binds the observed run ID. Reconciliation refuses an intent
+  without a binding and attaches an exact binding without starting a duplicate.
+  Nested implementers and reviewers never receive that authority.
 - Successful receipts are written only from fresh live Git/GitHub command
   output bound to lane, issue, branch, worktree, PR, and head.
 - The supervisor persists target-bound observations in its issue-local atomic
@@ -48,4 +51,7 @@ collisions. Lane and issue-supervisor state stores reject symlinked state
 paths, write transaction journals before transitions, recover incomplete
 transactions, preserve append-only event hashes, and atomically replace
 snapshots and receipt sets. DAG bindings are first-write exclusive and bind the
-lane, native run, graph definition, and snapshot event anchor.
+lane, issue, native run, one-node definition, canonical dependencies, and
+dispatch event anchor. Legacy lane-wide v1 bindings remain immutable fences.
+Blocked dependent terminalization requires fresh absence observations for its
+issue store, local/remote branch, worktree, native task, and PR.

--- a/.agents/VALIDATION.md
+++ b/.agents/VALIDATION.md
@@ -29,6 +29,11 @@ tooling/governance/issue-to-pr-native.test.ts
 tooling/governance/pr-to-merge-native.test.ts
 tooling/governance/execute-lane-native.test.ts
 tooling/governance/execute-lane-dag-supervisor.test.ts
+tooling/governance/execute-lane-dag-scheduling.test.ts
+tooling/governance/execute-lane-dag-binding-v2.test.ts
+tooling/governance/execute-lane-dependency-cleanup-gate.test.ts
+tooling/governance/execute-lane-dependency-assets.test.ts
+tooling/governance/execute-lane-dispatch-intent.test.ts
 tooling/governance/execute-lane-persistence.test.ts
 tooling/governance/execute-lane-resilience.test.ts
 tooling/governance/execute-lane-authority.test.ts
@@ -49,6 +54,15 @@ target-bound receipt. Publishing remains GitHub Actions-only.
 Validate the lane snapshot, event hash chain, lease, live branch/worktree/PR
 identity, current head, checks, and approval freshness before resuming. Never
 fill missing persisted fields with compatibility defaults.
+
+Before each issue dispatch, require canonical `done` for every dependency,
+reconcile intent/binding state, persist `supervisor.dispatch.intent`, and create
+one immutable issue v2 binding. Intent without binding must fail closed; exact
+binding must attach without another start.
+Task completion, merge without cleanup, `CLOSED` observations, and terminal
+blockers must never create a downstream issue store, branch, worktree, task, or
+PR. Terminalizing blocked dependents requires fresh absence observations for
+all six artifact classes.
 
 For non-empty `release_handoffs`, derive the consumed lane-plan receipt from
 the canonical repository approval directory. Recompute its approval binding

--- a/.agents/skills/execute-lane/SKILL.md
+++ b/.agents/skills/execute-lane/SKILL.md
@@ -9,16 +9,22 @@ Consume only a strict canonical lane v2 created by `$create-lane`. Do not
 rediscover issues, regroup scope, or infer missing persisted fields.
 
 The parent lead is the only shared lane snapshot/event/receipt/lease writer.
-It compiles the validated lane snapshot into one native DAG node per issue.
-Each issue node is a supervisor for one isolated issue lifecycle and may use
-only the Git/GitHub authority explicitly granted by the lane. Implementers and
-reviewers remain nested, separately delegated roles.
+It computes issue eligibility from the validated shared snapshot and starts
+one single-node native DAG per eligible issue. Independent eligible issues may
+run concurrently. A dependent issue is not compiled, bound, or spawned until
+every dependency is canonical `done` in shared `completed_issues`. Each issue
+node is a supervisor for one isolated issue lifecycle and may use only the
+Git/GitHub authority explicitly granted by the lane. Implementers and reviewers
+remain nested, separately delegated roles.
 
 Read `references/workflow.md` and `references/issue-supervisor.md` before
-execution. Compile the graph with `scripts/compile-dag.mjs`, bind the native
-run through `scripts/dag-binding.mjs`, and persist the binding at
-`.omo/lane-runs/<lane-id>/dag-binding.json`. Goal, todo, and DAG state remain
-projections of the persisted lane state and live observations.
+execution. Use `scripts/issue-dispatch.mjs` to reconcile intent and binding,
+persist the candidate dispatch intent, compile exactly one issue with
+`compileIssueSupervisorDag()`, then attach the observed native run through
+`attachIssueSupervisorRun()` at
+`.omo/lane-runs/<lane-id>/dag-bindings/issue-<number>.json`. Never start the
+legacy full-lane definition. Goal, todo, and DAG state remain projections of
+the persisted lane state and live observations.
 
 Production execution never uses `scripts/fixtures/run-replay.mjs`. The lead
 performs or observes each authorized Git/GitHub action, reads fresh raw output,
@@ -32,3 +38,10 @@ triad. A fixable CI failure returns that issue to implementation and invalidates
 all prior local review evidence. CI PASS on the exact reviewed PR head produces
 `merge-ready`; only an issue supervisor's fresh lead-authorized merge
 observation may create a merge receipt.
+
+After each one-node run settles, validate and import its terminal evidence
+before recomputing eligibility. Native task completion is never dependency
+success. `needs-human-check`, policy, budget, cleanup, malformed-output, and
+ledger terminal states do not release dependents; the parent records their
+dependent lanes as terminal blockers only after fresh issue-store, branch,
+worktree, task, and PR absence observations, without creating those artifacts.

--- a/.agents/skills/execute-lane/references/issue-supervisor.md
+++ b/.agents/skills/execute-lane/references/issue-supervisor.md
@@ -1,8 +1,10 @@
 # Native issue supervisor
 
-One DAG node owns one issue from initial implementation through merge and
-cleanup. Nodes for independent issues run concurrently; `dependsOn` mirrors the
-canonical lane dependency graph.
+One single-node DAG owns one issue from initial implementation through merge
+and cleanup. Parent-owned dispatch may start independent eligible issues
+concurrently. A dependent node is not created until every canonical dependency
+is already shared `done`; native DAG ordering is never used as success
+evidence.
 
 ## Role separation
 
@@ -67,6 +69,12 @@ Before any remote action, re-read live Git and GitHub identity. On task restart,
 resume from the issue state and live observations rather than repeating the
 last claimed action. The node returns typed transition evidence and receipts;
 the parent validates them before updating the shared lane ledger.
+
+Before creating a child, branch, or worktree, re-read the shared snapshot and
+require the issue to remain its lane's queued cursor with every dependency
+present in `completed_issues` and `issue_progress.status === 'done'`. If that
+precondition changed after dispatch, return a ledger-conflict terminal without
+performing a mutation.
 
 ## Stop
 

--- a/.agents/skills/execute-lane/references/workflow.md
+++ b/.agents/skills/execute-lane/references/workflow.md
@@ -7,7 +7,9 @@
 - Events: `.omo/lane-runs/<lane-id>/events.jsonl`
 - Receipts: `.omo/lane-runs/<lane-id>/receipts.json`
 - Lease: `.omo/lane-runs/<lane-id>/lease.json`
-- DAG binding: `.omo/lane-runs/<lane-id>/dag-binding.json`
+- Issue DAG bindings:
+  `.omo/lane-runs/<lane-id>/dag-bindings/issue-<number>.json`
+- Legacy lane-wide binding: `.omo/lane-runs/<lane-id>/dag-binding.json`
 - Issue runtime: `.omo/lane-runs/<lane-id>/issues/<issue-number>/`
 
 Acquire a per-ledger lease, validate the v2 snapshot and event hash chain, and
@@ -27,26 +29,45 @@ Each receipt attestation must retain the approved issue evidence digest,
 Recompute the receipt binding and require it to equal the independent
 `lane_plan_approval_sha256` stored in the ready ledger.
 
-## DAG projection
+## Parent-owned incremental dispatch
 
-Compile the validated lane through `scripts/compile-dag.mjs`. The definition
-contains one `issue-<number>-supervisor` node per confirmed issue, and
-`dependsOn` exactly mirrors `dependency_graph`. Every executable node owns a
-disjoint issue worktree and the complete issue lifecycle. Approval-bound
-release handoff nodes perform no implementation and park at
-`blocked-maintainer-decision`.
+Native `dependsOn` expresses task ordering, not predecessor success. Production
+therefore never starts the legacy full-lane definition. The parent repeatedly:
 
-Start the definition with the native DAG tool, then atomically persist its key,
-run ID, definition digest, and current event hash through
-`scripts/dag-binding.mjs`. On restart, reconcile Fluo state and live identities
-first, require the stored definition digest to match, and only then attach the
-recorded run. A missing or conflicting run fails closed; DAG journal state never
-overrides the lane ledger.
+1. reconciles existing issue bindings, stores, and live identities;
+2. imports validated terminal supervisor evidence;
+3. compiles one issue through `compileIssueSupervisorDag()` and calls
+   `reconcileIssueSupervisorDispatch()`;
+4. persists the returned `supervisor.dispatch.intent` candidate;
+5. starts a single-node native DAG whose node has `dependsOn: []`;
+6. immediately attaches the observed run with
+   `attachIssueSupervisorRun()`;
+7. persists its immutable v2 binding under
+   `dag-bindings/issue-<number>.json`.
 
-Each node initialises `scripts/issue-supervisor-store.mjs` under its issue
-runtime directory. Every local review, remote observation, receipt, and status
-transition is transactionally persisted there. The parent imports only a
-validated terminal supervisor state through `scripts/supervisor-terminal.mjs`.
+Independent issues returned by the gate may be dispatched concurrently. A
+dependency succeeds only when it appears in `completed_issues` and its shared
+`issue_progress.status` is `done`, preserving merge, CLOSED issue, and cleanup
+evidence. Merge alone, a CLOSED observation, native task completion, or any
+terminal blocker does not release a dependent.
+
+After a one-node run settles, the parent validates and imports it before
+computing the next eligible set. A blocked dependency terminalizes unreachable
+dependent lanes only after fresh absence observations prove no issue store,
+branch, worktree, task, or PR exists. Those observations are recorded in the
+`dependency.blocked` event. An existing dispatch intent without an exact issue
+binding is an ambiguous crash window and
+`reconcileIssueSupervisorDispatch()` fails closed. An existing exact binding
+returns only `attach`; it never authorizes a duplicate start.
+
+Legacy v1 lane-wide bindings remain immutable evidence only. Do not overwrite,
+amend, or resume them as the production scheduler. Reconcile their issue stores
+and live state, then require a new approved lane identity for unfinished work.
+
+Each dispatched node initialises `scripts/issue-supervisor-store.mjs` under its
+issue runtime directory. Every local review, remote observation, receipt, and
+status transition is transactionally persisted there. The parent imports only
+a validated terminal supervisor state through `scripts/supervisor-terminal.mjs`.
 
 ## Issue supervisor loop
 
@@ -115,14 +136,17 @@ git rev-parse HEAD
 git rev-parse origin/<base-branch>
 ```
 
-Before first push and every update, the issue supervisor verifies the complete
-local triad against the commit head. Before merge, it verifies the reviewed
+Before dispatch and again before first mutation, the parent and issue
+supervisor require the issue to remain the queued lane cursor with every
+dependency at canonical `done`. Before first push and every update, the issue
+supervisor verifies the complete local triad against the commit head. Before
+merge, it verifies the reviewed
 head, remote branch, `headRefOid`, and CI head are identical. After merge, it
 requires `state: MERGED`, a non-null merge commit, and the linked issue
 `state: CLOSED`. Cleanup receipts require the worktree and local/remote branch
-queries to prove absence. The parent performs root sync only after all DAG nodes
-are terminal; its receipt requires a clean primary checkout, successful
-`pull --ff-only`, and equal local/remote base-branch SHAs.
+queries to prove absence. The parent performs root sync only after every lane is
+done or explicitly terminal; its receipt requires a clean primary checkout,
+successful `pull --ff-only`, and equal local/remote base-branch SHAs.
 
 `scripts/fixtures/run-replay.mjs --fixture-only` is a deterministic transition
 exerciser and never grants or observes production side-effect authority.

--- a/.agents/skills/execute-lane/scripts/compile-dag.mjs
+++ b/.agents/skills/execute-lane/scripts/compile-dag.mjs
@@ -1,5 +1,6 @@
 import { assertContract } from '../../../workflow-contracts/contracts.mjs';
 import { validateLedger } from '../../../../tooling/governance/lane-ledger-state.mjs';
+import { dependencyGate } from './dependency-gate.mjs';
 
 const nodeId = (issueNumber) => `issue-${String(issueNumber)}-supervisor`;
 
@@ -19,6 +20,8 @@ SCOPE:
 - The issue supervisor owns issue-bound push, PR mutation, merge, cleanup, and
   issue-local evidence only under immutable lane authority.
 - The parent lead alone owns the shared lane ledger and root synchronization.
+- Before any mutation, re-read the shared lane snapshot and require this issue
+  to remain the queued lane cursor with every dependency at canonical done.
 
 VERIFY:
 - Bind every local review, PR observation, CI result, merge, and cleanup action to the current head.
@@ -47,7 +50,7 @@ Validate the issue number, release-handoff approval digest, and changeset_only=f
 STOP WHEN:
 The release handoff is persisted as blocked-maintainer-decision, or the approval binding is rejected.`;
 
-export const compileLaneSupervisorDag = (lane) => {
+export const compileLegacyLaneSupervisorDag = (lane) => {
   assertContract('lane-ledger-v2', lane);
   validateLedger('lane-ledger-v2', lane);
   const releaseHandoffs = new Set(lane.release_handoffs);
@@ -91,5 +94,39 @@ export const compileLaneSupervisorDag = (lane) => {
     key: `fluo:lane:${lane.lane_id}:issue-supervisors:v1`,
     name: `Fluo lane ${lane.lane_id} issue supervisors`,
     nodes,
+  };
+};
+
+export const compileIssueSupervisorDag = (lane, issueNumber) => {
+  assertContract('lane-ledger-v2', lane);
+  validateLedger('lane-ledger-v2', lane);
+  const laneState = lane.lanes.find(
+    (candidate) =>
+      candidate.status === 'queued' &&
+      candidate.current_issue === issueNumber,
+  );
+  if (laneState === undefined) {
+    throw new TypeError(
+      `issue ${String(issueNumber)} is not the queued lane cursor.`,
+    );
+  }
+  const gate = dependencyGate(lane, issueNumber);
+  if (gate.status !== 'ready') {
+    throw new TypeError(
+      `issue ${String(issueNumber)} dependency gate is ${gate.status}.`,
+    );
+  }
+  const node = compileLegacyLaneSupervisorDag(lane).nodes.find(
+    (candidate) => candidate.id === nodeId(issueNumber),
+  );
+  if (node === undefined) {
+    throw new TypeError(
+      `issue ${String(issueNumber)} is missing from the supervisor plan.`,
+    );
+  }
+  return {
+    key: `fluo:lane:${lane.lane_id}:issue-${String(issueNumber)}:supervisor:v2`,
+    name: `Fluo lane ${lane.lane_id} issue ${String(issueNumber)} supervisor`,
+    nodes: [{ ...node, dependsOn: [] }],
   };
 };

--- a/.agents/skills/execute-lane/scripts/dag-binding-files.mjs
+++ b/.agents/skills/execute-lane/scripts/dag-binding-files.mjs
@@ -1,0 +1,90 @@
+import { randomUUID } from 'node:crypto';
+import {
+  existsSync,
+  lstatSync,
+  linkSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { resolve, sep } from 'node:path';
+
+import { assertContract } from '../../../workflow-contracts/contracts.mjs';
+
+const assertRealFile = (path) => {
+  if (!existsSync(path)) {
+    return;
+  }
+  const stat = lstatSync(path);
+  if (stat.isSymbolicLink() || !stat.isFile()) {
+    throw new TypeError(`${path} must be a real regular file.`);
+  }
+};
+
+export const ensureRealDirectory = (directory) => {
+  if (!existsSync(directory)) {
+    mkdirSync(directory);
+  }
+  const stat = lstatSync(directory);
+  if (
+    stat.isSymbolicLink() ||
+    !stat.isDirectory() ||
+    realpathSync(directory) !== resolve(directory)
+  ) {
+    throw new TypeError('DAG binding directory must be a real directory.');
+  }
+};
+
+export const ensureLaneDirectory = (runtimeRoot, laneId) => {
+  ensureRealDirectory(runtimeRoot);
+  const directory = resolve(runtimeRoot, laneId);
+  if (!directory.startsWith(`${resolve(runtimeRoot)}${sep}`)) {
+    throw new TypeError('DAG binding lane path must stay under runtime root.');
+  }
+  ensureRealDirectory(directory);
+  return directory;
+};
+
+export const loadImmutableBinding = (target) => {
+  assertRealFile(target);
+  if (!existsSync(target)) {
+    return null;
+  }
+  const binding = JSON.parse(readFileSync(target, 'utf8'));
+  assertContract('lane-dag-binding', binding);
+  return binding;
+};
+
+export const persistImmutableBinding = (target, binding) => {
+  const persisted = loadImmutableBinding(target);
+  if (persisted !== null) {
+    if (JSON.stringify(persisted) === JSON.stringify(binding)) {
+      return;
+    }
+    throw new TypeError('DAG binding conflicts with the persisted run.');
+  }
+  const candidate = `${target}.${randomUUID()}.tmp`;
+  writeFileSync(candidate, `${JSON.stringify(binding, null, 2)}\n`, {
+    encoding: 'utf8',
+    flag: 'wx',
+  });
+  try {
+    try {
+      linkSync(candidate, target);
+    } catch (error) {
+      if (error?.code !== 'EEXIST') {
+        throw error;
+      }
+      const concurrent = loadImmutableBinding(target);
+      if (JSON.stringify(concurrent) !== JSON.stringify(binding)) {
+        throw new TypeError('DAG binding conflicts with the persisted run.');
+      }
+    }
+  } finally {
+    if (existsSync(candidate)) {
+      unlinkSync(candidate);
+    }
+  }
+};

--- a/.agents/skills/execute-lane/scripts/dag-binding.mjs
+++ b/.agents/skills/execute-lane/scripts/dag-binding.mjs
@@ -1,57 +1,17 @@
-import { randomUUID } from 'node:crypto';
-import {
-  existsSync,
-  lstatSync,
-  linkSync,
-  mkdirSync,
-  readFileSync,
-  realpathSync,
-  unlinkSync,
-  writeFileSync,
-} from 'node:fs';
-import { resolve, sep } from 'node:path';
+import { resolve } from 'node:path';
 
 import {
   assertContract,
   payloadDigest,
 } from '../../../workflow-contracts/contracts.mjs';
+import {
+  ensureLaneDirectory,
+  loadImmutableBinding,
+  persistImmutableBinding,
+} from './dag-binding-files.mjs';
 
 const bindingPath = (runtimeRoot, laneId) =>
   resolve(runtimeRoot, laneId, 'dag-binding.json');
-
-const assertRealFile = (path) => {
-  if (!existsSync(path)) {
-    return;
-  }
-  const stat = lstatSync(path);
-  if (stat.isSymbolicLink() || !stat.isFile()) {
-    throw new TypeError(`${path} must be a real regular file.`);
-  }
-};
-
-const ensureRealDirectory = (directory) => {
-  if (!existsSync(directory)) {
-    mkdirSync(directory);
-  }
-  const stat = lstatSync(directory);
-  if (
-    stat.isSymbolicLink() ||
-    !stat.isDirectory() ||
-    realpathSync(directory) !== resolve(directory)
-  ) {
-    throw new TypeError('DAG binding directory must be a real directory.');
-  }
-};
-
-const laneDirectory = (runtimeRoot, laneId) => {
-  ensureRealDirectory(runtimeRoot);
-  const directory = resolve(runtimeRoot, laneId);
-  if (!directory.startsWith(`${resolve(runtimeRoot)}${sep}`)) {
-    throw new TypeError('DAG binding lane path must stay under runtime root.');
-  }
-  ensureRealDirectory(directory);
-  return directory;
-};
 
 export const createDagBinding = ({
   definition,
@@ -81,6 +41,9 @@ export const assertDagBindingMatches = (
   { definition, lane_id, run_id, snapshot_event_hash },
 ) => {
   assertContract('lane-dag-binding', binding);
+  if (binding.version !== 1) {
+    throw new TypeError('Lane-wide DAG binding must use version 1.');
+  }
   if (binding.definition_sha256 !== payloadDigest(definition)) {
     throw new TypeError('DAG binding definition digest does not match.');
   }
@@ -102,50 +65,31 @@ export const assertDagBindingMatches = (
 
 export const persistDagBinding = (runtimeRoot, binding) => {
   assertContract('lane-dag-binding', binding);
-  laneDirectory(runtimeRoot, binding.lane_id);
-  const target = bindingPath(runtimeRoot, binding.lane_id);
-  assertRealFile(target);
-  const acceptPersisted = () => {
-    assertRealFile(target);
-    const persisted = JSON.parse(readFileSync(target, 'utf8'));
-    assertContract('lane-dag-binding', persisted);
-    if (JSON.stringify(persisted) === JSON.stringify(binding)) {
-      return;
-    }
-    throw new TypeError('DAG binding conflicts with the persisted run.');
-  };
-  if (existsSync(target)) {
-    return acceptPersisted();
+  if (binding.version !== 1) {
+    throw new TypeError('Lane-wide DAG binding must use version 1.');
   }
-  const candidate = `${target}.${randomUUID()}.tmp`;
-  writeFileSync(candidate, `${JSON.stringify(binding, null, 2)}\n`, {
-    encoding: 'utf8',
-    flag: 'wx',
-  });
-  try {
-    try {
-      linkSync(candidate, target);
-    } catch (error) {
-      if (error?.code !== 'EEXIST') {
-        throw error;
-      }
-      return acceptPersisted();
-    }
-  } finally {
-    if (existsSync(candidate)) {
-      unlinkSync(candidate);
-    }
-  }
+  ensureLaneDirectory(runtimeRoot, binding.lane_id);
+  persistImmutableBinding(
+    bindingPath(runtimeRoot, binding.lane_id),
+    binding,
+  );
 };
 
 export const loadDagBinding = (runtimeRoot, laneId) => {
-  laneDirectory(runtimeRoot, laneId);
-  const target = bindingPath(runtimeRoot, laneId);
-  assertRealFile(target);
-  if (!existsSync(target)) {
+  ensureLaneDirectory(runtimeRoot, laneId);
+  const binding = loadImmutableBinding(bindingPath(runtimeRoot, laneId));
+  if (binding === null) {
     return null;
   }
-  const binding = JSON.parse(readFileSync(target, 'utf8'));
-  assertContract('lane-dag-binding', binding);
+  if (binding.version !== 1) {
+    throw new TypeError('Lane-wide DAG binding path requires version 1.');
+  }
   return binding;
 };
+
+export {
+  assertIssueDagBindingMatches,
+  createIssueDagBinding,
+  loadIssueDagBinding,
+  persistIssueDagBinding,
+} from './issue-dag-binding.mjs';

--- a/.agents/skills/execute-lane/scripts/dependency-gate.mjs
+++ b/.agents/skills/execute-lane/scripts/dependency-gate.mjs
@@ -1,0 +1,205 @@
+import {
+  assertContract,
+  assertEventChain,
+} from '../../../workflow-contracts/contracts.mjs';
+import { terminalStatuses } from '../../../../tooling/governance/lane-ledger-contract.mjs';
+import { validateLedger } from '../../../../tooling/governance/lane-ledger-state.mjs';
+import {
+  appendEvent,
+  terminalize,
+} from './transition-application.mjs';
+
+const dependencySucceeded = (snapshot, issueNumber) =>
+  snapshot.completed_issues.includes(issueNumber) &&
+  snapshot.issue_progress[String(issueNumber)]?.status === 'done';
+
+export const dependencyGate = (snapshot, issueNumber) => {
+  assertContract('lane-ledger-v2', snapshot);
+  validateLedger('lane-ledger-v2', snapshot);
+  if (!snapshot.confirmed_issues.includes(issueNumber)) {
+    throw new TypeError(
+      `issue ${String(issueNumber)} is not confirmed by the lane.`,
+    );
+  }
+  const dependencies = snapshot.dependency_graph[String(issueNumber)] ?? [];
+  const unsatisfiedDependencies = dependencies.filter(
+    (dependency) => !dependencySucceeded(snapshot, dependency),
+  );
+  const blocked = unsatisfiedDependencies.some((dependency) => {
+    const status = snapshot.issue_progress[String(dependency)]?.status;
+    return (
+      status !== undefined &&
+      status !== 'done' &&
+      terminalStatuses.has(status)
+    );
+  });
+  return {
+    status:
+      unsatisfiedDependencies.length === 0
+        ? 'ready'
+        : blocked
+          ? 'blocked'
+          : 'waiting',
+    dependencies,
+    unsatisfied_dependencies: unsatisfiedDependencies,
+  };
+};
+
+export const dispatchableIssueNumbers = (snapshot) => {
+  assertContract('lane-ledger-v2', snapshot);
+  validateLedger('lane-ledger-v2', snapshot);
+  return snapshot.confirmed_issues.filter((issueNumber) => {
+    const lane = snapshot.lanes.find(
+      (candidate) =>
+        candidate.status === 'queued' &&
+        candidate.current_issue === issueNumber,
+    );
+    return (
+      lane !== undefined &&
+      dependencyGate(snapshot, issueNumber).status === 'ready'
+    );
+  });
+};
+
+export const prepareIssueSupervisorDispatch = (persisted, issueNumber) => {
+  const snapshot = structuredClone(persisted.snapshot);
+  const events = structuredClone(persisted.events);
+  const receipts = structuredClone(persisted.receipts);
+  assertContract('lane-ledger-v2', snapshot);
+  validateLedger('lane-ledger-v2', snapshot);
+  if (events.length > 0) {
+    assertEventChain(events);
+  }
+  if (
+    events.some(
+      (event) =>
+        event.event_type === 'supervisor.dispatch.intent' &&
+        event.subject_id === String(issueNumber),
+    )
+  ) {
+    throw new TypeError(
+      `issue ${String(issueNumber)} dispatch intent already exists.`,
+    );
+  }
+  if (!dispatchableIssueNumbers(snapshot).includes(issueNumber)) {
+    throw new TypeError(
+      `issue ${String(issueNumber)} dependency gate is not ready.`,
+    );
+  }
+  const dependencies =
+    snapshot.dependency_graph[String(issueNumber)] ?? [];
+  appendEvent(
+    events,
+    snapshot.lane_id,
+    'supervisor.dispatch.intent',
+    String(issueNumber),
+    { dependencies },
+  );
+  assertEventChain(events);
+  return {
+    snapshot,
+    events,
+    receipts,
+    dispatch_event_hash: events.at(-1).event_hash,
+  };
+};
+
+const artifactAbsenceFor = (observations, issueNumber) => {
+  if (!Array.isArray(observations)) {
+    throw new TypeError('Artifact absence observations must be an array.');
+  }
+  const observation = observations.find(
+    (candidate) => candidate?.issue_number === issueNumber,
+  );
+  const absenceKeys = [
+    'issue_store_absent',
+    'local_branch_absent',
+    'remote_branch_absent',
+    'worktree_absent',
+    'task_absent',
+    'pr_absent',
+  ];
+  if (
+    observation === undefined ||
+    absenceKeys.some((key) => observation[key] !== true) ||
+    typeof observation.observed_at !== 'string' ||
+    Number.isNaN(Date.parse(observation.observed_at))
+  ) {
+    throw new TypeError(
+      `issue ${String(issueNumber)} artifact absence observation is missing.`,
+    );
+  }
+  return observation;
+};
+
+export const terminalizeBlockedDependents = (
+  persisted,
+  artifactObservations,
+) => {
+  const snapshot = structuredClone(persisted.snapshot);
+  const events = structuredClone(persisted.events);
+  const receipts = structuredClone(persisted.receipts);
+  assertContract('lane-ledger-v2', snapshot);
+  validateLedger('lane-ledger-v2', snapshot);
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const [laneIndex, lane] of snapshot.lanes.entries()) {
+      const issueNumber = lane.current_issue;
+      if (lane.status !== 'queued' || issueNumber === null) {
+        continue;
+      }
+      const gate = dependencyGate(snapshot, issueNumber);
+      if (gate.status !== 'blocked') {
+        continue;
+      }
+      const artifactAbsence = artifactAbsenceFor(
+        artifactObservations,
+        issueNumber,
+      );
+      const evidence = `dependencies ${gate.unsatisfied_dependencies.join(', ')} did not reach canonical done`;
+      const blockers = [
+        {
+          reviewer: 'contract',
+          signature: 'dependency:not-done',
+          evidence,
+          fix_back_eligible: false,
+          status: 'unresolved',
+        },
+      ];
+      snapshot.issue_progress[String(issueNumber)] = {
+        status: 'blocked-terminal',
+        verification: evidence,
+        retry_count: 0,
+        blockers,
+      };
+      terminalize(
+        snapshot,
+        {
+          lane_id: snapshot.lane_id,
+          lane_index: laneIndex,
+          issue_number: issueNumber,
+        },
+        'blocked-terminal',
+        blockers,
+      );
+      appendEvent(
+        events,
+        snapshot.lane_id,
+        'dependency.blocked',
+        String(issueNumber),
+        {
+          unsatisfied_dependencies: gate.unsatisfied_dependencies,
+          artifact_absence: artifactAbsence,
+        },
+      );
+      changed = true;
+    }
+  }
+  assertContract('lane-ledger-v2', snapshot);
+  validateLedger('lane-ledger-v2', snapshot);
+  if (events.length > 0) {
+    assertEventChain(events);
+  }
+  return { snapshot, events, receipts };
+};

--- a/.agents/skills/execute-lane/scripts/issue-dag-binding.mjs
+++ b/.agents/skills/execute-lane/scripts/issue-dag-binding.mjs
@@ -1,0 +1,129 @@
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import {
+  assertContract,
+  payloadDigest,
+} from '../../../workflow-contracts/contracts.mjs';
+import {
+  ensureLaneDirectory,
+  ensureRealDirectory,
+  loadImmutableBinding,
+  persistImmutableBinding,
+} from './dag-binding-files.mjs';
+
+const issueBindingPath = (runtimeRoot, laneId, issueNumber) =>
+  resolve(
+    runtimeRoot,
+    laneId,
+    'dag-bindings',
+    `issue-${String(issueNumber)}.json`,
+  );
+
+const assertIssueNumber = (issueNumber) => {
+  if (!Number.isSafeInteger(issueNumber) || issueNumber < 1) {
+    throw new TypeError('Issue DAG binding requires a positive issue number.');
+  }
+};
+
+export const createIssueDagBinding = ({
+  definition,
+  lane_id,
+  issue_number,
+  dependencies,
+  run_id,
+  dispatch_event_hash,
+}) => {
+  assertIssueNumber(issue_number);
+  const canonicalKey = `fluo:lane:${lane_id}:issue-${String(issue_number)}:supervisor:v2`;
+  if (definition.key !== canonicalKey) {
+    throw new TypeError(
+      'Issue DAG definition key must be canonical for its lane and issue.',
+    );
+  }
+  const binding = {
+    version: 2,
+    lane_id,
+    issue_number,
+    dependencies,
+    dag_key: definition.key,
+    run_id,
+    definition_sha256: payloadDigest(definition),
+    dispatch_event_hash,
+    status: 'attached',
+  };
+  assertContract('lane-dag-binding', binding);
+  return binding;
+};
+
+export const assertIssueDagBindingMatches = (
+  binding,
+  {
+    definition,
+    lane_id,
+    issue_number,
+    dependencies,
+    run_id,
+    dispatch_event_hash,
+  },
+) => {
+  assertContract('lane-dag-binding', binding);
+  if (binding.version !== 2) {
+    throw new TypeError('Issue DAG binding must use version 2.');
+  }
+  if (binding.definition_sha256 !== payloadDigest(definition)) {
+    throw new TypeError('Issue DAG binding definition digest does not match.');
+  }
+  if (
+    binding.lane_id !== lane_id ||
+    binding.issue_number !== issue_number ||
+    JSON.stringify(binding.dependencies) !== JSON.stringify(dependencies) ||
+    binding.dag_key !== definition.key ||
+    binding.run_id !== run_id ||
+    binding.dispatch_event_hash !== dispatch_event_hash
+  ) {
+    throw new TypeError('Issue DAG binding identity does not match.');
+  }
+};
+
+export const persistIssueDagBinding = (runtimeRoot, binding) => {
+  assertContract('lane-dag-binding', binding);
+  if (binding.version !== 2) {
+    throw new TypeError('Issue DAG binding must use version 2.');
+  }
+  const directory = resolve(
+    ensureLaneDirectory(runtimeRoot, binding.lane_id),
+    'dag-bindings',
+  );
+  ensureRealDirectory(directory);
+  persistImmutableBinding(
+    issueBindingPath(runtimeRoot, binding.lane_id, binding.issue_number),
+    binding,
+  );
+};
+
+export const loadIssueDagBinding = (runtimeRoot, laneId, issueNumber) => {
+  assertIssueNumber(issueNumber);
+  const directory = resolve(
+    ensureLaneDirectory(runtimeRoot, laneId),
+    'dag-bindings',
+  );
+  if (!existsSync(directory)) {
+    return null;
+  }
+  ensureRealDirectory(directory);
+  const binding = loadImmutableBinding(
+    issueBindingPath(runtimeRoot, laneId, issueNumber),
+  );
+  if (binding === null) {
+    return null;
+  }
+  if (
+    binding.version !== 2 ||
+    binding.lane_id !== laneId ||
+    binding.issue_number !== issueNumber
+  ) {
+    throw new TypeError('Issue DAG binding identity does not match its path.');
+  }
+  return binding;
+};

--- a/.agents/skills/execute-lane/scripts/issue-dispatch.mjs
+++ b/.agents/skills/execute-lane/scripts/issue-dispatch.mjs
@@ -1,0 +1,133 @@
+import { assertEventChain } from '../../../workflow-contracts/contracts.mjs';
+import {
+  assertIssueDagBindingMatches,
+  createIssueDagBinding,
+  loadIssueDagBinding,
+  persistIssueDagBinding,
+} from './dag-binding.mjs';
+import {
+  dependencyGate,
+  dispatchableIssueNumbers,
+  prepareIssueSupervisorDispatch,
+} from './dependency-gate.mjs';
+
+const dispatchIntentFor = (events, issueNumber) => {
+  if (events.length > 0) {
+    assertEventChain(events);
+  }
+  const intents = events.filter(
+    (event) =>
+      event.event_type === 'supervisor.dispatch.intent' &&
+      event.subject_id === String(issueNumber),
+  );
+  if (intents.length > 1) {
+    throw new TypeError(
+      `issue ${String(issueNumber)} has conflicting dispatch intents.`,
+    );
+  }
+  return intents[0] ?? null;
+};
+
+export const reconcileIssueSupervisorDispatch = ({
+  persisted,
+  runtime_root,
+  issue_number,
+  definition,
+}) => {
+  const snapshot = persisted.snapshot;
+  const intent = dispatchIntentFor(persisted.events, issue_number);
+  const binding = loadIssueDagBinding(
+    runtime_root,
+    snapshot.lane_id,
+    issue_number,
+  );
+  if (binding !== null) {
+    if (intent === null) {
+      return {
+        action: 'blocked-ledger-conflict',
+        reason: 'issue DAG binding exists without dispatch intent',
+      };
+    }
+    assertIssueDagBindingMatches(binding, {
+      definition,
+      lane_id: snapshot.lane_id,
+      issue_number,
+      dependencies:
+        snapshot.dependency_graph[String(issue_number)] ?? [],
+      run_id: binding.run_id,
+      dispatch_event_hash: intent.event_hash,
+    });
+    return { action: 'attach', run_id: binding.run_id, binding };
+  }
+  if (intent !== null) {
+    return {
+      action: 'blocked-ledger-conflict',
+      reason: 'dispatch intent exists without issue DAG binding',
+    };
+  }
+  const gate = dependencyGate(snapshot, issue_number);
+  if (gate.status === 'blocked') {
+    return { action: 'dependency-blocked', gate };
+  }
+  if (
+    gate.status === 'waiting' ||
+    !dispatchableIssueNumbers(snapshot).includes(issue_number)
+  ) {
+    return { action: 'wait', gate };
+  }
+  const prepared = prepareIssueSupervisorDispatch(persisted, issue_number);
+  return {
+    action: 'persist-intent',
+    persisted: prepared,
+    dispatch_event_hash: prepared.dispatch_event_hash,
+  };
+};
+
+export const attachIssueSupervisorRun = ({
+  persisted,
+  runtime_root,
+  issue_number,
+  definition,
+  run_id,
+}) => {
+  const snapshot = persisted.snapshot;
+  const intent = dispatchIntentFor(persisted.events, issue_number);
+  if (intent === null) {
+    throw new TypeError(
+      `issue ${String(issue_number)} has no dispatch intent.`,
+    );
+  }
+  if (!dispatchableIssueNumbers(snapshot).includes(issue_number)) {
+    throw new TypeError(
+      `issue ${String(issue_number)} is no longer dispatchable.`,
+    );
+  }
+  const dependencies =
+    snapshot.dependency_graph[String(issue_number)] ?? [];
+  const existing = loadIssueDagBinding(
+    runtime_root,
+    snapshot.lane_id,
+    issue_number,
+  );
+  if (existing !== null) {
+    assertIssueDagBindingMatches(existing, {
+      definition,
+      lane_id: snapshot.lane_id,
+      issue_number,
+      dependencies,
+      run_id,
+      dispatch_event_hash: intent.event_hash,
+    });
+    return existing;
+  }
+  const binding = createIssueDagBinding({
+    definition,
+    lane_id: snapshot.lane_id,
+    issue_number,
+    dependencies,
+    run_id,
+    dispatch_event_hash: intent.event_hash,
+  });
+  persistIssueDagBinding(runtime_root, binding);
+  return binding;
+};

--- a/.agents/skills/execute-lane/scripts/lane-progression.mjs
+++ b/.agents/skills/execute-lane/scripts/lane-progression.mjs
@@ -12,23 +12,10 @@ import {
   requireSha,
   rootSyncObservation,
 } from './transition-contracts.mjs';
+import { dependencyGate } from './dependency-gate.mjs';
 
-export const unmetDependencies = (scenario, snapshot, identity) => {
-  const dependencies =
-    snapshot.dependency_graph[String(identity.issue_number)] ?? [];
-  const observations = Array.isArray(scenario.dependency_observations)
-    ? scenario.dependency_observations
-    : [];
-  return dependencies.filter(
-    (dependency) =>
-      !snapshot.completed_issues.includes(dependency) &&
-      !observations.some(
-        (observation) =>
-          observation?.issue_number === dependency &&
-          observation?.status === 'CLOSED',
-      ),
-  );
-};
+export const unmetDependencies = (_scenario, snapshot, identity) =>
+  dependencyGate(snapshot, identity.issue_number).unsatisfied_dependencies;
 
 export const parkReleaseHandoff = (snapshot, identity, events) => {
   const lane = snapshot.lanes[identity.lane_index];

--- a/.agents/skills/execute-lane/scripts/supervisor-terminal-evidence.mjs
+++ b/.agents/skills/execute-lane/scripts/supervisor-terminal-evidence.mjs
@@ -1,0 +1,113 @@
+export const laneFor = (snapshot, issueNumber) => {
+  const laneIndex = snapshot.lanes.findIndex((lane) =>
+    lane.queue.includes(issueNumber),
+  );
+  if (laneIndex === -1) {
+    throw new TypeError('supervisor issue is not assigned to a lane.');
+  }
+  return { lane: snapshot.lanes[laneIndex], laneIndex };
+};
+
+export const advanceLane = (snapshot, lane) => {
+  const nextIssue = lane.queue.find(
+    (issue) => !snapshot.completed_issues.includes(issue),
+  );
+  Object.assign(lane, {
+    status: nextIssue === undefined ? 'done' : 'queued',
+    current_issue: nextIssue ?? null,
+    branch: null,
+    worktree: null,
+    pr: null,
+    retry_count: 0,
+  });
+};
+
+export const identityFromSupervisor = (snapshot, supervisor, laneIndex) => ({
+  lane_id: snapshot.lane_id,
+  lane_index: laneIndex,
+  issue_number: supervisor.issue_number,
+  branch: supervisor.branch,
+  worktree: supervisor.worktree,
+  pr_number: supervisor.pr?.number ?? null,
+  pr_url: supervisor.pr?.url ?? null,
+  head_sha: supervisor.head_sha,
+});
+
+export const completedProgress = (supervisor) => ({
+  status: 'done',
+  branch: supervisor.branch,
+  worktree: supervisor.worktree,
+  pr: supervisor.pr.url,
+  head_sha: supervisor.head_sha,
+  verification: supervisor.verification,
+  retry_count: supervisor.attempt,
+  blockers: supervisor.blockers,
+  review_verdict: 'merge',
+  checks: 'PASS',
+  reviewers: supervisor.local_review.reviewers,
+  reviewed_head: supervisor.local_review.head_sha,
+  commits: [supervisor.head_sha],
+  merge_commit: supervisor.merge.commit_sha,
+  issue_state: 'CLOSED',
+  cleanup: supervisor.authority_scope.cleanup_command_worktrees
+    ? {
+        status: 'done',
+        worktree_removed: true,
+        local_branch_deleted: true,
+        remote_branch_deleted: true,
+      }
+    : { status: 'skipped-authority' },
+});
+
+export const blockedProgress = (supervisor) => ({
+  status: supervisor.status,
+  branch: supervisor.branch,
+  worktree: supervisor.worktree,
+  pr: supervisor.pr?.url ?? null,
+  head_sha: supervisor.head_sha,
+  verification: supervisor.verification,
+  retry_count: supervisor.attempt,
+  blockers: supervisor.blockers,
+});
+
+export const assertLiveCompletion = (supervisor, live) => {
+  const expected = {
+    issue_number: supervisor.issue_number,
+    issue_url: `https://github.com/fluojs/fluo/issues/${String(supervisor.issue_number)}`,
+    pr_number: supervisor.pr.number,
+    pr_url: supervisor.pr.url,
+    branch: supervisor.branch,
+    worktree: supervisor.worktree,
+    reviewed_head_sha: supervisor.head_sha,
+    remote_head_sha: supervisor.head_sha,
+    pr_head_sha: supervisor.head_sha,
+    ci_head_sha: supervisor.head_sha,
+    merge_commit_sha: supervisor.merge.commit_sha,
+    merge_method: 'squash',
+    pr_state: 'MERGED',
+    issue_state: 'CLOSED',
+    cleanup_status: supervisor.authority_scope.cleanup_command_worktrees
+      ? 'done'
+      : 'skipped-authority',
+  };
+  if (supervisor.authority_scope.cleanup_command_worktrees) {
+    Object.assign(expected, {
+      worktree_removed: true,
+      local_branch_deleted: true,
+      remote_branch_deleted: true,
+    });
+  }
+  const actualKeys = Object.keys(live ?? {}).sort();
+  const expectedKeys = Object.keys(expected).sort();
+  if (
+    actualKeys.length !== expectedKeys.length ||
+    actualKeys.some((key, index) => key !== expectedKeys[index])
+  ) {
+    throw new TypeError('supervisor live completion contains unexpected fields.');
+  }
+  for (const [key, value] of Object.entries(expected)) {
+    if (live?.[key] !== value) {
+      throw new TypeError(`supervisor live completion mismatch: ${key}.`);
+    }
+  }
+};

--- a/.agents/skills/execute-lane/scripts/supervisor-terminal.mjs
+++ b/.agents/skills/execute-lane/scripts/supervisor-terminal.mjs
@@ -9,8 +9,17 @@ import {
 } from './transition-application.mjs';
 import { assertIssueSupervisorState } from './issue-supervisor-contracts.mjs';
 import { assertIssueSupervisorBundle } from './issue-supervisor-store.mjs';
+import { dependencyGate } from './dependency-gate.mjs';
 import { parkReleaseHandoff } from './lane-progression.mjs';
 import { assertReleaseHandoffBinding } from './release-handoff-approval.mjs';
+import {
+  advanceLane,
+  assertLiveCompletion,
+  blockedProgress,
+  completedProgress,
+  identityFromSupervisor,
+  laneFor,
+} from './supervisor-terminal-evidence.mjs';
 
 const terminalStatuses = new Set([
   'done',
@@ -19,120 +28,6 @@ const terminalStatuses = new Set([
   'blocked-budget-exhausted',
   'blocked-maintainer-decision',
 ]);
-
-const laneFor = (snapshot, issueNumber) => {
-  const laneIndex = snapshot.lanes.findIndex((lane) =>
-    lane.queue.includes(issueNumber),
-  );
-  if (laneIndex === -1) {
-    throw new TypeError('supervisor issue is not assigned to a lane.');
-  }
-  return { lane: snapshot.lanes[laneIndex], laneIndex };
-};
-
-const advanceLane = (snapshot, lane) => {
-  const nextIssue = lane.queue.find(
-    (issue) => !snapshot.completed_issues.includes(issue),
-  );
-  Object.assign(lane, {
-    status: nextIssue === undefined ? 'done' : 'queued',
-    current_issue: nextIssue ?? null,
-    branch: null,
-    worktree: null,
-    pr: null,
-    retry_count: 0,
-  });
-};
-
-const identityFromSupervisor = (snapshot, supervisor, laneIndex) => ({
-  lane_id: snapshot.lane_id,
-  lane_index: laneIndex,
-  issue_number: supervisor.issue_number,
-  branch: supervisor.branch,
-  worktree: supervisor.worktree,
-  pr_number: supervisor.pr?.number ?? null,
-  pr_url: supervisor.pr?.url ?? null,
-  head_sha: supervisor.head_sha,
-});
-
-const completedProgress = (supervisor) => ({
-  status: 'done',
-  branch: supervisor.branch,
-  worktree: supervisor.worktree,
-  pr: supervisor.pr.url,
-  head_sha: supervisor.head_sha,
-  verification: supervisor.verification,
-  retry_count: supervisor.attempt,
-  blockers: supervisor.blockers,
-  review_verdict: 'merge',
-  checks: 'PASS',
-  reviewers: supervisor.local_review.reviewers,
-  reviewed_head: supervisor.local_review.head_sha,
-  commits: [supervisor.head_sha],
-  merge_commit: supervisor.merge.commit_sha,
-  issue_state: 'CLOSED',
-  cleanup: supervisor.authority_scope.cleanup_command_worktrees
-    ? {
-        status: 'done',
-        worktree_removed: true,
-        local_branch_deleted: true,
-        remote_branch_deleted: true,
-      }
-    : { status: 'skipped-authority' },
-});
-
-const blockedProgress = (supervisor) => ({
-  status: supervisor.status,
-  branch: supervisor.branch,
-  worktree: supervisor.worktree,
-  pr: supervisor.pr?.url ?? null,
-  head_sha: supervisor.head_sha,
-  verification: supervisor.verification,
-  retry_count: supervisor.attempt,
-  blockers: supervisor.blockers,
-});
-
-const assertLiveCompletion = (supervisor, live) => {
-  const expected = {
-    issue_number: supervisor.issue_number,
-    issue_url: `https://github.com/fluojs/fluo/issues/${String(supervisor.issue_number)}`,
-    pr_number: supervisor.pr.number,
-    pr_url: supervisor.pr.url,
-    branch: supervisor.branch,
-    worktree: supervisor.worktree,
-    reviewed_head_sha: supervisor.head_sha,
-    remote_head_sha: supervisor.head_sha,
-    pr_head_sha: supervisor.head_sha,
-    ci_head_sha: supervisor.head_sha,
-    merge_commit_sha: supervisor.merge.commit_sha,
-    merge_method: 'squash',
-    pr_state: 'MERGED',
-    issue_state: 'CLOSED',
-    cleanup_status: supervisor.authority_scope.cleanup_command_worktrees
-      ? 'done'
-      : 'skipped-authority',
-  };
-  if (supervisor.authority_scope.cleanup_command_worktrees) {
-    Object.assign(expected, {
-      worktree_removed: true,
-      local_branch_deleted: true,
-      remote_branch_deleted: true,
-    });
-  }
-  const actualKeys = Object.keys(live ?? {}).sort();
-  const expectedKeys = Object.keys(expected).sort();
-  if (
-    actualKeys.length !== expectedKeys.length ||
-    actualKeys.some((key, index) => key !== expectedKeys[index])
-  ) {
-    throw new TypeError('supervisor live completion contains unexpected fields.');
-  }
-  for (const [key, value] of Object.entries(expected)) {
-    if (live?.[key] !== value) {
-      throw new TypeError(`supervisor live completion mismatch: ${key}.`);
-    }
-  }
-};
 
 export const importSupervisorTerminal = (
   persisted,
@@ -178,10 +73,8 @@ export const importSupervisorTerminal = (
   }
 
   const { lane, laneIndex } = laneFor(snapshot, supervisor.issue_number);
-  const unmet = (
-    snapshot.dependency_graph[String(supervisor.issue_number)] ?? []
-  ).filter((issue) => !snapshot.completed_issues.includes(issue));
-  if (unmet.length > 0) {
+  const gate = dependencyGate(snapshot, supervisor.issue_number);
+  if (gate.status !== 'ready') {
     throw new TypeError('supervisor terminal import has unmet dependencies.');
   }
   const identity = identityFromSupervisor(snapshot, supervisor, laneIndex);
@@ -262,6 +155,7 @@ export const importSupervisorTerminal = (
       return { snapshot, events, receipts };
     }
     snapshot.issue_progress[String(supervisor.issue_number)] = progress;
+    lane.retry_count = progress.retry_count;
     terminalize(snapshot, identity, supervisor.status, supervisor.blockers);
     appendEvent(
       events,

--- a/.agents/workflow-contracts/contracts.mjs
+++ b/.agents/workflow-contracts/contracts.mjs
@@ -4,6 +4,7 @@ import { resolve } from 'node:path';
 
 import { isRecord, schemaFailure } from './schema-validator.mjs';
 
+// allow: SIZE_OK — central shared contract registry and cross-contract invariants.
 export const contractNames = [
   'search-artifact-v2',
   'lane-ledger-v2',
@@ -135,11 +136,36 @@ const assertSemanticContract = (name, value) => {
       assertLaneLedgerSemantics(value);
       return;
     case 'lane-dag-binding':
+      if (value.version === 1) {
+        if (
+          !Object.hasOwn(value, 'snapshot_event_hash') ||
+          Object.hasOwn(value, 'issue_number') ||
+          Object.hasOwn(value, 'dependencies') ||
+          Object.hasOwn(value, 'dispatch_event_hash')
+        ) {
+          fail(name, 'version 1 must contain only lane-wide binding fields');
+        }
+        if (
+          value.dag_key !==
+          `fluo:lane:${value.lane_id}:issue-supervisors:v1`
+        ) {
+          fail(name, 'dag_key must be canonical for lane_id');
+        }
+        return;
+      }
+      if (
+        !Object.hasOwn(value, 'issue_number') ||
+        !Object.hasOwn(value, 'dependencies') ||
+        !Object.hasOwn(value, 'dispatch_event_hash') ||
+        Object.hasOwn(value, 'snapshot_event_hash')
+      ) {
+        fail(name, 'version 2 must contain only per-issue binding fields');
+      }
       if (
         value.dag_key !==
-        `fluo:lane:${value.lane_id}:issue-supervisors:v1`
+        `fluo:lane:${value.lane_id}:issue-${String(value.issue_number)}:supervisor:v2`
       ) {
-        fail(name, 'dag_key must be canonical for lane_id');
+        fail(name, 'dag_key must be canonical for lane_id and issue_number');
       }
       return;
     case 'local-review-verdict':

--- a/.agents/workflow-contracts/lane-dag-binding.schema.json
+++ b/.agents/workflow-contracts/lane-dag-binding.schema.json
@@ -10,14 +10,19 @@
     "dag_key",
     "run_id",
     "definition_sha256",
-    "snapshot_event_hash",
     "status"
   ],
   "properties": {
-    "version": { "const": 1 },
+    "version": { "enum": [1, 2] },
     "lane_id": {
       "type": "string",
       "pattern": "^(?!.*(?:\\.|\\.lock)$)[A-Za-z0-9][A-Za-z0-9._-]*$"
+    },
+    "issue_number": { "type": "integer", "minimum": 1 },
+    "dependencies": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "type": "integer", "minimum": 1 }
     },
     "dag_key": { "type": "string", "minLength": 1 },
     "run_id": { "type": "string", "minLength": 1 },
@@ -30,6 +35,10 @@
         { "type": "string", "pattern": "^[a-f0-9]{64}$" },
         { "type": "null" }
       ]
+    },
+    "dispatch_event_hash": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
     },
     "status": { "const": "attached" }
   }

--- a/plans/three-stage-lane-workflow.md
+++ b/plans/three-stage-lane-workflow.md
@@ -102,8 +102,13 @@ skills never load archived command or role definitions.
    exists so removing the handoff array cannot bypass provenance checks. Use
    the canonical published ledger as the marker when validating persisted
    snapshots so removing both fields cannot impersonate a legacy ledger.
-5. Compile one native DAG issue-supervisor node per approved issue and mirror
-   the canonical dependency graph through `dependsOn`.
+5. Compute eligibility from the shared ledger, persist a dispatch intent, then
+   reconcile and bind one single-node native DAG per eligible issue. Independent
+   eligible issues may run concurrently. Intent without an exact binding fails
+   closed; an exact binding attaches without another start. A dependent issue
+   is not compiled or spawned until every predecessor is shared `done`; native
+   task completion, merge before cleanup, CLOSED observations, and terminal
+   blockers do not unlock it.
 6. Implement and locally verify one commit head, then aggregate exactly one
    contract, code, and verification result before any push or PR creation.
 7. Treat the successful local verdict as `ready-for-pr`, not `merge`. Fix local
@@ -116,8 +121,9 @@ skills never load archived command or role definitions.
    issue observed `CLOSED`.
 10. Cleanup only after merge observation; retain a terminal blocker when any
    worktree/local-branch/remote-branch removal is incomplete.
-11. Sync the clean root with a parent-lead `git pull --ff-only` observation
-    only after every issue-supervisor DAG node is terminal.
+11. Recompute eligibility only after each issue terminal is validated and
+    imported. Sync the clean root with a parent-lead `git pull --ff-only`
+    observation only after every lane is done or explicitly terminal.
 12. Append events, atomically replace the snapshot, record target-bound
    receipts, and release the lease after every transition.
 13. Run the canonical ledger verifier before final reporting.
@@ -134,6 +140,11 @@ pnpm exec vitest run \
   tooling/governance/create-lane-multi.test.ts \
   tooling/governance/execute-lane-native.test.ts \
   tooling/governance/execute-lane-dag-supervisor.test.ts \
+  tooling/governance/execute-lane-dag-scheduling.test.ts \
+  tooling/governance/execute-lane-dag-binding-v2.test.ts \
+  tooling/governance/execute-lane-dependency-cleanup-gate.test.ts \
+  tooling/governance/execute-lane-dependency-assets.test.ts \
+  tooling/governance/execute-lane-dispatch-intent.test.ts \
   tooling/governance/execute-lane-persistence.test.ts \
   tooling/governance/execute-lane-resilience.test.ts \
   tooling/governance/execute-lane-authority.test.ts \

--- a/tooling/governance/execute-lane-dag-binding-v2.test.ts
+++ b/tooling/governance/execute-lane-dag-binding-v2.test.ts
@@ -1,0 +1,156 @@
+import { mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+type DagDefinition = Readonly<{
+  key: string;
+  name: string;
+  nodes: readonly Readonly<Record<string, unknown>>[];
+}>;
+
+type IssueDagBinding = Readonly<{
+  version: 2;
+  lane_id: string;
+  issue_number: number;
+  dependencies: readonly number[];
+  dag_key: string;
+  run_id: string;
+  definition_sha256: string;
+  dispatch_event_hash: string;
+  status: 'attached';
+}>;
+
+const {
+  assertIssueDagBindingMatches,
+  createIssueDagBinding,
+  loadIssueDagBinding,
+  persistIssueDagBinding,
+} = (await import(
+  resolve(
+    process.cwd(),
+    '.agents/skills/execute-lane/scripts/dag-binding.mjs',
+  )
+)) as {
+  createIssueDagBinding: (input: {
+    definition: DagDefinition;
+    lane_id: string;
+    issue_number: number;
+    dependencies: readonly number[];
+    run_id: string;
+    dispatch_event_hash: string;
+  }) => IssueDagBinding;
+  persistIssueDagBinding: (
+    runtimeRoot: string,
+    binding: IssueDagBinding,
+  ) => void;
+  loadIssueDagBinding: (
+    runtimeRoot: string,
+    laneId: string,
+    issueNumber: number,
+  ) => IssueDagBinding | null;
+  assertIssueDagBindingMatches: (
+    binding: IssueDagBinding,
+    expected: {
+      definition: DagDefinition;
+      lane_id: string;
+      issue_number: number;
+      dependencies: readonly number[];
+      run_id: string;
+      dispatch_event_hash: string;
+    },
+  ) => void;
+};
+
+const laneId = 'lane-4101-runtime';
+const issueNumber = 4102;
+const dispatchEventHash = 'e'.repeat(64);
+const definition: DagDefinition = {
+  key: `fluo:lane:${laneId}:issue-${String(issueNumber)}:supervisor:v2`,
+  name: `Fluo lane ${laneId} issue ${String(issueNumber)} supervisor`,
+  nodes: [
+    {
+      id: `issue-${String(issueNumber)}-supervisor`,
+      category: 'deep',
+      dependsOn: [],
+      load_skills: ['execute-lane'],
+      prompt: 'fixture',
+    },
+  ],
+};
+
+describe('execute-lane per-issue DAG binding', () => {
+  it('persists one immutable binding for an eligible issue dispatch', () => {
+    // Given
+    const directory = mkdtempSync(
+      join(realpathSync(tmpdir()), 'fluo-issue-dag-binding-'),
+    );
+    const runtimeRoot = join(directory, 'lane-runs');
+    const binding = createIssueDagBinding({
+      definition,
+      lane_id: laneId,
+      issue_number: issueNumber,
+      dependencies: [4101],
+      run_id: 'run_issue_4102',
+      dispatch_event_hash: dispatchEventHash,
+    });
+
+    try {
+      // When
+      persistIssueDagBinding(runtimeRoot, binding);
+      persistIssueDagBinding(runtimeRoot, binding);
+
+      // Then
+      expect(loadIssueDagBinding(runtimeRoot, laneId, issueNumber)).toEqual(
+        binding,
+      );
+      expect(() =>
+        assertIssueDagBindingMatches(binding, {
+          definition,
+          lane_id: laneId,
+          issue_number: issueNumber,
+          dependencies: [4101],
+          run_id: 'run_issue_4102',
+          dispatch_event_hash: dispatchEventHash,
+        }),
+      ).not.toThrow();
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a substituted run or definition for the same issue', () => {
+    // Given
+    const binding = createIssueDagBinding({
+      definition,
+      lane_id: laneId,
+      issue_number: issueNumber,
+      dependencies: [4101],
+      run_id: 'run_issue_4102',
+      dispatch_event_hash: dispatchEventHash,
+    });
+
+    // When / Then
+    expect(() =>
+      assertIssueDagBindingMatches(binding, {
+        definition,
+        lane_id: laneId,
+        issue_number: issueNumber,
+        dependencies: [4101],
+        run_id: 'run_substituted',
+        dispatch_event_hash: dispatchEventHash,
+      }),
+    ).toThrow(/identity/u);
+    expect(() =>
+      assertIssueDagBindingMatches(binding, {
+        definition: { ...definition, name: 'tampered definition' },
+        lane_id: laneId,
+        issue_number: issueNumber,
+        dependencies: [4101],
+        run_id: 'run_issue_4102',
+        dispatch_event_hash: dispatchEventHash,
+      }),
+    ).toThrow(/definition digest/u);
+  });
+});

--- a/tooling/governance/execute-lane-dag-scheduling.test.ts
+++ b/tooling/governance/execute-lane-dag-scheduling.test.ts
@@ -1,0 +1,246 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+type DagNode = Readonly<{
+  id: string;
+  dependsOn: readonly string[];
+}>;
+
+type DagDefinition = Readonly<{
+  key: string;
+  name: string;
+  nodes: readonly DagNode[];
+}>;
+
+type DependencyGate = Readonly<{
+  status: 'ready' | 'waiting' | 'blocked';
+  dependencies: readonly number[];
+  unsatisfied_dependencies: readonly number[];
+}>;
+
+const { compileIssueSupervisorDag } = (await import(
+  resolve(
+    process.cwd(),
+    '.agents/skills/execute-lane/scripts/compile-dag.mjs',
+  )
+)) as {
+  compileIssueSupervisorDag: (
+    ledger: Readonly<Record<string, unknown>>,
+    issueNumber: number,
+  ) => DagDefinition;
+};
+const { dependencyGate, dispatchableIssueNumbers } = (await import(
+  resolve(
+    process.cwd(),
+    '.agents/skills/execute-lane/scripts/dependency-gate.mjs',
+  )
+)) as {
+  dependencyGate: (
+    ledger: Readonly<Record<string, unknown>>,
+    issueNumber: number,
+  ) => DependencyGate;
+  dispatchableIssueNumbers: (
+    ledger: Readonly<Record<string, unknown>>,
+  ) => readonly number[];
+};
+
+const headA = 'a'.repeat(40);
+const headB = 'b'.repeat(40);
+
+const isRecord = (
+  value: unknown,
+): value is Readonly<Record<string, unknown>> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const readyLedger = (): Readonly<Record<string, unknown>> => {
+  const parsed: unknown = JSON.parse(
+    readFileSync(
+      resolve(
+        process.cwd(),
+        'tooling/governance/fixtures/execute-lane-native/ready-ledger-two-lanes-v2.json',
+      ),
+      'utf8',
+    ),
+  );
+  if (!isRecord(parsed)) {
+    throw new TypeError('Ready lane fixture must be an object.');
+  }
+  return {
+    ...parsed,
+    dependency_graph: {
+      '4101': [],
+      '4102': [4101],
+    },
+  };
+};
+
+const completedPredecessorLedger = (): Readonly<
+  Record<string, unknown>
+> => ({
+  ...readyLedger(),
+  status: 'running',
+  execution: {
+    status: 'running',
+    last_command: '$execute-lane lane-4101-runtime',
+    last_updated: '2026-08-25T00:00:00.000Z',
+  },
+  completed_issues: [4101],
+  issue_progress: {
+    '4101': {
+      status: 'done',
+      branch: 'issue-4101-runtime',
+      worktree: '.worktrees/issue-4101-runtime',
+      pr: 'https://github.com/fluojs/fluo/pull/5101',
+      head_sha: headA,
+      verification: 'all required checks passed',
+      retry_count: 0,
+      blockers: [],
+      review_verdict: 'merge',
+      checks: 'PASS',
+      reviewers: {
+        contract: 'PASS',
+        code: 'PASS',
+        verification: 'PASS',
+      },
+      reviewed_head: headA,
+      commits: [headA],
+      merge_commit: headB,
+      issue_state: 'CLOSED',
+      cleanup: {
+        status: 'done',
+        worktree_removed: true,
+        local_branch_deleted: true,
+        remote_branch_deleted: true,
+      },
+    },
+  },
+  lanes: [
+    {
+      name: 'runtime',
+      queue: [4101],
+      current_issue: null,
+      status: 'done',
+      branch: null,
+      worktree: null,
+      pr: null,
+      retry_count: 0,
+    },
+    {
+      name: 'validation',
+      queue: [4102],
+      current_issue: 4102,
+      status: 'queued',
+      branch: null,
+      worktree: null,
+      pr: null,
+      retry_count: 0,
+    },
+  ],
+});
+
+const blockedPredecessorLedger = (): Readonly<Record<string, unknown>> => ({
+  ...readyLedger(),
+  status: 'running',
+  execution: {
+    status: 'running',
+    last_command: '$execute-lane lane-4101-runtime',
+    last_updated: '2026-08-25T00:00:00.000Z',
+  },
+  issue_progress: {
+    '4101': {
+      status: 'needs-human-check-terminal',
+      branch: 'issue-4101-runtime',
+      worktree: '.worktrees/issue-4101-runtime',
+      pr: null,
+      head_sha: headA,
+      verification: 'human review required',
+      retry_count: 0,
+      blockers: [],
+    },
+  },
+  lanes: [
+    {
+      name: 'runtime',
+      queue: [4101],
+      current_issue: null,
+      status: 'needs-human-check-terminal',
+      branch: null,
+      worktree: null,
+      pr: null,
+      retry_count: 0,
+    },
+    {
+      name: 'validation',
+      queue: [4102],
+      current_issue: 4102,
+      status: 'queued',
+      branch: null,
+      worktree: null,
+      pr: null,
+      retry_count: 0,
+    },
+  ],
+});
+
+describe('execute-lane DAG dependency scheduling', () => {
+  it('dispatches independent lane cursors concurrently', () => {
+    // Given
+    const ledger = {
+      ...readyLedger(),
+      dependency_graph: { '4101': [], '4102': [] },
+    };
+
+    // When / Then
+    expect(dispatchableIssueNumbers(ledger)).toEqual([4101, 4102]);
+  });
+
+  it('dispatches only issues whose dependencies are fully done', () => {
+    // Given
+    const ledger = readyLedger();
+
+    // When
+    const issues = dispatchableIssueNumbers(ledger);
+
+    // Then
+    expect(issues).toEqual([4101]);
+  });
+
+  it('blocks a dependent when its predecessor terminates blocked', () => {
+    // Given
+    const ledger = blockedPredecessorLedger();
+
+    // When
+    const gate = dependencyGate(ledger, 4102);
+
+    // Then
+    expect(gate).toEqual({
+      status: 'blocked',
+      dependencies: [4101],
+      unsatisfied_dependencies: [4101],
+    });
+    expect(dispatchableIssueNumbers(ledger)).toEqual([]);
+  });
+
+  it('compiles one dependency-free node after its predecessor is done', () => {
+    // Given
+    const ledger = completedPredecessorLedger();
+
+    // When
+    const definition = compileIssueSupervisorDag(ledger, 4102);
+
+    // Then
+    expect(dispatchableIssueNumbers(ledger)).toEqual([4102]);
+    expect(definition.key).toBe(
+      'fluo:lane:lane-4101-runtime:issue-4102:supervisor:v2',
+    );
+    expect(definition.nodes).toEqual([
+      expect.objectContaining({
+        id: 'issue-4102-supervisor',
+        dependsOn: [],
+      }),
+    ]);
+    expect(compileIssueSupervisorDag(ledger, 4102)).toEqual(definition);
+  });
+});

--- a/tooling/governance/execute-lane-dag-supervisor.test.ts
+++ b/tooling/governance/execute-lane-dag-supervisor.test.ts
@@ -13,6 +13,7 @@ import { join, resolve } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
+// allow: SIZE_OK — integrated legacy supervisor lifecycle regression matrix.
 type DagNode = Readonly<{
   id: string;
   category: string;
@@ -64,13 +65,13 @@ const {
     transition: unknown,
   ) => SupervisorState;
 };
-const { compileLaneSupervisorDag } = (await import(
+const { compileLegacyLaneSupervisorDag } = (await import(
   resolve(
     process.cwd(),
     '.agents/skills/execute-lane/scripts/compile-dag.mjs',
   )
 )) as {
-  compileLaneSupervisorDag: (ledger: unknown) => DagDefinition;
+  compileLegacyLaneSupervisorDag: (ledger: unknown) => DagDefinition;
 };
 const {
   assertDagBindingMatches,
@@ -230,8 +231,8 @@ const identity = {
   },
   retry_policy: {
     retry_count_is_terminal: true,
-    max_same_failure_repeats: 5,
-    max_wall_clock_minutes: 360,
+    max_same_failure_repeats: 3,
+    max_wall_clock_minutes: 180,
     stop_on_child_contract_error: true,
   },
 } as const;
@@ -802,36 +803,14 @@ describe('execute-lane issue supervisor lifecycle', () => {
   });
 
   it('imports blocked and release-handoff supervisor terminals', () => {
-    let blocked = createIssueSupervisor(identity);
-    blocked = transitionIssueSupervisor(blocked, {
-      kind: 'implementation-completed',
-      new_head: headA,
-      verification: 'focused tests passed',
-    });
-    blocked = transitionIssueSupervisor(blocked, {
-      kind: 'local-review',
-      reviews: [
-        passReviews(headA)[0],
-        {
-          reviewer: 'code',
-          reviewed_head_sha: headA,
-          verdict_signal: 'NEEDS-HUMAN-CHECK',
-          blockers: [],
-        },
-        passReviews(headA)[2],
-      ],
-    });
-    const ledger = JSON.parse(
-      readFileSync(
-        resolve(
-          process.cwd(),
-          'tooling/governance/fixtures/execute-lane-native/ready-ledger-multi-v2.json',
-        ),
-        'utf8',
-      ),
-    );
-    const blockedImport = importSupervisorTerminal(
-      { snapshot: ledger, events: [], receipts: [] },
+    const blocker = {
+      reviewer: 'code',
+      signature: 'runtime:worker:abort-path',
+      evidence: 'packages/runtime/src/worker.ts:42',
+      fix_back_eligible: true,
+      status: 'unresolved',
+    };
+    const blockedBundle = () =>
       persistedLifecycle(identity, [
         {
           kind: 'implementation-completed',
@@ -845,40 +824,59 @@ describe('execute-lane issue supervisor lifecycle', () => {
             {
               reviewer: 'code',
               reviewed_head_sha: headA,
-              verdict_signal: 'NEEDS-HUMAN-CHECK',
-              blockers: [],
+              verdict_signal: 'BLOCK',
+              blockers: [blocker],
             },
             passReviews(headA)[2],
           ],
         },
-      ]),
+        {
+          kind: 'fix-completed',
+          new_head: headB,
+          observed_at: observedAt,
+          verification: 'focused tests passed',
+          addressed_blockers: remediate([blocker]),
+        },
+        {
+          kind: 'local-review',
+          reviews: [
+            passReviews(headB)[0],
+            {
+              reviewer: 'code',
+              reviewed_head_sha: headB,
+              verdict_signal: 'NEEDS-HUMAN-CHECK',
+              blockers: [],
+            },
+            passReviews(headB)[2],
+          ],
+        },
+      ]);
+    const ledger = JSON.parse(
+      readFileSync(
+        resolve(
+          process.cwd(),
+          'tooling/governance/fixtures/execute-lane-native/ready-ledger-multi-v2.json',
+        ),
+        'utf8',
+      ),
+    );
+    const blockedImport = importSupervisorTerminal(
+      { snapshot: ledger, events: [], receipts: [] },
+      blockedBundle(),
     );
     expect(blockedImport.snapshot.lanes).toMatchObject([
-      { status: 'needs-human-check-terminal' },
+      { status: 'needs-human-check-terminal', retry_count: 1 },
     ]);
+    expect(blockedImport.snapshot.issue_progress).toMatchObject({
+      '4101': {
+        status: 'needs-human-check-terminal',
+        retry_count: 1,
+      },
+    });
     expect(
       importSupervisorTerminal(
         blockedImport,
-        persistedLifecycle(identity, [
-          {
-            kind: 'implementation-completed',
-            new_head: headA,
-            verification: 'focused tests passed',
-          },
-          {
-            kind: 'local-review',
-            reviews: [
-              passReviews(headA)[0],
-              {
-                reviewer: 'code',
-                reviewed_head_sha: headA,
-                verdict_signal: 'NEEDS-HUMAN-CHECK',
-                blockers: [],
-              },
-              passReviews(headA)[2],
-            ],
-          },
-        ]),
+        blockedBundle(),
       ),
     ).toEqual(blockedImport);
 
@@ -1002,7 +1000,7 @@ describe('execute-lane issue supervisor lifecycle', () => {
         'utf8',
       ),
     );
-    const definition = compileLaneSupervisorDag(ledger);
+    const definition = compileLegacyLaneSupervisorDag(ledger);
 
     expect(definition.key).toBe('fluo:lane:lane-4101-runtime:issue-supervisors:v1');
     expect(definition.nodes).toHaveLength(2);
@@ -1018,13 +1016,13 @@ describe('execute-lane issue supervisor lifecycle', () => {
     });
     expect(definition.nodes[0].prompt).toContain('STOP WHEN:');
     expect(() =>
-      compileLaneSupervisorDag({
+      compileLegacyLaneSupervisorDag({
         ...ledger,
         dependency_graph: { 4102: [9999] },
       }),
     ).toThrow(/dependency|confirmed issue/u);
     expect(() =>
-      compileLaneSupervisorDag({
+      compileLegacyLaneSupervisorDag({
         ...ledger,
         dependency_graph: { 4101: [4102], 4102: [4101] },
       }),
@@ -1038,7 +1036,7 @@ describe('execute-lane issue supervisor lifecycle', () => {
         'utf8',
       ),
     );
-    const releaseDefinition = compileLaneSupervisorDag(releaseLedger);
+    const releaseDefinition = compileLegacyLaneSupervisorDag(releaseLedger);
     expect(releaseDefinition.nodes).toHaveLength(1);
     expect(releaseDefinition.nodes[0]).toMatchObject({
       category: 'quick',
@@ -1108,4 +1106,5 @@ describe('execute-lane issue supervisor lifecycle', () => {
       rmSync(directory, { recursive: true, force: true });
     }
   });
+
 });

--- a/tooling/governance/execute-lane-dependency-assets.test.ts
+++ b/tooling/governance/execute-lane-dependency-assets.test.ts
@@ -1,0 +1,26 @@
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+describe('execute-lane dependency scheduler assets', () => {
+  it('ships the parent gate and per-issue binding modules', () => {
+    // Given
+    const skillRoot = resolve(process.cwd(), '.agents/skills/execute-lane');
+    const assets = [
+      'scripts/dag-binding-files.mjs',
+      'scripts/dependency-gate.mjs',
+      'scripts/issue-dag-binding.mjs',
+      'scripts/issue-dispatch.mjs',
+      'scripts/supervisor-terminal-evidence.mjs',
+    ];
+
+    // When
+    const shipped = assets.filter((path) =>
+      existsSync(resolve(skillRoot, path)),
+    );
+
+    // Then
+    expect(shipped).toEqual(assets);
+  });
+});

--- a/tooling/governance/execute-lane-dependency-cleanup-gate.test.ts
+++ b/tooling/governance/execute-lane-dependency-cleanup-gate.test.ts
@@ -1,0 +1,247 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const {
+  dependencyGate,
+  dispatchableIssueNumbers,
+  terminalizeBlockedDependents,
+} = (await import(
+  resolve(
+    process.cwd(),
+    '.agents/skills/execute-lane/scripts/dependency-gate.mjs',
+  )
+)) as {
+  dependencyGate: (
+    ledger: Readonly<Record<string, unknown>>,
+    issueNumber: number,
+  ) => Readonly<Record<string, unknown>>;
+  dispatchableIssueNumbers: (
+    ledger: Readonly<Record<string, unknown>>,
+  ) => readonly number[];
+  terminalizeBlockedDependents: (
+    persisted: {
+      snapshot: Readonly<Record<string, unknown>>;
+      events: readonly Readonly<Record<string, unknown>>[];
+      receipts: readonly Readonly<Record<string, unknown>>[];
+    },
+    observations: readonly Readonly<Record<string, unknown>>[],
+  ) => {
+    snapshot: Readonly<Record<string, unknown>>;
+    events: readonly Readonly<Record<string, unknown>>[];
+    receipts: readonly Readonly<Record<string, unknown>>[];
+  };
+};
+const { unmetDependencies } = (await import(
+  resolve(
+    process.cwd(),
+    '.agents/skills/execute-lane/scripts/lane-progression.mjs',
+  )
+)) as {
+  unmetDependencies: (
+    scenario: Readonly<Record<string, unknown>>,
+    ledger: Readonly<Record<string, unknown>>,
+    identity: Readonly<{ issue_number: number }>,
+  ) => readonly number[];
+};
+
+const isRecord = (
+  value: unknown,
+): value is Readonly<Record<string, unknown>> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const mergedPredecessorLedger = (): Readonly<Record<string, unknown>> => {
+  const parsed: unknown = JSON.parse(
+    readFileSync(
+      resolve(
+        process.cwd(),
+        'tooling/governance/fixtures/execute-lane-native/ready-ledger-two-lanes-v2.json',
+      ),
+      'utf8',
+    ),
+  );
+  if (!isRecord(parsed)) {
+    throw new TypeError('Ready lane fixture must be an object.');
+  }
+  const head = 'a'.repeat(40);
+  return {
+    ...parsed,
+    status: 'running',
+    execution: {
+      status: 'running',
+      last_command: '$execute-lane lane-4101-runtime',
+      last_updated: '2026-08-25T00:00:00.000Z',
+    },
+    completed_issues: [4101],
+    issue_progress: {
+      '4101': {
+        status: 'merged',
+        branch: 'issue-4101-runtime',
+        worktree: '.worktrees/issue-4101-runtime',
+        pr: 'https://github.com/fluojs/fluo/pull/5101',
+        head_sha: head,
+        verification: 'all required checks passed',
+        retry_count: 0,
+        blockers: [],
+        review_verdict: 'merge',
+        checks: 'PASS',
+        reviewers: {
+          contract: 'PASS',
+          code: 'PASS',
+          verification: 'PASS',
+        },
+        reviewed_head: head,
+        commits: [head],
+        merge_commit: 'b'.repeat(40),
+        issue_state: 'CLOSED',
+      },
+    },
+    lanes: [
+      {
+        name: 'runtime',
+        queue: [4101],
+        current_issue: 4101,
+        status: 'merged',
+        branch: 'issue-4101-runtime',
+        worktree: '.worktrees/issue-4101-runtime',
+        pr: 'https://github.com/fluojs/fluo/pull/5101',
+        retry_count: 0,
+      },
+      {
+        name: 'validation',
+        queue: [4102],
+        current_issue: 4102,
+        status: 'queued',
+        branch: null,
+        worktree: null,
+        pr: null,
+        retry_count: 0,
+      },
+    ],
+    dependency_graph: {
+      '4101': [],
+      '4102': [4101],
+    },
+  };
+};
+
+const blockedPredecessorLedger = (): Readonly<Record<string, unknown>> => {
+  const ledger = mergedPredecessorLedger();
+  return {
+    ...ledger,
+    completed_issues: [],
+    issue_progress: {
+      '4101': {
+        status: 'needs-human-check-terminal',
+        branch: 'issue-4101-runtime',
+        worktree: '.worktrees/issue-4101-runtime',
+        pr: null,
+        head_sha: 'a'.repeat(40),
+        verification: 'human review required',
+        retry_count: 0,
+        blockers: [],
+      },
+    },
+    lanes: [
+      {
+        name: 'runtime',
+        queue: [4101],
+        current_issue: null,
+        status: 'needs-human-check-terminal',
+        branch: null,
+        worktree: null,
+        pr: null,
+        retry_count: 0,
+      },
+      {
+        name: 'validation',
+        queue: [4102],
+        current_issue: 4102,
+        status: 'queued',
+        branch: null,
+        worktree: null,
+        pr: null,
+        retry_count: 0,
+      },
+    ],
+  };
+};
+
+describe('execute-lane dependency cleanup gate', () => {
+  it('does not unlock from merge or CLOSED observation before cleanup', () => {
+    // Given
+    const ledger = mergedPredecessorLedger();
+    const scenario = {
+      dependency_observations: [{ issue_number: 4101, status: 'CLOSED' }],
+    };
+
+    // When
+    const gate = dependencyGate(ledger, 4102);
+
+    // Then
+    expect(gate).toMatchObject({
+      status: 'waiting',
+      unsatisfied_dependencies: [4101],
+    });
+    expect(dispatchableIssueNumbers(ledger)).toEqual([]);
+    expect(
+      unmetDependencies(scenario, ledger, { issue_number: 4102 }),
+    ).toEqual([4101]);
+  });
+
+  it('terminalizes an unreachable dependent without dispatch artifacts', () => {
+    // Given
+    const persisted = {
+      snapshot: blockedPredecessorLedger(),
+      events: [],
+      receipts: [],
+    };
+    const observation = {
+      issue_number: 4102,
+      issue_store_absent: true,
+      local_branch_absent: true,
+      remote_branch_absent: true,
+      worktree_absent: true,
+      task_absent: true,
+      pr_absent: true,
+      observed_at: '2026-08-25T00:00:00.000Z',
+    };
+
+    // When / Then
+    expect(() => terminalizeBlockedDependents(persisted, [])).toThrow(
+      /artifact absence observation/u,
+    );
+    const terminal = terminalizeBlockedDependents(persisted, [observation]);
+
+    expect(terminal.snapshot).toMatchObject({
+      status: 'blocked-terminal',
+      issue_progress: {
+        '4102': {
+          status: 'blocked-terminal',
+          retry_count: 0,
+        },
+      },
+      lanes: [
+        { status: 'needs-human-check-terminal' },
+        {
+          current_issue: null,
+          status: 'blocked-terminal',
+          branch: null,
+          worktree: null,
+          pr: null,
+        },
+      ],
+    });
+    expect(terminal.events).toEqual([
+      expect.objectContaining({
+        event_type: 'dependency.blocked',
+        subject_id: '4102',
+        payload: expect.objectContaining({ artifact_absence: observation }),
+      }),
+    ]);
+    expect(
+      terminalizeBlockedDependents(terminal, [observation]),
+    ).toEqual(terminal);
+  });
+});

--- a/tooling/governance/execute-lane-dispatch-intent.test.ts
+++ b/tooling/governance/execute-lane-dispatch-intent.test.ts
@@ -1,0 +1,178 @@
+import { mkdtempSync, readFileSync, realpathSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+type PersistedState = Readonly<{
+  snapshot: Readonly<Record<string, unknown>>;
+  events: readonly Readonly<Record<string, unknown>>[];
+  receipts: readonly Readonly<Record<string, unknown>>[];
+}>;
+
+const { prepareIssueSupervisorDispatch } = (await import(
+  resolve(
+    process.cwd(),
+    '.agents/skills/execute-lane/scripts/dependency-gate.mjs',
+  )
+)) as {
+  prepareIssueSupervisorDispatch: (
+    persisted: PersistedState,
+    issueNumber: number,
+  ) => PersistedState & { dispatch_event_hash: string };
+};
+const { compileIssueSupervisorDag } = (await import(
+  resolve(
+    process.cwd(),
+    '.agents/skills/execute-lane/scripts/compile-dag.mjs',
+  )
+)) as {
+  compileIssueSupervisorDag: (
+    snapshot: Readonly<Record<string, unknown>>,
+    issueNumber: number,
+  ) => Readonly<Record<string, unknown>>;
+};
+const { attachIssueSupervisorRun, reconcileIssueSupervisorDispatch } =
+  (await import(
+    resolve(
+      process.cwd(),
+      '.agents/skills/execute-lane/scripts/issue-dispatch.mjs',
+    )
+  )) as {
+    attachIssueSupervisorRun: (input: {
+      persisted: PersistedState & { dispatch_event_hash: string };
+      runtime_root: string;
+      issue_number: number;
+      definition: Readonly<Record<string, unknown>>;
+      run_id: string;
+    }) => Readonly<Record<string, unknown>>;
+    reconcileIssueSupervisorDispatch: (input: {
+      persisted: PersistedState;
+      runtime_root: string;
+      issue_number: number;
+      definition: Readonly<Record<string, unknown>>;
+    }) => Readonly<Record<string, unknown>>;
+  };
+
+const isRecord = (
+  value: unknown,
+): value is Readonly<Record<string, unknown>> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const readyState = (): PersistedState => {
+  const parsed: unknown = JSON.parse(
+    readFileSync(
+      resolve(
+        process.cwd(),
+        'tooling/governance/fixtures/execute-lane-native/ready-ledger-two-lanes-v2.json',
+      ),
+      'utf8',
+    ),
+  );
+  if (!isRecord(parsed)) {
+    throw new TypeError('Ready lane fixture must be an object.');
+  }
+  return {
+    snapshot: {
+      ...parsed,
+      dependency_graph: {
+        '4101': [],
+        '4102': [4101],
+      },
+    },
+    events: [],
+    receipts: [],
+  };
+};
+
+describe('execute-lane issue dispatch intent', () => {
+  it('persists intent before an eligible issue supervisor starts', () => {
+    // Given
+    const persisted = readyState();
+
+    // When
+    const prepared = prepareIssueSupervisorDispatch(persisted, 4101);
+
+    // Then
+    expect(prepared.snapshot).toEqual(persisted.snapshot);
+    expect(prepared.receipts).toEqual([]);
+    expect(prepared.events).toEqual([
+      expect.objectContaining({
+        event_type: 'supervisor.dispatch.intent',
+        subject_id: '4101',
+        payload: { dependencies: [] },
+      }),
+    ]);
+    expect(prepared.dispatch_event_hash).toBe(
+      prepared.events[0]?.event_hash,
+    );
+  });
+
+  it('rejects unmet dependencies and duplicate dispatch intent', () => {
+    // Given
+    const persisted = readyState();
+    const prepared = prepareIssueSupervisorDispatch(persisted, 4101);
+
+    // When / Then
+    expect(() =>
+      prepareIssueSupervisorDispatch(persisted, 4102),
+    ).toThrow(/dependency gate/u);
+    expect(() =>
+      prepareIssueSupervisorDispatch(prepared, 4101),
+    ).toThrow(/dispatch intent already exists/u);
+  });
+
+  it('fails closed on an unbound intent and attaches one exact run', () => {
+    // Given
+    const directory = mkdtempSync(
+      join(realpathSync(tmpdir()), 'fluo-issue-dispatch-'),
+    );
+    const runtimeRoot = join(directory, 'lane-runs');
+    const persisted = readyState();
+    const definition = compileIssueSupervisorDag(persisted.snapshot, 4101);
+    const prepared = prepareIssueSupervisorDispatch(persisted, 4101);
+
+    try {
+      // When / Then
+      expect(
+        reconcileIssueSupervisorDispatch({
+          persisted: prepared,
+          runtime_root: runtimeRoot,
+          issue_number: 4101,
+          definition,
+        }),
+      ).toMatchObject({ action: 'blocked-ledger-conflict' });
+
+      const binding = attachIssueSupervisorRun({
+        persisted: prepared,
+        runtime_root: runtimeRoot,
+        issue_number: 4101,
+        definition,
+        run_id: 'run_issue_4101',
+      });
+      expect(
+        reconcileIssueSupervisorDispatch({
+          persisted: prepared,
+          runtime_root: runtimeRoot,
+          issue_number: 4101,
+          definition,
+        }),
+      ).toMatchObject({
+        action: 'attach',
+        run_id: 'run_issue_4101',
+        binding,
+      });
+      expect(() =>
+        attachIssueSupervisorRun({
+          persisted: prepared,
+          runtime_root: runtimeRoot,
+          issue_number: 4101,
+          definition: { ...definition, name: 'tampered' },
+          run_id: 'run_issue_4101',
+        }),
+      ).toThrow(/definition digest/u);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- dispatch dependent issue supervisors only after canonical shared `done` evidence includes merge, CLOSED issue, and cleanup
- replace production full-lane DAG execution with parent-owned single-node issue runs and immutable v2 bindings
- fail closed on dispatch intent/binding conflicts and record verified artifact absence for blocked dependents

## Verification
- related tooling: 13 files, 69 tests passed
- `pnpm typecheck`
- `pnpm lint` (pre-existing warnings only)
- `pnpm build`
- manual blocked/success dispatch QA and native one-node DAG marker

## Merge instruction
Per explicit maintainer request, merge immediately without waiting for CI.