### PR TITLE
Resolve #3382: make disconnect propagation regression causal

### DIFF
--- a/packages/platform-express/src/adapter.test.ts
+++ b/packages/platform-express/src/adapter.test.ts
@@ -73,6 +73,23 @@ function createDeferred<T>(): {
   return { promise, reject, resolve };
 }
 
+async function waitForSettlement<T>(promise: Promise<T>, timeoutMs = 2_000): Promise<T> {
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timeoutHandle = setTimeout(() => {
+      reject(new Error(`Timed out waiting for test settlement after ${String(timeoutMs)}ms.`));
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timeoutHandle !== undefined) {
+      clearTimeout(timeoutHandle);
+    }
+  }
+}
+
 function getBoundPort(server: unknown): number {
   if (!server || typeof (server as { address?: unknown }).address !== 'function') {
     throw new Error('Failed to resolve a bound test server.');
@@ -3035,7 +3052,8 @@ describe('@fluojs/platform-express', () => {
 
   it('propagates abort signal when the client disconnects', async () => {
     const aborted = createDeferred<void>();
-    const handlerReady = createDeferred<void>();
+    const abortListenerInstalled = createDeferred<void>();
+    const releaseHandler = createDeferred<void>();
 
     @Controller('/abort')
     class AbortController {
@@ -3046,7 +3064,8 @@ describe('@fluojs/platform-express', () => {
             aborted.resolve();
             resolve();
           }, { once: true });
-          handlerReady.resolve();
+          abortListenerInstalled.resolve();
+          void releaseHandler.promise.then(resolve);
         });
 
         return { ok: true };
@@ -3065,7 +3084,6 @@ describe('@fluojs/platform-express', () => {
     });
 
     let request: ReturnType<typeof httpRequest> | undefined;
-    let watchdogTimer: ReturnType<typeof setTimeout> | undefined;
 
     try {
       await app.listen();
@@ -3083,22 +3101,20 @@ describe('@fluojs/platform-express', () => {
       });
       request.end();
 
-      await handlerReady.promise;
+      const handlerReadySettlement = waitForSettlement(abortListenerInstalled.promise);
+      void handlerReadySettlement.catch(() => {
+        releaseHandler.resolve();
+      });
+      await expect(handlerReadySettlement).resolves.toBeUndefined();
       request.destroy();
 
-      await expect(Promise.race([
-        aborted.promise,
-        new Promise<void>((_resolve, reject) => {
-          watchdogTimer = setTimeout(() => {
-            reject(new Error('Abort signal was not propagated.'));
-          }, 2_000);
-        }),
-      ])).resolves.toBeUndefined();
+      const abortSettlement = waitForSettlement(aborted.promise);
+      void abortSettlement.catch(() => {
+        releaseHandler.resolve();
+      });
+      await expect(abortSettlement).resolves.toBeUndefined();
     } finally {
-      if (watchdogTimer) {
-        clearTimeout(watchdogTimer);
-      }
-
+      releaseHandler.resolve();
       request?.destroy();
       await app.close();
     }

--- a/packages/platform-express/src/adapter.test.ts
+++ b/packages/platform-express/src/adapter.test.ts
@@ -3035,6 +3035,7 @@ describe('@fluojs/platform-express', () => {
 
   it('propagates abort signal when the client disconnects', async () => {
     const aborted = createDeferred<void>();
+    const handlerReady = createDeferred<void>();
 
     @Controller('/abort')
     class AbortController {
@@ -3045,6 +3046,7 @@ describe('@fluojs/platform-express', () => {
             aborted.resolve();
             resolve();
           }, { once: true });
+          handlerReady.resolve();
         });
 
         return { ok: true };
@@ -3063,7 +3065,6 @@ describe('@fluojs/platform-express', () => {
     });
 
     let request: ReturnType<typeof httpRequest> | undefined;
-    let destroyTimer: ReturnType<typeof setTimeout> | undefined;
     let watchdogTimer: ReturnType<typeof setTimeout> | undefined;
 
     try {
@@ -3082,9 +3083,8 @@ describe('@fluojs/platform-express', () => {
       });
       request.end();
 
-      destroyTimer = setTimeout(() => {
-        request?.destroy();
-      }, 20);
+      await handlerReady.promise;
+      request.destroy();
 
       await expect(Promise.race([
         aborted.promise,
@@ -3095,9 +3095,6 @@ describe('@fluojs/platform-express', () => {
         }),
       ])).resolves.toBeUndefined();
     } finally {
-      if (destroyTimer) {
-        clearTimeout(destroyTimer);
-      }
       if (watchdogTimer) {
         clearTimeout(watchdogTimer);
       }


### PR DESCRIPTION
## Summary

Makes the platform-express disconnect-propagation regression causal: the request disconnect fires only after the handler has registered its AbortSignal listener (handlerReady + subscription-completion gates), with a bounded settlement watchdog; the fixed 20ms delay is gone.

Linked context: Closes #3382

## Changes

- packages/platform-express/src/adapter.test.ts: handlerReady/subscription gates, settlement watchdog, no wall-clock ordering (2 commits: initial gate + gate rework with watchdog).

## Testing

- pnpm --filter '@fluojs/platform-express...' build — pass; typecheck — pass
- Full suite 70/70 twice at the tip (adapter.test.ts 439ms/437ms)
- Mutation proofs: delayed subscription -> FAIL :3102 (abort not propagated); gate resolve removed -> FAIL :3107 (settlement watchdog); both reverted -> green
- Read-only triad: unanimous merge at 92497bbc, delta re-review unanimous merge at this exact tip

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary. (No public export changes.)
- [x] Changed exported functions document matching \`@param\` / \`@returns\` tags where applicable. (N/A)
- [x] Source \`@example\` blocks and README scenario examples still play complementary roles. (N/A)

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. (None added.)
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (No governance docs changed.)
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. (N/A)
- [ ] Any package README alignment/conformance claims are backed by the applicable platform harness tests. (N/A)
