### PR TITLE
fix(tooling): harden execute-lane dispatch safety

### DIFF
--- a/.agents/skills/execute-lane/SKILL.md
+++ b/.agents/skills/execute-lane/SKILL.md
@@ -29,6 +29,19 @@ attach; an intent/binding crash window fails closed and never authorizes a
 duplicate start. Goal, todo, and DAG state remain projections of the persisted
 lane state and live observations.
 
+The dispatch interface accepts `repository_root`, never a caller-selected
+runtime root, and derives `.omo/lane-runs` internally. Every issue supervisor
+must pass the event-driven startup gate before mutation:
+
+```text
+node .agents/skills/execute-lane/scripts/await-lane-dispatch.mjs \
+  --root . --ledger .omo/lanes/<lane-id>.json
+```
+
+After the native DAG settles, run `lane-settlement-audit.mjs`. Native node
+completion means only that a child returned. It is never lane success without
+canonical terminal issue stores and parent import.
+
 Production execution never uses `scripts/fixtures/run-replay.mjs`. The lead
 performs or observes each authorized Git/GitHub action, reads fresh raw output,
 then writes the target-bound receipt and transition. Synthetic observation JSON
@@ -42,11 +55,13 @@ all prior local review evidence. CI PASS on the exact reviewed PR head produces
 `merge-ready`; only an issue supervisor's fresh lead-authorized merge
 observation may create a merge receipt.
 
-Native task completion is ordering only, never dependency success. Before any
-mutation, a dependent supervisor validates each predecessor's persisted
+Native task completion is a settled claim only, never lane or dependency
+success. Before any mutation, a dependent supervisor validates each
+predecessor's persisted
 issue-store terminal evidence and proceeds only when every predecessor is
 canonical `done`. Missing, malformed, or blocked predecessor evidence produces
 a typed dependency blocker without creating issue artifacts. After the DAG
-settles, the parent imports terminal evidence in topological order into the
-shared lane ledger. `needs-human-check`, policy, external, cleanup,
+settles, the parent audits all canonical issue stores, then imports terminal
+evidence in topological order into the shared lane ledger.
+`needs-human-check`, policy, external, cleanup,
 malformed-output, and ledger terminal states never release mutation.

--- a/.agents/skills/execute-lane/SKILL.md
+++ b/.agents/skills/execute-lane/SKILL.md
@@ -24,10 +24,14 @@ Read `references/workflow.md` and `references/issue-supervisor.md` before
 execution. Compile the ledger once with `compileLaneSupervisorDag()`. Use
 `scripts/lane-dispatch.mjs` to persist one lane-bound dispatch intent before
 start, then attach the observed run through `attachLaneSupervisorRun()` at
-`.omo/lane-runs/<lane-id>/dag-binding.json`. An exact existing binding means
-attach; an intent/binding crash window fails closed and never authorizes a
-duplicate start. Goal, todo, and DAG state remain projections of the persisted
-lane state and live observations.
+`.omo/lane-runs/<lane-id>/dag-binding.json`. Attachment loads the canonical
+native run record from `.omo/senpi-task/dag/runs/<run-id>.json` and requires
+its submitted definition to match the intent-bound digest. An exact existing
+binding resumes from that native definition rather than recompiling current
+workflow source. A digestless legacy intent without its immutable binding
+requires a successor lane. An intent/binding crash window fails closed and
+never authorizes a duplicate start. Goal, todo, and DAG state remain
+projections of the persisted lane state and live observations.
 
 The dispatch interface accepts `repository_root`, never a caller-selected
 runtime root, and derives `.omo/lane-runs` internally. Every issue supervisor

--- a/.agents/skills/execute-lane/SKILL.md
+++ b/.agents/skills/execute-lane/SKILL.md
@@ -25,13 +25,14 @@ execution. Compile the ledger once with `compileLaneSupervisorDag()`. Use
 `scripts/lane-dispatch.mjs` to persist one lane-bound dispatch intent before
 start, then attach the observed run through `attachLaneSupervisorRun()` at
 `.omo/lane-runs/<lane-id>/dag-binding.json`. Attachment loads the canonical
-native run record from `.omo/senpi-task/dag/runs/<run-id>.json` and requires
-its submitted definition to match the intent-bound digest. An exact existing
-binding resumes from that native definition rather than recompiling current
-workflow source. A digestless legacy intent without its immutable binding
-requires a successor lane. An intent/binding crash window fails closed and
-never authorizes a duplicate start. Goal, todo, and DAG state remain
-projections of the persisted lane state and live observations.
+native run record from `.omo/senpi-task/dag/runs/<run-id>.json`, authenticates
+it against the canonical native key record, and requires its submitted
+definition to match the intent-bound digest. An exact existing binding resumes
+from that native definition rather than recompiling current workflow source.
+A digestless legacy intent without its immutable binding requires a successor
+lane. An intent/binding crash window fails closed and never authorizes a
+duplicate start. Goal, todo, and DAG state remain projections of the persisted
+lane state and live observations.
 
 The dispatch interface accepts `repository_root`, never a caller-selected
 runtime root, and derives `.omo/lane-runs` internally. Every issue supervisor

--- a/.agents/skills/execute-lane/references/issue-supervisor.md
+++ b/.agents/skills/execute-lane/references/issue-supervisor.md
@@ -117,8 +117,8 @@ node .agents/skills/execute-lane/scripts/await-lane-dispatch.mjs \
 Do not treat the short start/attach interval as a terminal ledger conflict.
 Wait for the exact canonical binding. A timeout or mismatched immutable
 binding remains fail-closed. The gate authenticates the binding against the
-native run's persisted submitted definition and does not recompile current
-workflow source for an already attached run.
+native run's key record and persisted submitted definition, and does not
+recompile current workflow source for an already attached run.
 
 ## Stop
 

--- a/.agents/skills/execute-lane/references/issue-supervisor.md
+++ b/.agents/skills/execute-lane/references/issue-supervisor.md
@@ -107,6 +107,17 @@ performing a mutation. The shared snapshot may still name an earlier queue
 cursor while the lane DAG runs because the parent imports settled terminals in
 topological order after the DAG settles.
 
+Before that dependency gate, run the event-driven canonical dispatch gate:
+
+```text
+node .agents/skills/execute-lane/scripts/await-lane-dispatch.mjs \
+  --root . --ledger .omo/lanes/<lane-id>.json
+```
+
+Do not treat the short start/attach interval as a terminal ledger conflict.
+Wait for the exact canonical binding. A timeout or mismatched immutable
+binding remains fail-closed.
+
 ## Stop
 
 Stop with `done` only after observed merge and cleanup. Otherwise stop with one

--- a/.agents/skills/execute-lane/references/issue-supervisor.md
+++ b/.agents/skills/execute-lane/references/issue-supervisor.md
@@ -116,7 +116,9 @@ node .agents/skills/execute-lane/scripts/await-lane-dispatch.mjs \
 
 Do not treat the short start/attach interval as a terminal ledger conflict.
 Wait for the exact canonical binding. A timeout or mismatched immutable
-binding remains fail-closed.
+binding remains fail-closed. The gate authenticates the binding against the
+native run's persisted submitted definition and does not recompile current
+workflow source for an already attached run.
 
 ## Stop
 

--- a/.agents/skills/execute-lane/references/workflow.md
+++ b/.agents/skills/execute-lane/references/workflow.md
@@ -54,8 +54,10 @@ must be acyclic. The parent:
 5. starts the complete native DAG once;
 6. immediately attaches the observed run with
    `attachLaneSupervisorRun()`;
-7. persists its immutable v3 binding at `dag-binding.json`;
-8. requires every supervisor to pass `await-lane-dispatch.mjs` before
+7. authenticates the run key and submitted definition from
+   `.omo/senpi-task/dag/runs/<run-id>.json`;
+8. persists its immutable v3 binding at `dag-binding.json`;
+9. requires every supervisor to pass `await-lane-dispatch.mjs` before
    mutation.
 
 The dispatch interface accepts the repository root and derives the only valid
@@ -63,6 +65,13 @@ runtime root, `.omo/lane-runs`, internally. Callers cannot select a binding
 directory. The startup gate subscribes to the canonical binding path before
 rechecking it, so a fast attach cannot be missed and a delayed attach does not
 become a false terminal blocker.
+
+An attached run resumes from the authenticated native run definition, not a
+fresh `compile-dag.mjs` result. This keeps a long-lived exact run attachable
+when workflow source changes later. A legacy dispatch intent that has no
+definition digest remains compatible only when its existing binding matches
+the native run record. If that binding is missing, recovery requires a
+successor lane; never synthesize a new binding from current source.
 
 Independent nodes run concurrently. Native `dependsOn` is an ordering signal,
 not semantic success. Before mutation, every dependent supervisor loads and

--- a/.agents/skills/execute-lane/references/workflow.md
+++ b/.agents/skills/execute-lane/references/workflow.md
@@ -54,7 +54,15 @@ must be acyclic. The parent:
 5. starts the complete native DAG once;
 6. immediately attaches the observed run with
    `attachLaneSupervisorRun()`;
-7. persists its immutable v3 binding at `dag-binding.json`.
+7. persists its immutable v3 binding at `dag-binding.json`;
+8. requires every supervisor to pass `await-lane-dispatch.mjs` before
+   mutation.
+
+The dispatch interface accepts the repository root and derives the only valid
+runtime root, `.omo/lane-runs`, internally. Callers cannot select a binding
+directory. The startup gate subscribes to the canonical binding path before
+rechecking it, so a fast attach cannot be missed and a delayed attach does not
+become a false terminal blocker.
 
 Independent nodes run concurrently. Native `dependsOn` is an ordering signal,
 not semantic success. Before mutation, every dependent supervisor loads and
