### PR TITLE
fix(tooling): resolve PR conflicts before CI wait

### DIFF
--- a/.agents/skills/execute-lane/references/issue-supervisor.md
+++ b/.agents/skills/execute-lane/references/issue-supervisor.md
@@ -49,8 +49,9 @@ before entering `ci-pending`.
 Immediately after entering `ci-pending`, and on every fresh PR observation
 while checks are pending, query `mergeable` and `mergeStateStatus`. A
 `CONFLICTING` or `DIRTY` result is a fixable PR conflict: persist a head-bound
-`pr-conflict` receipt and enter `ci-fix-back` without waiting for CI. Conflict
-resolution must produce a new head and rerun the complete local triad.
+`pr-conflict` receipt that proves the PR remains `OPEN`, then enter
+`ci-fix-back` without waiting for CI. Conflict resolution must produce a new
+head and rerun the complete local triad.
 
 When a successor lane reconciles an existing canonical branch, worktree, and
 OPEN PR, reuse those identities instead of creating duplicates. Rerun the full

--- a/.agents/skills/execute-lane/references/issue-supervisor.md
+++ b/.agents/skills/execute-lane/references/issue-supervisor.md
@@ -46,6 +46,12 @@ At `ready-for-pr`, push the reviewed head and create one PR. At
 that the remote branch, PR `headRefOid`, and reviewed local head are identical
 before entering `ci-pending`.
 
+Immediately after entering `ci-pending`, and on every fresh PR observation
+while checks are pending, query `mergeable` and `mergeStateStatus`. A
+`CONFLICTING` or `DIRTY` result is a fixable PR conflict: persist a head-bound
+`pr-conflict` receipt and enter `ci-fix-back` without waiting for CI. Conflict
+resolution must produce a new head and rerun the complete local triad.
+
 When a successor lane reconciles an existing canonical branch, worktree, and
 OPEN PR, reuse those identities instead of creating duplicates. Rerun the full
 local triad against the observed head, then persist a `pr-adopt` receipt binding

--- a/.agents/skills/execute-lane/references/workflow.md
+++ b/.agents/skills/execute-lane/references/workflow.md
@@ -93,6 +93,7 @@ queued -> implementing -> local-review
 local-review + fixable BLOCK -> implementing -> new head -> local-review
 local-review + all PASS -> ready-for-pr
 ready-for-pr -> observed push and PR creation -> ci-pending
+ci-pending + PR CONFLICTING/DIRTY -> ci-fix-back -> new head -> local-review
 ci-pending + fixable failure -> ci-fix-back -> new head -> local-review
 local-review + all PASS and existing PR -> ready-for-push
 ready-for-push -> observed push -> ci-pending
