### PR TITLE
fix(tooling): bind create-lane execution handoffs

### DIFF
--- a/.agents/skills/execute-lane/SKILL.md
+++ b/.agents/skills/execute-lane/SKILL.md
@@ -7,6 +7,9 @@ description: Drain one canonical Fluo lane through implementation, same-head rev
 
 Consume only a strict canonical lane v2 created by `$create-lane`. Do not
 rediscover issues, regroup scope, or infer missing persisted fields.
+Require the exact `.omo/lanes/<lane-id>.json` path, revalidate its source
+artifact and all three approval receipts, and bind every resumed snapshot to
+the canonical ledger's immutable plan before compiling or mutating anything.
 
 The parent lead is the only shared lane snapshot/event/receipt/lease writer.
 It compiles exactly one native DAG from the immutable lane ledger. Every

--- a/.agents/skills/execute-lane/references/workflow.md
+++ b/.agents/skills/execute-lane/references/workflow.md
@@ -16,6 +16,15 @@ Acquire a per-ledger lease, validate the v2 snapshot and event hash chain, and
 reconcile live branch, worktree, PR, head, checks, and issue identity before
 resuming.
 
+Before acquiring the lease, require the exact canonical
+`.omo/lanes/<lane-id>.json` path with a matching filename and reject symlinked
+or repository-escaping evidence. Re-read the source search artifact and the
+`confirmed-issues`, `suggested-additions`, and `lane-plan` approval receipts.
+Recompute every approval binding, require the artifact ID/SHA and approved plan
+to reproduce the ledger's immutable fields, and reject a resumed snapshot when
+its source, authority, retry policy, issue set, lane queues, dependencies, or
+release handoffs differ from that canonical plan.
+
 `release_handoffs` does not mean “Changeset required.” It contains only issues
 whose core task is release or publishing. Those issues are never dispatched to
 implementation and terminally park at `blocked-maintainer-decision`. When

--- a/.agents/skills/execute-lane/scripts/fixtures/run-replay.mjs
+++ b/.agents/skills/execute-lane/scripts/fixtures/run-replay.mjs
@@ -2,9 +2,9 @@ import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 
 import { runReplay } from '../state-machine.mjs';
+import { acquireLease } from '../lane-lease.mjs';
 import {
-  acquireLease,
-  loadState,
+  loadFixtureState,
   persistState,
 } from '../state-store.mjs';
 
