### PR TITLE
fix(tooling): align search issue lane handoff

### DIFF
--- a/.agents/skills/search-issue/references/workflow.md
+++ b/.agents/skills/search-issue/references/workflow.md
@@ -155,7 +155,7 @@ is inserted:
 }
 ```
 
-Emit `$create-lane .omo/search-issue/artifacts/<run-id>.json main`. Do not emit
+Emit `$create-lane .omo/search-issue/artifacts/<run-id>.json`. Do not emit
 or retain an active `.opencode` handoff.
 
 When zero issues are created, create no search artifact and report

--- a/.agents/skills/search-issue/scripts/publication.mjs
+++ b/.agents/skills/search-issue/scripts/publication.mjs
@@ -52,7 +52,7 @@ export const publishRun = ({ ghCalls, ledger, outputDirectory, runId }) => {
         ? null
         : {
             artifact_path: artifactPath,
-            command: `$create-lane ${artifactPath} main`,
+            command: `$create-lane ${artifactPath}`,
           },
   };
 

--- a/tooling/governance/search-issue-native.test.ts
+++ b/tooling/governance/search-issue-native.test.ts
@@ -183,7 +183,7 @@ describe('$search-issue native registration workflow', () => {
         drafts: [{ draft_id: 'D1' }, { draft_id: 'D2' }],
         handoff: {
           artifact_path: artifactPath,
-          command: `$create-lane ${artifactPath} main`,
+          command: `$create-lane ${artifactPath}`,
         },
       });
       expect(ghCalls).toEqual([{ draft_id: 'D1', issue_number: 4101 }]);


### PR DESCRIPTION
## Summary
- remove the legacy `main` positional argument from `$search-issue` handoffs
- align generated commands and workflow documentation with `$create-lane` artifact-only intake
- update the native workflow regression expectation

## Verification
- `vitest run tooling/governance/search-issue-native.test.ts tooling/governance/search-issue-intake.test.ts` (17 passed)
- changed-file LSP diagnostics: clean
- manual fixture scenario emitted `$create-lane .omo/search-issue/artifacts/search-native-full-registration.json`

Per maintainer instruction, merge immediately without waiting for CI.