### PR TITLE
feat(tooling): run lane implementers with Terra high

### DIFF
--- a/.agents/skills/execute-lane/references/issue-supervisor.md
+++ b/.agents/skills/execute-lane/references/issue-supervisor.md
@@ -17,6 +17,15 @@ The supervisor orchestrates but does not implement or review:
 - the parent execute-lane lead alone mutates the shared lane ledger and performs
   root synchronization.
 
+The implementer alone uses the `fluo-issue-implementer` subagent configured in
+`.omo/omo.jsonc` for `openai-codex/gpt-5.6-terra` with `high` reasoning. The
+supervisor must include the complete `issue-to-pr/references/implementer.md`
+contract in that child prompt without a category or model override. After the
+child terminates, `scripts/implementer-runtime.mjs` must verify the persisted
+task metadata and actual child session both prove Terra high execution. Missing
+or mismatched evidence is a terminal child-contract blocker. Reviewer routing
+is unchanged and must never reuse the implementer route.
+
 ## Local review loop
 
 ```text

--- a/.agents/skills/execute-lane/scripts/compile-dag.mjs
+++ b/.agents/skills/execute-lane/scripts/compile-dag.mjs
@@ -1,7 +1,10 @@
 import { assertContract } from '../../../workflow-contracts/contracts.mjs';
 import { validateLedger } from '../../../../tooling/governance/lane-ledger-state.mjs';
+import { implementerRoute } from './implementer-runtime.mjs';
 
 const nodeId = (issueNumber) => `issue-${String(issueNumber)}-supervisor`;
+
+export { implementerRoute };
 
 const supervisorPrompt = (lane, issueNumber, dependencies) => `TASK:
 Execute the complete Fluo lifecycle for issue ${String(issueNumber)} as an issue supervisor.
@@ -14,7 +17,18 @@ SCOPE:
 - Use one isolated issue branch and worktree.
 - Reconcile and reuse an existing canonical issue branch, worktree, and OPEN PR
   when their live identities and heads match; never create duplicates.
-- Delegate implementation and each contract/code/verification review to separate children.
+- Read .agents/skills/issue-to-pr/references/implementer.md before delegating implementation.
+- Delegate the implementer through the native task tool with
+  ${JSON.stringify(implementerRoute)}. Use only the configured subagent_type,
+  request a handle, and include the complete implementer contract plus
+  issue-bound inputs. Do not pass category or model overrides.
+- After the implementer reaches a terminal state, run
+  node .agents/skills/execute-lane/scripts/implementer-runtime.mjs
+  .omo/senpi-task <task-id>. Accept the child only when the verifier exits zero
+  and reports the actual Terra high session. Missing or mismatched runtime
+  evidence is a terminal child-contract blocker.
+- Never use the implementer route for contract, code, or verification review.
+  Delegate those three reviews to separate read-only children.
 - Reach READY_FOR_PR locally before the lead pushes or creates the PR.
 - After PR creation, observe required CI on the exact reviewed head.
 - Refresh PR mergeability immediately and while CI is pending. A GitHub

