### PR TITLE
Resolve #3366: deterministic published-artifact verification under CI load

### DIFF
--- a/packages/platform-cloudflare-workers/src/published-artifact-surface.test.ts
+++ b/packages/platform-cloudflare-workers/src/published-artifact-surface.test.ts
@@ -23,6 +23,14 @@ const requiredArtifactPaths = [
 const babelConfigPath = resolve(repoRootPath, 'tooling/babel/babel.config.cjs');
 const buildTsconfigPath = resolve(packageRootPath, 'tsconfig.build.json');
 
+type SourceArtifacts = {
+  readonly declaration: string;
+  readonly runtime: string;
+  readonly runtimeRootExports: readonly string[];
+};
+
+let sourceArtifacts: SourceArtifacts | undefined;
+
 function readRuntimeExports(filePath: string): readonly string[] {
   const sourceFile = ts.createSourceFile(
     filePath,
@@ -138,19 +146,36 @@ function readExportAllTargets(filePath: string): readonly string[] {
     .sort();
 }
 
+function getSourceArtifacts(): SourceArtifacts {
+  if (sourceArtifacts === undefined) {
+    throw new TypeError('Published source artifacts were not generated before the verification assertions.');
+  }
+
+  return sourceArtifacts;
+}
+
 describe('@fluojs/platform-cloudflare-workers published artifacts', () => {
   beforeAll(async () => {
-    if (requiredArtifactPaths.every((artifactPath) => existsSync(artifactPath))) {
-      return;
+    if (!requiredArtifactPaths.every((artifactPath) => existsSync(artifactPath))) {
+      await execFileAsync(process.execPath, [buildClosureScriptPath, '@fluojs/platform-cloudflare-workers'], {
+        cwd: repoRootPath,
+        env: process.env,
+      });
     }
 
-    await execFileAsync(process.execPath, [buildClosureScriptPath, '@fluojs/platform-cloudflare-workers'], {
-      cwd: repoRootPath,
-      env: process.env,
-    });
+    const runtimeRootPath = resolve(packageRootPath, 'dist/index.js');
+    const emittedSourceRuntimePromise = emitSourceRuntime();
+    const emittedSourceDeclaration = emitSourceDeclarations();
+    const runtimeRoot = await import(pathToFileURL(runtimeRootPath).href);
+
+    sourceArtifacts = {
+      declaration: emittedSourceDeclaration,
+      runtime: await emittedSourceRuntimePromise,
+      runtimeRootExports: Object.keys(runtimeRoot).sort(),
+    };
   }, 300_000);
 
-  it('keeps request context, WebSocket, SSE, and shutdown runtime behavior structurally aligned with source', async () => {
+  it('keeps request context, WebSocket, SSE, and shutdown runtime behavior structurally aligned with generated source', () => {
     // Given: the package manifest publishes its root runtime from dist/index.js.
     const manifest: unknown = JSON.parse(readFileSync(resolve(packageRootPath, 'package.json'), 'utf8'));
 
@@ -167,19 +192,18 @@ describe('@fluojs/platform-cloudflare-workers published artifacts', () => {
     const runtimeRootPath = resolve(packageRootPath, 'dist/index.js');
     const runtimeAdapterPath = resolve(packageRootPath, 'dist/adapter.js');
 
-    // When: source is transformed with the production Babel config and the published runtime is parsed.
-    const runtimeRoot = await import(pathToFileURL(runtimeRootPath).href);
-    const emittedSourceRuntime = await emitSourceRuntime();
+    // When: the published runtime is parsed against the source artifact generated at suite setup.
+    const generatedSourceArtifacts = getSourceArtifacts();
 
     // Then: the complete executable AST and manifest-root exports match, including lifecycle internals.
     expect(normalizeAst(
       readFileSync(runtimeAdapterPath, 'utf8'),
       runtimeAdapterPath,
       ts.ScriptKind.JS,
-    )).toEqual(normalizeAst(emittedSourceRuntime, sourceAdapterPath, ts.ScriptKind.JS));
+    )).toEqual(normalizeAst(generatedSourceArtifacts.runtime, sourceAdapterPath, ts.ScriptKind.JS));
     expect(readExportAllTargets(runtimeRootPath)).toEqual(readExportAllTargets(sourceRootPath));
-    expect(Object.keys(runtimeRoot).sort()).toEqual(readRuntimeExports(sourceAdapterPath));
-  }, 30_000);
+    expect(generatedSourceArtifacts.runtimeRootExports).toEqual(readRuntimeExports(sourceAdapterPath));
+  });
 
   it('keeps declaration members and signatures structurally aligned with source', () => {
     // Given: the package manifest publishes its root declarations from dist/index.d.ts.
@@ -198,15 +222,15 @@ describe('@fluojs/platform-cloudflare-workers published artifacts', () => {
     const declarationRootPath = resolve(packageRootPath, 'dist/index.d.ts');
     const declarationAdapterPath = resolve(packageRootPath, 'dist/adapter.d.ts');
 
-    // When: declarations are emitted in memory from source and the published declaration is parsed.
-    const emittedSourceDeclaration = emitSourceDeclarations();
+    // When: the published declaration is parsed against the source artifact generated at suite setup.
+    const generatedSourceArtifacts = getSourceArtifacts();
 
     // Then: every declaration member/signature and the manifest-root export graph match source.
     expect(normalizeAst(
       readFileSync(declarationAdapterPath, 'utf8'),
       declarationAdapterPath,
       ts.ScriptKind.TS,
-    )).toEqual(normalizeAst(emittedSourceDeclaration, sourceAdapterPath, ts.ScriptKind.TS));
+    )).toEqual(normalizeAst(generatedSourceArtifacts.declaration, sourceAdapterPath, ts.ScriptKind.TS));
     expect(readExportAllTargets(declarationRootPath)).toEqual(readExportAllTargets(sourceRootPath));
-  }, 30_000);
+  });
 });


### PR DESCRIPTION
## Summary

Makes the published-artifact verification for @fluojs/platform-cloudflare-workers deterministic under CI load: artifact generation and the runtime import move to a single \`beforeAll\` suite boundary; per-assertion 30s limits and in-test compile work are removed.

Linked context: Closes #3366

## Changes

- packages/platform-cloudflare-workers/src/published-artifact-surface.test.ts: generation + import in beforeAll (300s suite budget); assertions reuse the generated artifacts; zero setTimeout usages (AST-verified).

## Testing

- pnpm --filter '@fluojs/platform-cloudflare-workers...' build — pass
- typecheck — pass; full suite 37/37 twice (artifact test 3.9s -> 1.0-1.5s)
- Mutation proofs: dist mutation (void 0 injected) fails :203; DEFAULT_SHUTDOWN_TIMEOUT_MS drift fails :203; both reverted -> green
- Read-only triad at this exact head: unanimous merge

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary. (No public export changes.)
- [x] Changed exported functions document matching \`@param\` / \`@returns\` tags where applicable. (N/A)
- [x] Source \`@example\` blocks and README scenario examples still play complementary roles. (N/A)

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. (None added.)
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (No governance docs changed.)
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. (N/A)
- [ ] Any package README alignment/conformance claims are backed by the applicable platform harness tests. (N/A)
