### PR TITLE
Resolve #3359: cover shutdown with an accepted, still-open SSE stream

### DIFF
--- a/packages/platform-bun/src/adapter.test.ts
+++ b/packages/platform-bun/src/adapter.test.ts
@@ -1429,6 +1429,7 @@ describe('@fluojs/platform-bun', () => {
   it('drains an accepted, still-open SSE stream before Bun shutdown settles', async () => {
     const mockBun = installMockBun();
     const requestAbort = new AbortController();
+    const releaseServerStop = createDeferred<void>();
     const streamClosed = createDeferred<void>();
     const order: string[] = [];
     let closeSettled = false;
@@ -1467,7 +1468,13 @@ describe('@fluojs/platform-bun', () => {
       expect(response.status).toBe(200);
       expect(new TextDecoder().decode(firstFrame.value)).toContain('event: ready');
 
-      void reader.closed.then(streamClosed.resolve, streamClosed.reject);
+      void reader.closed.then(
+        () => {
+          order.push('stream-closed');
+          streamClosed.resolve();
+        },
+        streamClosed.reject,
+      );
 
       const server = mockBun.lastServer;
 
@@ -1477,6 +1484,7 @@ describe('@fluojs/platform-bun', () => {
 
       server.stop.mockImplementation(async () => {
         await streamClosed.promise;
+        await releaseServerStop.promise;
       });
 
       const closePromise = adapter.close();
@@ -1492,16 +1500,29 @@ describe('@fluojs/platform-bun', () => {
       );
 
       expect(server.stop).toHaveBeenCalledTimes(1);
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
       expect(closeSettled).toBe(false);
+      expect(order).toEqual([]);
 
-      order.push('stream-cancelled');
       requestAbort.abort(new Error('SSE client disconnected.'));
-      await waitForSettlement(closePromise);
+      await streamClosed.promise;
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+
+      expect(closeSettled).toBe(false);
+      expect(order).toEqual(['stream-closed']);
+
+      releaseServerStop.resolve();
+      await closePromise;
 
       expect(closeSettled).toBe(true);
-      expect(order).toEqual(['stream-cancelled', 'close-settled']);
+      expect(order).toEqual(['stream-closed', 'close-settled']);
     } finally {
       requestAbort.abort(new Error('SSE test cleanup.'));
+      releaseServerStop.resolve();
       await adapter.close();
     }
   });

--- a/packages/platform-bun/src/adapter.test.ts
+++ b/packages/platform-bun/src/adapter.test.ts
@@ -1426,6 +1426,86 @@ describe('@fluojs/platform-bun', () => {
     }
   });
 
+  it('drains an accepted, still-open SSE stream before Bun shutdown settles', async () => {
+    const mockBun = installMockBun();
+    const requestAbort = new AbortController();
+    const streamClosed = createDeferred<void>();
+    const order: string[] = [];
+    let closeSettled = false;
+
+    const adapter = new BunHttpApplicationAdapter();
+    await adapter.listen({
+      async dispatch(request, response) {
+        const stream = new SseResponse({
+          container: {} as RequestContext['container'],
+          metadata: {},
+          request,
+          response,
+        });
+
+        stream.send({ ready: true }, { event: 'ready', id: 'evt-1' });
+      },
+    });
+
+    try {
+      const response = await mockBun.lastServer?.fetch(new Request('http://127.0.0.1:4329/events', {
+        headers: { accept: 'text/event-stream' },
+        signal: requestAbort.signal,
+      }));
+
+      if (!response?.body) {
+        throw new TypeError('Expected the accepted SSE response body to be available.');
+      }
+
+      const reader = response.body.getReader();
+      const firstFrame = await reader.read();
+
+      if (firstFrame.done) {
+        throw new TypeError('Expected the accepted SSE response to emit its first frame.');
+      }
+
+      expect(response.status).toBe(200);
+      expect(new TextDecoder().decode(firstFrame.value)).toContain('event: ready');
+
+      void reader.closed.then(streamClosed.resolve, streamClosed.reject);
+
+      const server = mockBun.lastServer;
+
+      if (!server) {
+        throw new TypeError('Expected the Bun adapter test server to remain available.');
+      }
+
+      server.stop.mockImplementation(async () => {
+        await streamClosed.promise;
+      });
+
+      const closePromise = adapter.close();
+      void closePromise.then(
+        () => {
+          closeSettled = true;
+          order.push('close-settled');
+        },
+        () => {
+          closeSettled = true;
+          order.push('close-settled');
+        },
+      );
+
+      expect(server.stop).toHaveBeenCalledTimes(1);
+      expect(closeSettled).toBe(false);
+
+      order.push('stream-cancelled');
+      requestAbort.abort(new Error('SSE client disconnected.'));
+      await waitForSettlement(closePromise);
+
+      expect(closeSettled).toBe(true);
+      expect(order).toEqual(['stream-cancelled', 'close-settled']);
+    } finally {
+      requestAbort.abort(new Error('SSE test cleanup.'));
+      await adapter.close();
+    }
+  });
+
   it('logs listen target and removes registered shutdown listeners on close', async () => {
     const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
     const mockBun = installMockBun();


### PR DESCRIPTION
## Summary

Adds the missing shutdown regression for an accepted, still-open SSE stream on @fluojs/platform-bun: the stream's REAL close signal (reader.closed) must settle before close() settles, pinning the drain-await seam landed by #3356/#3357.

Linked context: Closes #3359

## Changes

- packages/platform-bun/src/adapter.test.ts: SSE shutdown regression with settlement-order recorders fed by reader.closed, two setImmediate-boundary not-settled gates, house patterns from #3356/#3357.

## Testing

- typecheck — pass; full suite 58/58 twice (adapter.test.ts 108/116ms)
- Mutation proof at the exact seam: server.stop() CALLED but returned promise discarded -> FAIL :1507 expect(order).toEqual([]); reverted -> green
- Read-only triad: round-1 blockers (sync marker, wrong mutation) fixed as prescribed; delta re-review unanimous merge at this exact head

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary. (N/A)
- [x] Changed exported functions document matching \`@param\` / \`@returns\` tags where applicable. (N/A)
- [x] Source \`@example\` blocks and README scenario examples still play complementary roles. (N/A)

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. (None added.)
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (No docs changed.)
- [ ] If platform contract docs changed... (N/A)
- [ ] Any package README alignment/conformance claims... (N/A)
