### PR TITLE
feat(http): expose runtime content negotiation

### DIFF
--- a/.changeset/negotiate-bootstrap-responses.md
+++ b/.changeset/negotiate-bootstrap-responses.md
@@ -1,0 +1,9 @@
+---
+'@fluojs/http': minor
+'@fluojs/runtime': minor
+---
+
+Expose successful-response content negotiation through runtime bootstrap, honor deterministic exact,
+structured-suffix, wildcard, quality, and `q=0` precedence through `@Produces(...)`, and add a
+deduplicated `Vary: Accept` field on negotiated successes across native fast-route and fallback
+dispatch.

--- a/.changeset/negotiate-bootstrap-responses.md
+++ b/.changeset/negotiate-bootstrap-responses.md
@@ -6,4 +6,6 @@
 Expose successful-response content negotiation through runtime bootstrap, honor deterministic exact,
 structured-suffix, wildcard, quality, and `q=0` precedence through `@Produces(...)`, and add a
 deduplicated `Vary: Accept` field on negotiated successes and framework-committed negotiation-generated
-`406` errors across native fast-route and fallback dispatch.
+`406` errors across native fast-route and fallback dispatch. Keep formatter failures free of uncommitted
+success metadata, and keep successful-response negotiation `406` errors canonical JSON when optional HTML
+error representation is enabled.

--- a/.changeset/negotiate-bootstrap-responses.md
+++ b/.changeset/negotiate-bootstrap-responses.md
@@ -5,5 +5,5 @@
 
 Expose successful-response content negotiation through runtime bootstrap, honor deterministic exact,
 structured-suffix, wildcard, quality, and `q=0` precedence through `@Produces(...)`, and add a
-deduplicated `Vary: Accept` field on negotiated successes across native fast-route and fallback
-dispatch.
+deduplicated `Vary: Accept` field on negotiated successes and negotiation-generated `406` errors
+across native fast-route and fallback dispatch.

--- a/.changeset/negotiate-bootstrap-responses.md
+++ b/.changeset/negotiate-bootstrap-responses.md
@@ -5,5 +5,5 @@
 
 Expose successful-response content negotiation through runtime bootstrap, honor deterministic exact,
 structured-suffix, wildcard, quality, and `q=0` precedence through `@Produces(...)`, and add a
-deduplicated `Vary: Accept` field on negotiated successes and negotiation-generated `406` errors
-across native fast-route and fallback dispatch.
+deduplicated `Vary: Accept` field on negotiated successes and framework-committed negotiation-generated
+`406` errors across native fast-route and fallback dispatch.