@@ -43,7 +43,7 @@ if (
 
 let result;
 for (const step of scenario.steps) {
-  const previous = loadState(
+  const previous = loadFixtureState(
     stateDirectory,
     ledgerPath,
     repositoryRoot,

--- a/.agents/skills/execute-lane/scripts/handoff-files.mjs
+++ b/.agents/skills/execute-lane/scripts/handoff-files.mjs
@@ -1,0 +1,178 @@
+import {
+  existsSync,
+  lstatSync,
+  readFileSync,
+} from 'node:fs';
+import { relative, resolve } from 'node:path';
+
+import { assertHandoffProvenance } from './handoff-provenance.mjs';
+import { assertReleaseHandoffBinding } from './release-handoff-approval.mjs';
+
+const approvalStages = [
+  'confirmed-issues',
+  'suggested-additions',
+  'lane-plan',
+];
+
+const assertRegularFile = (path) => {
+  if (!existsSync(path)) {
+    throw new TypeError(`${path} must exist.`);
+  }
+  const stat = lstatSync(path);
+  if (stat.isSymbolicLink() || !stat.isFile()) {
+    throw new TypeError(`${path} must be a real regular file.`);
+  }
+};
+
+const assertRealDirectory = (path) => {
+  const stat = lstatSync(path);
+  if (stat.isSymbolicLink() || !stat.isDirectory()) {
+    throw new TypeError(`${path} must be a real directory.`);
+  }
+};
+
+const readJson = (path) => {
+  assertRegularFile(path);
+  return JSON.parse(readFileSync(path, 'utf8'));
+};
+
+const assertContainedPaths = (repositoryRoot, paths) => {
+  for (const path of paths) {
+    const pathFromRoot = relative(repositoryRoot, path);
+    if (
+      pathFromRoot.startsWith('..') ||
+      resolve(repositoryRoot, pathFromRoot) !== path
+    ) {
+      throw new TypeError('lane handoff evidence escaped the repository root');
+    }
+  }
+};
+
+const evidencePaths = (repositoryRoot, ledger) => {
+  const omoDirectory = resolve(repositoryRoot, '.omo');
+  const approvalDirectory = resolve(omoDirectory, 'approvals');
+  const searchDirectory = resolve(omoDirectory, 'search-issue');
+  const artifactDirectory = resolve(searchDirectory, 'artifacts');
+  for (const directory of [
+    repositoryRoot,
+    omoDirectory,
+    approvalDirectory,
+    searchDirectory,
+    artifactDirectory,
+  ]) {
+    assertRealDirectory(directory);
+  }
+  if (ledger.source.search_ledger.includes('/legacy/')) {
+    assertRealDirectory(resolve(artifactDirectory, 'legacy'));
+  }
+  return {
+    artifactPath: resolve(repositoryRoot, ledger.source.search_ledger),
+    approvalPaths: approvalStages.map((stage) =>
+      resolve(
+        approvalDirectory,
+        `approval-${ledger.lane_id}-${stage}.json`,
+      ),
+    ),
+  };
+};
+
+export const loadCanonicalHandoffContext = (
+  repositoryRoot,
+  ledgerPath,
+  canonicalLedger,
+) => {
+  const laneDirectory = resolve(repositoryRoot, '.omo/lanes');
+  assertRealDirectory(laneDirectory);
+  const expectedLedgerPath = resolve(
+    laneDirectory,
+    `${canonicalLedger.lane_id}.json`,
+  );
+  if (resolve(ledgerPath) !== expectedLedgerPath) {
+    throw new TypeError(
+      'execute-lane requires the canonical lane path',
+    );
+  }
+  const { artifactPath, approvalPaths } = evidencePaths(
+    repositoryRoot,
+    canonicalLedger,
+  );
+  assertContainedPaths(repositoryRoot, [
+    expectedLedgerPath,
+    artifactPath,
+    ...approvalPaths,
+  ]);
+  const artifact = readJson(artifactPath);
+  const approvalReceipts = approvalPaths.map(readJson);
+  assertHandoffProvenance({
+    ledger: canonicalLedger,
+    receipts: approvalReceipts,
+    artifact,
+    artifactPath: canonicalLedger.source.search_ledger,
+  });
+  if (canonicalLedger.release_handoffs.length > 0) {
+    assertReleaseHandoffBinding(
+      canonicalLedger,
+      approvalReceipts[2],
+      artifact,
+      canonicalLedger.source.search_ledger,
+    );
+  }
+  return {
+    artifact,
+    artifactPath: canonicalLedger.source.search_ledger,
+    approvalReceipts,
+    canonicalLedger,
+  };
+};
+
+export const loadFixtureHandoffContext = (
+  repositoryRoot,
+  ledger,
+  canonicalLedger,
+) => {
+  const canonicalRequiresApproval =
+    canonicalLedger.release_handoffs.length > 0 ||
+    canonicalLedger.lane_plan_approval_sha256 !== undefined;
+  const snapshotRequiresApproval =
+    ledger.release_handoffs.length > 0 ||
+    ledger.lane_plan_approval_sha256 !== undefined;
+  if (!canonicalRequiresApproval && !snapshotRequiresApproval) {
+    return null;
+  }
+  if (
+    canonicalRequiresApproval &&
+    ledger.lane_plan_approval_sha256 !==
+      canonicalLedger.lane_plan_approval_sha256
+  ) {
+    throw new TypeError(
+      'persisted lane-plan approval binding does not match the canonical ledger',
+    );
+  }
+  const evidenceLedger = canonicalRequiresApproval
+    ? canonicalLedger
+    : ledger;
+  const { artifactPath, approvalPaths } = evidencePaths(
+    repositoryRoot,
+    evidenceLedger,
+  );
+  const lanePlanPath = approvalPaths[2];
+  assertContainedPaths(repositoryRoot, [lanePlanPath, artifactPath]);
+  if (!existsSync(lanePlanPath)) {
+    throw new TypeError(
+      'release handoffs require their consumed lane-plan approval receipt',
+    );
+  }
+  const receipt = readJson(lanePlanPath);
+  const artifact = readJson(artifactPath);
+  assertReleaseHandoffBinding(
+    ledger,
+    receipt,
+    artifact,
+    evidenceLedger.source.search_ledger,
+  );
+  return {
+    receipt,
+    artifact,
+    artifactPath: evidenceLedger.source.search_ledger,
+  };
+};

--- a/.agents/skills/execute-lane/scripts/handoff-provenance.mjs
+++ b/.agents/skills/execute-lane/scripts/handoff-provenance.mjs
@@ -28,8 +28,23 @@ const hasExactKeys = (record, keys) => {
   );
 };
 
+const canonicalValue = (value) => {
+  if (Array.isArray(value)) {
+    return value.map(canonicalValue);
+  }
+  if (!isRecord(value)) {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.keys(value)
+      .sort()
+      .map((key) => [key, canonicalValue(value[key])]),
+  );
+};
+
 const sameValue = (left, right) =>
-  JSON.stringify(left) === JSON.stringify(right);
+  JSON.stringify(canonicalValue(left)) ===
+  JSON.stringify(canonicalValue(right));
 
 const assertReceipt = (receipt, ledger, stage) => {
   const stageKeys =

--- a/.agents/skills/execute-lane/scripts/handoff-provenance.mjs
+++ b/.agents/skills/execute-lane/scripts/handoff-provenance.mjs
@@ -1,0 +1,177 @@
+import {
+  approvalBinding,
+} from '../../create-lane/scripts/approval-contracts.mjs';
+import {
+  planIsCanonical,
+  readyLedger,
+} from '../../create-lane/scripts/plan-contracts.mjs';
+import {
+  assertContract,
+  assertLaneSourceBinding,
+} from '../../../workflow-contracts/contracts.mjs';
+
+const stages = [
+  'confirmed-issues',
+  'suggested-additions',
+  'lane-plan',
+];
+
+const isRecord = (value) =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const hasExactKeys = (record, keys) => {
+  const actual = Object.keys(record).sort();
+  const expected = [...keys].sort();
+  return (
+    actual.length === expected.length &&
+    actual.every((key, index) => key === expected[index])
+  );
+};
+
+const sameValue = (left, right) =>
+  JSON.stringify(left) === JSON.stringify(right);
+
+const assertReceipt = (receipt, ledger, stage) => {
+  const stageKeys =
+    stage === 'lane-plan'
+      ? [
+          'version',
+          'approval_id',
+          'gate',
+          'binding_sha256',
+          'lane_id',
+          'release_handoff_attestations',
+          'plan',
+        ]
+      : [
+          'version',
+          'approval_id',
+          'gate',
+          'binding_sha256',
+          'lane_id',
+          'issue_numbers',
+        ];
+  if (
+    !isRecord(receipt) ||
+    !hasExactKeys(receipt, stageKeys) ||
+    receipt.version !== 1 ||
+    receipt.gate !== stage ||
+    receipt.lane_id !== ledger.lane_id ||
+    receipt.approval_id !== `approval-${ledger.lane_id}-${stage}` ||
+    typeof receipt.binding_sha256 !== 'string' ||
+    !/^[a-f0-9]{64}$/u.test(receipt.binding_sha256)
+  ) {
+    throw new TypeError(`Invalid ${stage} approval receipt.`);
+  }
+  if (
+    stage === 'lane-plan'
+      ? !Array.isArray(receipt.release_handoff_attestations) ||
+        !isRecord(receipt.plan)
+      : !Array.isArray(receipt.issue_numbers)
+  ) {
+    throw new TypeError(`Invalid ${stage} approval receipt payload.`);
+  }
+};
+
+const approvalValue = (receipt) => ({
+  gate: receipt.gate,
+  approval_id: receipt.approval_id,
+  approved: true,
+  ...(receipt.gate === 'lane-plan'
+    ? {
+        release_handoff_attestations:
+          receipt.release_handoff_attestations,
+      }
+    : { issue_numbers: receipt.issue_numbers }),
+  binding_sha256: receipt.binding_sha256,
+});
+
+const immutablePlan = (ledger) => ({
+  version: ledger.version,
+  run_id: ledger.run_id,
+  lane_id: ledger.lane_id,
+  created_by: ledger.created_by,
+  base_branch: ledger.base_branch,
+  source: ledger.source,
+  merge_policy: ledger.merge_policy,
+  pr_merge_method: ledger.pr_merge_method,
+  authority_scope: ledger.authority_scope,
+  retry_policy: ledger.retry_policy,
+  confirmed_issues: ledger.confirmed_issues,
+  suggested_but_excluded: ledger.suggested_but_excluded,
+  backlog_candidates: ledger.backlog_candidates,
+  release_handoffs: ledger.release_handoffs,
+  lanes: ledger.lanes.map(({ name, queue }) => ({ name, queue })),
+  dependency_graph: ledger.dependency_graph,
+  lane_plan_approval_sha256:
+    ledger.lane_plan_approval_sha256 ?? null,
+});
+
+export const assertImmutableLaneBinding = (snapshot, canonicalLedger) => {
+  if (
+    !sameValue(
+      immutablePlan(snapshot),
+      immutablePlan(canonicalLedger),
+    )
+  ) {
+    throw new TypeError(
+      'persisted lane snapshot does not match the canonical immutable plan',
+    );
+  }
+};
+
+export const assertHandoffProvenance = ({
+  ledger,
+  receipts,
+  artifact,
+  artifactPath,
+}) => {
+  if (!Array.isArray(receipts) || receipts.length !== stages.length) {
+    throw new TypeError(
+      'canonical lane handoff requires all three approval receipts',
+    );
+  }
+  for (const [index, stage] of stages.entries()) {
+    assertReceipt(receipts[index], ledger, stage);
+  }
+  const [confirmed, additions, lanePlan] = receipts;
+  assertContract('search-artifact-v2', artifact);
+  assertLaneSourceBinding(ledger, artifact);
+  if (!planIsCanonical(lanePlan.plan, artifact)) {
+    throw new TypeError('lane-plan approval receipt is not canonical');
+  }
+  const initialIssues = artifact.selected_issues;
+  const plannedIssues = lanePlan.plan.confirmed_issues;
+  const includedIssues = plannedIssues.slice(initialIssues.length);
+  if (
+    !sameValue(confirmed.issue_numbers, initialIssues) ||
+    !sameValue(
+      plannedIssues.slice(0, initialIssues.length),
+      initialIssues,
+    ) ||
+    !sameValue(additions.issue_numbers, includedIssues)
+  ) {
+    throw new TypeError(
+      'approval issue sets do not match the canonical lane plan',
+    );
+  }
+  for (const receipt of receipts) {
+    if (
+      receipt.binding_sha256 !==
+      approvalBinding(approvalValue(receipt), artifact, lanePlan.plan)
+    ) {
+      throw new TypeError(
+        `${receipt.gate} approval binding does not match`,
+      );
+    }
+  }
+  const expectedLedger = readyLedger(
+    lanePlan.plan,
+    artifact,
+    artifactPath,
+    ledger.release_handoffs.length === 0
+      ? undefined
+      : lanePlan.binding_sha256,
+  );
+  assertImmutableLaneBinding(ledger, expectedLedger);
+};

--- a/.agents/skills/execute-lane/scripts/lane-lease.mjs
+++ b/.agents/skills/execute-lane/scripts/lane-lease.mjs
@@ -1,0 +1,63 @@
+import { randomUUID } from 'node:crypto';
+import {
+  closeSync,
+  existsSync,
+  lstatSync,
+  openSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { resolve } from 'node:path';
+
+const assertRegularFile = (path) => {
+  if (!existsSync(path)) {
+    return;
+  }
+  const stat = lstatSync(path);
+  if (stat.isSymbolicLink() || !stat.isFile()) {
+    throw new TypeError(`${path} must be a real regular file.`);
+  }
+};
+
+const writeAtomic = (path, value) => {
+  assertRegularFile(path);
+  const candidate = `${path}.${randomUUID()}.tmp`;
+  writeFileSync(candidate, `${JSON.stringify(value, null, 2)}\n`, {
+    encoding: 'utf8',
+    flag: 'wx',
+  });
+  try {
+    renameSync(candidate, path);
+  } finally {
+    if (existsSync(candidate)) {
+      unlinkSync(candidate);
+    }
+  }
+};
+
+export const acquireLease = (stateDirectory, laneId) => {
+  const lockPath = resolve(stateDirectory, 'lease.lock');
+  const descriptor = openSync(lockPath, 'wx');
+  const token = randomUUID();
+  const leasePath = resolve(stateDirectory, 'lease.json');
+  writeAtomic(leasePath, {
+    version: 1,
+    lane_id: laneId,
+    holder: `execute-lane:${token}`,
+    status: 'active',
+  });
+  return {
+    release(outcome) {
+      closeSync(descriptor);
+      unlinkSync(lockPath);
+      writeAtomic(leasePath, {
+        version: 1,
+        lane_id: laneId,
+        holder: `execute-lane:${token}`,
+        status: 'released',
+        outcome,
+      });
+    },
+  };
+};

--- a/.agents/skills/execute-lane/scripts/lane-lease.mjs
+++ b/.agents/skills/execute-lane/scripts/lane-lease.mjs
@@ -41,16 +41,20 @@ export const acquireLease = (stateDirectory, laneId) => {
   const descriptor = openSync(lockPath, 'wx');
   const token = randomUUID();
   const leasePath = resolve(stateDirectory, 'lease.json');
-  writeAtomic(leasePath, {
-    version: 1,
-    lane_id: laneId,
-    holder: `execute-lane:${token}`,
-    status: 'active',
-  });
+  try {
+    writeAtomic(leasePath, {
+      version: 1,
+      lane_id: laneId,
+      holder: `execute-lane:${token}`,
+      status: 'active',
+    });
+  } catch (error) {
+    closeSync(descriptor);
+    unlinkSync(lockPath);
+    throw error;
+  }
   return {
     release(outcome) {
-      closeSync(descriptor);
-      unlinkSync(lockPath);
       writeAtomic(leasePath, {
         version: 1,
         lane_id: laneId,
@@ -58,6 +62,8 @@ export const acquireLease = (stateDirectory, laneId) => {
         status: 'released',
         outcome,
       });
+      closeSync(descriptor);
+      unlinkSync(lockPath);
     },
   };
 };

--- a/.agents/skills/execute-lane/scripts/state-store.mjs
+++ b/.agents/skills/execute-lane/scripts/state-store.mjs
@@ -1,23 +1,29 @@
 import { randomUUID } from 'node:crypto';
 import {
   appendFileSync,
-  closeSync,
   existsSync,
   lstatSync,
   mkdirSync,
-  openSync,
   readFileSync,
   renameSync,
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
-import { dirname, relative, resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
 
 import {
   assertContract,
   assertEventChain,
 } from '../../../workflow-contracts/contracts.mjs';
 import { validateLedger } from '../../../../tooling/governance/lane-ledger-state.mjs';
+import {
+  assertHandoffProvenance,
+  assertImmutableLaneBinding,
+} from './handoff-provenance.mjs';
+import {
+  loadCanonicalHandoffContext,
+  loadFixtureHandoffContext,
+} from './handoff-files.mjs';
 import { assertReleaseHandoffBinding } from './release-handoff-approval.mjs';
 
 const assertRegularFile = (path) => {
@@ -30,94 +36,9 @@ const assertRegularFile = (path) => {
   }
 };
 
-const assertRealDirectory = (path) => {
-  const stat = lstatSync(path);
-  if (stat.isSymbolicLink() || !stat.isDirectory()) {
-    throw new TypeError(`${path} must be a real directory.`);
-  }
-};
-
 const readJson = (path) => {
   assertRegularFile(path);
   return JSON.parse(readFileSync(path, 'utf8'));
-};
-
-const releaseHandoffContext = (repositoryRoot, ledger, canonicalLedger) => {
-  const canonicalRequiresApproval =
-    canonicalLedger.release_handoffs.length > 0 ||
-    canonicalLedger.lane_plan_approval_sha256 !== undefined;
-  const snapshotRequiresApproval =
-    ledger.release_handoffs.length > 0 ||
-    ledger.lane_plan_approval_sha256 !== undefined;
-  if (
-    !canonicalRequiresApproval &&
-    !snapshotRequiresApproval
-  ) {
-    return null;
-  }
-  if (
-    canonicalRequiresApproval &&
-    ledger.lane_plan_approval_sha256 !==
-      canonicalLedger.lane_plan_approval_sha256
-  ) {
-    throw new TypeError(
-      'persisted lane-plan approval binding does not match the canonical ledger',
-    );
-  }
-  const evidenceLedger = canonicalRequiresApproval
-    ? canonicalLedger
-    : ledger;
-  const omoDirectory = resolve(repositoryRoot, '.omo');
-  const approvalDirectory = resolve(omoDirectory, 'approvals');
-  const searchDirectory = resolve(omoDirectory, 'search-issue');
-  const artifactDirectory = resolve(searchDirectory, 'artifacts');
-  for (const directory of [
-    repositoryRoot,
-    omoDirectory,
-    approvalDirectory,
-    searchDirectory,
-    artifactDirectory,
-  ]) {
-    assertRealDirectory(directory);
-  }
-  if (evidenceLedger.source.search_ledger.includes('/legacy/')) {
-    assertRealDirectory(resolve(artifactDirectory, 'legacy'));
-  }
-  const approvalPath = resolve(
-    approvalDirectory,
-    `approval-${evidenceLedger.lane_id}-lane-plan.json`,
-  );
-  const artifactPath = resolve(
-    repositoryRoot,
-    evidenceLedger.source.search_ledger,
-  );
-  for (const path of [approvalPath, artifactPath]) {
-    const pathFromRoot = relative(repositoryRoot, path);
-    if (pathFromRoot.startsWith('..') || resolve(repositoryRoot, pathFromRoot) !== path) {
-      throw new TypeError('release handoff evidence escaped the repository root');
-    }
-  }
-  if (!existsSync(approvalPath)) {
-    throw new TypeError(
-      'release handoffs require their consumed lane-plan approval receipt',
-    );
-  }
-  if (!existsSync(artifactPath)) {
-    throw new TypeError('release handoff source artifact is missing');
-  }
-  const receipt = readJson(approvalPath);
-  const artifact = readJson(artifactPath);
-  assertReleaseHandoffBinding(
-    ledger,
-    receipt,
-    artifact,
-    evidenceLedger.source.search_ledger,
-  );
-  return {
-    receipt,
-    artifact,
-    artifactPath: evidenceLedger.source.search_ledger,
-  };
 };
 
 const ensureStateDirectory = (path) => {
@@ -215,11 +136,12 @@ const recoverTransaction = (stateDirectory) => {
   unlinkSync(path);
 };
 
-export const loadState = (
+const loadStateInternal = ({
   stateDirectory,
   ledgerPath,
-  repositoryRoot = resolve(dirname(ledgerPath), '../..'),
-) => {
+  repositoryRoot,
+  canonicalBoundary,
+}) => {
   ensureStateDirectory(stateDirectory);
   recoverTransaction(stateDirectory);
   const canonicalSnapshot = readJson(ledgerPath);
@@ -237,58 +159,77 @@ export const loadState = (
     receipts: [],
   });
   validateState(state);
-  const handoffContext = releaseHandoffContext(
-    repositoryRoot,
-    snapshot,
-    canonicalSnapshot,
-  );
-  return { ...state, handoffContext };
+  const handoffContext = canonicalBoundary
+    ? loadCanonicalHandoffContext(
+        repositoryRoot,
+        ledgerPath,
+        canonicalSnapshot,
+      )
+    : loadFixtureHandoffContext(
+        repositoryRoot,
+        snapshot,
+        canonicalSnapshot,
+      );
+  assertImmutableLaneBinding(snapshot, canonicalSnapshot);
+  return { ...state, canonicalSnapshot, handoffContext };
 };
 
-export const acquireLease = (stateDirectory, laneId) => {
-  const lockPath = resolve(stateDirectory, 'lease.lock');
-  const descriptor = openSync(lockPath, 'wx');
-  const token = randomUUID();
-  const leasePath = resolve(stateDirectory, 'lease.json');
-  writeAtomic(leasePath, {
-    version: 1,
-    lane_id: laneId,
-    holder: `execute-lane:${token}`,
-    status: 'active',
+export const loadState = (
+  stateDirectory,
+  ledgerPath,
+  repositoryRoot = resolve(dirname(ledgerPath), '../..'),
+) =>
+  loadStateInternal({
+    stateDirectory,
+    ledgerPath,
+    repositoryRoot,
+    canonicalBoundary: true,
   });
-  return {
-    release(outcome) {
-      closeSync(descriptor);
-      unlinkSync(lockPath);
-      writeAtomic(leasePath, {
-        version: 1,
-        lane_id: laneId,
-        holder: `execute-lane:${token}`,
-        status: 'released',
-        outcome,
-      });
-    },
-  };
-};
+
+export const loadFixtureState = (
+  stateDirectory,
+  ledgerPath,
+  repositoryRoot = resolve(dirname(ledgerPath), '../..'),
+) =>
+  loadStateInternal({
+    stateDirectory,
+    ledgerPath,
+    repositoryRoot,
+    canonicalBoundary: false,
+  });
 
 export const persistState = (stateDirectory, previous, next) => {
   validateState(next);
   const context = previous.handoffContext;
+  if (context?.approvalReceipts !== undefined) {
+    assertHandoffProvenance({
+      ledger: next.snapshot,
+      receipts: context.approvalReceipts,
+      artifact: context.artifact,
+      artifactPath: context.artifactPath,
+    });
+  }
   if (
-    (context !== null && context !== undefined) ||
+    context?.receipt !== undefined ||
     next.snapshot.release_handoffs.length > 0 ||
     next.snapshot.lane_plan_approval_sha256 !== undefined
   ) {
     if (context === null || context === undefined) {
       throw new TypeError('release handoff approval context is missing');
     }
+    const lanePlanReceipt =
+      context.approvalReceipts?.[2] ?? context.receipt;
     assertReleaseHandoffBinding(
       next.snapshot,
-      context.receipt,
+      lanePlanReceipt,
       context.artifact,
       context.artifactPath,
     );
   }
+  assertImmutableLaneBinding(
+    next.snapshot,
+    previous.canonicalSnapshot ?? previous.snapshot,
+  );
   assertEventPrefix(previous.events, next.events);
   const transactionPath = resolve(stateDirectory, 'transaction.json');
   writeAtomic(transactionPath, {

--- a/.agents/skills/execute-lane/scripts/state-store.mjs
+++ b/.agents/skills/execute-lane/scripts/state-store.mjs
@@ -142,9 +142,21 @@ const loadStateInternal = ({
   repositoryRoot,
   canonicalBoundary,
 }) => {
+  const canonicalSnapshot = readJson(ledgerPath);
+  validateState({
+    snapshot: canonicalSnapshot,
+    events: [],
+    receipts: [],
+  });
+  const canonicalContext = canonicalBoundary
+    ? loadCanonicalHandoffContext(
+        repositoryRoot,
+        ledgerPath,
+        canonicalSnapshot,
+      )
+    : null;
   ensureStateDirectory(stateDirectory);
   recoverTransaction(stateDirectory);
-  const canonicalSnapshot = readJson(ledgerPath);
   const snapshotPath = resolve(stateDirectory, 'snapshot.json');
   const snapshot = existsSync(snapshotPath)
     ? readJson(snapshotPath)
@@ -153,19 +165,10 @@ const loadStateInternal = ({
   const receiptsPath = resolve(stateDirectory, 'receipts.json');
   const receipts = existsSync(receiptsPath) ? readJson(receiptsPath) : [];
   const state = { snapshot, events, receipts };
-  validateState({
-    snapshot: canonicalSnapshot,
-    events: [],
-    receipts: [],
-  });
   validateState(state);
-  const handoffContext = canonicalBoundary
-    ? loadCanonicalHandoffContext(
-        repositoryRoot,
-        ledgerPath,
-        canonicalSnapshot,
-      )
-    : loadFixtureHandoffContext(
+  const handoffContext =
+    canonicalContext ??
+    loadFixtureHandoffContext(
         repositoryRoot,
         snapshot,
         canonicalSnapshot,

--- a/tooling/governance/execute-lane-handoff.test.ts
+++ b/tooling/governance/execute-lane-handoff.test.ts
@@ -149,12 +149,17 @@ describe('$execute-lane canonical handoff boundary', () => {
     // Given
     const handoff = createProducerOutput();
     const noncanonicalPath = resolve(handoff.root, 'lane.json');
+    const rejectedStateDirectory = resolve(
+      handoff.root,
+      '.omo/lane-runs/rejected',
+    );
     copyFileSync(handoff.ledgerPath, noncanonicalPath);
 
     // When / Then
     expect(() =>
-      loadState(handoff.stateDirectory, noncanonicalPath, handoff.root),
+      loadState(rejectedStateDirectory, noncanonicalPath, handoff.root),
     ).toThrow(/canonical lane path/u);
+    expect(existsSync(rejectedStateDirectory)).toBe(false);
   });
 
   it('rejects a normal lane whose source artifact was changed', () => {

--- a/tooling/governance/execute-lane-handoff.test.ts
+++ b/tooling/governance/execute-lane-handoff.test.ts
@@ -1,0 +1,206 @@
+import { execFileSync } from 'node:child_process';
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, resolve } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+const repositoryRoot = process.cwd();
+const createLaneRunner = resolve(
+  repositoryRoot,
+  '.agents/skills/create-lane/scripts/fixtures/run-scenario.mjs',
+);
+const createLaneFixture = resolve(
+  repositoryRoot,
+  'tooling/governance/fixtures/create-lane-native/valid-native-artifact.json',
+);
+const ledgerRelativePath = '.omo/lanes/lane-4101-runtime.json';
+const artifactRelativePath =
+  '.omo/search-issue/artifacts/search-native-runtime.json';
+const confirmedReceiptRelativePath =
+  '.omo/approvals/approval-lane-4101-runtime-confirmed-issues.json';
+const temporaryRoots: string[] = [];
+
+const { loadState } = (await import(
+  resolve(
+    repositoryRoot,
+    '.agents/skills/execute-lane/scripts/state-store.mjs',
+  )
+)) as {
+  loadState: (
+    stateDirectory: string,
+    ledgerPath: string,
+    root?: string,
+  ) => Readonly<Record<string, unknown>>;
+};
+
+const isRecord = (
+  value: unknown,
+): value is Readonly<Record<string, unknown>> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const parseRecord = (path: string): Readonly<Record<string, unknown>> => {
+  const parsed: unknown = JSON.parse(readFileSync(path, 'utf8'));
+  if (!isRecord(parsed)) {
+    throw new TypeError(`Expected a JSON object at ${path}.`);
+  }
+  return Object.fromEntries(Object.entries(parsed));
+};
+
+const writeRecord = (
+  path: string,
+  value: Readonly<Record<string, unknown>>,
+): void => {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+};
+
+const createProducerOutput = (): Readonly<{
+  root: string;
+  ledgerPath: string;
+  artifactPath: string;
+  confirmedReceiptPath: string;
+  stateDirectory: string;
+}> => {
+  const root = mkdtempSync(resolve(tmpdir(), 'fluo-lane-handoff-'));
+  temporaryRoots.push(root);
+  execFileSync(
+    process.execPath,
+    [
+      createLaneRunner,
+      '--fixture-only',
+      '--scenario',
+      createLaneFixture,
+      '--out',
+      root,
+    ],
+    { encoding: 'utf8' },
+  );
+  const fixture = parseRecord(createLaneFixture);
+  const artifacts = fixture['artifacts'];
+  if (!isRecord(artifacts)) {
+    throw new TypeError('Create-lane fixture must contain artifacts.');
+  }
+  const artifact = artifacts[artifactRelativePath];
+  if (!isRecord(artifact)) {
+    throw new TypeError('Create-lane fixture must contain the source artifact.');
+  }
+  const artifactPath = resolve(root, artifactRelativePath);
+  writeRecord(artifactPath, Object.fromEntries(Object.entries(artifact)));
+  const stateDirectory = resolve(
+    root,
+    '.omo/lane-runs/lane-4101-runtime',
+  );
+  mkdirSync(stateDirectory, { recursive: true });
+  return {
+    root,
+    ledgerPath: resolve(root, ledgerRelativePath),
+    artifactPath,
+    confirmedReceiptPath: resolve(root, confirmedReceiptRelativePath),
+    stateDirectory,
+  };
+};
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('$execute-lane canonical handoff boundary', () => {
+  it('accepts the exact normal-lane producer output', () => {
+    // Given
+    const handoff = createProducerOutput();
+
+    // When
+    const state = loadState(
+      handoff.stateDirectory,
+      handoff.ledgerPath,
+      handoff.root,
+    );
+
+    // Then
+    expect(state['snapshot']).toEqual(parseRecord(handoff.ledgerPath));
+  });
+
+  it('rejects a valid ledger outside the canonical lane path', () => {
+    // Given
+    const handoff = createProducerOutput();
+    const noncanonicalPath = resolve(handoff.root, 'lane.json');
+    copyFileSync(handoff.ledgerPath, noncanonicalPath);
+
+    // When / Then
+    expect(() =>
+      loadState(handoff.stateDirectory, noncanonicalPath, handoff.root),
+    ).toThrow(/canonical lane path/u);
+  });
+
+  it('rejects a normal lane whose source artifact was changed', () => {
+    // Given
+    const handoff = createProducerOutput();
+    writeRecord(handoff.artifactPath, {
+      ...parseRecord(handoff.artifactPath),
+      selected_issues: [9999],
+    });
+
+    // When / Then
+    expect(() =>
+      loadState(
+        handoff.stateDirectory,
+        handoff.ledgerPath,
+        handoff.root,
+      ),
+    ).toThrow();
+  });
+
+  it('rejects a normal lane whose approval receipt was changed', () => {
+    // Given
+    const handoff = createProducerOutput();
+    writeRecord(handoff.confirmedReceiptPath, {
+      ...parseRecord(handoff.confirmedReceiptPath),
+      binding_sha256: '0'.repeat(64),
+    });
+
+    // When / Then
+    expect(() =>
+      loadState(
+        handoff.stateDirectory,
+        handoff.ledgerPath,
+        handoff.root,
+      ),
+    ).toThrow(/approval binding/u);
+  });
+
+  it('rejects a resumed snapshot with a changed immutable authority', () => {
+    // Given
+    const handoff = createProducerOutput();
+    const ledger = parseRecord(handoff.ledgerPath);
+    const authority = ledger['authority_scope'];
+    if (!isRecord(authority)) {
+      throw new TypeError('Lane ledger must contain authority_scope.');
+    }
+    writeRecord(resolve(handoff.stateDirectory, 'snapshot.json'), {
+      ...ledger,
+      authority_scope: {
+        ...authority,
+        cleanup_command_worktrees: false,
+      },
+    });
+
+    // When / Then
+    expect(() =>
+      loadState(
+        handoff.stateDirectory,
+        handoff.ledgerPath,
+        handoff.root,
+      ),
+    ).toThrow(/immutable plan/u);
+  });
+});

--- a/tooling/governance/execute-lane-handoff.test.ts
+++ b/tooling/governance/execute-lane-handoff.test.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import {
   copyFileSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -24,8 +25,11 @@ const createLaneFixture = resolve(
 const ledgerRelativePath = '.omo/lanes/lane-4101-runtime.json';
 const artifactRelativePath =
   '.omo/search-issue/artifacts/search-native-runtime.json';
-const confirmedReceiptRelativePath =
-  '.omo/approvals/approval-lane-4101-runtime-confirmed-issues.json';
+const receiptRelativePaths = [
+  '.omo/approvals/approval-lane-4101-runtime-confirmed-issues.json',
+  '.omo/approvals/approval-lane-4101-runtime-suggested-additions.json',
+  '.omo/approvals/approval-lane-4101-runtime-lane-plan.json',
+];
 const temporaryRoots: string[] = [];
 
 const { loadState } = (await import(
@@ -38,6 +42,17 @@ const { loadState } = (await import(
     stateDirectory: string,
     ledgerPath: string,
     root?: string,
+  ) => Readonly<Record<string, unknown>>;
+};
+const { acquireLease } = (await import(
+  resolve(
+    repositoryRoot,
+    '.agents/skills/execute-lane/scripts/lane-lease.mjs',
+  )
+)) as {
+  acquireLease: (
+    stateDirectory: string,
+    laneId: string,
   ) => Readonly<Record<string, unknown>>;
 };
 
@@ -66,7 +81,7 @@ const createProducerOutput = (): Readonly<{
   root: string;
   ledgerPath: string;
   artifactPath: string;
-  confirmedReceiptPath: string;
+  receiptPaths: readonly string[];
   stateDirectory: string;
 }> => {
   const root = mkdtempSync(resolve(tmpdir(), 'fluo-lane-handoff-'));
@@ -103,7 +118,7 @@ const createProducerOutput = (): Readonly<{
     root,
     ledgerPath: resolve(root, ledgerRelativePath),
     artifactPath,
-    confirmedReceiptPath: resolve(root, confirmedReceiptRelativePath),
+    receiptPaths: receiptRelativePaths.map((path) => resolve(root, path)),
     stateDirectory,
   };
 };
@@ -160,12 +175,41 @@ describe('$execute-lane canonical handoff boundary', () => {
     ).toThrow();
   });
 
-  it('rejects a normal lane whose approval receipt was changed', () => {
+  it.each(receiptRelativePaths)(
+    'rejects a normal lane whose %s receipt was changed',
+    (receiptRelativePath) => {
+      // Given
+      const handoff = createProducerOutput();
+      const receiptPath = resolve(handoff.root, receiptRelativePath);
+      writeRecord(receiptPath, {
+        ...parseRecord(receiptPath),
+        binding_sha256: '0'.repeat(64),
+      });
+
+      // When / Then
+      expect(() =>
+        loadState(
+          handoff.stateDirectory,
+          handoff.ledgerPath,
+          handoff.root,
+        ),
+      ).toThrow(/approval binding/u);
+    },
+  );
+
+  it('accepts a resumed snapshot with reordered immutable object keys', () => {
     // Given
     const handoff = createProducerOutput();
-    writeRecord(handoff.confirmedReceiptPath, {
-      ...parseRecord(handoff.confirmedReceiptPath),
-      binding_sha256: '0'.repeat(64),
+    const ledger = parseRecord(handoff.ledgerPath);
+    const authority = ledger['authority_scope'];
+    if (!isRecord(authority)) {
+      throw new TypeError('Lane ledger must contain authority_scope.');
+    }
+    writeRecord(resolve(handoff.stateDirectory, 'snapshot.json'), {
+      ...ledger,
+      authority_scope: Object.fromEntries(
+        Object.entries(authority).reverse(),
+      ),
     });
 
     // When / Then
@@ -175,7 +219,7 @@ describe('$execute-lane canonical handoff boundary', () => {
         handoff.ledgerPath,
         handoff.root,
       ),
-    ).toThrow(/approval binding/u);
+    ).not.toThrow();
   });
 
   it('rejects a resumed snapshot with a changed immutable authority', () => {
@@ -202,5 +246,20 @@ describe('$execute-lane canonical handoff boundary', () => {
         handoff.root,
       ),
     ).toThrow(/immutable plan/u);
+  });
+
+  it('removes the lock when lease initialization fails', () => {
+    // Given
+    const stateDirectory = mkdtempSync(
+      resolve(tmpdir(), 'fluo-lane-lease-'),
+    );
+    temporaryRoots.push(stateDirectory);
+    mkdirSync(resolve(stateDirectory, 'lease.json'));
+
+    // When / Then
+    expect(() =>
+      acquireLease(stateDirectory, 'lane-4101-runtime'),
+    ).toThrow();
+    expect(existsSync(resolve(stateDirectory, 'lease.lock'))).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- require canonical `.omo/lanes/<lane-id>.json` input before state mutation
- revalidate source artifacts and all three approval receipts for normal lanes
- bind resumed snapshots to the approved immutable plan while preserving fixture-only replay
- make lease initialization cleanup fail safely

## Verification
- related create-lane/execute-lane governance: 15 files, 102 tests passed
- focused producer-consumer QA: 9 tests passed
- `pnpm build`: passed
- `pnpm typecheck`: passed
- `pnpm lint`: passed with existing non-blocking warnings
- five-lane post-implementation review: all PASS

Per maintainer instruction, merge immediately without waiting for CI.