@@ -150,7 +151,7 @@ executes root-state checks. Nested child output and fixture JSON are not live
 evidence:
 
 ```bash
-gh pr view <pr> --json number,url,state,headRefName,headRefOid,mergeCommit,mergedAt
+gh pr view <pr> --json number,url,state,headRefName,headRefOid,mergeable,mergeStateStatus,mergeCommit,mergedAt
 gh issue view <issue> --json number,state,url
 git worktree list --porcelain
 git show-ref --verify refs/heads/<branch>

--- a/.agents/skills/execute-lane/scripts/compile-dag.mjs
+++ b/.agents/skills/execute-lane/scripts/compile-dag.mjs
@@ -17,6 +17,8 @@ SCOPE:
 - Delegate implementation and each contract/code/verification review to separate children.
 - Reach READY_FOR_PR locally before the lead pushes or creates the PR.
 - After PR creation, observe required CI on the exact reviewed head.
+- Refresh PR mergeability immediately and while CI is pending. A GitHub
+  CONFLICTING/DIRTY observation enters CI fix-back without waiting for checks.
 - On a fixable CI failure, return to implementation, create a new head, rerun the full local triad, push, and observe CI again.
 - The issue supervisor owns issue-bound push, PR mutation, merge, cleanup, and
   issue-local evidence only under immutable lane authority.
@@ -31,6 +33,8 @@ SCOPE:
 
 VERIFY:
 - Bind every local review, PR observation, CI result, merge, and cleanup action to the current head.
+- Query PR state with mergeable and mergeStateStatus fields before waiting for
+  CI, and persist a head-bound pr-conflict receipt when either proves conflict.
 - Adopt an existing OPEN PR only after a same-head local triad and persist a
   pr-adopt receipt whose local, remote, and PR heads are identical.
 - Persist every transition and receipt through issue-supervisor-store.mjs.

--- a/.agents/skills/execute-lane/scripts/compile-dag.mjs
+++ b/.agents/skills/execute-lane/scripts/compile-dag.mjs
@@ -34,7 +34,8 @@ SCOPE:
 VERIFY:
 - Bind every local review, PR observation, CI result, merge, and cleanup action to the current head.
 - Query PR state with mergeable and mergeStateStatus fields before waiting for
-  CI, and persist a head-bound pr-conflict receipt when either proves conflict.
+  CI, and persist an OPEN, head-bound pr-conflict receipt when either proves
+  conflict.
 - Adopt an existing OPEN PR only after a same-head local triad and persist a
   pr-adopt receipt whose local, remote, and PR heads are identical.
 - Persist every transition and receipt through issue-supervisor-store.mjs.

--- a/.agents/skills/execute-lane/scripts/issue-supervisor-receipts.mjs
+++ b/.agents/skills/execute-lane/scripts/issue-supervisor-receipts.mjs
@@ -96,6 +96,7 @@ export const assertPersistedReceipt = (supervisor, value) => {
     receipt.kind === 'pr-conflict' &&
     (receipt.remote_head_sha !== receipt.head_sha ||
       receipt.pr_head_sha !== receipt.head_sha ||
+      receipt.pr_state !== 'OPEN' ||
       (receipt.pr_mergeable !== 'CONFLICTING' &&
         receipt.pr_merge_state_status !== 'DIRTY'))
   ) {

--- a/.agents/skills/execute-lane/scripts/issue-supervisor-receipts.mjs
+++ b/.agents/skills/execute-lane/scripts/issue-supervisor-receipts.mjs
@@ -61,9 +61,15 @@ export const assertPersistedReceipt = (supervisor, value) => {
   const historicalState = { ...supervisor, head_sha: receipt.head_sha };
   requireTargetReceipt(historicalState, receipt, receipt.kind);
   if (
-    !['pr-adopt', 'pr-create', 'pr-update', 'ci', 'merge', 'cleanup'].includes(
-      receipt.kind,
-    )
+    ![
+      'pr-adopt',
+      'pr-create',
+      'pr-update',
+      'pr-conflict',
+      'ci',
+      'merge',
+      'cleanup',
+    ].includes(receipt.kind)
   ) {
     throw new TypeError('persisted supervisor receipt kind is invalid.');
   }
@@ -85,6 +91,15 @@ export const assertPersistedReceipt = (supervisor, value) => {
     throw new TypeError(
       'persisted adopted PR must match the supervisor branch.',
     );
+  }
+  if (
+    receipt.kind === 'pr-conflict' &&
+    (receipt.remote_head_sha !== receipt.head_sha ||
+      receipt.pr_head_sha !== receipt.head_sha ||
+      (receipt.pr_mergeable !== 'CONFLICTING' &&
+        receipt.pr_merge_state_status !== 'DIRTY'))
+  ) {
+    throw new TypeError('persisted PR conflict receipt is invalid.');
   }
   if (
     receipt.kind === 'merge' &&

--- a/.agents/skills/execute-lane/scripts/issue-supervisor-remote.mjs
+++ b/.agents/skills/execute-lane/scripts/issue-supervisor-remote.mjs
@@ -81,6 +81,40 @@ const observeCi = (state, step) => {
   ];
 };
 
+const observePrConflict = (state, step) => {
+  requireStatus(state, 'ci-pending');
+  const receipt = requireTargetReceipt(
+    state,
+    step.receipt,
+    'pr-conflict',
+  );
+  requirePrIdentity(receipt, state.pr);
+  if (
+    receipt.remote_head_sha !== state.head_sha ||
+    receipt.pr_head_sha !== state.head_sha ||
+    (receipt.pr_mergeable !== 'CONFLICTING' &&
+      receipt.pr_merge_state_status !== 'DIRTY')
+  ) {
+    throw new TypeError(
+      'PR conflict receipt must bind the current head and a conflicting PR.',
+    );
+  }
+  const evidence = requireString(
+    receipt.evidence,
+    'PR conflict receipt evidence',
+  );
+  state.status = 'ci-fix-back';
+  state.blockers = [
+    {
+      reviewer: 'verification',
+      signature: 'pr:merge-conflict',
+      evidence,
+      fix_back_eligible: true,
+      status: 'unresolved',
+    },
+  ];
+};
+
 const observeMerge = (state, step) => {
   requireStatus(state, 'merge-ready');
   if (!state.authority_scope.pr_merge) {
@@ -144,6 +178,9 @@ export const applyRemoteTransition = (state, step) => {
       return true;
     case 'ci-observed':
       observeCi(state, step);
+      return true;
+    case 'pr-conflict-observed':
+      observePrConflict(state, step);
       return true;
     case 'merge-observed':
       observeMerge(state, step);

--- a/.agents/skills/execute-lane/scripts/issue-supervisor-remote.mjs
+++ b/.agents/skills/execute-lane/scripts/issue-supervisor-remote.mjs
@@ -92,6 +92,7 @@ const observePrConflict = (state, step) => {
   if (
     receipt.remote_head_sha !== state.head_sha ||
     receipt.pr_head_sha !== state.head_sha ||
+    receipt.pr_state !== 'OPEN' ||
     (receipt.pr_mergeable !== 'CONFLICTING' &&
       receipt.pr_merge_state_status !== 'DIRTY')
   ) {

--- a/tooling/governance/execute-lane-dag-supervisor.test.ts
+++ b/tooling/governance/execute-lane-dag-supervisor.test.ts
@@ -270,6 +270,24 @@ const passReviews = (head: string) =>
     blockers: [],
   }));
 
+const createCiPendingState = () => {
+  let state = createIssueSupervisor(identity);
+  state = transitionIssueSupervisor(state, {
+    kind: 'implementation-completed',
+    new_head: headA,
+    verification: 'pnpm test --filter runtime passed',
+  });
+  state = transitionIssueSupervisor(state, {
+    kind: 'local-review',
+    reviews: passReviews(headA),
+  });
+  return transitionIssueSupervisor(state, {
+    kind: 'pr-observed',
+    action: 'create',
+    receipt: prReceipt('pr-create', headA),
+  });
+};
+
 describe('execute-lane issue supervisor lifecycle', () => {
   it('rejects non-canonical issue branch and worktree identity', () => {
     expect(() =>
@@ -468,6 +486,7 @@ describe('execute-lane issue supervisor lifecycle', () => {
           pr_url: 'https://github.com/fluojs/fluo/pull/5101',
           remote_head_sha: headA,
           pr_head_sha: headA,
+          pr_state: 'OPEN',
           pr_mergeable: 'CONFLICTING',
           pr_merge_state_status: 'DIRTY',
           evidence: 'mergeable=CONFLICTING mergeStateStatus=DIRTY',
@@ -493,10 +512,72 @@ describe('execute-lane issue supervisor lifecycle', () => {
     expect(persisted.receipts).toContainEqual(
       expect.objectContaining({
         kind: 'pr-conflict',
+        pr_state: 'OPEN',
         pr_mergeable: 'CONFLICTING',
         pr_merge_state_status: 'DIRTY',
       }),
     );
+  });
+
+  it.each([
+    {
+      pr_mergeable: 'CONFLICTING',
+      pr_merge_state_status: 'UNKNOWN',
+    },
+    {
+      pr_mergeable: 'UNKNOWN',
+      pr_merge_state_status: 'DIRTY',
+    },
+  ])(
+    'accepts an independent $pr_mergeable/$pr_merge_state_status conflict signal',
+    ({ pr_mergeable, pr_merge_state_status }) => {
+      // Given
+      const state = createCiPendingState();
+
+      // When
+      const result = transitionIssueSupervisor(state, {
+        kind: 'pr-conflict-observed',
+        receipt: {
+          ...observationBase(headA),
+          kind: 'pr-conflict',
+          pr_number: 5101,
+          pr_url: 'https://github.com/fluojs/fluo/pull/5101',
+          remote_head_sha: headA,
+          pr_head_sha: headA,
+          pr_state: 'OPEN',
+          pr_mergeable,
+          pr_merge_state_status,
+          evidence: 'fresh GitHub conflict observation',
+        },
+      });
+
+      // Then
+      expect(result.status).toBe('ci-fix-back');
+    },
+  );
+
+  it('rejects a merge conflict receipt for a non-open PR', () => {
+    // Given
+    const state = createCiPendingState();
+
+    // When / Then
+    expect(() =>
+      transitionIssueSupervisor(state, {
+        kind: 'pr-conflict-observed',
+        receipt: {
+          ...observationBase(headA),
+          kind: 'pr-conflict',
+          pr_number: 5101,
+          pr_url: 'https://github.com/fluojs/fluo/pull/5101',
+          remote_head_sha: headA,
+          pr_head_sha: headA,
+          pr_state: 'MERGED',
+          pr_mergeable: 'CONFLICTING',
+          pr_merge_state_status: 'DIRTY',
+          evidence: 'stale merged PR observation',
+        },
+      }),
+    ).toThrow();
   });
 
   it('adopts an existing open PR after a same-head local triad', () => {

--- a/tooling/governance/execute-lane-dag-supervisor.test.ts
+++ b/tooling/governance/execute-lane-dag-supervisor.test.ts
@@ -442,6 +442,63 @@ describe('execute-lane issue supervisor lifecycle', () => {
     expect(state.status).toBe('done');
   });
 
+  it('returns a merge-conflicting PR through fix-back before waiting for CI', () => {
+    // Given
+    const transitions = [
+      {
+        kind: 'implementation-completed',
+        new_head: headA,
+        verification: 'pnpm test --filter runtime passed',
+      },
+      {
+        kind: 'local-review',
+        reviews: passReviews(headA),
+      },
+      {
+        kind: 'pr-observed',
+        action: 'create',
+        receipt: prReceipt('pr-create', headA),
+      },
+      {
+        kind: 'pr-conflict-observed',
+        receipt: {
+          ...observationBase(headA),
+          kind: 'pr-conflict',
+          pr_number: 5101,
+          pr_url: 'https://github.com/fluojs/fluo/pull/5101',
+          remote_head_sha: headA,
+          pr_head_sha: headA,
+          pr_mergeable: 'CONFLICTING',
+          pr_merge_state_status: 'DIRTY',
+          evidence: 'mergeable=CONFLICTING mergeStateStatus=DIRTY',
+        },
+      },
+    ];
+
+    // When
+    const persisted = persistedLifecycle(identity, transitions);
+
+    // Then
+    expect(persisted.snapshot.status).toBe('ci-fix-back');
+    expect(persisted.snapshot.ci).toBeNull();
+    expect(persisted.snapshot.blockers).toEqual([
+      {
+        reviewer: 'verification',
+        signature: 'pr:merge-conflict',
+        evidence: 'mergeable=CONFLICTING mergeStateStatus=DIRTY',
+        fix_back_eligible: true,
+        status: 'unresolved',
+      },
+    ]);
+    expect(persisted.receipts).toContainEqual(
+      expect.objectContaining({
+        kind: 'pr-conflict',
+        pr_mergeable: 'CONFLICTING',
+        pr_merge_state_status: 'DIRTY',
+      }),
+    );
+  });
+
   it('adopts an existing open PR after a same-head local triad', () => {
     const transitions = [
       {


### PR DESCRIPTION
## Summary
- refresh GitHub `mergeable` and `mergeStateStatus` immediately after PR creation/update and while checks are pending
- persist an OPEN, exact-head `pr-conflict` receipt for `CONFLICTING` or `DIRTY` observations
- move the issue supervisor directly from `ci-pending` to `ci-fix-back`, requiring a new head and complete local triad
- reject non-OPEN and forged clean conflict evidence

## Verification
- execute-lane supervisor lifecycle: 15 tests passed
- related create-lane/execute-lane governance: 16 files, 115 tests passed
- full build: passed
- full post-build typecheck: passed
- lint: exit 0 with pre-existing non-blocking warnings
- real module QA: conflict -> `ci-fix-back`; forged clean receipt rejected
- five-lane post-implementation review: all PASS

Per maintainer instruction, merge immediately without waiting for CI.