@@ -64,7 +72,10 @@ CLOSED issue, and cleanup authorizes mutation. Merge alone, a CLOSED
 observation, native task completion, missing or malformed evidence, or any
 terminal blocker does not release mutation.
 
-After the lane DAG settles, the parent validates and imports issue terminals in
+After the lane DAG settles, the parent first runs
+`scripts/lane-settlement-audit.mjs`. A native `completed` node is only a
+settled claim. Missing or nonterminal canonical issue stores keep the lane
+incomplete. The parent then validates and imports issue terminals in
 topological order. A blocked dependency terminalizes unreachable dependents
 only after fresh absence observations prove no branch, worktree, child, or PR
 was created for them. Those observations are recorded in the

--- a/.agents/skills/execute-lane/references/workflow.md
+++ b/.agents/skills/execute-lane/references/workflow.md
@@ -54,8 +54,8 @@ must be acyclic. The parent:
 5. starts the complete native DAG once;
 6. immediately attaches the observed run with
    `attachLaneSupervisorRun()`;
-7. authenticates the run key and submitted definition from
-   `.omo/senpi-task/dag/runs/<run-id>.json`;
+7. authenticates the run, its native key record, and submitted definition from
+   `.omo/senpi-task/dag/{runs,keys}`;
 8. persists its immutable v3 binding at `dag-binding.json`;
 9. requires every supervisor to pass `await-lane-dispatch.mjs` before
    mutation.

