### PR TITLE
Resolve #3383: prove EADDRINUSE retry attempt in platform-express regression

### DIFF
--- a/packages/platform-express/src/adapter.test.ts
+++ b/packages/platform-express/src/adapter.test.ts
@@ -2622,6 +2622,8 @@ describe('@fluojs/platform-express', () => {
   });
 
   it('retries startup after EADDRINUSE until the port becomes available', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+
     const blocker = createHttpServer((_request, response) => {
       response.statusCode = 200;
       response.end('blocked');
@@ -2654,15 +2656,28 @@ describe('@fluojs/platform-express', () => {
         await response.send({ ok: true });
       },
     };
+    const addressInUse = createDeferred<void>();
+    let observedAddressInUse = false;
+
+    adapter.getServer().once('error', (error) => {
+      if (error instanceof Error && 'code' in error && error.code === 'EADDRINUSE') {
+        observedAddressInUse = true;
+        addressInUse.resolve();
+        return;
+      }
+
+      addressInUse.reject(error);
+    });
 
     try {
       const listenPromise = adapter.listen(dispatcher);
 
-      setTimeout(() => {
-        void closeBlocker();
-      }, 80);
+      await addressInUse.promise;
+      await closeBlocker();
+      await vi.advanceTimersByTimeAsync(20);
 
       await listenPromise;
+      expect(observedAddressInUse).toBe(true);
 
       const response = await fetch(`http://127.0.0.1:${String(port)}/retry-check`);
 
@@ -2671,6 +2686,7 @@ describe('@fluojs/platform-express', () => {
     } finally {
       await adapter.close();
       await closeBlocker();
+      vi.useRealTimers();
     }
   });
 


### PR DESCRIPTION
## Summary

Makes the platform-express EADDRINUSE retry regression causally prove a failed bind: the test now observes the first `EADDRINUSE` on the real server `error` event before releasing the blocking listener, and controls the retry delay with scoped fake timers.

Linked context: Closes #3383

## Changes

- packages/platform-express/src/adapter.test.ts: listen-attempt boundary observed via server error event; blocker released only after the first EADDRINUSE; fake timers scoped to setTimeout/clearTimeout; explicit assertion that a failed bind occurred (mutation-proven: bypassing the gate fails the test).

## Testing

- pnpm --filter @fluojs/platform-express typecheck — pass
- pnpm --filter @fluojs/platform-express test — pass twice consecutively (70 tests)
- Mutation proof: resolving the gate immediately fails the test (AssertionError), restored -> green
- Read-only review triad at this exact head: unanimous merge

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary. (No public export changes.)
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. (N/A)
- [x] Source `@example` blocks and README scenario examples still play complementary roles. (N/A)

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. (None added.)
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (No governance docs changed.)
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. (N/A)
- [ ] Any package README alignment/conformance claims are backed by the applicable platform harness tests. (N/A)
