### PR TITLE
Resolve #3357: replace timer turns with causal shutdown settlement signals

### DIFF
--- a/packages/platform-bun/src/adapter.test.ts
+++ b/packages/platform-bun/src/adapter.test.ts
@@ -1924,6 +1924,7 @@ describe('@fluojs/platform-bun', () => {
       const responsePromise = mockBun.lastServer!.fetch(new Request('http://127.0.0.1:3000/timeout-check'));
       await Promise.resolve();
       const closeResultPromise = adapter.close().catch((error: unknown) => error);
+      const closeSettlementPromise = Reflect.get(adapter, 'closeInFlight') as Promise<void>;
 
       await vi.advanceTimersByTimeAsync(10_001);
 
@@ -1933,9 +1934,7 @@ describe('@fluojs/platform-bun', () => {
       deferred.resolve();
       await responsePromise;
       vi.useRealTimers();
-      await new Promise((resolve) => {
-        setTimeout(resolve, 0);
-      });
+      await waitForSettlement(closeSettlementPromise);
 
       expect(Reflect.get(adapter, 'dispatcher')).toBeUndefined();
     } finally {
@@ -2000,7 +1999,7 @@ describe('@fluojs/platform-bun', () => {
     const adapter = new BunHttpApplicationAdapter();
     const bindingStarted = createDeferred<void>();
     const bindingRelease = createDeferred<void>();
-    let closeSettled = false;
+    const order: string[] = [];
 
     adapter.configureRealtimeBinding({
       fetch: async () => {
@@ -2019,19 +2018,17 @@ describe('@fluojs/platform-bun', () => {
     await bindingStarted.promise;
 
     const closePromise = adapter.close().then(() => {
-      closeSettled = true;
-    });
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 0);
+      order.push('close-settled');
     });
 
-    expect(closeSettled).toBe(false);
+    expect(order).not.toContain('close-settled');
 
+    order.push('binding-released');
     bindingRelease.resolve();
 
     await expect(responsePromise).resolves.toMatchObject({ status: 202 });
-    await closePromise;
-    expect(closeSettled).toBe(true);
+    await waitForSettlement(closePromise);
+    expect(order).toEqual(['binding-released', 'close-settled']);
   });
 
   it('drains an accepted request through a delayed websocket upgrade without HTTP fallback', async () => {
@@ -2045,7 +2042,7 @@ describe('@fluojs/platform-bun', () => {
         await response.send({ fallback: 'http' });
       }),
     };
-    let closeSettled = false;
+    const order: string[] = [];
     let closePromise: Promise<void> | undefined;
     let responsePromise: Promise<Response | undefined> | undefined;
 
@@ -2075,21 +2072,19 @@ describe('@fluojs/platform-bun', () => {
       await waitForSettlement(bindingStarted.promise);
 
       closePromise = adapter.close().then(() => {
-        closeSettled = true;
+        order.push('close-settled');
       });
-      await waitForSettlement(new Promise<void>((resolve) => {
-        setTimeout(resolve, 0);
-      }));
 
-      expect(closeSettled).toBe(false);
+      expect(order).not.toContain('close-settled');
       expect(server.upgrade).not.toHaveBeenCalled();
       expect(dispatcher.dispatch).not.toHaveBeenCalled();
 
+      order.push('binding-released');
       bindingRelease.resolve();
 
       await expect(waitForSettlement(acceptedResponsePromise)).resolves.toBeUndefined();
       await waitForSettlement(closePromise);
-      expect(closeSettled).toBe(true);
+      expect(order).toEqual(['binding-released', 'close-settled']);
       expect(server.upgrade).toHaveBeenCalledTimes(1);
       expect(server.upgrade).toHaveReturnedWith(true);
       expect(dispatcher.dispatch).not.toHaveBeenCalled();
@@ -2113,7 +2108,7 @@ describe('@fluojs/platform-bun', () => {
         await response.send({ fallback: 'http' });
       }),
     };
-    let closeSettled = false;
+    const order: string[] = [];
 
     adapter.configureRealtimeBinding({
       fetch: async () => {
@@ -2130,14 +2125,12 @@ describe('@fluojs/platform-bun', () => {
     await bindingStarted.promise;
 
     const closePromise = adapter.close().then(() => {
-      closeSettled = true;
-    });
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 0);
+      order.push('close-settled');
     });
 
-    expect(closeSettled).toBe(false);
+    expect(order).not.toContain('close-settled');
 
+    order.push('binding-released');
     bindingRelease.resolve();
 
     await expect(responsePromise).resolves.toBeInstanceOf(Response);
@@ -2145,8 +2138,8 @@ describe('@fluojs/platform-bun', () => {
     expect(response?.status).toBe(200);
     await expect(response?.json()).resolves.toEqual({ fallback: 'http' });
     expect(dispatcher.dispatch).toHaveBeenCalledTimes(1);
-    await closePromise;
-    expect(closeSettled).toBe(true);
+    await waitForSettlement(closePromise);
+    expect(order).toEqual(['binding-released', 'close-settled']);
   });
 
   it('falls back to HTTP dispatch when a websocket binding does not upgrade the request', async () => {

--- a/packages/platform-bun/src/adapter.test.ts
+++ b/packages/platform-bun/src/adapter.test.ts
@@ -2000,6 +2000,7 @@ describe('@fluojs/platform-bun', () => {
     const bindingStarted = createDeferred<void>();
     const bindingRelease = createDeferred<void>();
     const order: string[] = [];
+    let closeSettled = false;
 
     adapter.configureRealtimeBinding({
       fetch: async () => {
@@ -2017,17 +2018,31 @@ describe('@fluojs/platform-bun', () => {
     const responsePromise = mockBun.lastServer?.fetch(new Request('http://127.0.0.1:3000/realtime'));
     await bindingStarted.promise;
 
-    const closePromise = adapter.close().then(() => {
-      order.push('close-settled');
+    const closePromise = adapter.close();
+    void closePromise.then(
+      () => {
+        closeSettled = true;
+        order.push('close-settled');
+      },
+      () => {
+        closeSettled = true;
+        order.push('close-settled');
+      },
+    );
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
     });
 
-    expect(order).not.toContain('close-settled');
+    expect(closeSettled).toBe(false);
+    expect(adapter.getServer()).toBe(mockBun.lastServer);
+    expect(Reflect.get(adapter, 'closeInFlight')).toBeDefined();
 
     order.push('binding-released');
     bindingRelease.resolve();
 
     await expect(responsePromise).resolves.toMatchObject({ status: 202 });
     await waitForSettlement(closePromise);
+    expect(closeSettled).toBe(true);
     expect(order).toEqual(['binding-released', 'close-settled']);
   });
 
@@ -2043,6 +2058,7 @@ describe('@fluojs/platform-bun', () => {
       }),
     };
     const order: string[] = [];
+    let closeSettled = false;
     let closePromise: Promise<void> | undefined;
     let responsePromise: Promise<Response | undefined> | undefined;
 
@@ -2071,11 +2087,24 @@ describe('@fluojs/platform-bun', () => {
       responsePromise = acceptedResponsePromise;
       await waitForSettlement(bindingStarted.promise);
 
-      closePromise = adapter.close().then(() => {
-        order.push('close-settled');
+      closePromise = adapter.close();
+      void closePromise.then(
+        () => {
+          closeSettled = true;
+          order.push('close-settled');
+        },
+        () => {
+          closeSettled = true;
+          order.push('close-settled');
+        },
+      );
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
       });
 
-      expect(order).not.toContain('close-settled');
+      expect(closeSettled).toBe(false);
+      expect(adapter.getServer()).toBe(server);
+      expect(Reflect.get(adapter, 'closeInFlight')).toBeDefined();
       expect(server.upgrade).not.toHaveBeenCalled();
       expect(dispatcher.dispatch).not.toHaveBeenCalled();
 
@@ -2084,6 +2113,7 @@ describe('@fluojs/platform-bun', () => {
 
       await expect(waitForSettlement(acceptedResponsePromise)).resolves.toBeUndefined();
       await waitForSettlement(closePromise);
+      expect(closeSettled).toBe(true);
       expect(order).toEqual(['binding-released', 'close-settled']);
       expect(server.upgrade).toHaveBeenCalledTimes(1);
       expect(server.upgrade).toHaveReturnedWith(true);
@@ -2109,6 +2139,7 @@ describe('@fluojs/platform-bun', () => {
       }),
     };
     const order: string[] = [];
+    let closeSettled = false;
 
     adapter.configureRealtimeBinding({
       fetch: async () => {
@@ -2124,11 +2155,24 @@ describe('@fluojs/platform-bun', () => {
     const responsePromise = mockBun.lastServer?.fetch(new Request('http://127.0.0.1:3000/fallback'));
     await bindingStarted.promise;
 
-    const closePromise = adapter.close().then(() => {
-      order.push('close-settled');
+    const closePromise = adapter.close();
+    void closePromise.then(
+      () => {
+        closeSettled = true;
+        order.push('close-settled');
+      },
+      () => {
+        closeSettled = true;
+        order.push('close-settled');
+      },
+    );
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
     });
 
-    expect(order).not.toContain('close-settled');
+    expect(closeSettled).toBe(false);
+    expect(adapter.getServer()).toBe(mockBun.lastServer);
+    expect(Reflect.get(adapter, 'closeInFlight')).toBeDefined();
 
     order.push('binding-released');
     bindingRelease.resolve();
@@ -2139,6 +2183,7 @@ describe('@fluojs/platform-bun', () => {
     await expect(response?.json()).resolves.toEqual({ fallback: 'http' });
     expect(dispatcher.dispatch).toHaveBeenCalledTimes(1);
     await waitForSettlement(closePromise);
+    expect(closeSettled).toBe(true);
     expect(order).toEqual(['binding-released', 'close-settled']);
   });
 


### PR DESCRIPTION
## Summary

Removes wall-clock ordering from the platform-bun shutdown lifecycle regressions: all four `setTimeout(resolve, 0)` turns are replaced with causal close/drain settlement signals (settlement-order recorders + not-yet-settled gates at a deterministic `setImmediate` boundary), building on the allSettled close semantics landed by #3356.

Linked context: Closes #3357 (depends on #3356, already merged as f667d2f9)

## Changes

- packages/platform-bun/src/adapter.test.ts: four shutdown lifecycle tests now (1) attach closeSettled recorders at trigger time, (2) assert close has NOT settled plus retained state after one deterministic setImmediate boundary BEFORE releasing bindings/drains, (3) assert final settlement order. No runtime changes.

## Testing

- pnpm --filter @fluojs/platform-bun typecheck — pass
- pnpm --filter @fluojs/platform-bun test — pass twice (57 tests; adapter.test.ts 106ms/94ms — no ~1s timer waits)
- PER-SITE mutation proofs (drain wait removed in adapter.ts, one at a time, uncommitted): realtime :2036, websocket upgrade :2105, HTTP fallback :2173 — each FAILS "expected true to be false"; reverted -> green
- Read-only review triad at this exact head: unanimous merge (round 2; round-1 blocker — sync release marker masking early-fulfilled close — fixed with the not-settled gate)

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary. (No public export changes.)
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. (N/A)
- [x] Source `@example` blocks and README scenario examples still play complementary roles. (N/A)

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. (None added.)
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (No governance docs changed.)
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. (N/A)
- [ ] Any package README alignment/conformance claims are backed by the applicable platform harness tests. (N/A)