--- a/.agents/skills/execute-lane/scripts/implementer-runtime.mjs
+++ b/.agents/skills/execute-lane/scripts/implementer-runtime.mjs
@@ -1,0 +1,148 @@
+import {
+  lstatSync,
+  readFileSync,
+  readdirSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const IMPLEMENTER_AGENT = 'fluo-issue-implementer';
+const IMPLEMENTER_PROVIDER = 'openai-codex';
+const IMPLEMENTER_MODEL = 'gpt-5.6-terra';
+const IMPLEMENTER_THINKING = 'high';
+const TASK_ID = /^st_[A-Za-z0-9]+$/u;
+
+export const implementerRoute = Object.freeze({
+  subagent_type: IMPLEMENTER_AGENT,
+  expected_model: `${IMPLEMENTER_PROVIDER}/${IMPLEMENTER_MODEL}`,
+  expected_thinking: IMPLEMENTER_THINKING,
+});
+
+const assertRegularFile = (path) => {
+  const stat = lstatSync(path);
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    throw new TypeError(`${path} must be a real regular file.`);
+  }
+};
+
+const assertDirectory = (path) => {
+  const stat = lstatSync(path);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new TypeError(`${path} must be a real directory.`);
+  }
+};
+
+const parseJson = (source, path) => {
+  try {
+    return JSON.parse(source);
+  } catch {
+    throw new TypeError(`${path} must contain valid JSON.`);
+  }
+};
+
+const assertTaskRecord = (record) => {
+  if (
+    record.status !== 'completed' ||
+    record.agent_type !== IMPLEMENTER_AGENT ||
+    record.resolved_model?.source !== 'agent' ||
+    record.resolved_model.provider !== IMPLEMENTER_PROVIDER ||
+    record.resolved_model.model_id !== IMPLEMENTER_MODEL ||
+    record.resolved_model.reasoning_effort !== IMPLEMENTER_THINKING
+  ) {
+    throw new TypeError(
+      'implementer task metadata must resolve the configured Terra high agent.',
+    );
+  }
+};
+
+const readSessionEvents = (sessionRoot) => {
+  assertDirectory(sessionRoot);
+  const files = readdirSync(sessionRoot)
+    .filter((name) => name.endsWith('.jsonl'))
+    .sort();
+  if (files.length === 0) {
+    throw new TypeError('implementer task must persist a child session.');
+  }
+  return files.flatMap((name) => {
+    const path = join(sessionRoot, name);
+    assertRegularFile(path);
+    return readFileSync(path, 'utf8')
+      .split('\n')
+      .filter((line) => line.length > 0)
+      .map((line) => parseJson(line, path));
+  });
+};
+
+const assertActualRuntime = (events) => {
+  const modelChanges = events.filter((event) => event.type === 'model_change');
+  const thinkingChanges = events.filter(
+    (event) => event.type === 'thinking_level_change',
+  );
+  const assistantMessages = events.filter(
+    (event) =>
+      event.type === 'message' &&
+      event.message?.role === 'assistant',
+  );
+  const modelMatches = modelChanges.length > 0 && modelChanges.every(
+    (event) =>
+      event.provider === IMPLEMENTER_PROVIDER &&
+      event.modelId === IMPLEMENTER_MODEL,
+  );
+  const thinkingMatches =
+    thinkingChanges.length > 0 &&
+    thinkingChanges.every(
+      (event) => event.thinkingLevel === IMPLEMENTER_THINKING,
+    );
+  const assistantMatches =
+    assistantMessages.length > 0 &&
+    assistantMessages.every(
+      (event) =>
+        event.message.provider === IMPLEMENTER_PROVIDER &&
+        event.message.model === IMPLEMENTER_MODEL,
+    );
+  if (!modelMatches || !thinkingMatches || !assistantMatches) {
+    throw new TypeError(
+      'actual implementer session must use openai-codex/gpt-5.6-terra with high thinking.',
+    );
+  }
+  return assistantMessages.length;
+};
+
+export const verifyImplementerRuntime = (runtimeRoot, taskId) => {
+  if (!TASK_ID.test(taskId)) {
+    throw new TypeError('implementer task id is malformed.');
+  }
+  const taskPath = join(runtimeRoot, 'tasks', `${taskId}.json`);
+  assertRegularFile(taskPath);
+  const taskRecord = parseJson(readFileSync(taskPath, 'utf8'), taskPath);
+  if (taskRecord.task_id !== taskId) {
+    throw new TypeError('implementer task record identity does not match.');
+  }
+  assertTaskRecord(taskRecord);
+  const events = readSessionEvents(
+    join(runtimeRoot, 'children', taskId, 'sessions', taskId),
+  );
+  return {
+    task_id: taskId,
+    provider: IMPLEMENTER_PROVIDER,
+    model_id: IMPLEMENTER_MODEL,
+    thinking_level: IMPLEMENTER_THINKING,
+    assistant_turns: assertActualRuntime(events),
+  };
+};
+
+const isCli =
+  process.argv[1] !== undefined &&
+  pathToFileURL(process.argv[1]).href === import.meta.url;
+
+if (isCli) {
+  const [runtimeRoot, taskId] = process.argv.slice(2);
+  if (runtimeRoot === undefined || taskId === undefined) {
+    throw new TypeError(
+      'usage: implementer-runtime.mjs <runtime-root> <task-id>',
+    );
+  }
+  process.stdout.write(
+    `${JSON.stringify(verifyImplementerRuntime(runtimeRoot, taskId))}\n`,
+  );
+}

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ coverage/
 .turbo/
 .sisyphus/
 .worktrees/