--- a/packages/http/README.ko.md
+++ b/packages/http/README.ko.md
@@ -135,21 +135,24 @@ export function markLanguageVariance(context: RequestContext): void {
 
 `createDispatcher(...)` 또는 runtime bootstrap에서 `ContentNegotiationOptions.formatters`를
 설정하세요. `ResponseFormatter.mediaType`은 representation을 식별하고 `format(...)`은 최종
-`string` 또는 `Uint8Array` body를 반환합니다. `@Produces(...)`가 없는 route는 configured
-formatter를 모두 사용합니다. `@Produces(...)`가 있는 route는 metadata가 지정한 exact media
-type과 일치하는 configured formatter만 사용하며 intersection이 비면 `406`을 반환합니다.
+`string` 또는 `Uint8Array` body를 반환합니다. Formatter, `defaultMediaType`, `@Produces(...)`는
+concrete representation media type만 받습니다. Wildcard type/subtype과 case-insensitive duplicate
+parameter name은 무시됩니다. Mixed list는 valid entry를 유지하고 invalid-only formatter set은
+negotiation을 비활성화합니다. `@Produces(...)`가 없는 route는 configured formatter를 모두 사용합니다.
+`@Produces(...)`가 있는 route는 valid한 exact configured media type만 사용하며, non-empty metadata에
+valid configured representation이 없으면 `406`을 반환합니다.
 
 `Accept` header가 없으면 `defaultMediaType`을 선택하고 valid한 default가 설정되지 않았으면 첫
-번째 unique configured formatter를 선택합니다. `*/*`도 같은 default tie-break를 사용합니다.
+번째 unique valid configured formatter를 선택합니다. `*/*`도 같은 default tie-break를 사용합니다.
 Header가 있으면 representation별로 exact range, `application/*+json` 같은 structured-suffix
 wildcard, `type/*`, `*/*` 순으로 우선합니다. 가장 specific한 matching range가 `q=0`을 포함한
 해당 representation의 quality를 제어하므로 더 넓은 positive wildcard가 specific exclusion을
 다시 활성화할 수 없습니다. 남은 candidate는 quality, range/type specificity, 일치한 media parameter 수,
 header order, configured default, formatter order 순으로 선택합니다.
 
-Malformed media range와 malformed quality는 추측하거나 clamp하지 않고 무시합니다. Valid token이
-남지 않거나, matching representation이 모두 `q=0`으로 제외되거나, configured formatter가
-하나도 match하지 않으면 dispatcher가 canonical JSON `406`을 반환합니다. Formatter를 선택한 모든
+Malformed Accept media range와 quality, 그리고 invalid concrete representation media type은
+추측하거나 clamp하지 않고 무시합니다. Valid Accept token이 남지 않거나, matching representation이 모두
+`q=0`으로 제외되거나, configured formatter가 하나도 match하지 않으면 dispatcher가 canonical JSON `406`을 반환합니다. Formatter를 선택한 모든
 성공 framework-managed response는 `appendVaryHeader(...)`를 통해 `Vary`에 `Accept`를 추가하여
 기존 field, wildcard semantics, case-insensitive deduplication을 보존합니다. Formatter 선택 전에
 response ownership을 가져가는 custom response writer에는 이 variance를 추가하지 않습니다.

--- a/packages/http/README.ko.md
+++ b/packages/http/README.ko.md
@@ -142,8 +142,9 @@ negotiation을 비활성화합니다. `@Produces(...)`가 없는 route는 config
 `@Produces(...)`가 있는 route는 valid한 exact configured media type만 사용하며, non-empty metadata에
 valid configured representation이 없으면 `406`을 반환합니다.
 
-`Accept` header가 없으면 `defaultMediaType`을 선택하고 valid한 default가 설정되지 않았으면 첫
+`Accept` header가 없을 때만 `defaultMediaType`을 선택하고 valid한 default가 설정되지 않았으면 첫
 번째 unique valid configured formatter를 선택합니다. `*/*`도 같은 default tie-break를 사용합니다.
+Present blank 또는 whitespace-only `Accept` field는 missing이 아니며 valid token이 없으므로 `406`을 반환합니다.
 Header가 있으면 representation별로 exact range, `application/*+json` 같은 structured-suffix
 wildcard, `type/*`, `*/*` 순으로 우선합니다. 가장 specific한 matching range가 `q=0`을 포함한
 해당 representation의 quality를 제어하므로 더 넓은 positive wildcard가 specific exclusion을
@@ -152,9 +153,10 @@ header order, configured default, formatter order 순으로 선택합니다.
 
 Malformed Accept media range와 quality, 그리고 invalid concrete representation media type은
 추측하거나 clamp하지 않고 무시합니다. Valid Accept token이 남지 않거나, matching representation이 모두
-`q=0`으로 제외되거나, configured formatter가 하나도 match하지 않으면 dispatcher가 canonical JSON `406`을 반환합니다. Formatter를 선택한 모든
-성공 framework-managed response는 `appendVaryHeader(...)`를 통해 `Vary`에 `Accept`를 추가하여
-기존 field, wildcard semantics, case-insensitive deduplication을 보존합니다. Formatter 선택 전에
+`q=0`으로 제외되거나, configured formatter가 하나도 match하지 않으면 dispatcher가 canonical JSON `406`을 반환합니다.
+모든 negotiation-generated `406`과 formatter를 선택한 모든 성공 framework-managed response는
+`appendVaryHeader(...)`를 통해 `Vary`에 `Accept`를 추가하여 기존 field, wildcard semantics,
+case-insensitive deduplication을 보존합니다. Formatter 선택 전에
 response ownership을 가져가는 custom response writer에는 이 variance를 추가하지 않습니다.
 Adapter-native fast route와 fallback dispatch는 같은 negotiation engine을 호출합니다.
 

--- a/packages/http/README.ko.md
+++ b/packages/http/README.ko.md
@@ -144,8 +144,8 @@ type과 일치하는 configured formatter만 사용하며 intersection이 비면
 Header가 있으면 representation별로 exact range, `application/*+json` 같은 structured-suffix
 wildcard, `type/*`, `*/*` 순으로 우선합니다. 가장 specific한 matching range가 `q=0`을 포함한
 해당 representation의 quality를 제어하므로 더 넓은 positive wildcard가 specific exclusion을
-다시 활성화할 수 없습니다. 남은 candidate는 quality, specificity, header order, configured
-default, formatter order 순으로 선택합니다.
+다시 활성화할 수 없습니다. 남은 candidate는 quality, range/type specificity, 일치한 media parameter 수,
+header order, configured default, formatter order 순으로 선택합니다.
 
 Malformed media range와 malformed quality는 추측하거나 clamp하지 않고 무시합니다. Valid token이
 남지 않거나, matching representation이 모두 `q=0`으로 제외되거나, configured formatter가

--- a/packages/http/README.ko.md
+++ b/packages/http/README.ko.md
@@ -143,8 +143,9 @@ negotiation을 비활성화합니다. `@Produces(...)`가 없는 route는 config
 valid configured representation이 없으면 `406`을 반환합니다.
 
 `Accept` header가 없을 때만 `defaultMediaType`을 선택하고 valid한 default가 설정되지 않았으면 첫
-번째 unique valid configured formatter를 선택합니다. `*/*`도 같은 default tie-break를 사용합니다.
-Present blank 또는 whitespace-only `Accept` field는 missing이 아니며 valid token이 없으므로 `406`을 반환합니다.
+번째 unique valid configured formatter를 선택합니다. Undefined scalar entry와 undefined만 포함한 array는
+missing입니다. `*/*`도 같은 default tie-break를 사용합니다. Present blank 또는 whitespace-only `Accept`
+field는 missing이 아니며 valid token이 없으므로 `406`을 반환합니다.
 Header가 있으면 representation별로 exact range, `application/*+json` 같은 structured-suffix
 wildcard, `type/*`, `*/*` 순으로 우선합니다. 가장 specific한 matching range가 `q=0`을 포함한
 해당 representation의 quality를 제어하므로 더 넓은 positive wildcard가 specific exclusion을
@@ -154,10 +155,11 @@ header order, configured default, formatter order 순으로 선택합니다.
 Malformed Accept media range와 quality, 그리고 invalid concrete representation media type은
 추측하거나 clamp하지 않고 무시합니다. Valid Accept token이 남지 않거나, matching representation이 모두
 `q=0`으로 제외되거나, configured formatter가 하나도 match하지 않으면 dispatcher가 canonical JSON `406`을 반환합니다.
-모든 negotiation-generated `406`과 formatter를 선택한 모든 성공 framework-managed response는
-`appendVaryHeader(...)`를 통해 `Vary`에 `Accept`를 추가하여 기존 field, wildcard semantics,
-case-insensitive deduplication을 보존합니다. Formatter 선택 전에
-response ownership을 가져가는 custom response writer에는 이 variance를 추가하지 않습니다.
+Framework가 commit하는 negotiation-generated `406`과 formatter를 선택한 모든 성공 framework-managed
+response는 `appendVaryHeader(...)`를 통해 `Vary`에 `Accept`를 추가하여 기존 field, wildcard semantics,
+case-insensitive deduplication을 보존합니다. Application error observer와 `onError` handler는 unmodified
+response를 받고 error를 handle하면 ownership을 유지합니다. Formatter 선택 전에 response ownership을
+가져가는 custom response writer에는 이 variance를 추가하지 않습니다.
 Adapter-native fast route와 fallback dispatch는 같은 negotiation engine을 호출합니다.
 
 ## 주요 패턴

--- a/packages/http/README.ko.md
+++ b/packages/http/README.ko.md
@@ -135,8 +135,10 @@ export function markLanguageVariance(context: RequestContext): void {
 
 `createDispatcher(...)` 또는 runtime bootstrap에서 `ContentNegotiationOptions.formatters`를
 설정하세요. `ResponseFormatter.mediaType`은 representation을 식별하고 `format(...)`은 최종
-`string` 또는 `Uint8Array` body를 반환합니다. Formatter, `defaultMediaType`, `@Produces(...)`는
-concrete representation media type만 받습니다. Wildcard type/subtype과 case-insensitive duplicate
+`string` 또는 `Uint8Array` body를 반환합니다. Framework는 formatter 실행이 완료된 뒤에만 success
+status, route header, negotiated `Content-Type`, serialized-body metadata, `Vary: Accept`를 적용하므로
+formatter failure는 success metadata가 누출되지 않은 상태로 일반 error handling으로 들어갑니다. Formatter,
+`defaultMediaType`, `@Produces(...)`는 concrete representation media type만 받습니다. Wildcard type/subtype과 case-insensitive duplicate
 parameter name은 무시됩니다. Mixed list는 valid entry를 유지하고 invalid-only formatter set은
 negotiation을 비활성화합니다. `@Produces(...)`가 없는 route는 configured formatter를 모두 사용합니다.
 `@Produces(...)`가 있는 route는 valid한 exact configured media type만 사용하며, non-empty metadata에
@@ -246,7 +248,9 @@ text-node contract가 해당 escape를 수행하는 rendering framework를 사�
 
 `Accept` negotiation은 deterministic하다. `Accept`가 없거나 wildcard/tie이면 JSON을 선택하고 quality와
 specificity가 `application/json`과 available `text/html` 사이를 선택하며 unsupported range는 canonical JSON
-406을 만든다. `canRender(...)`로 application 또는 matched handler별 HTML availability를 제한할 수 있다.
+406을 만든다. Successful-response negotiation에서 나온 `406`은 HTML provider를 우회하고 `Accept`가
+`text/html`을 허용하거나 error representation을 지원하지 않아도 canonical JSON으로 유지된다. Observer와
+`onError`는 error를 handle할 경우 계속 response ownership을 가진다. `canRender(...)`로 application 또는 matched handler별 HTML availability를 제한할 수 있다.
 Provider failure는 원래 canonical JSON outcome으로 한 번만 fallback하며 committed 또는 aborted request는
 다시 쓰지 않는다. Response writer `send(...)` 또는 stream/write failure는 그대로 propagate하며 두 번째 canonical
 JSON write를 시작하지 않는다. HTTP가 `Accept`를 추가할 때 기존 native `Vary` 값도 보존한다. Successful-route

--- a/packages/http/README.ko.md
+++ b/packages/http/README.ko.md
@@ -131,6 +131,30 @@ export function markLanguageVariance(context: RequestContext): void {
 }
 ```
 
+### 성공 응답 Content Negotiation
+
+`createDispatcher(...)` 또는 runtime bootstrap에서 `ContentNegotiationOptions.formatters`를
+설정하세요. `ResponseFormatter.mediaType`은 representation을 식별하고 `format(...)`은 최종
+`string` 또는 `Uint8Array` body를 반환합니다. `@Produces(...)`가 없는 route는 configured
+formatter를 모두 사용합니다. `@Produces(...)`가 있는 route는 metadata가 지정한 exact media
+type과 일치하는 configured formatter만 사용하며 intersection이 비면 `406`을 반환합니다.
+
+`Accept` header가 없으면 `defaultMediaType`을 선택하고 valid한 default가 설정되지 않았으면 첫
+번째 unique configured formatter를 선택합니다. `*/*`도 같은 default tie-break를 사용합니다.
+Header가 있으면 representation별로 exact range, `application/*+json` 같은 structured-suffix
+wildcard, `type/*`, `*/*` 순으로 우선합니다. 가장 specific한 matching range가 `q=0`을 포함한
+해당 representation의 quality를 제어하므로 더 넓은 positive wildcard가 specific exclusion을
+다시 활성화할 수 없습니다. 남은 candidate는 quality, specificity, header order, configured
+default, formatter order 순으로 선택합니다.
+
+Malformed media range와 malformed quality는 추측하거나 clamp하지 않고 무시합니다. Valid token이
+남지 않거나, matching representation이 모두 `q=0`으로 제외되거나, configured formatter가
+하나도 match하지 않으면 dispatcher가 canonical JSON `406`을 반환합니다. Formatter를 선택한 모든
+성공 framework-managed response는 `appendVaryHeader(...)`를 통해 `Vary`에 `Accept`를 추가하여
+기존 field, wildcard semantics, case-insensitive deduplication을 보존합니다. Formatter 선택 전에
+response ownership을 가져가는 custom response writer에는 이 variance를 추가하지 않습니다.
+Adapter-native fast route와 fallback dispatch는 같은 negotiation engine을 호출합니다.
+
 ## 주요 패턴
 
 ### 가드와 인터셉터

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -137,8 +137,10 @@ export function markLanguageVariance(context: RequestContext): void {
 
 Configure `ContentNegotiationOptions.formatters` on `createDispatcher(...)` or runtime bootstrap.
 `ResponseFormatter.mediaType` identifies the representation and `format(...)` returns its final
-`string` or `Uint8Array` body. Formatters, `defaultMediaType`, and `@Produces(...)` accept only
-concrete representation media types: wildcard types/subtypes and duplicate parameter names
+`string` or `Uint8Array` body. Formatter execution completes before the framework applies a success
+status, route headers, negotiated `Content-Type`, serialized-body metadata, or `Vary: Accept`; a
+formatter failure therefore enters ordinary error handling with no success metadata leaked. Formatters,
+`defaultMediaType`, and `@Produces(...)` accept only concrete representation media types: wildcard types/subtypes and duplicate parameter names
 (case-insensitive) are ignored. A mixed list retains valid entries; an invalid-only formatter set
 disables negotiation. A route without `@Produces(...)` uses every configured formatter; a route with
 `@Produces(...)` uses only its valid exact configured media types and returns `406` when its non-empty
@@ -250,7 +252,9 @@ every request-derived or error-derived value before interpolation, as the exampl
 
 `Accept` negotiation is deterministic: absent `Accept` and wildcard/tie cases select JSON; quality
 and specificity select between `application/json` and available `text/html`; unsupported ranges
-produce canonical JSON 406. `canRender(...)` may constrain HTML per application or matched handler.
+produce canonical JSON 406. A `406` from successful-response negotiation bypasses the HTML provider
+and remains canonical JSON even when `Accept` permits `text/html` or supports no error representation;
+observers and `onError` still retain response ownership if they handle it. `canRender(...)` may constrain HTML per application or matched handler.
 A provider failure falls back once to the original canonical JSON outcome, and committed or aborted
 requests are never rewritten. Response writer `send(...)` or stream/write failures propagate
 unchanged and do not trigger a second canonical JSON write. Existing native `Vary` values are

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -145,8 +145,9 @@ disables negotiation. A route without `@Produces(...)` uses every configured for
 metadata has no valid configured representation.
 
 Only a missing `Accept` header selects `defaultMediaType`, or the first unique valid configured
-formatter when no valid default is configured. `*/*` has the same default tie-break. A present blank or
-whitespace-only `Accept` field is not missing: it has no valid token and returns `406`.
+formatter when no valid default is configured. Undefined scalar entries and arrays containing only
+undefined entries are missing. `*/*` has the same default tie-break. A present blank or whitespace-only
+`Accept` field is not missing: it has no valid token and returns `406`.
 Present headers are evaluated per representation: exact ranges outrank structured-suffix wildcards
 such as `application/*+json`, which outrank `type/*`, which outrank `*/*`. The most specific matching
 range controls that representation's quality, including `q=0`; a broader positive wildcard therefore
@@ -156,10 +157,11 @@ quality, range/type specificity, matched media-parameter count, header order, co
 Malformed Accept media ranges and qualities, plus invalid concrete representation media types, are
 ignored rather than guessed or clamped. If no valid Accept token remains, every matching representation
 is excluded by `q=0`, or no configured formatter matches, the dispatcher returns canonical JSON `406`.
-Every negotiation-generated `406`, as well as every successful framework-managed response that selected
-a formatter, adds `Accept` to `Vary` through `appendVaryHeader(...)`, preserving existing fields,
-wildcard semantics, and case-insensitive deduplication. Custom response writers that take
-response ownership before formatter selection do not gain this variance. Adapter-native fast routes
+A framework-committed negotiation-generated `406`, as well as every successful framework-managed response
+that selected a formatter, adds `Accept` to `Vary` through `appendVaryHeader(...)`, preserving existing
+fields, wildcard semantics, and case-insensitive deduplication. Application error observers and `onError`
+handlers receive the unmodified response and retain ownership when they handle the error. Custom response
+writers that take response ownership before formatter selection do not gain this variance. Adapter-native fast routes
 and fallback dispatch call the same negotiation engine.
 
 ## Common Patterns

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -137,11 +137,14 @@ export function markLanguageVariance(context: RequestContext): void {
 
 Configure `ContentNegotiationOptions.formatters` on `createDispatcher(...)` or runtime bootstrap.
 `ResponseFormatter.mediaType` identifies the representation and `format(...)` returns its final
-`string` or `Uint8Array` body. A route without `@Produces(...)` uses every configured formatter; a
-route with `@Produces(...)` uses only the exact configured media types named by that metadata and
-returns `406` when the intersection is empty.
+`string` or `Uint8Array` body. Formatters, `defaultMediaType`, and `@Produces(...)` accept only
+concrete representation media types: wildcard types/subtypes and duplicate parameter names
+(case-insensitive) are ignored. A mixed list retains valid entries; an invalid-only formatter set
+disables negotiation. A route without `@Produces(...)` uses every configured formatter; a route with
+`@Produces(...)` uses only its valid exact configured media types and returns `406` when its non-empty
+metadata has no valid configured representation.
 
-For a missing `Accept` header, the selected formatter is `defaultMediaType`, or the first unique
+For a missing `Accept` header, the selected formatter is `defaultMediaType`, or the first unique valid
 configured formatter when no valid default is configured. `*/*` has the same default tie-break.
 Present headers are evaluated per representation: exact ranges outrank structured-suffix wildcards
 such as `application/*+json`, which outrank `type/*`, which outrank `*/*`. The most specific matching
@@ -149,9 +152,9 @@ range controls that representation's quality, including `q=0`; a broader positiv
 cannot re-enable a specifically excluded representation. Remaining candidates are selected by
 quality, range/type specificity, matched media-parameter count, header order, configured default, and formatter order.
 
-Malformed media ranges and malformed qualities are ignored rather than guessed or clamped. If no
-valid token remains, every matching representation is excluded by `q=0`, or no configured formatter
-matches, the dispatcher returns canonical JSON `406`. Every successful framework-managed response
+Malformed Accept media ranges and qualities, plus invalid concrete representation media types, are
+ignored rather than guessed or clamped. If no valid Accept token remains, every matching representation
+is excluded by `q=0`, or no configured formatter matches, the dispatcher returns canonical JSON `406`. Every successful framework-managed response
 that selected a formatter adds `Accept` to `Vary` through `appendVaryHeader(...)`, preserving existing
 fields, wildcard semantics, and case-insensitive deduplication. Custom response writers that take
 response ownership before formatter selection do not gain this variance. Adapter-native fast routes

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -133,6 +133,30 @@ export function markLanguageVariance(context: RequestContext): void {
 }
 ```
 
+### Successful response content negotiation
+
+Configure `ContentNegotiationOptions.formatters` on `createDispatcher(...)` or runtime bootstrap.
+`ResponseFormatter.mediaType` identifies the representation and `format(...)` returns its final
+`string` or `Uint8Array` body. A route without `@Produces(...)` uses every configured formatter; a
+route with `@Produces(...)` uses only the exact configured media types named by that metadata and
+returns `406` when the intersection is empty.
+
+For a missing `Accept` header, the selected formatter is `defaultMediaType`, or the first unique
+configured formatter when no valid default is configured. `*/*` has the same default tie-break.
+Present headers are evaluated per representation: exact ranges outrank structured-suffix wildcards
+such as `application/*+json`, which outrank `type/*`, which outrank `*/*`. The most specific matching
+range controls that representation's quality, including `q=0`; a broader positive wildcard therefore
+cannot re-enable a specifically excluded representation. Remaining candidates are selected by
+quality, specificity, header order, configured default, and formatter order.
+
+Malformed media ranges and malformed qualities are ignored rather than guessed or clamped. If no
+valid token remains, every matching representation is excluded by `q=0`, or no configured formatter
+matches, the dispatcher returns canonical JSON `406`. Every successful framework-managed response
+that selected a formatter adds `Accept` to `Vary` through `appendVaryHeader(...)`, preserving existing
+fields, wildcard semantics, and case-insensitive deduplication. Custom response writers that take
+response ownership before formatter selection do not gain this variance. Adapter-native fast routes
+and fallback dispatch call the same negotiation engine.
+
 ## Common Patterns
 
 ### Guards and interceptors

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -147,7 +147,7 @@ Present headers are evaluated per representation: exact ranges outrank structure
 such as `application/*+json`, which outrank `type/*`, which outrank `*/*`. The most specific matching
 range controls that representation's quality, including `q=0`; a broader positive wildcard therefore
 cannot re-enable a specifically excluded representation. Remaining candidates are selected by
-quality, specificity, header order, configured default, and formatter order.
+quality, range/type specificity, matched media-parameter count, header order, configured default, and formatter order.
 
 Malformed media ranges and malformed qualities are ignored rather than guessed or clamped. If no
 valid token remains, every matching representation is excluded by `q=0`, or no configured formatter

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -144,8 +144,9 @@ disables negotiation. A route without `@Produces(...)` uses every configured for
 `@Produces(...)` uses only its valid exact configured media types and returns `406` when its non-empty
 metadata has no valid configured representation.
 
-For a missing `Accept` header, the selected formatter is `defaultMediaType`, or the first unique valid
-configured formatter when no valid default is configured. `*/*` has the same default tie-break.
+Only a missing `Accept` header selects `defaultMediaType`, or the first unique valid configured
+formatter when no valid default is configured. `*/*` has the same default tie-break. A present blank or
+whitespace-only `Accept` field is not missing: it has no valid token and returns `406`.
 Present headers are evaluated per representation: exact ranges outrank structured-suffix wildcards
 such as `application/*+json`, which outrank `type/*`, which outrank `*/*`. The most specific matching
 range controls that representation's quality, including `q=0`; a broader positive wildcard therefore
@@ -154,9 +155,10 @@ quality, range/type specificity, matched media-parameter count, header order, co
 
 Malformed Accept media ranges and qualities, plus invalid concrete representation media types, are
 ignored rather than guessed or clamped. If no valid Accept token remains, every matching representation
-is excluded by `q=0`, or no configured formatter matches, the dispatcher returns canonical JSON `406`. Every successful framework-managed response
-that selected a formatter adds `Accept` to `Vary` through `appendVaryHeader(...)`, preserving existing
-fields, wildcard semantics, and case-insensitive deduplication. Custom response writers that take
+is excluded by `q=0`, or no configured formatter matches, the dispatcher returns canonical JSON `406`.
+Every negotiation-generated `406`, as well as every successful framework-managed response that selected
+a formatter, adds `Accept` to `Vary` through `appendVaryHeader(...)`, preserving existing fields,
+wildcard semantics, and case-insensitive deduplication. Custom response writers that take
 response ownership before formatter selection do not gain this variance. Adapter-native fast routes
 and fallback dispatch call the same negotiation engine.
 

--- a/packages/http/src/dispatch/dispatch-content-negotiation-error.ts
+++ b/packages/http/src/dispatch/dispatch-content-negotiation-error.ts
@@ -1,0 +1,6 @@
+import { NotAcceptableException } from '../exceptions.js';
+
+/**
+ * Signals that response content negotiation rejected every available representation.
+ */
+export class ContentNegotiationNotAcceptableException extends NotAcceptableException {}

--- a/packages/http/src/dispatch/dispatch-content-negotiation.ts
+++ b/packages/http/src/dispatch/dispatch-content-negotiation.ts
@@ -409,6 +409,10 @@ function selectPreferredCandidate(
     return candidate.token.specificity > current.token.specificity ? candidate : current;
   }
 
+  if (candidate.token.mediaParameters.length !== current.token.mediaParameters.length) {
+    return candidate.token.mediaParameters.length > current.token.mediaParameters.length ? candidate : current;
+  }
+
   if (candidate.token.order !== current.token.order) {
     return candidate.token.order < current.token.order ? candidate : current;
   }

--- a/packages/http/src/dispatch/dispatch-content-negotiation.ts
+++ b/packages/http/src/dispatch/dispatch-content-negotiation.ts
@@ -55,7 +55,11 @@ function getMediaRangeSpecificity(mediaRange: string): number {
   return subtype?.startsWith('*+') === true ? 2 : 3;
 }
 
-function splitOutsideQuotedStrings(value: string, delimiter: string): string[] | undefined {
+function splitOutsideQuotedStrings(
+  value: string,
+  delimiter: string,
+  preserveCompletedPartsOnMalformedTail = false,
+): string[] | undefined {
   const parts: string[] = [];
   let quoted = false;
   let escaped = false;
@@ -84,7 +88,7 @@ function splitOutsideQuotedStrings(value: string, delimiter: string): string[] |
   }
 
   if (quoted || escaped) {
-    return undefined;
+    return preserveCompletedPartsOnMalformedTail ? parts : undefined;
   }
 
   parts.push(value.slice(start));
@@ -159,7 +163,7 @@ function isValidParameterValue(value: string): boolean {
 }
 
 function parseAcceptHeader(acceptHeader: string): AcceptToken[] {
-  const tokenParts = splitOutsideQuotedStrings(acceptHeader, ',');
+  const tokenParts = splitOutsideQuotedStrings(acceptHeader, ',', true);
   if (!tokenParts) {
     return [];
   }

--- a/packages/http/src/dispatch/dispatch-content-negotiation.ts
+++ b/packages/http/src/dispatch/dispatch-content-negotiation.ts
@@ -71,10 +71,10 @@ function parseAcceptHeader(acceptHeader: string): AcceptToken[] {
     let malformed = false;
 
     for (const parameterPart of parameterParts) {
-      const [name, value] = parameterPart.trim().split('=');
+      const [name, value, ...extraValues] = parameterPart.trim().split('=');
 
       if (name?.toLowerCase() === 'q') {
-        const parsedQuality = parseQuality(value?.trim());
+        const parsedQuality = extraValues.length === 0 ? parseQuality(value?.trim()) : undefined;
         if (qualitySeen || parsedQuality === undefined) {
           malformed = true;
           break;

--- a/packages/http/src/dispatch/dispatch-content-negotiation.ts
+++ b/packages/http/src/dispatch/dispatch-content-negotiation.ts
@@ -1,10 +1,10 @@
-import { NotAcceptableException } from '../exceptions.js';
 import type {
   ContentNegotiationOptions,
   FrameworkRequest,
   HandlerDescriptor,
   ResponseFormatter,
 } from '../types.js';
+import { ContentNegotiationNotAcceptableException } from './dispatch-content-negotiation-error.js';
 
 interface MediaParameter {
   name: string;
@@ -44,9 +44,13 @@ function readAcceptHeader(request: FrameworkRequest): { isPresent: boolean; valu
       continue;
     }
 
-    isPresent = true;
     for (const entry of Array.isArray(value) ? value : [value]) {
-      const normalized = entry?.trim();
+      if (entry === undefined) {
+        continue;
+      }
+
+      isPresent = true;
+      const normalized = entry.trim();
       if (normalized) {
         values.push(normalized);
       }
@@ -562,7 +566,7 @@ export function selectResponseFormatter(
   );
 
   if (!allowedFormatters.length) {
-    throw new NotAcceptableException(NO_ACCEPTABLE_REPRESENTATION_MESSAGE);
+    throw new ContentNegotiationNotAcceptableException(NO_ACCEPTABLE_REPRESENTATION_MESSAGE);
   }
 
   const defaultFormatter = resolveDefaultFormatter(allowedFormatters, allowedNormalizedMediaTypes, contentNegotiation);
@@ -575,7 +579,7 @@ export function selectResponseFormatter(
   const acceptTokens = parseAcceptHeader(acceptHeader.values);
 
   if (!acceptTokens.length) {
-    throw new NotAcceptableException(NO_ACCEPTABLE_REPRESENTATION_MESSAGE);
+    throw new ContentNegotiationNotAcceptableException(NO_ACCEPTABLE_REPRESENTATION_MESSAGE);
   }
 
   let selected: FormatterCandidate | undefined;
@@ -623,5 +627,5 @@ export function selectResponseFormatter(
     return selected.formatter;
   }
 
-  throw new NotAcceptableException(NO_ACCEPTABLE_REPRESENTATION_MESSAGE);
+  throw new ContentNegotiationNotAcceptableException(NO_ACCEPTABLE_REPRESENTATION_MESSAGE);
 }

--- a/packages/http/src/dispatch/dispatch-content-negotiation.ts
+++ b/packages/http/src/dispatch/dispatch-content-negotiation.ts
@@ -1,5 +1,4 @@
 import { NotAcceptableException } from '../exceptions.js';
-import { readFirstNonEmptyRequestHeaderValue } from '../header-helpers.js';
 import type {
   ContentNegotiationOptions,
   FrameworkRequest,
@@ -37,7 +36,22 @@ function normalizeMediaType(value: string): string {
 }
 
 function readAcceptHeader(request: FrameworkRequest): string | undefined {
-  return readFirstNonEmptyRequestHeaderValue(request, 'accept');
+  const values: string[] = [];
+
+  for (const [name, value] of Object.entries(request.headers)) {
+    if (name.toLowerCase() !== 'accept') {
+      continue;
+    }
+
+    for (const entry of Array.isArray(value) ? value : [value]) {
+      const normalized = entry?.trim();
+      if (normalized) {
+        values.push(normalized);
+      }
+    }
+  }
+
+  return values.length > 0 ? values.join(',') : undefined;
 }
 
 function parseQuality(value: string | undefined): number | undefined {

--- a/packages/http/src/dispatch/dispatch-content-negotiation.ts
+++ b/packages/http/src/dispatch/dispatch-content-negotiation.ts
@@ -234,17 +234,22 @@ function parseMediaType(value: string): { mediaRange: string; parameters: MediaP
   return { mediaRange, parameters };
 }
 
+function encodeMediaParameters(parameters: readonly MediaParameter[]): string {
+  return parameters
+    .map((parameter) => `${parameter.name.length}:${parameter.name}${parameter.value.length}:${parameter.value}`)
+    .sort()
+    .join('');
+}
+
 function normalizeRepresentationMediaType(value: string): string {
   const mediaType = parseMediaType(value);
   if (!mediaType) {
     return normalizeMediaType(value);
   }
 
-  const parameters = mediaType.parameters
-    .map((parameter) => `${parameter.name}=${parameter.value}`)
-    .sort();
+  const parameters = encodeMediaParameters(mediaType.parameters);
 
-  return parameters.length ? `${mediaType.mediaRange};${parameters.join(';')}` : mediaType.mediaRange;
+  return parameters ? `${mediaType.mediaRange};${parameters}` : mediaType.mediaRange;
 }
 
 function parseAcceptHeader(acceptHeader: string): AcceptToken[] {
@@ -281,9 +286,14 @@ function parseAcceptHeader(acceptHeader: string): AcceptToken[] {
       }
 
       const [name, value] = parameter;
+      if (qualitySeen) {
+        malformed = true;
+        break;
+      }
+
       if (name.toLowerCase() === 'q') {
         const parsedQuality = parseQuality(value);
-        if (qualitySeen || parsedQuality === undefined) {
+        if (parsedQuality === undefined) {
           malformed = true;
           break;
         }
@@ -540,7 +550,13 @@ export function selectResponseFormatter(
         || token.specificity > controllingToken.specificity
         || (
           token.specificity === controllingToken.specificity
-          && token.order < controllingToken.order
+          && (
+            token.mediaParameters.length > controllingToken.mediaParameters.length
+            || (
+              token.mediaParameters.length === controllingToken.mediaParameters.length
+              && token.order < controllingToken.order
+            )
+          )
         )
       ) {
         controllingToken = token;

--- a/packages/http/src/dispatch/dispatch-content-negotiation.ts
+++ b/packages/http/src/dispatch/dispatch-content-negotiation.ts
@@ -55,11 +55,124 @@ function getMediaRangeSpecificity(mediaRange: string): number {
   return subtype?.startsWith('*+') === true ? 2 : 3;
 }
 
+function splitOutsideQuotedStrings(value: string, delimiter: string): string[] | undefined {
+  const parts: string[] = [];
+  let quoted = false;
+  let escaped = false;
+  let start = 0;
+
+  for (let index = 0; index < value.length; index++) {
+    const character = value[index]!;
+
+    if (quoted) {
+      if (escaped) {
+        escaped = false;
+      } else if (character === '\\') {
+        escaped = true;
+      } else if (character === '"') {
+        quoted = false;
+      }
+      continue;
+    }
+
+    if (character === '"') {
+      quoted = true;
+    } else if (character === delimiter) {
+      parts.push(value.slice(start, index));
+      start = index + 1;
+    }
+  }
+
+  if (quoted || escaped) {
+    return undefined;
+  }
+
+  parts.push(value.slice(start));
+  return parts;
+}
+
+function parseParameter(parameter: string): [name: string, value: string] | undefined {
+  let equalsIndex = -1;
+  let quoted = false;
+  let escaped = false;
+
+  for (let index = 0; index < parameter.length; index++) {
+    const character = parameter[index]!;
+
+    if (quoted) {
+      if (escaped) {
+        escaped = false;
+      } else if (character === '\\') {
+        escaped = true;
+      } else if (character === '"') {
+        quoted = false;
+      }
+      continue;
+    }
+
+    if (character === '"') {
+      quoted = true;
+    } else if (character === '=') {
+      if (equalsIndex >= 0) {
+        return undefined;
+      }
+      equalsIndex = index;
+    }
+  }
+
+  if (quoted || escaped || equalsIndex <= 0) {
+    return undefined;
+  }
+
+  const name = parameter.slice(0, equalsIndex);
+  const value = parameter.slice(equalsIndex + 1);
+  if (!MEDIA_TYPE_TOKEN_PATTERN.test(name) || !isValidParameterValue(value)) {
+    return undefined;
+  }
+
+  return [name, value];
+}
+
+function isValidParameterValue(value: string): boolean {
+  if (MEDIA_TYPE_TOKEN_PATTERN.test(value)) {
+    return true;
+  }
+
+  if (value.length < 2 || value[0] !== '"' || value.at(-1) !== '"') {
+    return false;
+  }
+
+  let escaped = false;
+  for (let index = 1; index < value.length - 1; index++) {
+    const character = value[index]!;
+
+    if (escaped) {
+      escaped = false;
+    } else if (character === '\\') {
+      escaped = true;
+    } else if (character === '"' || character === '\r' || character === '\n') {
+      return false;
+    }
+  }
+
+  return !escaped;
+}
+
 function parseAcceptHeader(acceptHeader: string): AcceptToken[] {
+  const tokenParts = splitOutsideQuotedStrings(acceptHeader, ',');
+  if (!tokenParts) {
+    return [];
+  }
+
   const tokens: AcceptToken[] = [];
 
-  for (const [order, token] of acceptHeader.split(',').entries()) {
-    const [rawMediaRange, ...parameterParts] = token.trim().split(';');
+  for (const [order, token] of tokenParts.entries()) {
+    const parts = splitOutsideQuotedStrings(token.trim(), ';');
+    if (!parts) {
+      continue;
+    }
+
+    const [rawMediaRange, ...parameterParts] = parts;
     const mediaRange = normalizeMediaType(rawMediaRange ?? '');
 
     if (!isValidMediaRange(mediaRange)) {
@@ -71,10 +184,15 @@ function parseAcceptHeader(acceptHeader: string): AcceptToken[] {
     let malformed = false;
 
     for (const parameterPart of parameterParts) {
-      const [name, value, ...extraValues] = parameterPart.trim().split('=');
+      const parameter = parseParameter(parameterPart.trim());
+      if (!parameter) {
+        malformed = true;
+        break;
+      }
 
-      if (name?.toLowerCase() === 'q') {
-        const parsedQuality = extraValues.length === 0 ? parseQuality(value?.trim()) : undefined;
+      const [name, value] = parameter;
+      if (name.toLowerCase() === 'q') {
+        const parsedQuality = parseQuality(value);
         if (qualitySeen || parsedQuality === undefined) {
           malformed = true;
           break;

--- a/packages/http/src/dispatch/dispatch-content-negotiation.ts
+++ b/packages/http/src/dispatch/dispatch-content-negotiation.ts
@@ -255,10 +255,10 @@ function encodeMediaParameters(parameters: readonly MediaParameter[]): string {
     .join('');
 }
 
-function normalizeRepresentationMediaType(value: string): string {
+function normalizeRepresentationMediaType(value: string): string | undefined {
   const mediaType = parseMediaType(value);
   if (!mediaType) {
-    return normalizeMediaType(value);
+    return undefined;
   }
 
   const parameters = encodeMediaParameters(mediaType.parameters);
@@ -452,30 +452,31 @@ export function resolveContentNegotiation(options: ContentNegotiationOptions | u
   }
 
   const seen = new Set<string>();
-  const formatters = options.formatters.filter((formatter) => {
-    const mediaType = normalizeRepresentationMediaType(formatter.mediaType);
+  const candidates: { formatter: ResponseFormatter; mediaType: string }[] = [];
 
+  for (const formatter of options.formatters) {
+    const mediaType = normalizeRepresentationMediaType(formatter.mediaType);
     if (!mediaType || seen.has(mediaType)) {
-      return false;
+      continue;
     }
 
     seen.add(mediaType);
-    return true;
-  });
+    candidates.push({ formatter, mediaType });
+  }
 
-  if (!formatters.length) {
+  if (!candidates.length) {
     return undefined;
   }
 
   const defaultMediaType = normalizeRepresentationMediaType(options.defaultMediaType ?? '');
   const defaultFormatter = defaultMediaType
-    ? formatters.find((formatter) => normalizeRepresentationMediaType(formatter.mediaType) === defaultMediaType) ?? formatters[0]
-    : formatters[0];
+    ? candidates.find((candidate) => candidate.mediaType === defaultMediaType) ?? candidates[0]!
+    : candidates[0]!;
 
   return {
-    defaultFormatter,
-    formatters,
-    normalizedMediaTypes: formatters.map((f) => normalizeRepresentationMediaType(f.mediaType)),
+    defaultFormatter: defaultFormatter.formatter,
+    formatters: candidates.map((candidate) => candidate.formatter),
+    normalizedMediaTypes: candidates.map((candidate) => candidate.mediaType),
   };
 }
 
@@ -487,7 +488,11 @@ function resolveAllowedFormatters(
     return { formatters: contentNegotiation.formatters, normalizedMediaTypes: contentNegotiation.normalizedMediaTypes };
   }
 
-  const allowed = new Set(handler.route.produces.map((mediaType) => normalizeRepresentationMediaType(mediaType)));
+  const allowed = new Set(
+    handler.route.produces
+      .map((mediaType) => normalizeRepresentationMediaType(mediaType))
+      .filter((mediaType): mediaType is string => mediaType !== undefined),
+  );
   const formatters: ResponseFormatter[] = [];
   const normalizedMediaTypes: string[] = [];
 
@@ -509,7 +514,7 @@ function resolveDefaultFormatter(
   contentNegotiation: ResolvedContentNegotiation,
 ): ResponseFormatter {
   const defaultMediaType = normalizeRepresentationMediaType(contentNegotiation.defaultFormatter.mediaType);
-  const idx = allowedNormalizedMediaTypes.indexOf(defaultMediaType);
+  const idx = defaultMediaType === undefined ? -1 : allowedNormalizedMediaTypes.indexOf(defaultMediaType);
 
   return idx >= 0 ? allowedFormatters[idx]! : (allowedFormatters[0] ?? contentNegotiation.defaultFormatter);
 }

--- a/packages/http/src/dispatch/dispatch-content-negotiation.ts
+++ b/packages/http/src/dispatch/dispatch-content-negotiation.ts
@@ -35,14 +35,16 @@ function normalizeMediaType(value: string): string {
   return value.split(';')[0]?.trim().toLowerCase() ?? '';
 }
 
-function readAcceptHeader(request: FrameworkRequest): string[] {
+function readAcceptHeader(request: FrameworkRequest): { isPresent: boolean; values: string[] } {
   const values: string[] = [];
+  let isPresent = false;
 
   for (const [name, value] of Object.entries(request.headers)) {
     if (name.toLowerCase() !== 'accept') {
       continue;
     }
 
+    isPresent = true;
     for (const entry of Array.isArray(value) ? value : [value]) {
       const normalized = entry?.trim();
       if (normalized) {
@@ -51,7 +53,7 @@ function readAcceptHeader(request: FrameworkRequest): string[] {
     }
   }
 
-  return values;
+  return { isPresent, values };
 }
 
 function parseQuality(value: string | undefined): number | undefined {
@@ -564,13 +566,13 @@ export function selectResponseFormatter(
   }
 
   const defaultFormatter = resolveDefaultFormatter(allowedFormatters, allowedNormalizedMediaTypes, contentNegotiation);
-  const acceptHeaders = readAcceptHeader(request);
+  const acceptHeader = readAcceptHeader(request);
 
-  if (acceptHeaders.length === 0) {
+  if (!acceptHeader.isPresent) {
     return defaultFormatter;
   }
 
-  const acceptTokens = parseAcceptHeader(acceptHeaders);
+  const acceptTokens = parseAcceptHeader(acceptHeader.values);
 
   if (!acceptTokens.length) {
     throw new NotAcceptableException(NO_ACCEPTABLE_REPRESENTATION_MESSAGE);

--- a/packages/http/src/dispatch/dispatch-content-negotiation.ts
+++ b/packages/http/src/dispatch/dispatch-content-negotiation.ts
@@ -35,7 +35,7 @@ function normalizeMediaType(value: string): string {
   return value.split(';')[0]?.trim().toLowerCase() ?? '';
 }
 
-function readAcceptHeader(request: FrameworkRequest): string | undefined {
+function readAcceptHeader(request: FrameworkRequest): string[] {
   const values: string[] = [];
 
   for (const [name, value] of Object.entries(request.headers)) {
@@ -51,7 +51,7 @@ function readAcceptHeader(request: FrameworkRequest): string | undefined {
     }
   }
 
-  return values.length > 0 ? values.join(',') : undefined;
+  return values;
 }
 
 function parseQuality(value: string | undefined): number | undefined {
@@ -230,11 +230,12 @@ function parseMediaType(value: string): { mediaRange: string; parameters: MediaP
 
   const [rawMediaRange, ...parameterParts] = parts;
   const mediaRange = normalizeMediaType(rawMediaRange ?? '');
-  if (!isValidMediaRange(mediaRange)) {
+  if (!isValidConcreteMediaType(mediaRange)) {
     return undefined;
   }
 
   const parameters: MediaParameter[] = [];
+  const parameterNames = new Set<string>();
   for (const parameterPart of parameterParts) {
     const parameter = parseParameter(parameterPart.trim());
     if (!parameter) {
@@ -242,7 +243,12 @@ function parseMediaType(value: string): { mediaRange: string; parameters: MediaP
     }
 
     const [name, parameterValue] = parameter;
-    parameters.push({ name: name.toLowerCase(), value: normalizeParameterValue(parameterValue) });
+    const normalizedName = name.toLowerCase();
+    if (parameterNames.has(normalizedName)) {
+      return undefined;
+    }
+    parameterNames.add(normalizedName);
+    parameters.push({ name: normalizedName, value: normalizeParameterValue(parameterValue) });
   }
 
   return { mediaRange, parameters };
@@ -266,69 +272,76 @@ function normalizeRepresentationMediaType(value: string): string | undefined {
   return parameters ? `${mediaType.mediaRange};${parameters}` : mediaType.mediaRange;
 }
 
-function parseAcceptHeader(acceptHeader: string): AcceptToken[] {
-  const tokenParts = splitOutsideQuotedStrings(acceptHeader, ',', true);
-  if (!tokenParts) {
-    return [];
-  }
-
+function parseAcceptHeader(acceptHeaders: readonly string[]): AcceptToken[] {
   const tokens: AcceptToken[] = [];
+  let order = 0;
 
-  for (const [order, token] of tokenParts.entries()) {
-    const parts = splitOutsideQuotedStrings(token.trim(), ';');
-    if (!parts) {
+  for (const acceptHeader of acceptHeaders) {
+    const tokenParts = splitOutsideQuotedStrings(acceptHeader, ',', true);
+    if (!tokenParts) {
       continue;
     }
 
-    const [rawMediaRange, ...parameterParts] = parts;
-    const mediaRange = normalizeMediaType(rawMediaRange ?? '');
-
-    if (!isValidMediaRange(mediaRange)) {
-      continue;
-    }
-
-    const mediaParameters: MediaParameter[] = [];
-    let quality = 1;
-    let qualitySeen = false;
-    let malformed = false;
-
-    for (const parameterPart of parameterParts) {
-      const parameter = parseParameter(parameterPart.trim());
-      if (!parameter) {
-        malformed = true;
-        break;
+    for (const token of tokenParts) {
+      const parts = splitOutsideQuotedStrings(token.trim(), ';');
+      if (!parts) {
+        continue;
       }
 
-      const [name, value] = parameter;
-      if (qualitySeen) {
-        malformed = true;
-        break;
+      const [rawMediaRange, ...parameterParts] = parts;
+      const mediaRange = normalizeMediaType(rawMediaRange ?? '');
+
+      if (!isValidMediaRange(mediaRange)) {
+        continue;
       }
 
-      if (name.toLowerCase() === 'q') {
-        const parsedQuality = parseQuality(value);
-        if (parsedQuality === undefined) {
+      const mediaParameters: MediaParameter[] = [];
+      const parameterNames = new Set<string>();
+      let quality = 1;
+      let qualitySeen = false;
+      let malformed = false;
+
+      for (const parameterPart of parameterParts) {
+        const parameter = parseParameter(parameterPart.trim());
+        if (!parameter) {
           malformed = true;
           break;
         }
-        quality = parsedQuality;
-        qualitySeen = true;
-      } else {
-        mediaParameters.push({ name: name.toLowerCase(), value: normalizeParameterValue(value) });
+
+        const [name, value] = parameter;
+        const normalizedName = name.toLowerCase();
+        if (parameterNames.has(normalizedName) || qualitySeen) {
+          malformed = true;
+          break;
+        }
+        parameterNames.add(normalizedName);
+
+        if (normalizedName === 'q') {
+          const parsedQuality = parseQuality(value);
+          if (parsedQuality === undefined) {
+            malformed = true;
+            break;
+          }
+          quality = parsedQuality;
+          qualitySeen = true;
+        } else {
+          mediaParameters.push({ name: normalizedName, value: normalizeParameterValue(value) });
+        }
       }
-    }
 
-    if (malformed) {
-      continue;
-    }
+      if (malformed) {
+        continue;
+      }
 
-    tokens.push({
-      mediaParameters,
-      mediaRange,
-      order,
-      quality,
-      specificity: getMediaRangeSpecificity(mediaRange),
-    });
+      tokens.push({
+        mediaParameters,
+        mediaRange,
+        order,
+        quality,
+        specificity: getMediaRangeSpecificity(mediaRange),
+      });
+      order++;
+    }
   }
 
   return tokens;
@@ -363,6 +376,15 @@ function isValidMediaRange(mediaRange: string): boolean {
   }
 
   return !subtype.includes('*') && MEDIA_TYPE_TOKEN_PATTERN.test(subtype);
+}
+
+function isValidConcreteMediaType(mediaType: string): boolean {
+  if (!isValidMediaRange(mediaType)) {
+    return false;
+  }
+
+  const [type, subtype] = mediaType.split('/');
+  return type !== '*' && subtype !== '*' && subtype?.startsWith('*+') !== true;
 }
 
 function matchesMediaParameters(mediaParameters: readonly MediaParameter[], mediaType: string): boolean {
@@ -542,13 +564,13 @@ export function selectResponseFormatter(
   }
 
   const defaultFormatter = resolveDefaultFormatter(allowedFormatters, allowedNormalizedMediaTypes, contentNegotiation);
-  const acceptHeader = readAcceptHeader(request);
+  const acceptHeaders = readAcceptHeader(request);
 
-  if (!acceptHeader) {
+  if (acceptHeaders.length === 0) {
     return defaultFormatter;
   }
 
-  const acceptTokens = parseAcceptHeader(acceptHeader);
+  const acceptTokens = parseAcceptHeader(acceptHeaders);
 
   if (!acceptTokens.length) {
     throw new NotAcceptableException(NO_ACCEPTABLE_REPRESENTATION_MESSAGE);

--- a/packages/http/src/dispatch/dispatch-content-negotiation.ts
+++ b/packages/http/src/dispatch/dispatch-content-negotiation.ts
@@ -7,7 +7,13 @@ import type {
   ResponseFormatter,
 } from '../types.js';
 
+interface MediaParameter {
+  name: string;
+  value: string;
+}
+
 interface AcceptToken {
+  mediaParameters: MediaParameter[];
   mediaRange: string;
   order: number;
   quality: number;
@@ -137,6 +143,20 @@ function parseParameter(parameter: string): [name: string, value: string] | unde
   return [name, value];
 }
 
+function isValidQuotedTextOctet(character: string): boolean {
+  const code = character.charCodeAt(0);
+
+  return code === 0x09
+    || (code >= 0x20 && code <= 0x7e && character !== '"' && character !== '\\')
+    || (code >= 0x80 && code <= 0xff);
+}
+
+function isValidQuotedPairOctet(character: string): boolean {
+  const code = character.charCodeAt(0);
+
+  return code === 0x09 || (code >= 0x20 && code <= 0x7e) || (code >= 0x80 && code <= 0xff);
+}
+
 function isValidParameterValue(value: string): boolean {
   if (MEDIA_TYPE_TOKEN_PATTERN.test(value)) {
     return true;
@@ -151,15 +171,80 @@ function isValidParameterValue(value: string): boolean {
     const character = value[index]!;
 
     if (escaped) {
+      if (!isValidQuotedPairOctet(character)) {
+        return false;
+      }
       escaped = false;
     } else if (character === '\\') {
       escaped = true;
-    } else if (character === '"' || character === '\r' || character === '\n') {
+    } else if (!isValidQuotedTextOctet(character)) {
       return false;
     }
   }
 
   return !escaped;
+}
+
+function normalizeParameterValue(value: string): string {
+  if (value[0] !== '"') {
+    return value;
+  }
+
+  let normalized = '';
+  let escaped = false;
+  for (let index = 1; index < value.length - 1; index++) {
+    const character = value[index]!;
+
+    if (escaped) {
+      normalized += character;
+      escaped = false;
+    } else if (character === '\\') {
+      escaped = true;
+    } else {
+      normalized += character;
+    }
+  }
+
+  return normalized;
+}
+
+function parseMediaType(value: string): { mediaRange: string; parameters: MediaParameter[] } | undefined {
+  const parts = splitOutsideQuotedStrings(value.trim(), ';');
+  if (!parts) {
+    return undefined;
+  }
+
+  const [rawMediaRange, ...parameterParts] = parts;
+  const mediaRange = normalizeMediaType(rawMediaRange ?? '');
+  if (!isValidMediaRange(mediaRange)) {
+    return undefined;
+  }
+
+  const parameters: MediaParameter[] = [];
+  for (const parameterPart of parameterParts) {
+    const parameter = parseParameter(parameterPart.trim());
+    if (!parameter) {
+      return undefined;
+    }
+
+    const [name, parameterValue] = parameter;
+    parameters.push({ name: name.toLowerCase(), value: normalizeParameterValue(parameterValue) });
+  }
+
+  return { mediaRange, parameters };
+}
+
+function normalizeRepresentationMediaType(value: string): string {
+  const mediaType = parseMediaType(value);
+  if (!mediaType) {
+    return normalizeMediaType(value);
+  }
+
+  const parameters = mediaType.parameters
+    .map((parameter) => `${parameter.name}=${parameter.value}`)
+    .sort();
+
+  return parameters.length ? `${mediaType.mediaRange};${parameters.join(';')}` : mediaType.mediaRange;
 }
 
 function parseAcceptHeader(acceptHeader: string): AcceptToken[] {
@@ -183,6 +268,7 @@ function parseAcceptHeader(acceptHeader: string): AcceptToken[] {
       continue;
     }
 
+    const mediaParameters: MediaParameter[] = [];
     let quality = 1;
     let qualitySeen = false;
     let malformed = false;
@@ -203,6 +289,8 @@ function parseAcceptHeader(acceptHeader: string): AcceptToken[] {
         }
         quality = parsedQuality;
         qualitySeen = true;
+      } else {
+        mediaParameters.push({ name: name.toLowerCase(), value: normalizeParameterValue(value) });
       }
     }
 
@@ -211,6 +299,7 @@ function parseAcceptHeader(acceptHeader: string): AcceptToken[] {
     }
 
     tokens.push({
+      mediaParameters,
       mediaRange,
       order,
       quality,
@@ -250,6 +339,14 @@ function isValidMediaRange(mediaRange: string): boolean {
   }
 
   return !subtype.includes('*') && MEDIA_TYPE_TOKEN_PATTERN.test(subtype);
+}
+
+function matchesMediaParameters(mediaParameters: readonly MediaParameter[], mediaType: string): boolean {
+  const parsedMediaType = parseMediaType(mediaType);
+
+  return parsedMediaType !== undefined && mediaParameters.every((mediaParameter) => parsedMediaType.parameters.some(
+    (parameter) => parameter.name === mediaParameter.name && parameter.value === mediaParameter.value,
+  ));
 }
 
 function matchesMediaRange(mediaRange: string, mediaType: string): boolean {
@@ -328,7 +425,7 @@ export function resolveContentNegotiation(options: ContentNegotiationOptions | u
 
   const seen = new Set<string>();
   const formatters = options.formatters.filter((formatter) => {
-    const mediaType = normalizeMediaType(formatter.mediaType);
+    const mediaType = normalizeRepresentationMediaType(formatter.mediaType);
 
     if (!mediaType || seen.has(mediaType)) {
       return false;
@@ -342,15 +439,15 @@ export function resolveContentNegotiation(options: ContentNegotiationOptions | u
     return undefined;
   }
 
-  const defaultMediaType = normalizeMediaType(options.defaultMediaType ?? '');
+  const defaultMediaType = normalizeRepresentationMediaType(options.defaultMediaType ?? '');
   const defaultFormatter = defaultMediaType
-    ? formatters.find((formatter) => normalizeMediaType(formatter.mediaType) === defaultMediaType) ?? formatters[0]
+    ? formatters.find((formatter) => normalizeRepresentationMediaType(formatter.mediaType) === defaultMediaType) ?? formatters[0]
     : formatters[0];
 
   return {
     defaultFormatter,
     formatters,
-    normalizedMediaTypes: formatters.map((f) => normalizeMediaType(f.mediaType)),
+    normalizedMediaTypes: formatters.map((f) => normalizeRepresentationMediaType(f.mediaType)),
   };
 }
 
@@ -362,7 +459,7 @@ function resolveAllowedFormatters(
     return { formatters: contentNegotiation.formatters, normalizedMediaTypes: contentNegotiation.normalizedMediaTypes };
   }
 
-  const allowed = new Set(handler.route.produces.map((mediaType) => normalizeMediaType(mediaType)));
+  const allowed = new Set(handler.route.produces.map((mediaType) => normalizeRepresentationMediaType(mediaType)));
   const formatters: ResponseFormatter[] = [];
   const normalizedMediaTypes: string[] = [];
 
@@ -383,7 +480,7 @@ function resolveDefaultFormatter(
   allowedNormalizedMediaTypes: string[],
   contentNegotiation: ResolvedContentNegotiation,
 ): ResponseFormatter {
-  const defaultMediaType = normalizeMediaType(contentNegotiation.defaultFormatter.mediaType);
+  const defaultMediaType = normalizeRepresentationMediaType(contentNegotiation.defaultFormatter.mediaType);
   const idx = allowedNormalizedMediaTypes.indexOf(defaultMediaType);
 
   return idx >= 0 ? allowedFormatters[idx]! : (allowedFormatters[0] ?? contentNegotiation.defaultFormatter);
@@ -428,11 +525,13 @@ export function selectResponseFormatter(
 
   for (let formatterIndex = 0; formatterIndex < allowedFormatters.length; formatterIndex++) {
     const formatter = allowedFormatters[formatterIndex]!;
-    const normalizedMediaType = allowedNormalizedMediaTypes[formatterIndex]!;
     let controllingToken: AcceptToken | undefined;
 
     for (const token of acceptTokens) {
-      if (!matchesMediaRange(token.mediaRange, normalizedMediaType)) {
+      if (
+        !matchesMediaRange(token.mediaRange, normalizeMediaType(formatter.mediaType))
+        || !matchesMediaParameters(token.mediaParameters, formatter.mediaType)
+      ) {
         continue;
       }
 

--- a/packages/http/src/dispatch/dispatch-content-negotiation.ts
+++ b/packages/http/src/dispatch/dispatch-content-negotiation.ts
@@ -9,6 +9,7 @@ import type {
 
 interface AcceptToken {
   mediaRange: string;
+  order: number;
   quality: number;
   specificity: number;
 }
@@ -23,6 +24,7 @@ export interface ResolvedContentNegotiation {
 }
 
 const NO_ACCEPTABLE_REPRESENTATION_MESSAGE = 'No acceptable response representation found.';
+const MEDIA_TYPE_TOKEN_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
 
 function normalizeMediaType(value: string): string {
   return value.split(';')[0]?.trim().toLowerCase() ?? '';
@@ -32,22 +34,12 @@ function readAcceptHeader(request: FrameworkRequest): string | undefined {
   return readFirstNonEmptyRequestHeaderValue(request, 'accept');
 }
 
-function parseQuality(value: string | undefined): number {
-  if (!value) {
-    return 1;
+function parseQuality(value: string | undefined): number | undefined {
+  if (value === undefined || !/^(?:0(?:\.\d{0,3})?|1(?:\.0{0,3})?)$/.test(value)) {
+    return undefined;
   }
 
-  const parsed = Number(value);
-
-  if (!Number.isFinite(parsed) || parsed < 0) {
-    return 0;
-  }
-
-  if (parsed > 1) {
-    return 1;
-  }
-
-  return parsed;
+  return Number(value);
 }
 
 function getMediaRangeSpecificity(mediaRange: string): number {
@@ -59,49 +51,83 @@ function getMediaRangeSpecificity(mediaRange: string): number {
     return 1;
   }
 
-  return 2;
+  const [, subtype] = mediaRange.split('/');
+  return subtype?.startsWith('*+') === true ? 2 : 3;
 }
 
 function parseAcceptHeader(acceptHeader: string): AcceptToken[] {
   const tokens: AcceptToken[] = [];
 
-  for (const token of acceptHeader.split(',')) {
+  for (const [order, token] of acceptHeader.split(',').entries()) {
     const [rawMediaRange, ...parameterParts] = token.trim().split(';');
     const mediaRange = normalizeMediaType(rawMediaRange ?? '');
 
-    if (!mediaRange || !mediaRange.includes('/')) {
+    if (!isValidMediaRange(mediaRange)) {
       continue;
     }
 
     let quality = 1;
+    let qualitySeen = false;
+    let malformed = false;
 
     for (const parameterPart of parameterParts) {
       const [name, value] = parameterPart.trim().split('=');
 
       if (name?.toLowerCase() === 'q') {
-        quality = parseQuality(value?.trim());
-        break;
+        const parsedQuality = parseQuality(value?.trim());
+        if (qualitySeen || parsedQuality === undefined) {
+          malformed = true;
+          break;
+        }
+        quality = parsedQuality;
+        qualitySeen = true;
       }
     }
 
-    if (quality <= 0) {
+    if (malformed) {
       continue;
     }
 
     tokens.push({
       mediaRange,
+      order,
       quality,
       specificity: getMediaRangeSpecificity(mediaRange),
     });
   }
 
-  return tokens.sort((left, right) => {
-    if (right.quality !== left.quality) {
-      return right.quality - left.quality;
-    }
+  return tokens;
+}
 
-    return right.specificity - left.specificity;
-  });
+function isValidMediaRange(mediaRange: string): boolean {
+  const parts = mediaRange.split('/');
+  if (parts.length !== 2) {
+    return false;
+  }
+
+  const [type, subtype] = parts;
+  if (!type || !subtype) {
+    return false;
+  }
+
+  if (type === '*') {
+    return subtype === '*';
+  }
+
+  if (!MEDIA_TYPE_TOKEN_PATTERN.test(type)) {
+    return false;
+  }
+
+  if (subtype === '*') {
+    return true;
+  }
+
+  if (subtype.startsWith('*+')) {
+    const suffix = subtype.slice(2);
+    return suffix.length > 0 && MEDIA_TYPE_TOKEN_PATTERN.test(suffix);
+  }
+
+  return !subtype.includes('*') && MEDIA_TYPE_TOKEN_PATTERN.test(subtype);
 }
 
 function matchesMediaRange(mediaRange: string, mediaType: string): boolean {
@@ -120,7 +146,51 @@ function matchesMediaRange(mediaRange: string, mediaType: string): boolean {
     return false;
   }
 
-  return rangeSubtype === '*' || rangeSubtype === mediaTypeSubtype;
+  if (rangeSubtype === '*') {
+    return true;
+  }
+
+  if (rangeSubtype.startsWith('*+')) {
+    return mediaTypeSubtype.endsWith(rangeSubtype.slice(1));
+  }
+
+  return rangeSubtype === mediaTypeSubtype;
+}
+
+interface FormatterCandidate {
+  formatter: ResponseFormatter;
+  formatterIndex: number;
+  token: AcceptToken;
+}
+
+function selectPreferredCandidate(
+  current: FormatterCandidate | undefined,
+  candidate: FormatterCandidate,
+  defaultFormatter: ResponseFormatter,
+): FormatterCandidate {
+  if (!current) {
+    return candidate;
+  }
+
+  if (candidate.token.quality !== current.token.quality) {
+    return candidate.token.quality > current.token.quality ? candidate : current;
+  }
+
+  if (candidate.token.specificity !== current.token.specificity) {
+    return candidate.token.specificity > current.token.specificity ? candidate : current;
+  }
+
+  if (candidate.token.order !== current.token.order) {
+    return candidate.token.order < current.token.order ? candidate : current;
+  }
+
+  const candidateIsDefault = candidate.formatter === defaultFormatter;
+  const currentIsDefault = current.formatter === defaultFormatter;
+  if (candidateIsDefault !== currentIsDefault) {
+    return candidateIsDefault ? candidate : current;
+  }
+
+  return candidate.formatterIndex < current.formatterIndex ? candidate : current;
 }
 
 /**
@@ -232,23 +302,41 @@ export function selectResponseFormatter(
     throw new NotAcceptableException(NO_ACCEPTABLE_REPRESENTATION_MESSAGE);
   }
 
-  for (const token of acceptTokens) {
-    if (token.mediaRange === '*/*') {
-      return defaultFormatter;
-    }
+  let selected: FormatterCandidate | undefined;
 
-    let matchedFormatter: ResponseFormatter | undefined;
+  for (let formatterIndex = 0; formatterIndex < allowedFormatters.length; formatterIndex++) {
+    const formatter = allowedFormatters[formatterIndex]!;
+    const normalizedMediaType = allowedNormalizedMediaTypes[formatterIndex]!;
+    let controllingToken: AcceptToken | undefined;
 
-    for (let i = 0; i < allowedFormatters.length; i++) {
-      if (matchesMediaRange(token.mediaRange, allowedNormalizedMediaTypes[i]!)) {
-        matchedFormatter = allowedFormatters[i];
-        break;
+    for (const token of acceptTokens) {
+      if (!matchesMediaRange(token.mediaRange, normalizedMediaType)) {
+        continue;
+      }
+
+      if (
+        controllingToken === undefined
+        || token.specificity > controllingToken.specificity
+        || (
+          token.specificity === controllingToken.specificity
+          && token.order < controllingToken.order
+        )
+      ) {
+        controllingToken = token;
       }
     }
 
-    if (matchedFormatter) {
-      return matchedFormatter;
+    if (controllingToken && controllingToken.quality > 0) {
+      selected = selectPreferredCandidate(
+        selected,
+        { formatter, formatterIndex, token: controllingToken },
+        defaultFormatter,
+      );
     }
+  }
+
+  if (selected) {
+    return selected.formatter;
   }
 
   throw new NotAcceptableException(NO_ACCEPTABLE_REPRESENTATION_MESSAGE);

--- a/packages/http/src/dispatch/dispatch-error-representation.ts
+++ b/packages/http/src/dispatch/dispatch-error-representation.ts
@@ -6,6 +6,7 @@ import {
   NotAcceptableException,
   NotFoundException,
 } from '../exceptions.js';
+import { appendVaryHeader } from '../header-helpers.js';
 import type {
   DispatcherLogger,
   FrameworkResponse,
@@ -15,12 +16,12 @@ import type {
   HttpErrorRepresentationOptions,
   RequestContext,
 } from '../types.js';
+import { ContentNegotiationNotAcceptableException } from './dispatch-content-negotiation-error.js';
 import {
   canNegotiateHtml,
   readAcceptHeader,
   selectErrorRepresentation,
 } from './dispatch-error-negotiation.js';
-import { appendVaryHeader } from '../header-helpers.js';
 import { isRequestAborted } from './request-abort.js';
 
 const HTML_CONTENT_TYPE = 'text/html; charset=utf-8';
@@ -94,6 +95,10 @@ async function writeBody(
 }
 
 async function writeCanonicalJson(error: HttpException, requestContext: RequestContext): Promise<void> {
+  if (error instanceof ContentNegotiationNotAcceptableException) {
+    appendVaryHeader(requestContext.response, 'Accept');
+  }
+
   await writeBody(
     requestContext,
     error.status,
@@ -123,6 +128,10 @@ export async function writeErrorResponse(
   const provider = options.representation?.html;
 
   if (provider === undefined || !isHttpRepresentationEligible(error)) {
+    if (httpError instanceof ContentNegotiationNotAcceptableException) {
+      appendVaryHeader(requestContext.response, 'Accept');
+    }
+
     requestContext.response.setStatus(httpError.status);
     if (requestContext.request.method.toUpperCase() === 'HEAD') {
       requestContext.response.setHeader('Content-Type', JSON_CONTENT_TYPE);

--- a/packages/http/src/dispatch/dispatch-error-representation.ts
+++ b/packages/http/src/dispatch/dispatch-error-representation.ts
@@ -125,6 +125,12 @@ export async function writeErrorResponse(
   }
 
   const httpError = toHttpException(error);
+
+  if (httpError instanceof ContentNegotiationNotAcceptableException) {
+    await writeCanonicalJson(httpError, requestContext);
+    return;
+  }
+
   const provider = options.representation?.html;
 
   if (provider === undefined || !isHttpRepresentationEligible(error)) {
@@ -133,8 +139,8 @@ export async function writeErrorResponse(
     }
 
     requestContext.response.setStatus(httpError.status);
+    requestContext.response.setHeader('Content-Type', JSON_CONTENT_TYPE);
     if (requestContext.request.method.toUpperCase() === 'HEAD') {
-      requestContext.response.setHeader('Content-Type', JSON_CONTENT_TYPE);
       await requestContext.response.send(undefined);
       return;
     }

--- a/packages/http/src/dispatch/dispatch-response-policy.ts
+++ b/packages/http/src/dispatch/dispatch-response-policy.ts
@@ -1,3 +1,4 @@
+import { NotAcceptableException } from '../exceptions.js';
 import { appendVaryHeader } from '../header-helpers.js';
 import type {
   FrameworkRequest,
@@ -158,6 +159,16 @@ function applyImplicitHeadContentType(response: FrameworkResponse, value: unknow
   response.setHeader('Content-Type', typeof value === 'string' ? TEXT_CONTENT_TYPE : JSON_CONTENT_TYPE);
 }
 
+function appendNegotiationErrorVary(handler: HandlerDescriptor, response: FrameworkResponse): void {
+  for (const header of handler.route.headers ?? []) {
+    if (header.name.toLowerCase() === 'vary') {
+      response.setHeader(header.name, header.value);
+    }
+  }
+
+  appendVaryHeader(response, 'Accept');
+}
+
 /**
  * Write success response.
  *
@@ -213,9 +224,17 @@ export function writeSuccessResponse(
     });
   }
 
-  const formatter = contentNegotiation
-    ? selectResponseFormatter(handler, request, contentNegotiation)
-    : undefined;
+  let formatter: ResponseFormatter | undefined;
+  if (contentNegotiation) {
+    try {
+      formatter = selectResponseFormatter(handler, request, contentNegotiation);
+    } catch (error) {
+      if (error instanceof NotAcceptableException) {
+        appendNegotiationErrorVary(handler, response);
+      }
+      throw error;
+    }
+  }
 
   applySuccessResponseMetadata({ formatter, handler, response, value: responseValue });
 

--- a/packages/http/src/dispatch/dispatch-response-policy.ts
+++ b/packages/http/src/dispatch/dispatch-response-policy.ts
@@ -1,4 +1,3 @@
-import { NotAcceptableException } from '../exceptions.js';
 import { appendVaryHeader } from '../header-helpers.js';
 import type {
   FrameworkRequest,
@@ -159,16 +158,6 @@ function applyImplicitHeadContentType(response: FrameworkResponse, value: unknow
   response.setHeader('Content-Type', typeof value === 'string' ? TEXT_CONTENT_TYPE : JSON_CONTENT_TYPE);
 }
 
-function appendNegotiationErrorVary(handler: HandlerDescriptor, response: FrameworkResponse): void {
-  for (const header of handler.route.headers ?? []) {
-    if (header.name.toLowerCase() === 'vary') {
-      response.setHeader(header.name, header.value);
-    }
-  }
-
-  appendVaryHeader(response, 'Accept');
-}
-
 /**
  * Write success response.
  *
@@ -224,17 +213,9 @@ export function writeSuccessResponse(
     });
   }
 
-  let formatter: ResponseFormatter | undefined;
-  if (contentNegotiation) {
-    try {
-      formatter = selectResponseFormatter(handler, request, contentNegotiation);
-    } catch (error) {
-      if (error instanceof NotAcceptableException) {
-        appendNegotiationErrorVary(handler, response);
-      }
-      throw error;
-    }
-  }
+  const formatter = contentNegotiation
+    ? selectResponseFormatter(handler, request, contentNegotiation)
+    : undefined;
 
   applySuccessResponseMetadata({ formatter, handler, response, value: responseValue });
 

--- a/packages/http/src/dispatch/dispatch-response-policy.ts
+++ b/packages/http/src/dispatch/dispatch-response-policy.ts
@@ -217,25 +217,30 @@ export function writeSuccessResponse(
     ? selectResponseFormatter(handler, request, contentNegotiation)
     : undefined;
 
-  applySuccessResponseMetadata({ formatter, handler, response, value: responseValue });
-
-  if (formatter) {
-    appendVaryHeader(response, 'Accept');
-  }
-
   if (request.method.toUpperCase() === 'HEAD') {
+    applySuccessResponseMetadata({ formatter, handler, response, value: responseValue });
+    if (formatter) {
+      appendVaryHeader(response, 'Accept');
+    }
     applyImplicitHeadContentType(response, responseValue);
     return response.send(undefined);
   }
 
-  if (!formatter && hasSimpleJsonResponseWriter(response) && canUseSimpleJsonFastPath(response, responseValue)) {
+  if (formatter) {
+    const responseBody = formatter.format(responseValue);
+
+    applySuccessResponseMetadata({ formatter, handler, response, value: responseValue });
+    appendVaryHeader(response, 'Accept');
+    return response.send(responseBody);
+  }
+
+  applySuccessResponseMetadata({ formatter: undefined, handler, response, value: responseValue });
+
+  if (hasSimpleJsonResponseWriter(response) && canUseSimpleJsonFastPath(response, responseValue)) {
     return response.sendSimpleJson(responseValue);
   }
 
-  const responseBody = formatter
-    ? formatter.format(responseValue)
-    : responseValue;
-  return response.send(responseBody);
+  return response.send(responseValue);
 }
 
 export type { ResolvedContentNegotiation };

--- a/packages/http/src/dispatch/dispatch-response-policy.ts
+++ b/packages/http/src/dispatch/dispatch-response-policy.ts
@@ -1,3 +1,4 @@
+import { appendVaryHeader } from '../header-helpers.js';
 import type {
   FrameworkRequest,
   FrameworkResponse,
@@ -217,6 +218,10 @@ export function writeSuccessResponse(
     : undefined;
 
   applySuccessResponseMetadata({ formatter, handler, response, value: responseValue });
+
+  if (formatter) {
+    appendVaryHeader(response, 'Accept');
+  }
 
   if (request.method.toUpperCase() === 'HEAD') {
     applyImplicitHeadContentType(response, responseValue);

--- a/packages/http/src/dispatch/dispatch-success-content-negotiation.test.ts
+++ b/packages/http/src/dispatch/dispatch-success-content-negotiation.test.ts
@@ -17,10 +17,14 @@ import {
 
 type TestResponse = FrameworkResponse & { body?: unknown };
 
-function createRequest(path: string, accept?: string): FrameworkRequest {
+function createRequest(
+  path: string,
+  accept?: string,
+  headers?: FrameworkRequest['headers'],
+): FrameworkRequest {
   return {
     cookies: {},
-    headers: accept === undefined ? {} : { accept },
+    headers: headers ?? (accept === undefined ? {} : { accept }),
     method: 'GET',
     params: {},
     path,
@@ -160,7 +164,7 @@ function createNegotiatingDispatchers() {
   return { fallbackDispatcher, nativeDispatcher };
 }
 
-async function dispatchBoth(path: string, accept?: string) {
+async function dispatchBoth(path: string, accept?: string, headers?: FrameworkRequest['headers']) {
   const { fallbackDispatcher, nativeDispatcher } = createNegotiatingDispatchers();
   if (!nativeDispatcher.describeRoutes || !nativeDispatcher.dispatchNativeRoute) {
     throw new Error('Expected native route dispatch support.');
@@ -175,10 +179,10 @@ async function dispatchBoth(path: string, accept?: string) {
   const fallbackResponse = createResponse();
   const nativeHandled = await nativeDispatcher.dispatchNativeRoute(
     { descriptor, params: {} },
-    createRequest(path, accept),
+    createRequest(path, accept, headers),
     nativeResponse,
   );
-  await fallbackDispatcher.dispatch(createRequest(path, accept), fallbackResponse);
+  await fallbackDispatcher.dispatch(createRequest(path, accept, headers), fallbackResponse);
 
   expect(nativeHandled).toBe(true);
   expect({
@@ -244,6 +248,18 @@ describe('successful response content negotiation', () => {
       200,
       'application/json;profile=v2',
       'json-profile',
+    ],
+    [
+      'combines duplicate-case Accept field arrays before candidate selection',
+      '/representations/all',
+      undefined,
+      200,
+      'application/json;profile=v2',
+      'json-profile',
+      {
+        Accept: ['application/json;q=1', 'text/plain;q=0.1'],
+        ACCEPT: ['application/json;profile=v2;q=1'],
+      },
     ],
     [
       'rejects media parameters after q',
@@ -368,8 +384,8 @@ describe('successful response content negotiation', () => {
     ],
   ])(
     'keeps native and fallback dispatch identical for %s',
-    async (_name, path, accept, status, contentType, body) => {
-      const { nativeDispatcher, fallbackDispatcher, response } = await dispatchBoth(path, accept);
+    async (_name, path, accept, status, contentType, body, headers?: FrameworkRequest['headers']) => {
+      const { nativeDispatcher, fallbackDispatcher, response } = await dispatchBoth(path, accept, headers);
 
       expect(response.statusCode).toBe(status);
       expect(response.headers['Content-Type']).toBe(contentType);

--- a/packages/http/src/dispatch/dispatch-success-content-negotiation.test.ts
+++ b/packages/http/src/dispatch/dispatch-success-content-negotiation.test.ts
@@ -55,7 +55,7 @@ function createResponse(): TestResponse {
 
 @Controller('/representations')
 class RepresentationController {
-  @Produces('application/json', 'application/problem+json', 'text/plain')
+  @Produces('application/json', 'application/problem+json', 'text/plain', 'application/json;note="a,b=c\\"d\\\\e"')
   @Get('/all')
   all() {
     return { ok: true };
@@ -93,6 +93,12 @@ const formatters = [
       return 'plain';
     },
     mediaType: 'text/plain',
+  },
+  {
+    format() {
+      return 'json-note';
+    },
+    mediaType: 'application/json;note="a,b=c\\"d\\\\e"',
   },
 ];
 
@@ -184,6 +190,78 @@ describe('successful response content negotiation', () => {
       200,
       'text/plain',
       'plain',
+    ],
+    [
+      'valid quoted comma equals escaped quote and backslash',
+      '/representations/all',
+      'application/json;note="a,b=c\\"d\\\\e";q=1, text/plain;q=0',
+      200,
+      'application/json;note="a,b=c\\"d\\\\e"',
+      'json-note',
+    ],
+    [
+      'raw NUL in quoted parameter',
+      '/representations/all',
+      'application/json;note="a\0b";q=1, text/plain;q=0',
+      406,
+      undefined,
+      undefined,
+    ],
+    [
+      'escaped NUL in quoted parameter',
+      '/representations/all',
+      'application/json;note="a\\\0b";q=1, text/plain;q=0',
+      406,
+      undefined,
+      undefined,
+    ],
+    [
+      'raw carriage return in quoted parameter',
+      '/representations/all',
+      'application/json;note="a\rb";q=1, text/plain;q=0',
+      406,
+      undefined,
+      undefined,
+    ],
+    [
+      'escaped carriage return in quoted parameter',
+      '/representations/all',
+      'application/json;note="a\\\rb";q=1, text/plain;q=0',
+      406,
+      undefined,
+      undefined,
+    ],
+    [
+      'raw line feed in quoted parameter',
+      '/representations/all',
+      'application/json;note="a\nb";q=1, text/plain;q=0',
+      406,
+      undefined,
+      undefined,
+    ],
+    [
+      'escaped line feed in quoted parameter',
+      '/representations/all',
+      'application/json;note="a\\\nb";q=1, text/plain;q=0',
+      406,
+      undefined,
+      undefined,
+    ],
+    [
+      'media parameter without a matching representation',
+      '/representations/without-suffix',
+      'application/json;profile=v2',
+      406,
+      undefined,
+      undefined,
+    ],
+    [
+      'quoted parameter with an invalid escaped control octet',
+      '/representations/without-suffix',
+      'application/json;profile="a\\\u0001"',
+      406,
+      undefined,
+      undefined,
     ],
     [
       'unterminated quoted parameter after a valid entry',

--- a/packages/http/src/dispatch/dispatch-success-content-negotiation.test.ts
+++ b/packages/http/src/dispatch/dispatch-success-content-negotiation.test.ts
@@ -67,6 +67,18 @@ class RepresentationController {
     return { ok: true };
   }
 
+  @Produces('application/json;note="a,b=c\\"d\\\\e"')
+  @Get('/parameterized')
+  parameterized() {
+    return { ok: true };
+  }
+
+  @Produces('application/json;a="x;b=y"')
+  @Get('/structural-quoted')
+  structuralQuoted() {
+    return { ok: true };
+  }
+
   @Header('Vary', 'Accept-Encoding, accept')
   @Produces('application/json', 'text/plain')
   @Get('/existing-vary')
@@ -99,6 +111,18 @@ const formatters = [
       return 'json-note';
     },
     mediaType: 'application/json;note="a,b=c\\"d\\\\e"',
+  },
+  {
+    format() {
+      return 'json-a-x-b-y';
+    },
+    mediaType: 'application/json;a=x;b=y',
+  },
+  {
+    format() {
+      return 'json-a-x-semicolon-b-y';
+    },
+    mediaType: 'application/json;a="x;b=y"',
   },
 ];
 
@@ -198,6 +222,38 @@ describe('successful response content negotiation', () => {
       200,
       'application/json;note="a,b=c\\"d\\\\e"',
       'json-note',
+    ],
+    [
+      'rejects media parameters after q',
+      '/representations/all',
+      'application/json;q=1;note="a,b=c\\"d\\\\e", text/plain;q=0',
+      406,
+      undefined,
+      undefined,
+    ],
+    [
+      'parameterized q=0 overrides a preceding generic range',
+      '/representations/parameterized',
+      'application/json;q=1, application/json;note="a,b=c\\"d\\\\e";q=0',
+      406,
+      undefined,
+      undefined,
+    ],
+    [
+      'parameterized q=0 overrides a following generic range',
+      '/representations/parameterized',
+      'application/json;note="a,b=c\\"d\\\\e";q=0, application/json;q=1',
+      406,
+      undefined,
+      undefined,
+    ],
+    [
+      'keeps structurally distinct media parameter representations',
+      '/representations/structural-quoted',
+      'application/json;a="x;b=y"',
+      200,
+      'application/json;a="x;b=y"',
+      'json-a-x-semicolon-b-y',
     ],
     [
       'raw NUL in quoted parameter',

--- a/packages/http/src/dispatch/dispatch-success-content-negotiation.test.ts
+++ b/packages/http/src/dispatch/dispatch-success-content-negotiation.test.ts
@@ -13,10 +13,23 @@ import {
   type MiddlewareContext,
   type Next,
   Produces,
+  type RequestObserver,
   type ResponseFormatter,
 } from '../index.js';
 
 type TestResponse = FrameworkResponse & { body?: unknown };
+type TestErrorHandler = (
+  error: unknown,
+  request: FrameworkRequest,
+  response: FrameworkResponse,
+  requestId?: string,
+) => boolean | void | Promise<boolean | void>;
+
+type DispatcherControls = {
+  readonly nativeFallback?: boolean;
+  readonly observers?: RequestObserver[];
+  readonly onError?: TestErrorHandler;
+};
 
 function createRequest(
   path: string,
@@ -152,6 +165,7 @@ const formatters: ResponseFormatter[] = [
 function createNegotiatingDispatchers(
   configuredFormatters: ResponseFormatter[] = formatters,
   defaultMediaType = 'text/plain',
+  controls: DispatcherControls = {},
 ) {
   const root = new Container().register(RepresentationController);
   const handlerMapping = createHandlerMapping([{ controllerToken: RepresentationController }]);
@@ -161,6 +175,8 @@ function createNegotiatingDispatchers(
       formatters: configuredFormatters,
     },
     handlerMapping,
+    ...(controls.observers === undefined ? {} : { observers: controls.observers }),
+    onError: controls.onError,
     rootContainer: root,
   });
   const fallbackDispatcher = createDispatcher({
@@ -174,6 +190,8 @@ function createNegotiatingDispatchers(
       formatters: configuredFormatters,
     },
     handlerMapping,
+    ...(controls.observers === undefined ? {} : { observers: controls.observers }),
+    onError: controls.onError,
     rootContainer: root,
   });
 
@@ -186,8 +204,9 @@ async function dispatchBoth(
   headers?: FrameworkRequest['headers'],
   configuredFormatters?: ResponseFormatter[],
   defaultMediaType?: string,
+  controls?: DispatcherControls,
 ) {
-  const { fallbackDispatcher, nativeDispatcher } = createNegotiatingDispatchers(configuredFormatters, defaultMediaType);
+  const { fallbackDispatcher, nativeDispatcher } = createNegotiatingDispatchers(configuredFormatters, defaultMediaType, controls);
   if (!nativeDispatcher.describeRoutes || !nativeDispatcher.dispatchNativeRoute) {
     throw new Error('Expected native route dispatch support.');
   }
@@ -199,14 +218,18 @@ async function dispatchBoth(
 
   const nativeResponse = createResponse();
   const fallbackResponse = createResponse();
+  const nativeRequest = createRequest(path, accept, headers);
   const nativeHandled = await nativeDispatcher.dispatchNativeRoute(
     { descriptor, params: {} },
-    createRequest(path, accept, headers),
+    nativeRequest,
     nativeResponse,
   );
+  if (!nativeHandled && controls?.nativeFallback) {
+    await nativeDispatcher.dispatch(nativeRequest, nativeResponse);
+  }
   await fallbackDispatcher.dispatch(createRequest(path, accept, headers), fallbackResponse);
 
-  expect(nativeHandled).toBe(true);
+  expect(nativeHandled).toBe(!controls?.nativeFallback);
   expect({
     body: nativeResponse.body,
     committed: nativeResponse.committed,
@@ -228,6 +251,36 @@ describe('successful response content negotiation', () => {
     ['subtype wildcard', '/representations/all', 'text/*', 200, 'text/plain', 'plain'],
     ['structured suffix wildcard', '/representations/all', 'application/*+json', 200, 'application/problem+json', 'problem'],
     ['configured default without Accept', '/representations/all', undefined, 200, 'text/plain', 'plain'],
+    [
+      'treats an undefined scalar Accept field as missing',
+      '/representations/all',
+      undefined,
+      200,
+      'text/plain',
+      'plain',
+      { accept: undefined },
+    ],
+    [
+      'treats case-variant Accept arrays containing only undefined entries as missing',
+      '/representations/all',
+      undefined,
+      200,
+      'text/plain',
+      'plain',
+      {
+        Accept: [undefined] as unknown as string[],
+        ACCEPT: [undefined] as unknown as string[],
+      },
+    ],
+    [
+      'recovers a later valid Accept entry after undefined array entries',
+      '/representations/all',
+      undefined,
+      200,
+      'application/json;profile=v2',
+      'json-profile',
+      { Accept: [undefined, 'application/json;profile=v2;q=1'] as unknown as string[] },
+    ],
     [
       'rejects a blank scalar Accept field',
       '/representations/all',
@@ -562,6 +615,57 @@ describe('successful response content negotiation', () => {
     expect(response.body).toEqual({ ok: true });
   });
 
+  it('keeps route Vary metadata out of native and fallback observers and onError responses', async () => {
+    const observedVary: unknown[] = [];
+    const { response } = await dispatchBoth(
+      '/representations/existing-vary',
+      'image/avif',
+      undefined,
+      undefined,
+      undefined,
+      {
+        nativeFallback: true,
+        observers: [{
+          onRequestError(context) {
+            observedVary.push(context.requestContext.response.headers.Vary);
+          },
+        }],
+        onError(_error, _request, errorResponse) {
+          errorResponse.setHeader('Vary', 'Origin');
+          errorResponse.setStatus(406);
+          errorResponse.send({ handled: true });
+          return true;
+        },
+      },
+    );
+
+    expect(observedVary).toEqual([undefined, undefined]);
+    expect(response.statusCode).toBe(406);
+    expect(response.body).toEqual({ handled: true });
+    expect(response.headers.Vary).toBe('Origin');
+  });
+
+  it('keeps negotiation Vary out of fallback error observers before they commit a response', async () => {
+    let observedVary: unknown;
+    const { fallbackDispatcher } = createNegotiatingDispatchers(formatters, 'text/plain', {
+      observers: [{
+        onRequestError(context) {
+          observedVary = context.requestContext.response.headers.Vary;
+          context.requestContext.response.setStatus(406);
+          context.requestContext.response.send({ handled: true });
+        },
+      }],
+    });
+    const response = createResponse();
+
+    await fallbackDispatcher.dispatch(createRequest('/representations/existing-vary', 'image/avif'), response);
+
+    expect(observedVary).toBeUndefined();
+    expect(response.statusCode).toBe(406);
+    expect(response.body).toEqual({ handled: true });
+    expect(response.headers.Vary).toBeUndefined();
+  });
+
   it('deduplicates Accept while preserving existing Vary fields', async () => {
     const { response } = await dispatchBoth('/representations/existing-vary', 'application/json');
 
@@ -578,7 +682,7 @@ describe('successful response content negotiation', () => {
 
     expect(response.statusCode).toBe(406);
     expect(response.body).toMatchObject({ error: { code: 'NOT_ACCEPTABLE', status: 406 } });
-    expect(response.headers.Vary).toBe('Accept-Encoding, accept');
+    expect(response.headers.Vary).toBe('Accept');
     expect(
       String(response.headers.Vary)
         .split(',')

--- a/packages/http/src/dispatch/dispatch-success-content-negotiation.test.ts
+++ b/packages/http/src/dispatch/dispatch-success-content-negotiation.test.ts
@@ -10,6 +10,8 @@ import {
   Get,
   getDispatcherFastPathStats,
   Header,
+  type HtmlErrorRepresentationProvider,
+  HttpCode,
   type MiddlewareContext,
   type Next,
   Produces,
@@ -26,6 +28,7 @@ type TestErrorHandler = (
 ) => boolean | void | Promise<boolean | void>;
 
 type DispatcherControls = {
+  readonly errorRepresentation?: { html: HtmlErrorRepresentationProvider };
   readonly nativeFallback?: boolean;
   readonly observers?: RequestObserver[];
   readonly onError?: TestErrorHandler;
@@ -115,6 +118,15 @@ class RepresentationController {
   existingVary() {
     return { ok: true };
   }
+
+  @Header('X-Route-Success', 'should-not-leak')
+  @Header('Vary', 'Origin')
+  @HttpCode(202)
+  @Produces('application/json')
+  @Get('/formatter-throws')
+  formatterThrows() {
+    return { ok: true };
+  }
 }
 
 const formatters: ResponseFormatter[] = [
@@ -175,6 +187,7 @@ function createNegotiatingDispatchers(
       formatters: configuredFormatters,
     },
     handlerMapping,
+    ...(controls.errorRepresentation === undefined ? {} : { errorRepresentation: controls.errorRepresentation }),
     ...(controls.observers === undefined ? {} : { observers: controls.observers }),
     onError: controls.onError,
     rootContainer: root,
@@ -190,6 +203,7 @@ function createNegotiatingDispatchers(
       formatters: configuredFormatters,
     },
     handlerMapping,
+    ...(controls.errorRepresentation === undefined ? {} : { errorRepresentation: controls.errorRepresentation }),
     ...(controls.observers === undefined ? {} : { observers: controls.observers }),
     onError: controls.onError,
     rootContainer: root,
@@ -552,7 +566,9 @@ describe('successful response content negotiation', () => {
       const { nativeDispatcher, fallbackDispatcher, response } = await dispatchBoth(path, accept, headers);
 
       expect(response.statusCode).toBe(status);
-      expect(response.headers['Content-Type']).toBe(contentType);
+      expect(response.headers['Content-Type']).toBe(
+        status === 406 ? 'application/json; charset=utf-8' : contentType,
+      );
       expect(getDispatcherFastPathStats(nativeDispatcher)?.routes.every((route) => route.executionPath === 'fast')).toBe(true);
       expect(getDispatcherFastPathStats(fallbackDispatcher)?.routes.every((route) => route.executionPath === 'full')).toBe(true);
       if (status === 200) {
@@ -613,6 +629,144 @@ describe('successful response content negotiation', () => {
     expect(response.statusCode).toBe(200);
     expect(response.headers['Content-Type']).toBeUndefined();
     expect(response.body).toEqual({ ok: true });
+  });
+
+  it('writes a generic JSON 500 without leaking throwing formatter success metadata on native and fallback paths', async () => {
+    const formatterFailure = new Error('formatter failed');
+    const { fallbackDispatcher, nativeDispatcher, response } = await dispatchBoth(
+      '/representations/formatter-throws',
+      'application/json',
+      undefined,
+      [{
+        format() {
+          throw formatterFailure;
+        },
+        mediaType: 'application/json',
+      }],
+      undefined,
+      {
+        errorRepresentation: {
+          html: {
+            render() {
+              return '<main>unused</main>';
+            },
+          },
+        },
+      },
+    );
+
+    expect(response.statusCode).toBe(500);
+    expect(response.headers).toEqual({
+      'Content-Type': 'application/json; charset=utf-8',
+    });
+    expect(response.body).toMatchObject({ error: { code: 'INTERNAL_SERVER_ERROR', status: 500 } });
+    expect(getDispatcherFastPathStats(nativeDispatcher)?.routes.every((route) => route.executionPath === 'fast')).toBe(true);
+    expect(getDispatcherFastPathStats(fallbackDispatcher)?.routes.every((route) => route.executionPath === 'full')).toBe(true);
+  });
+
+  it('keeps formatter failures pristine for native and fallback observers and onError custom handling', async () => {
+    const observedResponses: Array<{ headers: FrameworkResponse['headers']; statusCode: number | undefined }> = [];
+    const onErrorResponses: Array<{ headers: FrameworkResponse['headers']; statusCode: number | undefined }> = [];
+    const { response } = await dispatchBoth(
+      '/representations/formatter-throws',
+      'application/json',
+      undefined,
+      [{
+        format() {
+          throw new Error('formatter failed');
+        },
+        mediaType: 'application/json',
+      }],
+      undefined,
+      {
+        nativeFallback: true,
+        observers: [{
+          onRequestError(context) {
+            observedResponses.push({
+              headers: { ...context.requestContext.response.headers },
+              statusCode: context.requestContext.response.statusCode,
+            });
+          },
+        }],
+        onError(_error, _request, errorResponse) {
+          onErrorResponses.push({
+            headers: { ...errorResponse.headers },
+            statusCode: errorResponse.statusCode,
+          });
+          errorResponse.setHeader('X-Error-Handled', 'true');
+          errorResponse.setStatus(418);
+          errorResponse.send({ handled: true });
+          return true;
+        },
+      },
+    );
+
+    expect(observedResponses).toEqual([{ headers: {}, statusCode: undefined }, { headers: {}, statusCode: undefined }]);
+    expect(onErrorResponses).toEqual([{ headers: {}, statusCode: undefined }, { headers: {}, statusCode: undefined }]);
+    expect(response.statusCode).toBe(418);
+    expect(response.headers).toEqual({ 'X-Error-Handled': 'true' });
+    expect(response.body).toEqual({ handled: true });
+  });
+
+  it('applies route success metadata after a formatter successfully completes', async () => {
+    const { fallbackDispatcher, nativeDispatcher, response } = await dispatchBoth(
+      '/representations/formatter-throws',
+      'application/json',
+      undefined,
+      [{
+        format() {
+          return 'formatted';
+        },
+        mediaType: 'application/json',
+      }],
+    );
+
+    expect(response.statusCode).toBe(202);
+    expect(response.headers).toEqual({
+      'Content-Type': 'application/json',
+      'X-Route-Success': 'should-not-leak',
+      Vary: 'Origin, Accept',
+    });
+    expect(response.body).toBe('formatted');
+    expect(getDispatcherFastPathStats(nativeDispatcher)?.routes.every((route) => route.executionPath === 'fast')).toBe(true);
+    expect(getDispatcherFastPathStats(fallbackDispatcher)?.routes.every((route) => route.executionPath === 'full')).toBe(true);
+  });
+
+  it.each([
+    'text/html',
+    'image/avif, text/html;q=0.5',
+    'image/avif',
+  ])('bypasses HTML error representations for negotiation 406 Accept=%s', async (accept) => {
+    let canRenderCalls = 0;
+    let renderCalls = 0;
+    const { response } = await dispatchBoth(
+      '/representations/all',
+      accept,
+      undefined,
+      undefined,
+      undefined,
+      {
+        errorRepresentation: {
+          html: {
+            canRender() {
+              canRenderCalls++;
+              return true;
+            },
+            render() {
+              renderCalls++;
+              return '<main>unused</main>';
+            },
+          },
+        },
+      },
+    );
+
+    expect(response.statusCode).toBe(406);
+    expect(response.headers['Content-Type']).toBe('application/json; charset=utf-8');
+    expect(response.headers.Vary).toBe('Accept');
+    expect(response.body).toMatchObject({ error: { code: 'NOT_ACCEPTABLE', status: 406 } });
+    expect(canRenderCalls).toBe(0);
+    expect(renderCalls).toBe(0);
   });
 
   it('keeps route Vary metadata out of native and fallback observers and onError responses', async () => {

--- a/packages/http/src/dispatch/dispatch-success-content-negotiation.test.ts
+++ b/packages/http/src/dispatch/dispatch-success-content-negotiation.test.ts
@@ -84,6 +84,18 @@ class RepresentationController {
     return { ok: true };
   }
 
+  @Produces('application/*', 'application/json')
+  @Get('/mixed-invalid-produces')
+  mixedInvalidProduces() {
+    return { ok: true };
+  }
+
+  @Produces('application/*', '*/*', 'application/json;profile=v2;PROFILE=v3')
+  @Get('/invalid-produces')
+  invalidProduces() {
+    return { ok: true };
+  }
+
   @Header('Vary', 'Accept-Encoding, accept')
   @Produces('application/json', 'text/plain')
   @Get('/existing-vary')
@@ -137,12 +149,15 @@ const formatters: ResponseFormatter[] = [
   },
 ];
 
-function createNegotiatingDispatchers(configuredFormatters: ResponseFormatter[] = formatters) {
+function createNegotiatingDispatchers(
+  configuredFormatters: ResponseFormatter[] = formatters,
+  defaultMediaType = 'text/plain',
+) {
   const root = new Container().register(RepresentationController);
   const handlerMapping = createHandlerMapping([{ controllerToken: RepresentationController }]);
   const nativeDispatcher = createDispatcher({
     contentNegotiation: {
-      defaultMediaType: 'text/plain',
+      defaultMediaType,
       formatters: configuredFormatters,
     },
     handlerMapping,
@@ -155,7 +170,7 @@ function createNegotiatingDispatchers(configuredFormatters: ResponseFormatter[] 
       },
     }],
     contentNegotiation: {
-      defaultMediaType: 'text/plain',
+      defaultMediaType,
       formatters: configuredFormatters,
     },
     handlerMapping,
@@ -170,8 +185,9 @@ async function dispatchBoth(
   accept?: string,
   headers?: FrameworkRequest['headers'],
   configuredFormatters?: ResponseFormatter[],
+  defaultMediaType?: string,
 ) {
-  const { fallbackDispatcher, nativeDispatcher } = createNegotiatingDispatchers(configuredFormatters);
+  const { fallbackDispatcher, nativeDispatcher } = createNegotiatingDispatchers(configuredFormatters, defaultMediaType);
   if (!nativeDispatcher.describeRoutes || !nativeDispatcher.dispatchNativeRoute) {
     throw new Error('Expected native route dispatch support.');
   }
@@ -266,6 +282,62 @@ describe('successful response content negotiation', () => {
         Accept: ['application/json;q=1', 'text/plain;q=0.1'],
         ACCEPT: ['application/json;profile=v2;q=1'],
       },
+    ],
+    [
+      'parses a later Accept field after a malformed earlier field',
+      '/representations/all',
+      undefined,
+      200,
+      'application/json;profile=v2',
+      'json-profile',
+      {
+        Accept: ['application/json;note="unterminated'],
+        ACCEPT: ['application/json;profile=v2;q=1'],
+      },
+    ],
+    [
+      'preserves an earlier valid Accept field before a malformed later field',
+      '/representations/all',
+      undefined,
+      200,
+      'application/json;profile=v2',
+      'json-profile',
+      {
+        Accept: ['application/json;profile=v2;q=1'],
+        ACCEPT: ['application/json;note="unterminated'],
+      },
+    ],
+    [
+      'ignores a duplicated parameter q=0 after a valid Accept token',
+      '/representations/all',
+      'application/json;profile=v2;q=1, application/json;profile=v2;PROFILE=v2;q=0',
+      200,
+      'application/json;profile=v2',
+      'json-profile',
+    ],
+    [
+      'ignores a duplicated parameter q=0 before a valid Accept token',
+      '/representations/all',
+      'application/json;profile=v2;PROFILE=v2;q=0, application/json;profile=v2;q=1',
+      200,
+      'application/json;profile=v2',
+      'json-profile',
+    ],
+    [
+      'retains a valid @Produces representation beside invalid concrete types',
+      '/representations/mixed-invalid-produces',
+      'application/json',
+      200,
+      'application/json',
+      'json',
+    ],
+    [
+      'returns 406 when non-empty @Produces values are all invalid concrete types',
+      '/representations/invalid-produces',
+      'application/json',
+      406,
+      undefined,
+      undefined,
     ],
     [
       'rejects media parameters after q',
@@ -410,13 +482,35 @@ describe('successful response content negotiation', () => {
     ['drops a malformed formatter before a valid formatter', [
       { format: () => 'invalid', mediaType: 'application/json;broken' },
       { format: () => 'valid', mediaType: 'application/json' },
-    ]],
+    ], 'application/json', 'application/json', 'valid'],
     ['keeps a valid formatter before a malformed formatter', [
       { format: () => 'valid', mediaType: 'application/json' },
       { format: () => 'invalid', mediaType: 'application/json;broken' },
-    ]],
-  ])('%s', async (_name, configuredFormatters) => {
-    const { response } = await dispatchBoth('/representations/all', 'application/json', undefined, configuredFormatters);
+    ], 'application/json', 'application/json', 'valid'],
+    ['drops wildcard and duplicate concrete formatters before a valid formatter', [
+      { format: () => 'invalid-wildcard', mediaType: 'application/*' },
+      { format: () => 'invalid-duplicate', mediaType: 'application/json;profile=v2;PROFILE=v3' },
+      { format: () => 'valid-profile', mediaType: 'application/json;profile=v2' },
+    ], 'application/json;profile=v2', 'application/json;profile=v2', 'valid-profile'],
+    ['keeps a valid formatter before wildcard and duplicate concrete formatters', [
+      { format: () => 'valid-profile', mediaType: 'application/json;profile=v2' },
+      { format: () => 'invalid-wildcard', mediaType: 'application/*' },
+      { format: () => 'invalid-duplicate', mediaType: 'application/json;profile=v2;PROFILE=v3' },
+    ], 'application/json;profile=v2', 'application/json;profile=v2', 'valid-profile'],
+  ])('%s', async (_name, configuredFormatters, accept, contentType, body) => {
+    const { response } = await dispatchBoth('/representations/all', accept, undefined, configuredFormatters);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['Content-Type']).toBe(contentType);
+    expect(response.body).toBe(body);
+  });
+
+  it('falls back to the first unique valid formatter when defaultMediaType is invalid', async () => {
+    const { response } = await dispatchBoth('/representations/all', undefined, undefined, [
+      { format: () => 'invalid-wildcard', mediaType: 'application/*' },
+      { format: () => 'valid', mediaType: 'application/json' },
+      { format: () => 'plain', mediaType: 'text/plain' },
+    ], 'application/*');
 
     expect(response.statusCode).toBe(200);
     expect(response.headers['Content-Type']).toBe('application/json');
@@ -425,7 +519,8 @@ describe('successful response content negotiation', () => {
 
   it('disables negotiation when no formatter media type is valid', async () => {
     const { response } = await dispatchBoth('/representations/all', 'application/json', undefined, [
-      { format: () => 'invalid', mediaType: 'application/json;broken' },
+      { format: () => 'invalid-wildcard', mediaType: 'application/*' },
+      { format: () => 'invalid-duplicate', mediaType: 'application/json;profile=v2;PROFILE=v3' },
     ]);
 
     expect(response.statusCode).toBe(200);

--- a/packages/http/src/dispatch/dispatch-success-content-negotiation.test.ts
+++ b/packages/http/src/dispatch/dispatch-success-content-negotiation.test.ts
@@ -169,6 +169,14 @@ describe('successful response content negotiation', () => {
     ['configured default for */*', '/representations/all', '*/*', 200, 'text/plain', 'plain'],
     ['valid entry after malformed range', '/representations/all', 'not-a-range, application/json', 200, 'application/json', 'json'],
     ['malformed quality', '/representations/all', 'application/json;q=2', 406, undefined, undefined],
+    [
+      'malformed quality alongside a valid entry',
+      '/representations/all',
+      'application/json;q=0.9=invalid, text/plain;q=0.2',
+      200,
+      'text/plain',
+      'plain',
+    ],
     ['unsupported range', '/representations/all', 'image/avif', 406, undefined, undefined],
     [
       'exact q=0 overrides a positive wildcard',

--- a/packages/http/src/dispatch/dispatch-success-content-negotiation.test.ts
+++ b/packages/http/src/dispatch/dispatch-success-content-negotiation.test.ts
@@ -228,6 +228,39 @@ describe('successful response content negotiation', () => {
     ['subtype wildcard', '/representations/all', 'text/*', 200, 'text/plain', 'plain'],
     ['structured suffix wildcard', '/representations/all', 'application/*+json', 200, 'application/problem+json', 'problem'],
     ['configured default without Accept', '/representations/all', undefined, 200, 'text/plain', 'plain'],
+    [
+      'rejects a blank scalar Accept field',
+      '/representations/all',
+      undefined,
+      406,
+      undefined,
+      undefined,
+      { Accept: '   ' },
+    ],
+    [
+      'rejects duplicate Accept fields whose blank arrays and malformed values contain no valid token',
+      '/representations/all',
+      undefined,
+      406,
+      undefined,
+      undefined,
+      {
+        Accept: ['', ' \t ', 'application/json;note="unterminated'],
+        ACCEPT: ['\t', 'not-a-range'],
+      },
+    ],
+    [
+      'recovers a valid later Accept field after blank array entries',
+      '/representations/all',
+      undefined,
+      200,
+      'application/json;profile=v2',
+      'json-profile',
+      {
+        Accept: ['', '  '],
+        ACCEPT: ['application/json;profile=v2;q=1'],
+      },
+    ],
     ['configured default for */*', '/representations/all', '*/*', 200, 'text/plain', 'plain'],
     ['valid entry after malformed range', '/representations/all', 'not-a-range, application/json', 200, 'application/json', 'json'],
     ['malformed quality', '/representations/all', 'application/json;q=2', 406, undefined, undefined],
@@ -474,6 +507,7 @@ describe('successful response content negotiation', () => {
         expect(response.headers.Vary).toBe('Accept');
       } else {
         expect(response.body).toMatchObject({ error: { code: 'NOT_ACCEPTABLE', status: 406 } });
+        expect(response.headers.Vary).toBe('Accept');
       }
     },
   );
@@ -531,6 +565,19 @@ describe('successful response content negotiation', () => {
   it('deduplicates Accept while preserving existing Vary fields', async () => {
     const { response } = await dispatchBoth('/representations/existing-vary', 'application/json');
 
+    expect(response.headers.Vary).toBe('Accept-Encoding, accept');
+    expect(
+      String(response.headers.Vary)
+        .split(',')
+        .filter((field) => field.trim().toLowerCase() === 'accept'),
+    ).toHaveLength(1);
+  });
+
+  it('adds deduplicated Accept to existing Vary fields for negotiation 406 responses', async () => {
+    const { response } = await dispatchBoth('/representations/existing-vary', 'image/avif');
+
+    expect(response.statusCode).toBe(406);
+    expect(response.body).toMatchObject({ error: { code: 'NOT_ACCEPTABLE', status: 406 } });
     expect(response.headers.Vary).toBe('Accept-Encoding, accept');
     expect(
       String(response.headers.Vary)

--- a/packages/http/src/dispatch/dispatch-success-content-negotiation.test.ts
+++ b/packages/http/src/dispatch/dispatch-success-content-negotiation.test.ts
@@ -186,6 +186,14 @@ describe('successful response content negotiation', () => {
       'plain',
     ],
     [
+      'unterminated quoted parameter after a valid entry',
+      '/representations/all',
+      'application/json, text/plain;note="unterminated',
+      200,
+      'application/json',
+      'json',
+    ],
+    [
       'malformed whitespace before quality assignment',
       '/representations/all',
       'application/json;q =0, text/plain;q=0',

--- a/packages/http/src/dispatch/dispatch-success-content-negotiation.test.ts
+++ b/packages/http/src/dispatch/dispatch-success-content-negotiation.test.ts
@@ -177,6 +177,22 @@ describe('successful response content negotiation', () => {
       'text/plain',
       'plain',
     ],
+    [
+      'quoted media parameter',
+      '/representations/all',
+      'application/json;profile="a,b";q=0.1, text/plain;q=0.9',
+      200,
+      'text/plain',
+      'plain',
+    ],
+    [
+      'malformed whitespace before quality assignment',
+      '/representations/all',
+      'application/json;q =0, text/plain;q=0',
+      406,
+      undefined,
+      undefined,
+    ],
     ['unsupported range', '/representations/all', 'image/avif', 406, undefined, undefined],
     [
       'exact q=0 overrides a positive wildcard',

--- a/packages/http/src/dispatch/dispatch-success-content-negotiation.test.ts
+++ b/packages/http/src/dispatch/dispatch-success-content-negotiation.test.ts
@@ -55,7 +55,7 @@ function createResponse(): TestResponse {
 
 @Controller('/representations')
 class RepresentationController {
-  @Produces('application/json', 'application/problem+json', 'text/plain', 'application/json;note="a,b=c\\"d\\\\e"')
+  @Produces('application/json', 'application/problem+json', 'text/plain', 'application/json;note="a,b=c\\"d\\\\e"', 'application/json;profile=v2')
   @Get('/all')
   all() {
     return { ok: true };
@@ -111,6 +111,12 @@ const formatters = [
       return 'json-note';
     },
     mediaType: 'application/json;note="a,b=c\\"d\\\\e"',
+  },
+  {
+    format() {
+      return 'json-profile';
+    },
+    mediaType: 'application/json;profile=v2',
   },
   {
     format() {
@@ -222,6 +228,22 @@ describe('successful response content negotiation', () => {
       200,
       'application/json;note="a,b=c\\"d\\\\e"',
       'json-note',
+    ],
+    [
+      'parameterized representation wins after a generic range',
+      '/representations/all',
+      'application/json;q=1, application/json;profile=v2;q=1',
+      200,
+      'application/json;profile=v2',
+      'json-profile',
+    ],
+    [
+      'parameterized representation wins before a generic range',
+      '/representations/all',
+      'application/json;profile=v2;q=1, application/json;q=1',
+      200,
+      'application/json;profile=v2',
+      'json-profile',
     ],
     [
       'rejects media parameters after q',

--- a/packages/http/src/dispatch/dispatch-success-content-negotiation.test.ts
+++ b/packages/http/src/dispatch/dispatch-success-content-negotiation.test.ts
@@ -1,0 +1,209 @@
+import { Container } from '@fluojs/di';
+import { describe, expect, it } from 'vitest';
+
+import {
+  Controller,
+  createDispatcher,
+  createHandlerMapping,
+  type FrameworkRequest,
+  type FrameworkResponse,
+  Get,
+  getDispatcherFastPathStats,
+  Header,
+  type MiddlewareContext,
+  type Next,
+  Produces,
+} from '../index.js';
+
+type TestResponse = FrameworkResponse & { body?: unknown };
+
+function createRequest(path: string, accept?: string): FrameworkRequest {
+  return {
+    cookies: {},
+    headers: accept === undefined ? {} : { accept },
+    method: 'GET',
+    params: {},
+    path,
+    query: {},
+    raw: {},
+    url: path,
+  };
+}
+
+function createResponse(): TestResponse {
+  return {
+    committed: false,
+    headers: {},
+    redirect(status, location) {
+      this.setStatus(status);
+      this.setHeader('Location', location);
+      this.committed = true;
+    },
+    send(body) {
+      this.body = body;
+      this.committed = true;
+    },
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    setStatus(code) {
+      this.statusCode = code;
+      this.statusSet = true;
+    },
+  };
+}
+
+@Controller('/representations')
+class RepresentationController {
+  @Produces('application/json', 'application/problem+json', 'text/plain')
+  @Get('/all')
+  all() {
+    return { ok: true };
+  }
+
+  @Produces('application/json', 'text/plain')
+  @Get('/without-suffix')
+  withoutSuffix() {
+    return { ok: true };
+  }
+
+  @Header('Vary', 'Accept-Encoding, accept')
+  @Produces('application/json', 'text/plain')
+  @Get('/existing-vary')
+  existingVary() {
+    return { ok: true };
+  }
+}
+
+const formatters = [
+  {
+    format() {
+      return 'json';
+    },
+    mediaType: 'application/json',
+  },
+  {
+    format() {
+      return 'problem';
+    },
+    mediaType: 'application/problem+json',
+  },
+  {
+    format() {
+      return 'plain';
+    },
+    mediaType: 'text/plain',
+  },
+];
+
+function createNegotiatingDispatchers() {
+  const root = new Container().register(RepresentationController);
+  const handlerMapping = createHandlerMapping([{ controllerToken: RepresentationController }]);
+  const nativeDispatcher = createDispatcher({
+    contentNegotiation: {
+      defaultMediaType: 'text/plain',
+      formatters,
+    },
+    handlerMapping,
+    rootContainer: root,
+  });
+  const fallbackDispatcher = createDispatcher({
+    appMiddleware: [{
+      async handle(_context: MiddlewareContext, next: Next) {
+        await next();
+      },
+    }],
+    contentNegotiation: {
+      defaultMediaType: 'text/plain',
+      formatters,
+    },
+    handlerMapping,
+    rootContainer: root,
+  });
+
+  return { fallbackDispatcher, nativeDispatcher };
+}
+
+async function dispatchBoth(path: string, accept?: string) {
+  const { fallbackDispatcher, nativeDispatcher } = createNegotiatingDispatchers();
+  if (!nativeDispatcher.describeRoutes || !nativeDispatcher.dispatchNativeRoute) {
+    throw new Error('Expected native route dispatch support.');
+  }
+
+  const descriptor = nativeDispatcher.describeRoutes().find((candidate) => candidate.route.path === path);
+  if (!descriptor) {
+    throw new Error(`Missing native descriptor for ${path}.`);
+  }
+
+  const nativeResponse = createResponse();
+  const fallbackResponse = createResponse();
+  const nativeHandled = await nativeDispatcher.dispatchNativeRoute(
+    { descriptor, params: {} },
+    createRequest(path, accept),
+    nativeResponse,
+  );
+  await fallbackDispatcher.dispatch(createRequest(path, accept), fallbackResponse);
+
+  expect(nativeHandled).toBe(true);
+  expect({
+    body: nativeResponse.body,
+    committed: nativeResponse.committed,
+    headers: nativeResponse.headers,
+    statusCode: nativeResponse.statusCode,
+  }).toEqual({
+    body: fallbackResponse.body,
+    committed: fallbackResponse.committed,
+    headers: fallbackResponse.headers,
+    statusCode: fallbackResponse.statusCode,
+  });
+  return { fallbackDispatcher, nativeDispatcher, response: nativeResponse };
+}
+
+describe('successful response content negotiation', () => {
+  it.each([
+    ['quality', '/representations/all', 'application/json;q=0.4, text/plain;q=0.9', 200, 'text/plain', 'plain'],
+    ['exact range', '/representations/all', 'application/problem+json', 200, 'application/problem+json', 'problem'],
+    ['subtype wildcard', '/representations/all', 'text/*', 200, 'text/plain', 'plain'],
+    ['structured suffix wildcard', '/representations/all', 'application/*+json', 200, 'application/problem+json', 'problem'],
+    ['configured default without Accept', '/representations/all', undefined, 200, 'text/plain', 'plain'],
+    ['configured default for */*', '/representations/all', '*/*', 200, 'text/plain', 'plain'],
+    ['valid entry after malformed range', '/representations/all', 'not-a-range, application/json', 200, 'application/json', 'json'],
+    ['malformed quality', '/representations/all', 'application/json;q=2', 406, undefined, undefined],
+    ['unsupported range', '/representations/all', 'image/avif', 406, undefined, undefined],
+    [
+      'exact q=0 overrides a positive wildcard',
+      '/representations/without-suffix',
+      'application/*;q=1, application/json;q=0, text/plain;q=0',
+      406,
+      undefined,
+      undefined,
+    ],
+  ])(
+    'keeps native and fallback dispatch identical for %s',
+    async (_name, path, accept, status, contentType, body) => {
+      const { nativeDispatcher, fallbackDispatcher, response } = await dispatchBoth(path, accept);
+
+      expect(response.statusCode).toBe(status);
+      expect(response.headers['Content-Type']).toBe(contentType);
+      expect(getDispatcherFastPathStats(nativeDispatcher)?.routes.every((route) => route.executionPath === 'fast')).toBe(true);
+      expect(getDispatcherFastPathStats(fallbackDispatcher)?.routes.every((route) => route.executionPath === 'full')).toBe(true);
+      if (status === 200) {
+        expect(response.body).toBe(body);
+        expect(response.headers.Vary).toBe('Accept');
+      } else {
+        expect(response.body).toMatchObject({ error: { code: 'NOT_ACCEPTABLE', status: 406 } });
+      }
+    },
+  );
+
+  it('deduplicates Accept while preserving existing Vary fields', async () => {
+    const { response } = await dispatchBoth('/representations/existing-vary', 'application/json');
+
+    expect(response.headers.Vary).toBe('Accept-Encoding, accept');
+    expect(
+      String(response.headers.Vary)
+        .split(',')
+        .filter((field) => field.trim().toLowerCase() === 'accept'),
+    ).toHaveLength(1);
+  });
+});

--- a/packages/http/src/dispatch/dispatch-success-content-negotiation.test.ts
+++ b/packages/http/src/dispatch/dispatch-success-content-negotiation.test.ts
@@ -13,6 +13,7 @@ import {
   type MiddlewareContext,
   type Next,
   Produces,
+  type ResponseFormatter,
 } from '../index.js';
 
 type TestResponse = FrameworkResponse & { body?: unknown };
@@ -91,7 +92,7 @@ class RepresentationController {
   }
 }
 
-const formatters = [
+const formatters: ResponseFormatter[] = [
   {
     format() {
       return 'json';
@@ -136,13 +137,13 @@ const formatters = [
   },
 ];
 
-function createNegotiatingDispatchers() {
+function createNegotiatingDispatchers(configuredFormatters: ResponseFormatter[] = formatters) {
   const root = new Container().register(RepresentationController);
   const handlerMapping = createHandlerMapping([{ controllerToken: RepresentationController }]);
   const nativeDispatcher = createDispatcher({
     contentNegotiation: {
       defaultMediaType: 'text/plain',
-      formatters,
+      formatters: configuredFormatters,
     },
     handlerMapping,
     rootContainer: root,
@@ -155,7 +156,7 @@ function createNegotiatingDispatchers() {
     }],
     contentNegotiation: {
       defaultMediaType: 'text/plain',
-      formatters,
+      formatters: configuredFormatters,
     },
     handlerMapping,
     rootContainer: root,
@@ -164,8 +165,13 @@ function createNegotiatingDispatchers() {
   return { fallbackDispatcher, nativeDispatcher };
 }
 
-async function dispatchBoth(path: string, accept?: string, headers?: FrameworkRequest['headers']) {
-  const { fallbackDispatcher, nativeDispatcher } = createNegotiatingDispatchers();
+async function dispatchBoth(
+  path: string,
+  accept?: string,
+  headers?: FrameworkRequest['headers'],
+  configuredFormatters?: ResponseFormatter[],
+) {
+  const { fallbackDispatcher, nativeDispatcher } = createNegotiatingDispatchers(configuredFormatters);
   if (!nativeDispatcher.describeRoutes || !nativeDispatcher.dispatchNativeRoute) {
     throw new Error('Expected native route dispatch support.');
   }
@@ -399,6 +405,33 @@ describe('successful response content negotiation', () => {
       }
     },
   );
+
+  it.each([
+    ['drops a malformed formatter before a valid formatter', [
+      { format: () => 'invalid', mediaType: 'application/json;broken' },
+      { format: () => 'valid', mediaType: 'application/json' },
+    ]],
+    ['keeps a valid formatter before a malformed formatter', [
+      { format: () => 'valid', mediaType: 'application/json' },
+      { format: () => 'invalid', mediaType: 'application/json;broken' },
+    ]],
+  ])('%s', async (_name, configuredFormatters) => {
+    const { response } = await dispatchBoth('/representations/all', 'application/json', undefined, configuredFormatters);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['Content-Type']).toBe('application/json');
+    expect(response.body).toBe('valid');
+  });
+
+  it('disables negotiation when no formatter media type is valid', async () => {
+    const { response } = await dispatchBoth('/representations/all', 'application/json', undefined, [
+      { format: () => 'invalid', mediaType: 'application/json;broken' },
+    ]);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['Content-Type']).toBeUndefined();
+    expect(response.body).toEqual({ ok: true });
+  });
 
   it('deduplicates Accept while preserving existing Vary fields', async () => {
     const { response } = await dispatchBoth('/representations/existing-vary', 'application/json');

--- a/packages/http/src/dispatch/dispatcher.test.ts
+++ b/packages/http/src/dispatch/dispatcher.test.ts
@@ -32,6 +32,7 @@ import {
   Head,
   Header,
   HttpCode,
+  NotAcceptableException,
   Options,
   Post,
   Produces,
@@ -1671,7 +1672,7 @@ describe('dispatcher runtime', () => {
     });
   });
 
-  it('does not leak @Header values onto 406 negotiation error responses', async () => {
+  it('does not leak non-Vary @Header values and adds Vary for 406 negotiation error responses', async () => {
     @Controller('/negotiation')
     class NegotiationController {
       @Header('X-Secret', 'sensitive')
@@ -1703,6 +1704,39 @@ describe('dispatcher runtime', () => {
 
     expect(response.statusCode).toBe(406);
     expect((response.headers as Record<string, unknown>)['X-Secret']).toBeUndefined();
+    expect(response.headers.Vary).toBe('Accept');
+  });
+
+  it('does not append Vary for application-generated 406 responses', async () => {
+    @Controller('/application-error')
+    class ApplicationErrorController {
+      @Get('/')
+      getValue() {
+        throw new NotAcceptableException('Application rejected the request.');
+      }
+    }
+
+    const root = new Container().register(ApplicationErrorController);
+    const dispatcher = createDispatcher({
+      contentNegotiation: {
+        formatters: [
+          {
+            format(body) {
+              return JSON.stringify(body);
+            },
+            mediaType: 'application/json',
+          },
+        ],
+      },
+      handlerMapping: createHandlerMapping([{ controllerToken: ApplicationErrorController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(createRequest('/application-error', 'GET', { accept: 'application/json' }), response);
+
+    expect(response.statusCode).toBe(406);
+    expect(response.headers.Vary).toBeUndefined();
   });
 
   it('falls back to default formatter for wildcard Accept header', async () => {

--- a/packages/http/src/dispatch/fast-path/eligibility-checker.ts
+++ b/packages/http/src/dispatch/fast-path/eligibility-checker.ts
@@ -7,7 +7,7 @@ import type {
   MiddlewareLike,
 } from '../../types.js';
 import type { CreateDispatcherOptions } from '../dispatcher.js';
-import { type FastPathEligibility, FAST_PATH_ELIGIBILITY_SYMBOL } from './eligibility.js';
+import { FAST_PATH_ELIGIBILITY_SYMBOL, type FastPathEligibility } from './eligibility.js';
 
 interface RequestScopeInspector {
   hasRequestScopedDependency(token: unknown): boolean;
@@ -94,7 +94,6 @@ export function compileFastPathEligibility(
   const hasPipe = handler.route.request !== undefined;
   const hasRequestScopedDI = determineRequestScopeRequirement(handler, options);
   const hasMiddleware = determineMiddlewareRequirement(handler, options.appMiddleware ?? []);
-  const hasContentNegotiation = options.contentNegotiation?.formatters !== undefined && options.contentNegotiation.formatters.length > 0;
   const isSseRoute = handler.route.produces?.some((mediaType) => mediaType.toLowerCase().startsWith('text/event-stream')) === true;
 
   const eligibilityBase = {
@@ -133,9 +132,6 @@ export function compileFastPathEligibility(
   }
   if (eligibilityBase.hasCustomBodyParser) {
     blockingReasons.push('custom binder');
-  }
-  if (hasContentNegotiation) {
-    blockingReasons.push('content negotiation');
   }
   if (isSseRoute) {
     blockingReasons.push('SSE streaming');

--- a/packages/runtime/README.ko.md
+++ b/packages/runtime/README.ko.md
@@ -156,13 +156,17 @@ const app = await fluoFactory.create(AppModule, {
 });
 ```
 
-`Accept` header가 없거나 `*/*`이면 `defaultMediaType`(또는 첫 번째 configured formatter)을
-선택합니다. Header가 있으면 exact range, `application/*+json` 같은 structured-suffix range,
-`type/*`, `*/*` 순으로 우선합니다. Controlling range가 quality를 제공하므로 exact `q=0`
-exclusion을 더 넓은 positive wildcard가 우회하지 못합니다. Malformed entry는 무시하며 valid하고
-acceptable한 formatter가 남지 않으면 HTTP가 `406`을 반환합니다. 성공한 framework-managed
-negotiated response는 `Vary`에 case-insensitive하게 deduplicate된 `Accept` field 하나를 추가합니다.
-Native fast-route handoff와 fallback dispatch는 같은 selection policy를 사용합니다.
+`Accept` header가 없거나 `*/*`이면 `defaultMediaType`(또는 첫 번째 unique valid configured
+formatter)을 선택합니다. Formatter, `defaultMediaType`, `@Produces(...)`는 concrete representation
+media type만 받습니다. Wildcard type/subtype과 case-insensitive duplicate parameter name은 무시됩니다.
+Mixed list는 valid entry를 유지하고 invalid-only formatter set은 negotiation을 비활성화하며, non-empty
+`@Produces(...)` metadata에 valid configured representation이 없으면 `406`을 반환합니다. Header가 있으면
+exact range, `application/*+json` 같은 structured-suffix range, `type/*`, `*/*` 순으로 우선합니다.
+Controlling range가 quality를 제공하므로 exact `q=0` exclusion을 더 넓은 positive wildcard가 우회하지
+못합니다. Malformed Accept entry와 invalid concrete representation media type은 무시하며 valid하고
+acceptable한 formatter가 남지 않으면 HTTP가 `406`을 반환합니다. 성공한 framework-managed negotiated
+response는 `Vary`에 case-insensitive하게 deduplicate된 `Accept` field 하나를 추가합니다. Native fast-route
+handoff와 fallback dispatch는 같은 selection policy를 사용합니다.
 
 ### Optional HTML Error Representations
 

--- a/packages/runtime/README.ko.md
+++ b/packages/runtime/README.ko.md
@@ -157,16 +157,17 @@ const app = await fluoFactory.create(AppModule, {
 ```
 
 `Accept` header가 없거나 `*/*`이면 `defaultMediaType`(또는 첫 번째 unique valid configured
-formatter)을 선택합니다. Formatter, `defaultMediaType`, `@Produces(...)`는 concrete representation
+formatter)을 선택합니다. Present blank 또는 whitespace-only `Accept` field는 valid token이 없으므로
+`406`을 반환합니다. Formatter, `defaultMediaType`, `@Produces(...)`는 concrete representation
 media type만 받습니다. Wildcard type/subtype과 case-insensitive duplicate parameter name은 무시됩니다.
 Mixed list는 valid entry를 유지하고 invalid-only formatter set은 negotiation을 비활성화하며, non-empty
 `@Produces(...)` metadata에 valid configured representation이 없으면 `406`을 반환합니다. Header가 있으면
 exact range, `application/*+json` 같은 structured-suffix range, `type/*`, `*/*` 순으로 우선합니다.
 Controlling range가 quality를 제공하므로 exact `q=0` exclusion을 더 넓은 positive wildcard가 우회하지
 못합니다. Malformed Accept entry와 invalid concrete representation media type은 무시하며 valid하고
-acceptable한 formatter가 남지 않으면 HTTP가 `406`을 반환합니다. 성공한 framework-managed negotiated
-response는 `Vary`에 case-insensitive하게 deduplicate된 `Accept` field 하나를 추가합니다. Native fast-route
-handoff와 fallback dispatch는 같은 selection policy를 사용합니다.
+acceptable한 formatter가 남지 않으면 HTTP가 `406`을 반환합니다. Negotiation-generated `406` response와
+성공한 framework-managed negotiated response는 `Vary`에 case-insensitive하게 deduplicate된 `Accept` field
+하나를 추가합니다. Native fast-route handoff와 fallback dispatch는 같은 selection policy를 사용합니다.
 
 ### Optional HTML Error Representations
 

--- a/packages/runtime/README.ko.md
+++ b/packages/runtime/README.ko.md
@@ -157,17 +157,20 @@ const app = await fluoFactory.create(AppModule, {
 ```
 
 `Accept` header가 없거나 `*/*`이면 `defaultMediaType`(또는 첫 번째 unique valid configured
-formatter)을 선택합니다. Present blank 또는 whitespace-only `Accept` field는 valid token이 없으므로
-`406`을 반환합니다. Formatter, `defaultMediaType`, `@Produces(...)`는 concrete representation
+formatter)을 선택합니다. Undefined scalar entry와 undefined만 포함한 array는 absent입니다. Present blank
+또는 whitespace-only `Accept` field는 valid token이 없으므로 `406`을 반환합니다. Formatter,
+`defaultMediaType`, `@Produces(...)`는 concrete representation
 media type만 받습니다. Wildcard type/subtype과 case-insensitive duplicate parameter name은 무시됩니다.
 Mixed list는 valid entry를 유지하고 invalid-only formatter set은 negotiation을 비활성화하며, non-empty
 `@Produces(...)` metadata에 valid configured representation이 없으면 `406`을 반환합니다. Header가 있으면
 exact range, `application/*+json` 같은 structured-suffix range, `type/*`, `*/*` 순으로 우선합니다.
 Controlling range가 quality를 제공하므로 exact `q=0` exclusion을 더 넓은 positive wildcard가 우회하지
 못합니다. Malformed Accept entry와 invalid concrete representation media type은 무시하며 valid하고
-acceptable한 formatter가 남지 않으면 HTTP가 `406`을 반환합니다. Negotiation-generated `406` response와
-성공한 framework-managed negotiated response는 `Vary`에 case-insensitive하게 deduplicate된 `Accept` field
-하나를 추가합니다. Native fast-route handoff와 fallback dispatch는 같은 selection policy를 사용합니다.
+acceptable한 formatter가 남지 않으면 HTTP가 `406`을 반환합니다. Framework가 commit하는
+negotiation-generated `406` response와 성공한 framework-managed negotiated response는 `Vary`에
+case-insensitive하게 deduplicate된 `Accept` field 하나를 추가합니다. Error observer와 `onError` handler는
+error를 handle하면 response ownership을 유지합니다. Native fast-route handoff와 fallback dispatch는 같은
+selection policy를 사용합니다.
 
 ### Optional HTML Error Representations
 

--- a/packages/runtime/README.ko.md
+++ b/packages/runtime/README.ko.md
@@ -158,7 +158,9 @@ const app = await fluoFactory.create(AppModule, {
 
 `Accept` header가 없거나 `*/*`이면 `defaultMediaType`(또는 첫 번째 unique valid configured
 formatter)을 선택합니다. Undefined scalar entry와 undefined만 포함한 array는 absent입니다. Present blank
-또는 whitespace-only `Accept` field는 valid token이 없으므로 `406`을 반환합니다. Formatter,
+또는 whitespace-only `Accept` field는 valid token이 없으므로 `406`을 반환합니다. Framework는 formatter
+실행이 완료된 뒤에만 success status, route header, negotiated `Content-Type`, serialized-body metadata,
+`Vary: Accept`를 적용하므로 formatter failure는 success metadata 없이 일반 error handling으로 들어갑니다. Formatter,
 `defaultMediaType`, `@Produces(...)`는 concrete representation
 media type만 받습니다. Wildcard type/subtype과 case-insensitive duplicate parameter name은 무시됩니다.
 Mixed list는 valid entry를 유지하고 invalid-only formatter set은 negotiation을 비활성화하며, non-empty
@@ -201,7 +203,9 @@ const app = await fluoFactory.create(AppModule, {
 ```
 
 Runtime은 이 option을 wiring만 합니다. Error classification, `Accept` negotiation, request scope, response status와
-header, `HEAD`, abort, commit, canonical JSON fallback은 `@fluojs/http`가 소유합니다. 반환 string/byte는
+header, `HEAD`, abort, commit, canonical JSON fallback은 `@fluojs/http`가 소유합니다. Successful-response
+negotiation에서 나온 `406`은 HTML provider를 우회하고 `Accept`가 `text/html`을 허용하거나 error representation을
+지원하지 않아도 canonical JSON으로 유지되며 observer와 `onError`는 계속 이를 handle할 수 있습니다. 반환 string/byte는
 application이 책임지는 trusted HTML입니다. Runtime은 request-derived 또는 error-derived value를 escape하거나
 sanitize하지 않으므로 provider가 interpolation 전에 처리해야 합니다. Standalone application
 context는 HTTP dispatcher를 생성하지 않으므로 이 option을 사용하지 않습니다. 자세한 내용은

--- a/packages/runtime/README.ko.md
+++ b/packages/runtime/README.ko.md
@@ -122,6 +122,48 @@ const app = await fluoFactory.create(AppModule, {
 });
 ```
 
+### 성공 응답 Content Negotiation
+
+`FluoFactory.create(...)`와 `bootstrapApplication(...)`은 `contentNegotiation`을 받아 같은 formatter
+set을 HTTP dispatcher로 전달합니다. Route-level `@Produces(...)` metadata는 이 set을 좁힙니다.
+
+```typescript
+import { Controller, Get, Produces } from '@fluojs/http';
+
+@Controller('/reports')
+class ReportsController {
+  @Produces('application/json', 'text/plain')
+  @Get('/daily')
+  daily() {
+    return { total: 42 };
+  }
+}
+
+const app = await fluoFactory.create(AppModule, {
+  contentNegotiation: {
+    defaultMediaType: 'application/json',
+    formatters: [
+      {
+        mediaType: 'application/json',
+        format: (body) => JSON.stringify(body),
+      },
+      {
+        mediaType: 'text/plain',
+        format: (body) => `total=${String((body as { total: number }).total)}`,
+      },
+    ],
+  },
+});
+```
+
+`Accept` header가 없거나 `*/*`이면 `defaultMediaType`(또는 첫 번째 configured formatter)을
+선택합니다. Header가 있으면 exact range, `application/*+json` 같은 structured-suffix range,
+`type/*`, `*/*` 순으로 우선합니다. Controlling range가 quality를 제공하므로 exact `q=0`
+exclusion을 더 넓은 positive wildcard가 우회하지 못합니다. Malformed entry는 무시하며 valid하고
+acceptable한 formatter가 남지 않으면 HTTP가 `406`을 반환합니다. 성공한 framework-managed
+negotiated response는 `Vary`에 case-insensitive하게 deduplicate된 `Accept` field 하나를 추가합니다.
+Native fast-route handoff와 fallback dispatch는 같은 selection policy를 사용합니다.
+
 ### Optional HTML Error Representations
 
 `FluoFactory.create(...)`와 `bootstrapApplication(...)`은 `errorRepresentation`을 받아 HTTP dispatcher에
@@ -235,7 +277,7 @@ class UsersModule {}
 - `RuntimeHealthModule`: `HealthModule.forRoot(...)`가 반환하는 module class contract이며 `addReadinessCheck(...)`, `markReady()`, `markStarting()`을 포함합니다.
 - `ReadinessCheck`: runtime health module이 사용하는 function type입니다. Check는 `/ready` request context를 받고 boolean 또는 promise를 반환합니다.
 - `defineModule(cls, metadata)`: 프로그래밍 방식의 모듈 정의 헬퍼입니다.
-- `bootstrapApplication(options)`: 저수준 비동기 부트스트랩 함수입니다. `BootstrapApplicationOptions.errorRepresentation`은 optional HTTP-owned HTML representation provider를 등록하며 `CreateApplicationOptions`는 `FluoFactory.create(...)`에서 같은 field를 노출합니다.
+- `bootstrapApplication(options)`: 저수준 비동기 부트스트랩 함수입니다. `BootstrapApplicationOptions.contentNegotiation`은 성공 응답 formatter를 설정하고 `BootstrapApplicationOptions.errorRepresentation`은 optional HTTP-owned HTML representation provider를 등록하며 `CreateApplicationOptions`는 `FluoFactory.create(...)`에서 두 field를 모두 노출합니다.
 - `bootstrapModule(...)`: 저수준 module graph bootstrap helper입니다. `BootstrapModuleOptions`에는 opt-in compile-result cache를 위한 `moduleGraphCache`와 authored module identity를 안정적으로 유지하는 testing-only module replacement compilation을 위한 `moduleReplacements` / `ModuleReplacementMap`이 포함됩니다.
 - `createBootstrapTimingDiagnostics(...)`, `createRuntimeDiagnosticsGraph(...)`: CLI/support tooling을 위한 runtime 소유 diagnostics snapshot helper입니다. 이 helper들은 기계 읽기 가능한 데이터를 생산하며, Studio가 viewer parsing, graph presentation, Mermaid rendering을 소유합니다.
 - `createRuntimeRouteInspection(...)`, `createRuntimeRouteCatalog(...)`, `createRuntimeInspectionSnapshot(...)`: HTTP route behavior를 변경하지 않고 platform snapshot에 effective compiled route diagnostics를 추가하는 runtime-owned immutable projection입니다.

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -158,7 +158,9 @@ const app = await fluoFactory.create(AppModule, {
 
 An absent `Accept` header and `*/*` select `defaultMediaType` (or the first unique valid configured
 formatter). Undefined scalar entries and arrays containing only undefined entries are absent. A present
-blank or whitespace-only `Accept` field has no valid token and returns `406`.
+blank or whitespace-only `Accept` field has no valid token and returns `406`. Formatter execution completes
+before the framework applies success status, route headers, negotiated `Content-Type`, serialized-body
+metadata, or `Vary: Accept`; formatter failures therefore enter ordinary error handling without success metadata.
 Formatters, `defaultMediaType`, and `@Produces(...)` accept only concrete representation
 media types: wildcard types/subtypes and case-insensitive duplicate parameter names are ignored. Mixed
 lists retain valid entries, an invalid-only formatter set disables negotiation, and non-empty
@@ -201,7 +203,9 @@ const app = await fluoFactory.create(AppModule, {
 ```
 
 Runtime only wires this option. `@fluojs/http` owns error classification, `Accept` negotiation,
-request scope, response status and headers, `HEAD`, abort, commit, and canonical JSON fallback.
+request scope, response status and headers, `HEAD`, abort, commit, and canonical JSON fallback. A `406`
+from successful-response negotiation bypasses the HTML provider and remains canonical JSON even when
+`Accept` permits `text/html` or supports no error representation; observers and `onError` can still handle it.
 The returned string or bytes are trusted application HTML: runtime does not escape or sanitize
 request-derived or error-derived values, so the provider must do so before interpolation.
 Standalone application contexts do not use the option because they do not create an HTTP dispatcher.

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -157,16 +157,18 @@ const app = await fluoFactory.create(AppModule, {
 ```
 
 An absent `Accept` header and `*/*` select `defaultMediaType` (or the first unique valid configured
-formatter). Formatters, `defaultMediaType`, and `@Produces(...)` accept only concrete representation
+formatter). A present blank or whitespace-only `Accept` field has no valid token and returns `406`.
+Formatters, `defaultMediaType`, and `@Produces(...)` accept only concrete representation
 media types: wildcard types/subtypes and case-insensitive duplicate parameter names are ignored. Mixed
 lists retain valid entries, an invalid-only formatter set disables negotiation, and non-empty
 `@Produces(...)` metadata without a valid configured representation returns `406`. For present headers,
 exact ranges take precedence over structured-suffix ranges such as `application/*+json`, then `type/*`,
 then `*/*`. The controlling range supplies the quality, so an exact `q=0` exclusion is not bypassed by
 a broader positive wildcard. Malformed Accept entries and invalid concrete representation media types are
-ignored; when no valid acceptable formatter remains, HTTP returns `406`. Successful framework-managed
-negotiated responses append one case-insensitively deduplicated `Accept` field to `Vary`. Native
-fast-route handoff and fallback dispatch use the same selection policy.
+ignored; when no valid acceptable formatter remains, HTTP returns `406`. Negotiation-generated `406`
+responses and successful framework-managed negotiated responses append one case-insensitively
+deduplicated `Accept` field to `Vary`. Native fast-route handoff and fallback dispatch use the same
+selection policy.
 
 ### Optional HTML Error Representations
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -156,11 +156,15 @@ const app = await fluoFactory.create(AppModule, {
 });
 ```
 
-An absent `Accept` header and `*/*` select `defaultMediaType` (or the first configured formatter).
-For present headers, exact ranges take precedence over structured-suffix ranges such as
-`application/*+json`, then `type/*`, then `*/*`. The controlling range supplies the quality, so an
-exact `q=0` exclusion is not bypassed by a broader positive wildcard. Malformed entries are ignored;
-when no valid acceptable formatter remains, HTTP returns `406`. Successful framework-managed
+An absent `Accept` header and `*/*` select `defaultMediaType` (or the first unique valid configured
+formatter). Formatters, `defaultMediaType`, and `@Produces(...)` accept only concrete representation
+media types: wildcard types/subtypes and case-insensitive duplicate parameter names are ignored. Mixed
+lists retain valid entries, an invalid-only formatter set disables negotiation, and non-empty
+`@Produces(...)` metadata without a valid configured representation returns `406`. For present headers,
+exact ranges take precedence over structured-suffix ranges such as `application/*+json`, then `type/*`,
+then `*/*`. The controlling range supplies the quality, so an exact `q=0` exclusion is not bypassed by
+a broader positive wildcard. Malformed Accept entries and invalid concrete representation media types are
+ignored; when no valid acceptable formatter remains, HTTP returns `406`. Successful framework-managed
 negotiated responses append one case-insensitively deduplicated `Accept` field to `Vary`. Native
 fast-route handoff and fallback dispatch use the same selection policy.
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -157,7 +157,8 @@ const app = await fluoFactory.create(AppModule, {
 ```
 
 An absent `Accept` header and `*/*` select `defaultMediaType` (or the first unique valid configured
-formatter). A present blank or whitespace-only `Accept` field has no valid token and returns `406`.
+formatter). Undefined scalar entries and arrays containing only undefined entries are absent. A present
+blank or whitespace-only `Accept` field has no valid token and returns `406`.
 Formatters, `defaultMediaType`, and `@Produces(...)` accept only concrete representation
 media types: wildcard types/subtypes and case-insensitive duplicate parameter names are ignored. Mixed
 lists retain valid entries, an invalid-only formatter set disables negotiation, and non-empty
@@ -165,10 +166,11 @@ lists retain valid entries, an invalid-only formatter set disables negotiation, 
 exact ranges take precedence over structured-suffix ranges such as `application/*+json`, then `type/*`,
 then `*/*`. The controlling range supplies the quality, so an exact `q=0` exclusion is not bypassed by
 a broader positive wildcard. Malformed Accept entries and invalid concrete representation media types are
-ignored; when no valid acceptable formatter remains, HTTP returns `406`. Negotiation-generated `406`
-responses and successful framework-managed negotiated responses append one case-insensitively
-deduplicated `Accept` field to `Vary`. Native fast-route handoff and fallback dispatch use the same
-selection policy.
+ignored; when no valid acceptable formatter remains, HTTP returns `406`. Framework-committed
+negotiation-generated `406` responses and successful framework-managed negotiated responses append one
+case-insensitively deduplicated `Accept` field to `Vary`; error observers and `onError` handlers retain
+response ownership when they handle the error. Native fast-route handoff and fallback dispatch use the
+same selection policy.
 
 ### Optional HTML Error Representations
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -122,6 +122,48 @@ const app = await fluoFactory.create(AppModule, {
 });
 ```
 
+### Successful Response Content Negotiation
+
+`FluoFactory.create(...)` and `bootstrapApplication(...)` accept `contentNegotiation` and forward the
+same formatter set to the HTTP dispatcher. Route-level `@Produces(...)` metadata narrows that set:
+
+```typescript
+import { Controller, Get, Produces } from '@fluojs/http';
+
+@Controller('/reports')
+class ReportsController {
+  @Produces('application/json', 'text/plain')
+  @Get('/daily')
+  daily() {
+    return { total: 42 };
+  }
+}
+
+const app = await fluoFactory.create(AppModule, {
+  contentNegotiation: {
+    defaultMediaType: 'application/json',
+    formatters: [
+      {
+        mediaType: 'application/json',
+        format: (body) => JSON.stringify(body),
+      },
+      {
+        mediaType: 'text/plain',
+        format: (body) => `total=${String((body as { total: number }).total)}`,
+      },
+    ],
+  },
+});
+```
+
+An absent `Accept` header and `*/*` select `defaultMediaType` (or the first configured formatter).
+For present headers, exact ranges take precedence over structured-suffix ranges such as
+`application/*+json`, then `type/*`, then `*/*`. The controlling range supplies the quality, so an
+exact `q=0` exclusion is not bypassed by a broader positive wildcard. Malformed entries are ignored;
+when no valid acceptable formatter remains, HTTP returns `406`. Successful framework-managed
+negotiated responses append one case-insensitively deduplicated `Accept` field to `Vary`. Native
+fast-route handoff and fallback dispatch use the same selection policy.
+
 ### Optional HTML Error Representations
 
 `FluoFactory.create(...)` and `bootstrapApplication(...)` accept `errorRepresentation` and pass it
@@ -235,7 +277,7 @@ class UsersModule {}
 - `RuntimeHealthModule`: Module class contract returned by `HealthModule.forRoot(...)`, including `addReadinessCheck(...)`, `markReady()`, and `markStarting()`.
 - `ReadinessCheck`: Function type used by runtime health modules. Checks receive the `/ready` request context and return a boolean or promise.
 - `defineModule(cls, metadata)`: Programmatic module definition helper.
-- `bootstrapApplication(options)`: Lower-level async bootstrap function. `BootstrapApplicationOptions.errorRepresentation` registers the optional HTTP-owned HTML representation provider; `CreateApplicationOptions` exposes the same field through `FluoFactory.create(...)`.
+- `bootstrapApplication(options)`: Lower-level async bootstrap function. `BootstrapApplicationOptions.contentNegotiation` configures successful-response formatters and `BootstrapApplicationOptions.errorRepresentation` registers the optional HTTP-owned HTML representation provider; `CreateApplicationOptions` exposes both fields through `FluoFactory.create(...)`.
 - `bootstrapModule(...)`: Lower-level module graph bootstrap helper. Its `BootstrapModuleOptions` include `moduleGraphCache` for opt-in compile-result caching and `moduleReplacements` / `ModuleReplacementMap` for testing-only module replacement compilation that keeps authored module identities stable.
 - `createBootstrapTimingDiagnostics(...)`, `createRuntimeDiagnosticsGraph(...)`: Runtime-owned diagnostics snapshot helpers for CLI/support tooling. They produce machine-readable data; Studio owns viewer parsing, graph presentation, and Mermaid rendering.
 - `createRuntimeRouteInspection(...)`, `createRuntimeRouteCatalog(...)`, and `createRuntimeInspectionSnapshot(...)`: Runtime-owned immutable projections that add effective compiled route diagnostics to platform snapshots without changing HTTP route behavior.

--- a/packages/runtime/src/bootstrap.ts
+++ b/packages/runtime/src/bootstrap.ts
@@ -1458,6 +1458,9 @@ function createRuntimeDispatcherOptions(
   const converters = options.converters ?? [];
   const dispatcherOptions: ErrorAwareDispatcherOptions = {
     appMiddleware: options.middleware ?? [],
+    ...(options.contentNegotiation === undefined
+      ? {}
+      : { contentNegotiation: options.contentNegotiation }),
     ...(options.errorRepresentation === undefined
       ? {}
       : { errorRepresentation: options.errorRepresentation }),

--- a/packages/runtime/src/content-negotiation.test.ts
+++ b/packages/runtime/src/content-negotiation.test.ts
@@ -1,0 +1,105 @@
+import { Module } from '@fluojs/core';
+import {
+  Controller,
+  type FrameworkRequest,
+  type FrameworkResponse,
+  Get,
+  Produces,
+} from '@fluojs/http';
+import { describe, expect, it } from 'vitest';
+
+import { bootstrapApplication } from './bootstrap.js';
+import type {
+  BootstrapApplicationOptions,
+  CreateApplicationOptions,
+} from './types.js';
+
+type TestResponse = FrameworkResponse & { body?: unknown };
+
+function createRequest(accept: string): FrameworkRequest {
+  return {
+    cookies: {},
+    headers: { accept },
+    method: 'GET',
+    params: {},
+    path: '/runtime-negotiation/report',
+    query: {},
+    raw: {},
+    url: '/runtime-negotiation/report',
+  };
+}
+
+function createResponse(): TestResponse {
+  return {
+    committed: false,
+    headers: {},
+    redirect(status: number, location: string) {
+      this.setStatus(status);
+      this.setHeader('Location', location);
+      this.committed = true;
+    },
+    send(body: unknown) {
+      this.body = body;
+      this.committed = true;
+    },
+    setHeader(name: string, value: string | string[]) {
+      this.headers[name] = value;
+    },
+    setStatus(code: number) {
+      this.statusCode = code;
+      this.statusSet = true;
+    },
+  };
+}
+
+describe('runtime successful response content negotiation', () => {
+  it('exposes and forwards bootstrap formatters through @Produces metadata', async () => {
+    @Controller('/runtime-negotiation')
+    class NegotiationController {
+      @Produces('application/json', 'text/plain')
+      @Get('/report')
+      report() {
+        return { total: 42 };
+      }
+    }
+
+    @Module({ controllers: [NegotiationController] })
+    class AppModule {}
+
+    const contentNegotiation = {
+      defaultMediaType: 'application/json',
+      formatters: [
+        {
+          format(body: unknown) {
+            return JSON.stringify(body);
+          },
+          mediaType: 'application/json',
+        },
+        {
+          format(body: unknown) {
+            return `total=${String((body as { total: number }).total)}`;
+          },
+          mediaType: 'text/plain',
+        },
+      ],
+    };
+    const createOptions: CreateApplicationOptions = { contentNegotiation };
+    const options: BootstrapApplicationOptions = {
+      ...createOptions,
+      rootModule: AppModule,
+    };
+    const app = await bootstrapApplication(options);
+
+    try {
+      const response = createResponse();
+      await app.dispatch(createRequest('text/plain'), response);
+
+      expect(response.statusCode).toBe(200);
+      expect(response.headers['Content-Type']).toBe('text/plain');
+      expect(response.headers.Vary).toBe('Accept');
+      expect(response.body).toBe('total=42');
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -1,12 +1,13 @@
 import type { Constructor, MaybePromise, Token } from '@fluojs/core';
 import type { Container, Provider } from '@fluojs/di';
 import type {
+  ContentNegotiationOptions,
   ConverterLike,
   Dispatcher,
   FrameworkRequest,
   FrameworkResponse,
-  HttpErrorRepresentationOptions,
   HttpApplicationAdapter,
+  HttpErrorRepresentationOptions,
   InterceptorLike,
   MiddlewareLike,
   RequestObserverLike,
@@ -140,6 +141,8 @@ export interface ExceptionFilterHandler {
 /** High-level bootstrap options for creating an HTTP application shell. */
 export interface BootstrapApplicationOptions {
   adapter?: HttpApplicationAdapter;
+  /** Successful-response formatters selected from `Accept` and route-level `@Produces(...)` metadata. */
+  contentNegotiation?: ContentNegotiationOptions;
   /** Application-owned HTML provider for HTTP-classified error and not-found outcomes. */
   errorRepresentation?: HttpErrorRepresentationOptions;
   /**


### PR DESCRIPTION
## Summary

Expose the existing HTTP content-negotiation engine through runtime bootstrap and make successful negotiated responses cache-correct with canonical `Vary: Accept` behavior.

Linked context: Closes https://github.com/fluojs/fluo/issues/3305

Direct conformance evidence:
- [HTTP negotiation documentation](https://github.com/fluojs/fluo/blob/657260082451546a4ccb5c422a231c7c99215a17/packages/http/README.md)
- [Runtime bootstrap documentation](https://github.com/fluojs/fluo/blob/657260082451546a4ccb5c422a231c7c99215a17/packages/runtime/README.md)
- [Native/fallback regression suite](https://github.com/fluojs/fluo/blob/657260082451546a4ccb5c422a231c7c99215a17/packages/http/src/dispatch/dispatch-success-content-negotiation.test.ts)
- [Runtime bootstrap regression suite](https://github.com/fluojs/fluo/blob/657260082451546a4ccb5c422a231c7c99215a17/packages/runtime/src/content-negotiation.test.ts)

## Changes

- Forward `contentNegotiation` through high-level runtime bootstrap.
- Harden Accept parsing, malformed-field isolation, media-parameter precedence, q=0 exclusions, and concrete representation validation.
- Apply deduplicated `Vary: Accept` consistently on native and fallback dispatch paths.
- Document the behavior in synchronized HTTP/runtime EN/KO READMEs.
- Add `.changeset/negotiate-bootstrap-responses.md`.

## Testing

- `@fluojs/http`: 361 tests passed.
- Focused HTTP/runtime negotiation: 44 tests passed.
- Typecheck, build, Biome, LSP diagnostics, docs locale sync, platform governance, changeset lane, and diff checks passed.
- Fresh exact-head contract/code/verification reviews passed on `657260082451546a4ccb5c422a231c7c99215a17`.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated.
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized.
- [x] Applicable platform consistency and documentation verifiers pass.
- [x] Native fast-route and fallback behavior is covered by parity tests.