--- a/.agents/skills/execute-lane/scripts/await-lane-dispatch.mjs
+++ b/.agents/skills/execute-lane/scripts/await-lane-dispatch.mjs
@@ -3,7 +3,10 @@ import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { awaitLaneSupervisorDispatch } from './lane-dispatch.mjs';
-import { canonicalLaneLedgerPath } from './lane-runtime-paths.mjs';
+import {
+  canonicalLaneLedgerPath,
+  canonicalLaneRuntimeRoot,
+} from './lane-runtime-paths.mjs';
 import { loadState } from './state-store.mjs';
 
 const valueAfter = (args, flag) => {
@@ -30,12 +33,10 @@ export const awaitCanonicalLaneDispatch = async ({
       'lane ledger identity does not match its canonical path.',
     );
   }
-  const stateDirectory = resolve(
+  const runtimeRoot = canonicalLaneRuntimeRoot(
     canonical.repositoryRoot,
-    '.omo',
-    'lane-runs',
-    canonical.laneId,
   );
+  const stateDirectory = resolve(runtimeRoot, canonical.laneId);
   const persisted = loadState(
     stateDirectory,
     canonical.ledgerPath,

--- a/.agents/skills/execute-lane/scripts/await-lane-dispatch.mjs
+++ b/.agents/skills/execute-lane/scripts/await-lane-dispatch.mjs
@@ -2,7 +2,6 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { compileLaneSupervisorDag } from './compile-dag.mjs';
 import { awaitLaneSupervisorDispatch } from './lane-dispatch.mjs';
 import { canonicalLaneLedgerPath } from './lane-runtime-paths.mjs';
 import { loadState } from './state-store.mjs';
@@ -42,11 +41,9 @@ export const awaitCanonicalLaneDispatch = async ({
     canonical.ledgerPath,
     canonical.repositoryRoot,
   );
-  const definition = compileLaneSupervisorDag(persisted.snapshot);
   return awaitLaneSupervisorDispatch({
     persisted,
     repository_root: canonical.repositoryRoot,
-    definition,
     timeout_ms: timeoutMs,
   });
 };

--- a/.agents/skills/execute-lane/scripts/await-lane-dispatch.mjs
+++ b/.agents/skills/execute-lane/scripts/await-lane-dispatch.mjs
@@ -1,0 +1,78 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { compileLaneSupervisorDag } from './compile-dag.mjs';
+import { awaitLaneSupervisorDispatch } from './lane-dispatch.mjs';
+import { canonicalLaneLedgerPath } from './lane-runtime-paths.mjs';
+import { loadState } from './state-store.mjs';
+
+const valueAfter = (args, flag) => {
+  const index = args.indexOf(flag);
+  const value = index === -1 ? undefined : args[index + 1];
+  if (value === undefined) {
+    throw new TypeError(`Missing ${flag}.`);
+  }
+  return value;
+};
+
+export const awaitCanonicalLaneDispatch = async ({
+  repositoryRoot,
+  ledgerPath,
+  timeoutMs = 30_000,
+}) => {
+  const canonical = canonicalLaneLedgerPath(
+    repositoryRoot,
+    ledgerPath,
+  );
+  const lane = JSON.parse(readFileSync(canonical.ledgerPath, 'utf8'));
+  if (lane.lane_id !== canonical.laneId) {
+    throw new TypeError(
+      'lane ledger identity does not match its canonical path.',
+    );
+  }
+  const stateDirectory = resolve(
+    canonical.repositoryRoot,
+    '.omo',
+    'lane-runs',
+    canonical.laneId,
+  );
+  const persisted = loadState(
+    stateDirectory,
+    canonical.ledgerPath,
+    canonical.repositoryRoot,
+  );
+  const definition = compileLaneSupervisorDag(persisted.snapshot);
+  return awaitLaneSupervisorDispatch({
+    persisted,
+    repository_root: canonical.repositoryRoot,
+    definition,
+    timeout_ms: timeoutMs,
+  });
+};
+
+if (resolve(process.argv[1] ?? '') === fileURLToPath(import.meta.url)) {
+  const args = process.argv.slice(2);
+  if (args.includes('--help')) {
+    process.stdout.write(
+      'Usage: node await-lane-dispatch.mjs --root <repository> --ledger <lane-ledger> [--timeout-ms <milliseconds>]\n',
+    );
+    process.exit(0);
+  }
+  const result = await awaitCanonicalLaneDispatch({
+    repositoryRoot: valueAfter(args, '--root'),
+    ledgerPath: valueAfter(args, '--ledger'),
+    timeoutMs: Number(
+      args.includes('--timeout-ms')
+        ? valueAfter(args, '--timeout-ms')
+        : 30_000,
+    ),
+  });
+  process.stdout.write(
+    `${JSON.stringify({
+      status: 'attached',
+      run_id: result.run_id,
+      binding: result.binding,
+    })}\n`,
+  );
+}

--- a/.agents/skills/execute-lane/scripts/compile-dag.mjs
+++ b/.agents/skills/execute-lane/scripts/compile-dag.mjs
@@ -6,11 +6,20 @@ const nodeId = (issueNumber) => `issue-${String(issueNumber)}-supervisor`;
 
 export { implementerRoute };
 
+const dispatchGate = (laneId) => `STARTUP GATE:
+- Before any mutation or terminal decision, run:
+  node .agents/skills/execute-lane/scripts/await-lane-dispatch.mjs
+  --root . --ledger .omo/lanes/${laneId}.json
+- Continue only when it exits zero and reports the attached native run.
+- A delayed parent attach is not a ledger conflict.`;
+
 const supervisorPrompt = (lane, issueNumber, dependencies) => `TASK:
 Execute the complete Fluo lifecycle for issue ${String(issueNumber)} as an issue supervisor.
 
 DELIVERABLE:
 Return one typed terminal report for lane ${lane.lane_id} and issue ${String(issueNumber)}.
+
+${dispatchGate(lane.lane_id)}
 
 SCOPE:
 - Consume the canonical lane ledger at .omo/lanes/${lane.lane_id}.json.
@@ -64,6 +73,8 @@ Represent approved release handoff issue ${String(issueNumber)} in lane ${lane.l
 
 DELIVERABLE:
 Return one typed blocked-maintainer-decision result bound to the approved lane-plan receipt.
+
+${dispatchGate(lane.lane_id)}
 
 SCOPE:
 - Do not dispatch implementation.

--- a/.agents/skills/execute-lane/scripts/lane-dispatch-intent.mjs
+++ b/.agents/skills/execute-lane/scripts/lane-dispatch-intent.mjs
@@ -1,0 +1,71 @@
+import {
+  assertContract,
+  assertEventChain,
+  payloadDigest,
+} from '../../../workflow-contracts/contracts.mjs';
+import { validateLedger } from '../../../../tooling/governance/lane-ledger-state.mjs';
+import { appendEvent } from './transition-application.mjs';
+
+export const dispatchIntentFor = (events, laneId) => {
+  if (events.length > 0) {
+    assertEventChain(events);
+  }
+  const intents = events.filter(
+    (event) =>
+      event.event_type === 'lane.dag.dispatch.intent' &&
+      event.subject_id === laneId,
+  );
+  if (intents.length > 1) {
+    throw new TypeError(`lane ${laneId} has conflicting DAG dispatch intents.`);
+  }
+  return intents[0] ?? null;
+};
+
+export const dispatchDefinitionDigestFor = (intent) => {
+  const digest = intent?.payload?.definition_sha256;
+  if (digest === undefined) {
+    return null;
+  }
+  if (typeof digest !== 'string' || !/^[a-f0-9]{64}$/u.test(digest)) {
+    throw new TypeError('dispatch definition digest is malformed.');
+  }
+  return digest;
+};
+
+export const prepareLaneSupervisorDispatch = (persisted, definition) => {
+  if (
+    typeof definition !== 'object' ||
+    definition === null ||
+    Array.isArray(definition)
+  ) {
+    throw new TypeError('compiled lane DAG definition is required.');
+  }
+  const snapshot = structuredClone(persisted.snapshot);
+  const events = structuredClone(persisted.events);
+  const receipts = structuredClone(persisted.receipts);
+  assertContract('lane-ledger-v2', snapshot);
+  validateLedger('lane-ledger-v2', snapshot);
+  if (
+    definition.key !==
+    `fluo:lane:${snapshot.lane_id}:issue-supervisors:v2`
+  ) {
+    throw new TypeError('Lane DAG definition key is not canonical.');
+  }
+  appendEvent(
+    events,
+    snapshot.lane_id,
+    'lane.dag.dispatch.intent',
+    snapshot.lane_id,
+    {
+      dag_key: definition.key,
+      definition_sha256: payloadDigest(definition),
+    },
+  );
+  assertEventChain(events);
+  return {
+    snapshot,
+    events,
+    receipts,
+    dispatch_event_hash: events.at(-1).event_hash,
+  };
+};

--- a/.agents/skills/execute-lane/scripts/lane-dispatch.mjs
+++ b/.agents/skills/execute-lane/scripts/lane-dispatch.mjs
@@ -1,6 +1,10 @@
+import { watch } from 'node:fs';
+import { resolve } from 'node:path';
+
 import {
   assertContract,
   assertEventChain,
+  payloadDigest,
 } from '../../../workflow-contracts/contracts.mjs';
 import { validateLedger } from '../../../../tooling/governance/lane-ledger-state.mjs';
 import {
@@ -9,6 +13,7 @@ import {
   loadDagBinding,
   persistDagBinding,
 } from './dag-binding.mjs';
+import { canonicalLaneRuntimeRoot } from './lane-runtime-paths.mjs';
 import { appendEvent } from './transition-application.mjs';
 
 const dispatchIntentFor = (events, laneId) => {
@@ -24,6 +29,22 @@ const dispatchIntentFor = (events, laneId) => {
     throw new TypeError(`lane ${laneId} has conflicting DAG dispatch intents.`);
   }
   return intents[0] ?? null;
+};
+
+const assertDispatchDefinition = (intent, definition) => {
+  const expected = intent?.payload?.definition_sha256;
+  if (expected === undefined) {
+    return;
+  }
+  if (
+    typeof expected !== 'string' ||
+    !/^[a-f0-9]{64}$/u.test(expected) ||
+    expected !== payloadDigest(definition)
+  ) {
+    throw new TypeError(
+      'dispatch definition digest does not match the compiled definition.',
+    );
+  }
 };
 
 const prepareLaneSupervisorDispatch = (persisted, definition) => {
@@ -43,7 +64,10 @@ const prepareLaneSupervisorDispatch = (persisted, definition) => {
     snapshot.lane_id,
     'lane.dag.dispatch.intent',
     snapshot.lane_id,
-    { dag_key: definition.key },
+    {
+      dag_key: definition.key,
+      definition_sha256: payloadDigest(definition),
+    },
   );
   assertEventChain(events);
   return {
@@ -56,14 +80,16 @@ const prepareLaneSupervisorDispatch = (persisted, definition) => {
 
 export const reconcileLaneSupervisorDispatch = ({
   persisted,
-  runtime_root,
+  repository_root,
   definition,
 }) => {
   assertContract('lane-ledger-v2', persisted.snapshot);
   validateLedger('lane-ledger-v2', persisted.snapshot);
   const laneId = persisted.snapshot.lane_id;
+  const runtimeRoot = canonicalLaneRuntimeRoot(repository_root);
   const intent = dispatchIntentFor(persisted.events, laneId);
-  const binding = loadDagBinding(runtime_root, laneId);
+  assertDispatchDefinition(intent, definition);
+  const binding = loadDagBinding(runtimeRoot, laneId);
   if (binding !== null) {
     if (intent === null) {
       return {
@@ -95,18 +121,20 @@ export const reconcileLaneSupervisorDispatch = ({
 
 export const attachLaneSupervisorRun = ({
   persisted,
-  runtime_root,
+  repository_root,
   definition,
   run_id,
 }) => {
   assertContract('lane-ledger-v2', persisted.snapshot);
   validateLedger('lane-ledger-v2', persisted.snapshot);
   const laneId = persisted.snapshot.lane_id;
+  const runtimeRoot = canonicalLaneRuntimeRoot(repository_root);
   const intent = dispatchIntentFor(persisted.events, laneId);
   if (intent === null) {
     throw new TypeError(`lane ${laneId} has no DAG dispatch intent.`);
   }
-  const existing = loadDagBinding(runtime_root, laneId);
+  assertDispatchDefinition(intent, definition);
+  const existing = loadDagBinding(runtimeRoot, laneId);
   if (existing !== null) {
     assertDagBindingMatches(existing, {
       definition,
@@ -122,6 +150,98 @@ export const attachLaneSupervisorRun = ({
     run_id,
     dispatch_event_hash: intent.event_hash,
   });
-  persistDagBinding(runtime_root, binding);
+  persistDagBinding(runtimeRoot, binding);
   return binding;
+};
+
+const missingBindingCrashWindow = (result) =>
+  result.action === 'blocked-ledger-conflict' &&
+  result.reason === 'dispatch intent exists without lane DAG binding';
+
+export const awaitLaneSupervisorDispatch = ({
+  persisted,
+  repository_root,
+  definition,
+  timeout_ms = 30_000,
+}) => {
+  if (!Number.isSafeInteger(timeout_ms) || timeout_ms <= 0) {
+    throw new TypeError('timeout_ms must be a positive integer.');
+  }
+  const initial = reconcileLaneSupervisorDispatch({
+    persisted,
+    repository_root,
+    definition,
+  });
+  if (initial.action === 'attach') {
+    return Promise.resolve(initial);
+  }
+  if (!missingBindingCrashWindow(initial)) {
+    throw new TypeError(
+      initial.reason ?? 'lane supervisor dispatch is not attachable.',
+    );
+  }
+
+  const runtimeRoot = canonicalLaneRuntimeRoot(repository_root);
+  const laneDirectory = resolve(runtimeRoot, persisted.snapshot.lane_id);
+  return new Promise((resolveWait, rejectWait) => {
+    let settled = false;
+    const finish = (callback, value) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      watcher.close();
+      callback(value);
+    };
+    const inspect = () => {
+      try {
+        const current = reconcileLaneSupervisorDispatch({
+          persisted,
+          repository_root,
+          definition,
+        });
+        if (current.action === 'attach') {
+          finish(resolveWait, current);
+        } else if (!missingBindingCrashWindow(current)) {
+          finish(
+            rejectWait,
+            new TypeError(
+              current.reason ??
+                'lane supervisor dispatch became non-attachable.',
+            ),
+          );
+        }
+      } catch (error) {
+        finish(rejectWait, error);
+      }
+    };
+    const watcher = watch(
+      laneDirectory,
+      { persistent: false },
+      (_eventType, filename) => {
+        if (
+          filename === null ||
+          String(filename) === 'dag-binding.json'
+        ) {
+          inspect();
+        }
+      },
+    );
+    watcher.on('error', (error) => {
+      finish(rejectWait, error);
+    });
+    const timeout = setTimeout(() => {
+      inspect();
+      if (!settled) {
+        finish(
+          rejectWait,
+          new TypeError(
+            `lane ${persisted.snapshot.lane_id} DAG binding did not appear before the startup deadline.`,
+          ),
+        );
+      }
+    }, timeout_ms);
+    inspect();
+  });
 };

--- a/.agents/skills/execute-lane/scripts/lane-dispatch.mjs
+++ b/.agents/skills/execute-lane/scripts/lane-dispatch.mjs
@@ -1,11 +1,7 @@
 import { watch } from 'node:fs';
 import { resolve } from 'node:path';
 
-import {
-  assertContract,
-  assertEventChain,
-  payloadDigest,
-} from '../../../workflow-contracts/contracts.mjs';
+import { assertContract } from '../../../workflow-contracts/contracts.mjs';
 import { validateLedger } from '../../../../tooling/governance/lane-ledger-state.mjs';
 import {
   assertDagBindingMatches,
@@ -13,69 +9,33 @@ import {
   loadDagBinding,
   persistDagBinding,
 } from './dag-binding.mjs';
+import {
+  dispatchDefinitionDigestFor,
+  dispatchIntentFor,
+  prepareLaneSupervisorDispatch,
+} from './lane-dispatch-intent.mjs';
 import { canonicalLaneRuntimeRoot } from './lane-runtime-paths.mjs';
-import { appendEvent } from './transition-application.mjs';
+import { loadLaneNativeDagRun } from './native-dag-run.mjs';
 
-const dispatchIntentFor = (events, laneId) => {
-  if (events.length > 0) {
-    assertEventChain(events);
-  }
-  const intents = events.filter(
-    (event) =>
-      event.event_type === 'lane.dag.dispatch.intent' &&
-      event.subject_id === laneId,
-  );
-  if (intents.length > 1) {
-    throw new TypeError(`lane ${laneId} has conflicting DAG dispatch intents.`);
-  }
-  return intents[0] ?? null;
-};
-
-const assertDispatchDefinition = (intent, definition) => {
-  const expected = intent?.payload?.definition_sha256;
-  if (expected === undefined) {
-    return;
-  }
-  if (
-    typeof expected !== 'string' ||
-    !/^[a-f0-9]{64}$/u.test(expected) ||
-    expected !== payloadDigest(definition)
-  ) {
+const assertNativeRunMatchesIntent = (
+  intent,
+  nativeRun,
+  allowLegacyBinding,
+) => {
+  const expected = dispatchDefinitionDigestFor(intent);
+  if (expected === null) {
+    if (allowLegacyBinding) {
+      return;
+    }
     throw new TypeError(
-      'dispatch definition digest does not match the compiled definition.',
+      'legacy dispatch intent without a binding requires a successor lane.',
     );
   }
-};
-
-const prepareLaneSupervisorDispatch = (persisted, definition) => {
-  const snapshot = structuredClone(persisted.snapshot);
-  const events = structuredClone(persisted.events);
-  const receipts = structuredClone(persisted.receipts);
-  assertContract('lane-ledger-v2', snapshot);
-  validateLedger('lane-ledger-v2', snapshot);
-  if (
-    definition.key !==
-    `fluo:lane:${snapshot.lane_id}:issue-supervisors:v2`
-  ) {
-    throw new TypeError('Lane DAG definition key is not canonical.');
+  if (expected !== nativeRun.definition_sha256) {
+    throw new TypeError(
+      'native DAG definition digest does not match the dispatch intent.',
+    );
   }
-  appendEvent(
-    events,
-    snapshot.lane_id,
-    'lane.dag.dispatch.intent',
-    snapshot.lane_id,
-    {
-      dag_key: definition.key,
-      definition_sha256: payloadDigest(definition),
-    },
-  );
-  assertEventChain(events);
-  return {
-    snapshot,
-    events,
-    receipts,
-    dispatch_event_hash: events.at(-1).event_hash,
-  };
 };
 
 export const reconcileLaneSupervisorDispatch = ({
@@ -88,7 +48,6 @@ export const reconcileLaneSupervisorDispatch = ({
   const laneId = persisted.snapshot.lane_id;
   const runtimeRoot = canonicalLaneRuntimeRoot(repository_root);
   const intent = dispatchIntentFor(persisted.events, laneId);
-  assertDispatchDefinition(intent, definition);
   const binding = loadDagBinding(runtimeRoot, laneId);
   if (binding !== null) {
     if (intent === null) {
@@ -97,18 +56,32 @@ export const reconcileLaneSupervisorDispatch = ({
         reason: 'lane DAG binding exists without dispatch intent',
       };
     }
+    const nativeRun = loadLaneNativeDagRun({
+      repository_root,
+      lane_id: laneId,
+      run_id: binding.run_id,
+    });
+    assertNativeRunMatchesIntent(intent, nativeRun, true);
     assertDagBindingMatches(binding, {
-      definition,
+      definition: nativeRun.definition,
       lane_id: laneId,
       run_id: binding.run_id,
       dispatch_event_hash: intent.event_hash,
     });
-    return { action: 'attach', run_id: binding.run_id, binding };
+    return {
+      action: 'attach',
+      run_id: binding.run_id,
+      binding,
+      definition: nativeRun.definition,
+    };
   }
   if (intent !== null) {
+    const legacy = dispatchDefinitionDigestFor(intent) === null;
     return {
       action: 'blocked-ledger-conflict',
-      reason: 'dispatch intent exists without lane DAG binding',
+      reason: legacy
+        ? 'legacy dispatch intent without a binding requires a successor lane'
+        : 'dispatch intent exists without lane DAG binding',
     };
   }
   const prepared = prepareLaneSupervisorDispatch(persisted, definition);
@@ -122,7 +95,6 @@ export const reconcileLaneSupervisorDispatch = ({
 export const attachLaneSupervisorRun = ({
   persisted,
   repository_root,
-  definition,
   run_id,
 }) => {
   assertContract('lane-ledger-v2', persisted.snapshot);
@@ -133,11 +105,16 @@ export const attachLaneSupervisorRun = ({
   if (intent === null) {
     throw new TypeError(`lane ${laneId} has no DAG dispatch intent.`);
   }
-  assertDispatchDefinition(intent, definition);
   const existing = loadDagBinding(runtimeRoot, laneId);
+  const nativeRun = loadLaneNativeDagRun({
+    repository_root,
+    lane_id: laneId,
+    run_id,
+  });
+  assertNativeRunMatchesIntent(intent, nativeRun, existing !== null);
   if (existing !== null) {
     assertDagBindingMatches(existing, {
-      definition,
+      definition: nativeRun.definition,
       lane_id: laneId,
       run_id,
       dispatch_event_hash: intent.event_hash,
@@ -145,7 +122,7 @@ export const attachLaneSupervisorRun = ({
     return existing;
   }
   const binding = createDagBinding({
-    definition,
+    definition: nativeRun.definition,
     lane_id: laneId,
     run_id,
     dispatch_event_hash: intent.event_hash,
@@ -161,7 +138,6 @@ const missingBindingCrashWindow = (result) =>
 export const awaitLaneSupervisorDispatch = ({
   persisted,
   repository_root,
-  definition,
   timeout_ms = 30_000,
 }) => {
   if (!Number.isSafeInteger(timeout_ms) || timeout_ms <= 0) {
@@ -170,7 +146,6 @@ export const awaitLaneSupervisorDispatch = ({
   const initial = reconcileLaneSupervisorDispatch({
     persisted,
     repository_root,
-    definition,
   });
   if (initial.action === 'attach') {
     return Promise.resolve(initial);
@@ -199,7 +174,6 @@ export const awaitLaneSupervisorDispatch = ({
         const current = reconcileLaneSupervisorDispatch({
           persisted,
           repository_root,
-          definition,
         });
         if (current.action === 'attach') {
           finish(resolveWait, current);

--- a/.agents/skills/execute-lane/scripts/lane-runtime-paths.mjs
+++ b/.agents/skills/execute-lane/scripts/lane-runtime-paths.mjs
@@ -85,3 +85,40 @@ export const canonicalLaneRuntimeRoot = (repositoryRoot) => {
   requireRealDirectory(runtimeRoot, true);
   return runtimeRoot;
 };
+
+export const canonicalNativeDagRunPath = (
+  repositoryRoot,
+  runId,
+) => {
+  if (
+    typeof runId !== 'string' ||
+    !/^dag_[a-z0-9]+(?:-[a-z0-9]+)*$/u.test(runId)
+  ) {
+    throw new TypeError('run_id must be a canonical native DAG run ID.');
+  }
+  const canonicalRoot = canonicalRepositoryRoot(repositoryRoot);
+  const runDirectory = resolve(
+    canonicalRoot,
+    '.omo',
+    'senpi-task',
+    'dag',
+    'runs',
+  );
+  if (!existsSync(runDirectory)) {
+    throw new TypeError(`native DAG run ${runId} must exist.`);
+  }
+  requireRealDirectory(runDirectory);
+  const runPath = resolve(runDirectory, `${runId}.json`);
+  if (!existsSync(runPath)) {
+    throw new TypeError(`native DAG run ${runId} must exist.`);
+  }
+  const stat = lstatSync(runPath);
+  if (
+    stat.isSymbolicLink() ||
+    !stat.isFile() ||
+    realpathSync(runPath) !== runPath
+  ) {
+    throw new TypeError('native DAG run must be a real canonical file.');
+  }
+  return runPath;
+};

--- a/.agents/skills/execute-lane/scripts/lane-runtime-paths.mjs
+++ b/.agents/skills/execute-lane/scripts/lane-runtime-paths.mjs
@@ -122,3 +122,40 @@ export const canonicalNativeDagRunPath = (
   }
   return runPath;
 };
+
+export const canonicalNativeDagKeyPath = (
+  repositoryRoot,
+  keyId,
+) => {
+  if (
+    typeof keyId !== 'string' ||
+    !/^[a-f0-9]{64}$/u.test(keyId)
+  ) {
+    throw new TypeError('native DAG key ID must be canonical.');
+  }
+  const canonicalRoot = canonicalRepositoryRoot(repositoryRoot);
+  const keyDirectory = resolve(
+    canonicalRoot,
+    '.omo',
+    'senpi-task',
+    'dag',
+    'keys',
+  );
+  if (!existsSync(keyDirectory)) {
+    throw new TypeError('native DAG key record must exist.');
+  }
+  requireRealDirectory(keyDirectory);
+  const keyPath = resolve(keyDirectory, `${keyId}.json`);
+  if (!existsSync(keyPath)) {
+    throw new TypeError('native DAG key record must exist.');
+  }
+  const stat = lstatSync(keyPath);
+  if (
+    stat.isSymbolicLink() ||
+    !stat.isFile() ||
+    realpathSync(keyPath) !== keyPath
+  ) {
+    throw new TypeError('native DAG key record must be a real canonical file.');
+  }
+  return keyPath;
+};

--- a/.agents/skills/execute-lane/scripts/lane-runtime-paths.mjs
+++ b/.agents/skills/execute-lane/scripts/lane-runtime-paths.mjs
@@ -1,0 +1,87 @@
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  realpathSync,
+} from 'node:fs';
+import { basename, dirname, resolve } from 'node:path';
+
+const requireRealDirectory = (path, create = false) => {
+  if (!existsSync(path)) {
+    if (!create) {
+      throw new TypeError(`${path} must exist.`);
+    }
+    mkdirSync(path);
+  }
+  const stat = lstatSync(path);
+  if (
+    stat.isSymbolicLink() ||
+    !stat.isDirectory() ||
+    realpathSync(path) !== resolve(path)
+  ) {
+    throw new TypeError(`${path} must be a real directory.`);
+  }
+};
+
+const canonicalRepositoryRoot = (repositoryRoot) => {
+  if (
+    typeof repositoryRoot !== 'string' ||
+    repositoryRoot.length === 0
+  ) {
+    throw new TypeError('repository_root must be a nonempty path.');
+  }
+  const requestedRoot = resolve(repositoryRoot);
+  requireRealDirectory(requestedRoot);
+  return realpathSync(requestedRoot);
+};
+
+export const canonicalLaneLedgerPath = (
+  repositoryRoot,
+  requestedLedgerPath,
+) => {
+  if (
+    typeof requestedLedgerPath !== 'string' ||
+    requestedLedgerPath.length === 0
+  ) {
+    throw new TypeError(
+      'ledger_path must be a nonempty canonical lane ledger path.',
+    );
+  }
+  const canonicalRoot = canonicalRepositoryRoot(repositoryRoot);
+  const ledgerDirectory = resolve(canonicalRoot, '.omo', 'lanes');
+  const ledgerPath = resolve(canonicalRoot, requestedLedgerPath);
+  const laneId = basename(ledgerPath, '.json');
+  if (
+    dirname(ledgerPath) !== ledgerDirectory ||
+    basename(ledgerPath) !== `${laneId}.json` ||
+    !/^(?!.*(?:\.|\.lock)$)[A-Za-z0-9][A-Za-z0-9._-]*$/u.test(laneId)
+  ) {
+    throw new TypeError(
+      'ledger_path must be an existing canonical lane ledger path.',
+    );
+  }
+  requireRealDirectory(ledgerDirectory);
+  if (!existsSync(ledgerPath)) {
+    throw new TypeError(
+      'ledger_path must be an existing canonical lane ledger path.',
+    );
+  }
+  const stat = lstatSync(ledgerPath);
+  if (
+    stat.isSymbolicLink() ||
+    !stat.isFile() ||
+    realpathSync(ledgerPath) !== ledgerPath
+  ) {
+    throw new TypeError('ledger_path must be a real canonical lane ledger.');
+  }
+  return { repositoryRoot: canonicalRoot, laneId, ledgerPath };
+};
+
+export const canonicalLaneRuntimeRoot = (repositoryRoot) => {
+  const canonicalRoot = canonicalRepositoryRoot(repositoryRoot);
+  const omoDirectory = resolve(canonicalRoot, '.omo');
+  const runtimeRoot = resolve(omoDirectory, 'lane-runs');
+  requireRealDirectory(omoDirectory, true);
+  requireRealDirectory(runtimeRoot, true);
+  return runtimeRoot;
+};

--- a/.agents/skills/execute-lane/scripts/lane-settlement-audit.mjs
+++ b/.agents/skills/execute-lane/scripts/lane-settlement-audit.mjs
@@ -1,0 +1,115 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { assertContract } from '../../../workflow-contracts/contracts.mjs';
+import { loadIssueSupervisorStore } from './issue-supervisor-store.mjs';
+import {
+  canonicalLaneLedgerPath,
+  canonicalLaneRuntimeRoot,
+} from './lane-runtime-paths.mjs';
+
+const terminalStatuses = new Set([
+  'done',
+  'needs-human-check-terminal',
+  'blocked-terminal',
+  'blocked-budget-exhausted',
+  'blocked-maintainer-decision',
+]);
+
+export const auditLaneSupervisorSettlement = ({
+  repository_root,
+  lane,
+}) => {
+  assertContract('lane-ledger-v2', lane);
+  const runtimeRoot = canonicalLaneRuntimeRoot(repository_root);
+  const doneIssues = [];
+  const blockedIssues = [];
+  const activeIssues = [];
+  const missingIssues = [];
+
+  for (const issueNumber of lane.confirmed_issues) {
+    const snapshotPath = resolve(
+      runtimeRoot,
+      lane.lane_id,
+      'issues',
+      String(issueNumber),
+      'snapshot.json',
+    );
+    if (!existsSync(snapshotPath)) {
+      missingIssues.push(issueNumber);
+      continue;
+    }
+    const bundle = loadIssueSupervisorStore(
+      runtimeRoot,
+      lane.lane_id,
+      issueNumber,
+    );
+    if (
+      bundle.snapshot.lane_id !== lane.lane_id ||
+      bundle.snapshot.issue_number !== issueNumber
+    ) {
+      throw new TypeError(
+        `issue store identity does not match lane ${lane.lane_id} issue ${String(issueNumber)}.`,
+      );
+    }
+    const status = bundle.snapshot.status;
+    if (status === 'done') {
+      doneIssues.push(issueNumber);
+    } else if (terminalStatuses.has(status)) {
+      blockedIssues.push({ issue_number: issueNumber, status });
+    } else {
+      activeIssues.push({ issue_number: issueNumber, status });
+    }
+  }
+
+  return {
+    version: 1,
+    lane_id: lane.lane_id,
+    status:
+      activeIssues.length === 0 && missingIssues.length === 0
+        ? 'terminal-claims-ready'
+        : 'incomplete',
+    done_issues: doneIssues,
+    blocked_issues: blockedIssues,
+    active_issues: activeIssues,
+    missing_issues: missingIssues,
+  };
+};
+
+const valueAfter = (args, flag) => {
+  const index = args.indexOf(flag);
+  const value = index === -1 ? undefined : args[index + 1];
+  if (value === undefined) {
+    throw new TypeError(`Missing ${flag}.`);
+  }
+  return value;
+};
+
+if (resolve(process.argv[1] ?? '') === fileURLToPath(import.meta.url)) {
+  const args = process.argv.slice(2);
+  if (args.includes('--help')) {
+    process.stdout.write(
+      'Usage: node lane-settlement-audit.mjs --root <repository> --ledger <lane-ledger>\n',
+    );
+    process.exit(0);
+  }
+  const canonical = canonicalLaneLedgerPath(
+    valueAfter(args, '--root'),
+    valueAfter(args, '--ledger'),
+  );
+  const lane = JSON.parse(readFileSync(canonical.ledgerPath, 'utf8'));
+  if (lane.lane_id !== canonical.laneId) {
+    throw new TypeError(
+      'lane ledger identity does not match its canonical path.',
+    );
+  }
+  const result = auditLaneSupervisorSettlement({
+    repository_root: canonical.repositoryRoot,
+    lane,
+  });
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+  if (result.status !== 'terminal-claims-ready') {
+    process.exitCode = 1;
+  }
+}

--- a/.agents/skills/execute-lane/scripts/native-dag-run.mjs
+++ b/.agents/skills/execute-lane/scripts/native-dag-run.mjs
@@ -1,7 +1,11 @@
+import { createHash } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 
 import { payloadDigest } from '../../../workflow-contracts/contracts.mjs';
-import { canonicalNativeDagRunPath } from './lane-runtime-paths.mjs';
+import {
+  canonicalNativeDagKeyPath,
+  canonicalNativeDagRunPath,
+} from './lane-runtime-paths.mjs';
 
 const isRecord = (value) =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -45,6 +49,8 @@ export const loadLaneNativeDagRun = ({
     run.schemaVersion !== 1 ||
     run.runId !== run_id ||
     run.runKey !== expectedKey ||
+    typeof run.parentSessionId !== 'string' ||
+    !/^[a-z0-9-]{20,}$/u.test(run.parentSessionId) ||
     typeof run.name !== 'string' ||
     typeof run.definitionFingerprint !== 'string' ||
     !/^[a-f0-9]{64}$/u.test(run.definitionFingerprint) ||
@@ -55,6 +61,23 @@ export const loadLaneNativeDagRun = ({
   ) {
     throw new TypeError(
       `native DAG run ${run_id} does not match lane ${lane_id}.`,
+    );
+  }
+  const keyId = createHash('sha256')
+    .update(`${run.parentSessionId}\0${run.runKey}`)
+    .digest('hex');
+  const keyPath = canonicalNativeDagKeyPath(repository_root, keyId);
+  const keyRecord = JSON.parse(readFileSync(keyPath, 'utf8'));
+  if (
+    !isRecord(keyRecord) ||
+    keyRecord.schemaVersion !== 1 ||
+    keyRecord.parentSessionId !== run.parentSessionId ||
+    keyRecord.runKey !== run.runKey ||
+    keyRecord.runId !== run.runId ||
+    keyRecord.definitionFingerprint !== run.definitionFingerprint
+  ) {
+    throw new TypeError(
+      'native DAG key record does not authenticate the run.',
     );
   }
   const definition = {

--- a/.agents/skills/execute-lane/scripts/native-dag-run.mjs
+++ b/.agents/skills/execute-lane/scripts/native-dag-run.mjs
@@ -1,0 +1,71 @@
+import { readFileSync } from 'node:fs';
+
+import { payloadDigest } from '../../../workflow-contracts/contracts.mjs';
+import { canonicalNativeDagRunPath } from './lane-runtime-paths.mjs';
+
+const isRecord = (value) =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const submittedNode = (node) => {
+  if (
+    !isRecord(node) ||
+    typeof node.id !== 'string' ||
+    typeof node.label !== 'string' ||
+    typeof node.description !== 'string' ||
+    typeof node.task_summary !== 'string' ||
+    typeof node.category !== 'string' ||
+    !Array.isArray(node.load_skills) ||
+    !Array.isArray(node.dependsOn) ||
+    typeof node.prompt !== 'string'
+  ) {
+    throw new TypeError('native DAG definition contains an invalid node.');
+  }
+  return {
+    id: node.id,
+    label: node.label,
+    description: node.description,
+    task_summary: node.task_summary,
+    category: node.category,
+    load_skills: node.load_skills,
+    dependsOn: node.dependsOn,
+    prompt: node.prompt,
+  };
+};
+
+export const loadLaneNativeDagRun = ({
+  repository_root,
+  lane_id,
+  run_id,
+}) => {
+  const path = canonicalNativeDagRunPath(repository_root, run_id);
+  const run = JSON.parse(readFileSync(path, 'utf8'));
+  const expectedKey = `fluo:lane:${lane_id}:issue-supervisors:v2`;
+  if (
+    !isRecord(run) ||
+    run.schemaVersion !== 1 ||
+    run.runId !== run_id ||
+    run.runKey !== expectedKey ||
+    typeof run.name !== 'string' ||
+    typeof run.definitionFingerprint !== 'string' ||
+    !/^[a-f0-9]{64}$/u.test(run.definitionFingerprint) ||
+    !isRecord(run.definition) ||
+    run.definition.key !== expectedKey ||
+    run.definition.name !== run.name ||
+    !Array.isArray(run.definition.nodes)
+  ) {
+    throw new TypeError(
+      `native DAG run ${run_id} does not match lane ${lane_id}.`,
+    );
+  }
+  const definition = {
+    key: run.definition.key,
+    name: run.definition.name,
+    nodes: run.definition.nodes.map(submittedNode),
+  };
+  return {
+    run_id,
+    definition,
+    definition_sha256: payloadDigest(definition),
+    definition_fingerprint: run.definitionFingerprint,
+  };
+};

--- a/tooling/governance/execute-lane-dag-supervisor.test.ts
+++ b/tooling/governance/execute-lane-dag-supervisor.test.ts
@@ -1317,6 +1317,9 @@ describe('execute-lane issue supervisor lifecycle', () => {
       load_skills: ['execute-lane'],
     });
     expect(definition.nodes[0].prompt).toContain('STOP WHEN:');
+    expect(definition.nodes[0].prompt).toContain(
+      'await-lane-dispatch.mjs',
+    );
     expect(() =>
       compileLaneSupervisorDag({
         ...ledger,
@@ -1346,6 +1349,9 @@ describe('execute-lane issue supervisor lifecycle', () => {
     });
     expect(releaseDefinition.nodes[0].prompt).toContain(
       'blocked-maintainer-decision',
+    );
+    expect(releaseDefinition.nodes[0].prompt).toContain(
+      'await-lane-dispatch.mjs',
     );
 
     const binding = createDagBinding({

--- a/tooling/governance/execute-lane-dispatch-intent.test.ts
+++ b/tooling/governance/execute-lane-dispatch-intent.test.ts
@@ -1,4 +1,10 @@
-import { mkdtempSync, readFileSync, realpathSync, rmSync } from 'node:fs';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 
@@ -20,7 +26,26 @@ const { compileLaneSupervisorDag } = (await import(
     snapshot: Readonly<Record<string, unknown>>,
   ) => Readonly<Record<string, unknown>>;
 };
-const { attachLaneSupervisorRun, reconcileLaneSupervisorDispatch } =
+const { canonicalLaneLedgerPath } = (await import(
+  resolve(
+    process.cwd(),
+    '.agents/skills/execute-lane/scripts/lane-runtime-paths.mjs',
+  )
+)) as {
+  canonicalLaneLedgerPath: (
+    repositoryRoot: string,
+    ledgerPath: string,
+  ) => Readonly<{
+    laneId: string;
+    ledgerPath: string;
+    repositoryRoot: string;
+  }>;
+};
+const {
+  attachLaneSupervisorRun,
+  awaitLaneSupervisorDispatch,
+  reconcileLaneSupervisorDispatch,
+} =
   (await import(
     resolve(
       process.cwd(),
@@ -29,13 +54,19 @@ const { attachLaneSupervisorRun, reconcileLaneSupervisorDispatch } =
   )) as {
     attachLaneSupervisorRun: (input: {
       persisted: PersistedState & { dispatch_event_hash: string };
-      runtime_root: string;
+      repository_root: string;
       definition: Readonly<Record<string, unknown>>;
       run_id: string;
     }) => Readonly<Record<string, unknown>>;
+    awaitLaneSupervisorDispatch: (input: {
+      persisted: PersistedState;
+      repository_root: string;
+      definition: Readonly<Record<string, unknown>>;
+      timeout_ms?: number;
+    }) => Promise<Readonly<Record<string, unknown>>>;
     reconcileLaneSupervisorDispatch: (input: {
       persisted: PersistedState;
-      runtime_root: string;
+      repository_root: string;
       definition: Readonly<Record<string, unknown>>;
     }) => Readonly<Record<string, unknown>>;
   };
@@ -72,6 +103,24 @@ const readyState = (): PersistedState => {
 };
 
 describe('execute-lane lane DAG dispatch intent', () => {
+  it('accepts only exact canonical lane ledger paths', () => {
+    const directory = mkdtempSync(
+      join(realpathSync(tmpdir()), 'fluo-lane-ledger-path-'),
+    );
+    const outsideLedger = resolve(
+      process.cwd(),
+      'tooling/governance/fixtures/execute-lane-native/ready-ledger-two-lanes-v2.json',
+    );
+
+    try {
+      expect(() =>
+        canonicalLaneLedgerPath(directory, outsideLedger),
+      ).toThrow(/canonical lane ledger path/u);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
   it('persists one lane intent before the DAG starts', () => {
     // Given
     const persisted = readyState();
@@ -84,7 +133,7 @@ describe('execute-lane lane DAG dispatch intent', () => {
       // When
       const result = reconcileLaneSupervisorDispatch({
         persisted,
-        runtime_root: join(directory, 'lane-runs'),
+        repository_root: directory,
         definition,
       });
 
@@ -101,6 +150,7 @@ describe('execute-lane lane DAG dispatch intent', () => {
           subject_id: 'lane-4101-runtime',
           payload: {
             dag_key: 'fluo:lane:lane-4101-runtime:issue-supervisors:v2',
+            definition_sha256: expect.stringMatching(/^[a-f0-9]{64}$/u),
           },
         }),
       ]);
@@ -117,12 +167,11 @@ describe('execute-lane lane DAG dispatch intent', () => {
     const directory = mkdtempSync(
       join(realpathSync(tmpdir()), 'fluo-lane-dispatch-'),
     );
-    const runtimeRoot = join(directory, 'lane-runs');
     const persisted = readyState();
     const definition = compileLaneSupervisorDag(persisted.snapshot);
     const prepared = reconcileLaneSupervisorDispatch({
       persisted,
-      runtime_root: runtimeRoot,
+      repository_root: directory,
       definition,
     }).persisted as PersistedState & { dispatch_event_hash: string };
 
@@ -131,21 +180,45 @@ describe('execute-lane lane DAG dispatch intent', () => {
       expect(
         reconcileLaneSupervisorDispatch({
           persisted: prepared,
-          runtime_root: runtimeRoot,
+          repository_root: directory,
           definition,
         }),
       ).toMatchObject({ action: 'blocked-ledger-conflict' });
+      expect(() =>
+        attachLaneSupervisorRun({
+          persisted: prepared,
+          repository_root: directory,
+          definition: { ...definition, name: 'definition drifted' },
+          run_id: 'run_lane_4101',
+        }),
+      ).toThrow(/dispatch definition digest/u);
 
       const binding = attachLaneSupervisorRun({
         persisted: prepared,
-        runtime_root: runtimeRoot,
+        repository_root: directory,
         definition,
         run_id: 'run_lane_4101',
       });
       expect(
+        existsSync(
+          join(
+            directory,
+            '.omo',
+            'lane-runs',
+            'lane-4101-runtime',
+            'dag-binding.json',
+          ),
+        ),
+      ).toBe(true);
+      expect(
+        existsSync(
+          join(directory, 'lane-4101-runtime', 'dag-binding.json'),
+        ),
+      ).toBe(false);
+      expect(
         reconcileLaneSupervisorDispatch({
           persisted: prepared,
-          runtime_root: runtimeRoot,
+          repository_root: directory,
           definition,
         }),
       ).toMatchObject({
@@ -156,11 +229,48 @@ describe('execute-lane lane DAG dispatch intent', () => {
       expect(() =>
         attachLaneSupervisorRun({
           persisted: prepared,
-          runtime_root: runtimeRoot,
+          repository_root: directory,
           definition: { ...definition, name: 'tampered' },
           run_id: 'run_lane_4101',
         }),
       ).toThrow(/definition digest/u);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('waits for the exact canonical binding before supervisor startup', async () => {
+    const directory = mkdtempSync(
+      join(realpathSync(tmpdir()), 'fluo-lane-startup-gate-'),
+    );
+    const persisted = readyState();
+    const definition = compileLaneSupervisorDag(persisted.snapshot);
+    const prepared = reconcileLaneSupervisorDispatch({
+      persisted,
+      repository_root: directory,
+      definition,
+    }).persisted as PersistedState & { dispatch_event_hash: string };
+
+    try {
+      const waiting = awaitLaneSupervisorDispatch({
+        persisted: prepared,
+        repository_root: directory,
+        definition,
+        timeout_ms: 1_000,
+      });
+      setImmediate(() => {
+        attachLaneSupervisorRun({
+          persisted: prepared,
+          repository_root: directory,
+          definition,
+          run_id: 'run_lane_4101',
+        });
+      });
+
+      await expect(waiting).resolves.toMatchObject({
+        action: 'attach',
+        run_id: 'run_lane_4101',
+      });
     } finally {
       rmSync(directory, { recursive: true, force: true });
     }

--- a/tooling/governance/execute-lane-dispatch-intent.test.ts
+++ b/tooling/governance/execute-lane-dispatch-intent.test.ts
@@ -1,9 +1,11 @@
 import {
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   realpathSync,
   rmSync,
+  writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -16,6 +18,17 @@ type PersistedState = Readonly<{
   receipts: readonly Readonly<Record<string, unknown>>[];
 }>;
 
+const { hashEvent, payloadDigest } = (await import(
+  resolve(
+    process.cwd(),
+    '.agents/workflow-contracts/contracts.mjs',
+  )
+)) as {
+  hashEvent: (
+    event: Readonly<Record<string, unknown>>,
+  ) => string;
+  payloadDigest: (value: unknown) => string;
+};
 const { compileLaneSupervisorDag } = (await import(
   resolve(
     process.cwd(),
@@ -41,6 +54,20 @@ const { canonicalLaneLedgerPath } = (await import(
     repositoryRoot: string;
   }>;
 };
+const { createDagBinding, persistDagBinding } = (await import(
+  resolve(
+    process.cwd(),
+    '.agents/skills/execute-lane/scripts/dag-binding.mjs',
+  )
+)) as {
+  createDagBinding: (
+    input: Readonly<Record<string, unknown>>,
+  ) => Readonly<Record<string, unknown>>;
+  persistDagBinding: (
+    runtimeRoot: string,
+    binding: Readonly<Record<string, unknown>>,
+  ) => void;
+};
 const {
   attachLaneSupervisorRun,
   awaitLaneSupervisorDispatch,
@@ -55,19 +82,17 @@ const {
     attachLaneSupervisorRun: (input: {
       persisted: PersistedState & { dispatch_event_hash: string };
       repository_root: string;
-      definition: Readonly<Record<string, unknown>>;
       run_id: string;
     }) => Readonly<Record<string, unknown>>;
     awaitLaneSupervisorDispatch: (input: {
       persisted: PersistedState;
       repository_root: string;
-      definition: Readonly<Record<string, unknown>>;
       timeout_ms?: number;
     }) => Promise<Readonly<Record<string, unknown>>>;
     reconcileLaneSupervisorDispatch: (input: {
       persisted: PersistedState;
       repository_root: string;
-      definition: Readonly<Record<string, unknown>>;
+      definition?: Readonly<Record<string, unknown>>;
     }) => Readonly<Record<string, unknown>>;
   };
 
@@ -99,6 +124,78 @@ const readyState = (): PersistedState => {
     },
     events: [],
     receipts: [],
+  };
+};
+
+const persistNativeDagRun = (
+  repositoryRoot: string,
+  runId: string,
+  definition: Readonly<Record<string, unknown>>,
+) => {
+  const runDirectory = resolve(
+    repositoryRoot,
+    '.omo',
+    'senpi-task',
+    'dag',
+    'runs',
+  );
+  mkdirSync(runDirectory, { recursive: true });
+  if (!Array.isArray(definition.nodes)) {
+    throw new TypeError('Test DAG definition nodes must be an array.');
+  }
+  const nodes = definition.nodes.map((node) => {
+    if (!isRecord(node)) {
+      throw new TypeError('Test DAG node must be an object.');
+    }
+    return {
+      id: node.id,
+      prompt: node.prompt,
+      label: node.label,
+      dependsOn: node.dependsOn,
+      task_summary: node.task_summary,
+      description: node.description,
+      load_skills: node.load_skills,
+      category: node.category,
+      effectivePrompt: `loaded:${String(node.prompt)}`,
+    };
+  });
+  writeFileSync(
+    resolve(runDirectory, `${runId}.json`),
+    `${JSON.stringify({
+      schemaVersion: 1,
+      runId,
+      runKey: definition.key,
+      name: definition.name,
+      status: 'running',
+      definitionFingerprint: 'a'.repeat(64),
+      definition: {
+        key: definition.key,
+        name: definition.name,
+        nodes,
+      },
+      nodes: [],
+    })}\n`,
+  );
+};
+
+const withoutDefinitionDigest = (
+  persisted: PersistedState & { dispatch_event_hash: string },
+) => {
+  const [event] = persisted.events;
+  if (!isRecord(event) || !isRecord(event.payload)) {
+    throw new TypeError('Dispatch event fixture must exist.');
+  }
+  const payload = { dag_key: event.payload.dag_key };
+  const draft = {
+    ...event,
+    payload,
+    payload_sha256: payloadDigest(payload),
+  };
+  const legacyEvent = { ...draft, event_hash: hashEvent(draft) };
+  return {
+    ...persisted,
+    events: [legacyEvent],
+    dispatch_event_hash: legacyEvent.event_hash,
   };
 };
 
@@ -188,16 +285,15 @@ describe('execute-lane lane DAG dispatch intent', () => {
         attachLaneSupervisorRun({
           persisted: prepared,
           repository_root: directory,
-          definition: { ...definition, name: 'definition drifted' },
-          run_id: 'run_lane_4101',
+          run_id: 'dag_missing',
         }),
-      ).toThrow(/dispatch definition digest/u);
+      ).toThrow(/native DAG run/u);
 
+      persistNativeDagRun(directory, 'dag_4101', definition);
       const binding = attachLaneSupervisorRun({
         persisted: prepared,
         repository_root: directory,
-        definition,
-        run_id: 'run_lane_4101',
+        run_id: 'dag_4101',
       });
       expect(
         existsSync(
@@ -223,17 +319,79 @@ describe('execute-lane lane DAG dispatch intent', () => {
         }),
       ).toMatchObject({
         action: 'attach',
-        run_id: 'run_lane_4101',
+        run_id: 'dag_4101',
         binding,
+      });
+      expect(
+        reconcileLaneSupervisorDispatch({
+          persisted: prepared,
+          repository_root: directory,
+          definition: { ...definition, name: 'tampered' },
+        }),
+      ).toMatchObject({
+        action: 'attach',
+        run_id: 'dag_4101',
+      });
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects legacy intent rebinding and a mismatched native run', () => {
+    const directory = mkdtempSync(
+      join(realpathSync(tmpdir()), 'fluo-lane-native-binding-'),
+    );
+    const persisted = readyState();
+    const definition = compileLaneSupervisorDag(persisted.snapshot);
+    const prepared = reconcileLaneSupervisorDispatch({
+      persisted,
+      repository_root: directory,
+      definition,
+    }).persisted as PersistedState & { dispatch_event_hash: string };
+
+    try {
+      const legacy = withoutDefinitionDigest(prepared);
+      persistNativeDagRun(directory, 'dag_legacy', definition);
+      expect(() =>
+        attachLaneSupervisorRun({
+          persisted: legacy,
+          repository_root: directory,
+          run_id: 'dag_legacy',
+        }),
+      ).toThrow(/legacy dispatch intent.*successor lane/u);
+
+      persistNativeDagRun(directory, 'dag_mismatch', {
+        ...definition,
+        name: 'different native definition',
       });
       expect(() =>
         attachLaneSupervisorRun({
           persisted: prepared,
           repository_root: directory,
-          definition: { ...definition, name: 'tampered' },
-          run_id: 'run_lane_4101',
+          run_id: 'dag_mismatch',
         }),
-      ).toThrow(/definition digest/u);
+      ).toThrow(/native DAG definition digest/u);
+
+      const binding = createDagBinding({
+        definition,
+        lane_id: 'lane-4101-runtime',
+        run_id: 'dag_legacy',
+        dispatch_event_hash: legacy.dispatch_event_hash,
+      });
+      persistDagBinding(
+        resolve(directory, '.omo', 'lane-runs'),
+        binding,
+      );
+      expect(
+        reconcileLaneSupervisorDispatch({
+          persisted: legacy,
+          repository_root: directory,
+        }),
+      ).toMatchObject({
+        action: 'attach',
+        run_id: 'dag_legacy',
+        binding,
+      });
     } finally {
       rmSync(directory, { recursive: true, force: true });
     }
@@ -255,21 +413,20 @@ describe('execute-lane lane DAG dispatch intent', () => {
       const waiting = awaitLaneSupervisorDispatch({
         persisted: prepared,
         repository_root: directory,
-        definition,
         timeout_ms: 1_000,
       });
       setImmediate(() => {
+        persistNativeDagRun(directory, 'dag_4101', definition);
         attachLaneSupervisorRun({
           persisted: prepared,
           repository_root: directory,
-          definition,
-          run_id: 'run_lane_4101',
+          run_id: 'dag_4101',
         });
       });
 
       await expect(waiting).resolves.toMatchObject({
         action: 'attach',
-        run_id: 'run_lane_4101',
+        run_id: 'dag_4101',
       });
     } finally {
       rmSync(directory, { recursive: true, force: true });

--- a/tooling/governance/execute-lane-dispatch-intent.test.ts
+++ b/tooling/governance/execute-lane-dispatch-intent.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import {
   existsSync,
   mkdirSync,
@@ -131,6 +132,7 @@ const persistNativeDagRun = (
   repositoryRoot: string,
   runId: string,
   definition: Readonly<Record<string, unknown>>,
+  writeKey = true,
 ) => {
   const runDirectory = resolve(
     repositoryRoot,
@@ -159,15 +161,21 @@ const persistNativeDagRun = (
       effectivePrompt: `loaded:${String(node.prompt)}`,
     };
   });
+  const parentSessionId = createHash('sha256')
+    .update(runId)
+    .digest('hex')
+    .slice(0, 36);
+  const definitionFingerprint = 'a'.repeat(64);
   writeFileSync(
     resolve(runDirectory, `${runId}.json`),
     `${JSON.stringify({
       schemaVersion: 1,
+      parentSessionId,
       runId,
       runKey: definition.key,
       name: definition.name,
       status: 'running',
-      definitionFingerprint: 'a'.repeat(64),
+      definitionFingerprint,
       definition: {
         key: definition.key,
         name: definition.name,
@@ -176,6 +184,29 @@ const persistNativeDagRun = (
       nodes: [],
     })}\n`,
   );
+  if (writeKey) {
+    const keyId = createHash('sha256')
+      .update(`${parentSessionId}\0${String(definition.key)}`)
+      .digest('hex');
+    const keyDirectory = resolve(
+      repositoryRoot,
+      '.omo',
+      'senpi-task',
+      'dag',
+      'keys',
+    );
+    mkdirSync(keyDirectory, { recursive: true });
+    writeFileSync(
+      resolve(keyDirectory, `${keyId}.json`),
+      `${JSON.stringify({
+        schemaVersion: 1,
+        parentSessionId,
+        runKey: definition.key,
+        runId,
+        definitionFingerprint,
+      })}\n`,
+    );
+  }
 };
 
 const withoutDefinitionDigest = (
@@ -288,6 +319,20 @@ describe('execute-lane lane DAG dispatch intent', () => {
           run_id: 'dag_missing',
         }),
       ).toThrow(/native DAG run/u);
+
+      persistNativeDagRun(
+        directory,
+        'dag_forged',
+        definition,
+        false,
+      );
+      expect(() =>
+        attachLaneSupervisorRun({
+          persisted: prepared,
+          repository_root: directory,
+          run_id: 'dag_forged',
+        }),
+      ).toThrow(/native DAG key record/u);
 
       persistNativeDagRun(directory, 'dag_4101', definition);
       const binding = attachLaneSupervisorRun({

--- a/tooling/governance/execute-lane-handoff.test.ts
+++ b/tooling/governance/execute-lane-handoff.test.ts
@@ -5,7 +5,9 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  realpathSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -55,6 +57,18 @@ const { acquireLease } = (await import(
     laneId: string,
   ) => Readonly<Record<string, unknown>>;
 };
+const { awaitCanonicalLaneDispatch } = (await import(
+  resolve(
+    repositoryRoot,
+    '.agents/skills/execute-lane/scripts/await-lane-dispatch.mjs',
+  )
+)) as {
+  awaitCanonicalLaneDispatch: (input: {
+    repositoryRoot: string;
+    ledgerPath: string;
+    timeoutMs?: number;
+  }) => Promise<Readonly<Record<string, unknown>>>;
+};
 
 const isRecord = (
   value: unknown,
@@ -84,7 +98,11 @@ const createProducerOutput = (): Readonly<{
   receiptPaths: readonly string[];
   stateDirectory: string;
 }> => {
-  const root = mkdtempSync(resolve(tmpdir(), 'fluo-lane-handoff-'));
+  const root = realpathSync(
+    mkdtempSync(
+      resolve(realpathSync(tmpdir()), 'fluo-lane-handoff-'),
+    ),
+  );
   temporaryRoots.push(root);
   execFileSync(
     process.execPath,
@@ -143,6 +161,33 @@ describe('$execute-lane canonical handoff boundary', () => {
 
     // Then
     expect(state['snapshot']).toEqual(parseRecord(handoff.ledgerPath));
+  });
+
+  it('rejects a symlinked runtime root before loading state', async () => {
+    const handoff = createProducerOutput();
+    const runtimeRoot = resolve(handoff.root, '.omo/lane-runs');
+    const externalRoot = realpathSync(
+      mkdtempSync(
+        resolve(
+          realpathSync(tmpdir()),
+          'fluo-lane-runtime-external-',
+        ),
+      ),
+    );
+    temporaryRoots.push(externalRoot);
+    rmSync(runtimeRoot, { recursive: true, force: true });
+    symlinkSync(externalRoot, runtimeRoot, 'dir');
+
+    await expect(
+      awaitCanonicalLaneDispatch({
+        repositoryRoot: handoff.root,
+        ledgerPath: ledgerRelativePath,
+        timeoutMs: 100,
+      }),
+    ).rejects.toThrow(/real directory/u);
+    expect(
+      existsSync(resolve(externalRoot, 'lane-4101-runtime')),
+    ).toBe(false);
   });
 
   it('rejects a valid ledger outside the canonical lane path', () => {

--- a/tooling/governance/execute-lane-settlement-audit.test.ts
+++ b/tooling/governance/execute-lane-settlement-audit.test.ts
@@ -1,0 +1,126 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const { auditLaneSupervisorSettlement } = (await import(
+  resolve(
+    process.cwd(),
+    '.agents/skills/execute-lane/scripts/lane-settlement-audit.mjs',
+  )
+)) as {
+  auditLaneSupervisorSettlement: (input: {
+    repository_root: string;
+    lane: Readonly<Record<string, unknown>>;
+  }) => Readonly<Record<string, unknown>>;
+};
+const { initialiseIssueSupervisorStore } = (await import(
+  resolve(
+    process.cwd(),
+    '.agents/skills/execute-lane/scripts/issue-supervisor-store.mjs',
+  )
+)) as {
+  initialiseIssueSupervisorStore: (
+    runtimeRoot: string,
+    identity: Readonly<Record<string, unknown>>,
+  ) => Readonly<Record<string, unknown>>;
+};
+
+describe('execute-lane supervisor settlement audit', () => {
+  it('rejects native DAG completion without canonical issue stores', () => {
+    const directory = mkdtempSync(
+      join(realpathSync(tmpdir()), 'fluo-lane-settlement-'),
+    );
+    const lane = JSON.parse(
+      readFileSync(
+        resolve(
+          process.cwd(),
+          'tooling/governance/fixtures/execute-lane-native/ready-ledger-two-lanes-v2.json',
+        ),
+        'utf8',
+      ),
+    ) as Readonly<Record<string, unknown>>;
+
+    try {
+      expect(
+        auditLaneSupervisorSettlement({
+          repository_root: directory,
+          lane,
+        }),
+      ).toEqual({
+        version: 1,
+        lane_id: 'lane-4101-runtime',
+        status: 'incomplete',
+        done_issues: [],
+        blocked_issues: [],
+        active_issues: [],
+        missing_issues: [4101, 4102],
+      });
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a valid bundle copied under another issue path', () => {
+    const directory = mkdtempSync(
+      join(realpathSync(tmpdir()), 'fluo-lane-settlement-identity-'),
+    );
+    const lane = JSON.parse(
+      readFileSync(
+        resolve(
+          process.cwd(),
+          'tooling/governance/fixtures/execute-lane-native/ready-ledger-two-lanes-v2.json',
+        ),
+        'utf8',
+      ),
+    ) as Readonly<Record<string, unknown>>;
+    const omoDirectory = join(directory, '.omo');
+    const runtimeRoot = join(omoDirectory, 'lane-runs');
+
+    try {
+      mkdirSync(omoDirectory);
+      mkdirSync(runtimeRoot);
+      initialiseIssueSupervisorStore(runtimeRoot, {
+        lane_id: 'lane-4101-runtime',
+        issue_number: 4101,
+        branch: 'issue-4101-runtime',
+        worktree: '.worktrees/issue-4101-runtime',
+        starting_head_sha: '0'.repeat(40),
+        started_at: '2026-08-25T00:00:00.000Z',
+        release_handoff: false,
+        authority_scope: {
+          pr_creation: true,
+          pr_merge: true,
+          cleanup_command_worktrees: true,
+        },
+        retry_policy: {
+          retry_count_is_terminal: true,
+          max_same_failure_repeats: 3,
+          max_wall_clock_minutes: 180,
+          stop_on_child_contract_error: true,
+        },
+      });
+      renameSync(
+        join(runtimeRoot, 'lane-4101-runtime', 'issues', '4101'),
+        join(runtimeRoot, 'lane-4101-runtime', 'issues', '4102'),
+      );
+
+      expect(() =>
+        auditLaneSupervisorSettlement({
+          repository_root: directory,
+          lane,
+        }),
+      ).toThrow(/issue store identity/u);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- derive lane runtime paths from the canonical repository root and reject non-canonical ledger paths before state loading
- synchronize supervisor startup with the exact DAG binding and bind dispatch intents to the compiled definition
- authenticate attached run IDs against canonical native run/key records and resume from the persisted submitted definition
- reject digestless legacy intents when their immutable binding is missing
- audit canonical issue-store settlement before accepting native DAG completion

## Verification
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `vitest run tooling/governance/execute-lane-*.test.ts` (15 files, 83 tests)
- manual CLI QA for authenticated attach, forged run/key rejection, runtime symlink preflight, legacy false-binding rejection, help, invalid ledger path, and incomplete settlement

No Changeset: internal workflow tooling only.