### PR TITLE
Resolve #3371: correct Early Hints changeset intent for Workers

### DIFF
--- a/.changeset/add-optional-http-early-hints.md
+++ b/.changeset/add-optional-http-early-hints.md
@@ -6,7 +6,7 @@
 "@fluojs/platform-fastify": minor
 "@fluojs/platform-bun": minor
 "@fluojs/platform-deno": minor
-"@fluojs/platform-cloudflare-workers": minor
+"@fluojs/platform-cloudflare-workers": patch
 ---
 
 Add an optional request-scoped Early Hints capability with deterministic write, error, and disconnect behavior.


### PR DESCRIPTION
## Summary

Corrects the Early Hints changeset intent for @fluojs/platform-cloudflare-workers from minor to patch: Workers exposes no observable 103 writer, so the change documents a capability absence rather than shipping a feature.

Linked context: Closes #3371

## Changes

- .changeset/add-optional-http-early-hints.md: platform-cloudflare-workers bump intent minor -> patch (one line).

## Testing

- pnpm verify:changeset-release-lane -- --lane=stable --base-ref=d580dc48 — pass (machine gate for changeset intent)
- pnpm --filter @fluojs/platform-cloudflare-workers typecheck — pass
- Read-only triad at this exact head: unanimous merge (semver correctness + EN/KO parity unaffected)

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact. (It corrects an EXISTING changeset's intent; no new changeset needed.)

## Public export documentation

- [x] Changed public exports include a source-level summary. (N/A)
- [x] Changed exported functions document matching \`@param\` / \`@returns\` tags where applicable. (N/A)
- [x] Source \`@example\` blocks and README scenario examples still play complementary roles. (N/A)

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. (None.)
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests. (No runtime change.)

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (No docs changed.)
- [ ] If platform contract docs changed... (N/A)
- [ ] Any package README alignment/conformance claims... (N/A)