-.omo/
+.omo/*
+!.omo/omo.jsonc
 .opencode/search-issue/

--- a/.omo/omo.jsonc
+++ b/.omo/omo.jsonc
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/omo.schema.json",
+  "agents": {
+    "fluo-issue-implementer": {
+      "description": "Implements one Fluo issue inside its assigned worktree.",
+      "model": "openai-codex/gpt-5.6-terra",
+      "reasoning": "high"
+    }
+  },
+  "_migrations": [
+    "2026-08-reasoning-unification"
+  ]
+}

--- a/tooling/governance/execute-lane-dag-supervisor.test.ts
+++ b/tooling/governance/execute-lane-dag-supervisor.test.ts
@@ -26,6 +26,11 @@ type DagDefinition = Readonly<{
   name: string;
   nodes: readonly DagNode[];
 }>;
+type ImplementerRoute = Readonly<{
+  subagent_type: 'fluo-issue-implementer';
+  expected_model: 'openai-codex/gpt-5.6-terra';
+  expected_thinking: 'high';
+}>;
 type DagBinding = Readonly<{
   version: number;
   lane_id: string;
@@ -65,13 +70,14 @@ const {
     transition: unknown,
   ) => SupervisorState;
 };
-const { compileLaneSupervisorDag } = (await import(
+const { compileLaneSupervisorDag, implementerRoute } = (await import(
   resolve(
     process.cwd(),
     '.agents/skills/execute-lane/scripts/compile-dag.mjs',
   )
 )) as {
   compileLaneSupervisorDag: (ledger: unknown) => DagDefinition;
+  implementerRoute: ImplementerRoute;
 };
 const {
   assertDagBindingMatches,
@@ -1294,6 +1300,11 @@ describe('execute-lane issue supervisor lifecycle', () => {
     const definition = compileLaneSupervisorDag(ledger);
 
     expect(definition.key).toBe('fluo:lane:lane-4101-runtime:issue-supervisors:v2');
+    expect(implementerRoute).toEqual({
+      subagent_type: 'fluo-issue-implementer',
+      expected_model: 'openai-codex/gpt-5.6-terra',
+      expected_thinking: 'high',
+    });
     expect(definition.nodes).toHaveLength(2);
     expect(definition.nodes[0]).toMatchObject({
       id: 'issue-4101-supervisor',

--- a/tooling/governance/execute-lane-implementer-route.test.ts
+++ b/tooling/governance/execute-lane-implementer-route.test.ts
@@ -1,0 +1,145 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = process.cwd();
+const { implementerRoute, verifyImplementerRuntime } = (await import(
+  resolve(
+    repoRoot,
+    '.agents/skills/execute-lane/scripts/implementer-runtime.mjs',
+  )
+)) as {
+  implementerRoute: Readonly<{
+    subagent_type: 'fluo-issue-implementer';
+    expected_model: 'openai-codex/gpt-5.6-terra';
+    expected_thinking: 'high';
+  }>;
+  verifyImplementerRuntime: (
+    runtimeRoot: string,
+    taskId: string,
+  ) => Readonly<{
+    task_id: string;
+    provider: string;
+    model_id: string;
+    thinking_level: string;
+    assistant_turns: number;
+  }>;
+};
+
+const sessionEvents = (
+  provider: string,
+  modelId: string,
+  thinkingLevel: string,
+): string =>
+  [
+    {
+      type: 'model_change',
+      provider,
+      modelId,
+    },
+    {
+      type: 'thinking_level_change',
+      thinkingLevel,
+    },
+    {
+      type: 'message',
+      message: {
+        role: 'assistant',
+        provider,
+        model: modelId,
+        content: [{ type: 'text', text: 'done' }],
+      },
+    },
+  ]
+    .map((event) => JSON.stringify(event))
+    .join('\n');
+
+const writeTaskEvidence = (
+  runtimeRoot: string,
+  taskId: string,
+  session: string,
+): void => {
+  const taskRoot = join(runtimeRoot, 'tasks');
+  const sessionRoot = join(
+    runtimeRoot,
+    'children',
+    taskId,
+    'sessions',
+    taskId,
+  );
+  mkdirSync(taskRoot, { recursive: true });
+  mkdirSync(sessionRoot, { recursive: true });
+  writeFileSync(
+    join(taskRoot, `${taskId}.json`),
+    JSON.stringify({
+      task_id: taskId,
+      status: 'completed',
+      agent_type: 'fluo-issue-implementer',
+      resolved_model: {
+        source: 'agent',
+        provider: 'openai-codex',
+        model_id: 'gpt-5.6-terra',
+        reasoning_effort: 'high',
+      },
+    }),
+  );
+  writeFileSync(join(sessionRoot, 'session.jsonl'), `${session}\n`);
+};
+
+describe('execute-lane implementer runtime routing', () => {
+  it('ships a project agent that resolves Terra with high reasoning', () => {
+    const config = JSON.parse(
+      readFileSync(resolve(repoRoot, '.omo/omo.jsonc'), 'utf8'),
+    );
+
+    expect(config.agents['fluo-issue-implementer']).toMatchObject({
+      model: 'openai-codex/gpt-5.6-terra',
+      reasoning: 'high',
+    });
+    expect(implementerRoute).toEqual({
+      subagent_type: 'fluo-issue-implementer',
+      expected_model: 'openai-codex/gpt-5.6-terra',
+      expected_thinking: 'high',
+    });
+  });
+
+  it('accepts only child session evidence from Terra high', () => {
+    const root = mkdtempSync(join(tmpdir(), 'fluo-implementer-runtime-'));
+    try {
+      writeTaskEvidence(
+        root,
+        'st_valid',
+        sessionEvents('openai-codex', 'gpt-5.6-terra', 'high'),
+      );
+
+      expect(verifyImplementerRuntime(root, 'st_valid')).toEqual({
+        task_id: 'st_valid',
+        provider: 'openai-codex',
+        model_id: 'gpt-5.6-terra',
+        thinking_level: 'high',
+        assistant_turns: 1,
+      });
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it('rejects request metadata when the child actually ran a fallback model', () => {
+    const root = mkdtempSync(join(tmpdir(), 'fluo-implementer-fallback-'));
+    try {
+      writeTaskEvidence(
+        root,
+        'st_fallback',
+        sessionEvents('alibaba-token-plan', 'qwen3.7-max', 'medium'),
+      );
+
+      expect(() =>
+        verifyImplementerRuntime(root, 'st_fallback'),
+      ).toThrow(/actual implementer session must use openai-codex\/gpt-5\.6-terra with high thinking/u);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- register project-local `fluo-issue-implementer` on `openai-codex/gpt-5.6-terra` with high reasoning
- keep execute-lane supervisors and reviewers on existing routes
- fail closed by verifying actual child session model and thinking events

## Verification
- `pnpm vitest run tooling/governance/execute-lane tooling/governance/omo-native-assets.test.ts` (81 passed)
- `pnpm typecheck`
- `pnpm build`
- `pnpm lint` (pre-existing warnings only)
- native runtime QA: task `st_01a03be9` verified as Terra high; medium/fallback task rejected
- five-lane local review: PASS

## Known unrelated test issue
- full `pnpm verify` reached tests with build/typecheck/lint green, then hit the existing `packages/runtime/src/multipart.test.ts` closed-stream unhandled rejection; focused workflow tests are green