### PR TITLE
Resolve #3373: release adapter ownership after forced Deno shutdown

### DIFF
--- a/.changeset/release-deno-forced-shutdown-ownership.md
+++ b/.changeset/release-deno-forced-shutdown-ownership.md
@@ -2,4 +2,4 @@
 "@fluojs/platform-deno": patch
 ---
 
-Release managed Deno adapter ownership after forced shutdown completes even when graceful `shutdown()` remains pending.
+Release managed Deno adapter ownership after forced shutdown termination settles, even when graceful `server.shutdown()` remains pending.

--- a/.changeset/release-deno-forced-shutdown-ownership.md
+++ b/.changeset/release-deno-forced-shutdown-ownership.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/platform-deno": patch
+---
+
+Release managed Deno adapter ownership after forced shutdown completes even when graceful `shutdown()` remains pending.

--- a/packages/platform-deno/src/adapter.test.ts
+++ b/packages/platform-deno/src/adapter.test.ts
@@ -1058,6 +1058,54 @@ describe('@fluojs/platform-deno', () => {
     expect(adapter.getServer()).toBeUndefined();
   });
 
+  it('releases Deno ownership after forced termination settles while graceful shutdown remains pending', async () => {
+    const shutdownStarted = createDeferred<void>();
+    const finished = createDeferred<void>();
+    const adapter = new DenoHttpApplicationAdapter({
+      hostname: '0.0.0.0',
+      port: 3000,
+      serve: vi.fn((options) => {
+        options.signal?.addEventListener('abort', () => {
+          finished.resolve();
+        }, { once: true });
+
+        return {
+          finished: finished.promise,
+          shutdown: async () => {
+            shutdownStarted.resolve();
+            await new Promise<void>(() => {});
+          },
+        };
+      }),
+    });
+
+    await adapter.listen({
+      async dispatch(_request: FrameworkRequest, response: FrameworkResponse) {
+        response.setStatus(204);
+      },
+    });
+
+    const closePromise = adapter.close();
+    await shutdownStarted.promise;
+
+    expect(adapter.getServer()).toBeDefined();
+    expect(Reflect.get(adapter, 'closeInFlight')).toBeDefined();
+    expect((await adapter.handle(new Request('https://runtime.test/during-forced-close'))).status).toBe(503);
+
+    const abortController = Reflect.get(adapter, 'abortController');
+    if (!(abortController instanceof AbortController)) {
+      throw new TypeError('Expected the Deno adapter abort controller while close is in flight.');
+    }
+
+    abortController.abort();
+    await closePromise;
+
+    expect(adapter.getServer()).toBeUndefined();
+    expect(Reflect.get(adapter, 'closeInFlight')).toBeUndefined();
+    expect(Reflect.get(adapter, 'dispatcher')).toBeUndefined();
+    expect((await adapter.handle(new Request('https://runtime.test/after-forced-close'))).status).toBe(500);
+  });
+
   it('aborts the Deno serve signal when in-flight drain rejects', async () => {
     const drainError = new Error('drain failed');
     let serveSignal: AbortSignal | undefined;

--- a/packages/platform-deno/src/adapter.test.ts
+++ b/packages/platform-deno/src/adapter.test.ts
@@ -1058,17 +1058,17 @@ describe('@fluojs/platform-deno', () => {
     expect(adapter.getServer()).toBeUndefined();
   });
 
-  it('releases Deno ownership after forced termination settles while graceful shutdown remains pending', async () => {
+  it('retains Deno ownership after forced abort until server termination settles', async () => {
+    const requestAccepted = createDeferred<void>();
+    const requestDrain = createDeferred<void>();
     const shutdownStarted = createDeferred<void>();
     const finished = createDeferred<void>();
+    let handler: DenoServeHandler | undefined;
     const adapter = new DenoHttpApplicationAdapter({
       hostname: '0.0.0.0',
       port: 3000,
-      serve: vi.fn((options) => {
-        options.signal?.addEventListener('abort', () => {
-          finished.resolve();
-        }, { once: true });
-
+      serve: vi.fn((_options, capturedHandler) => {
+        handler = capturedHandler;
         return {
           finished: finished.promise,
           shutdown: async () => {
@@ -1081,11 +1081,22 @@ describe('@fluojs/platform-deno', () => {
 
     await adapter.listen({
       async dispatch(_request: FrameworkRequest, response: FrameworkResponse) {
+        requestAccepted.resolve();
+        await requestDrain.promise;
         response.setStatus(204);
       },
     });
 
-    const closePromise = adapter.close();
+    if (!handler) {
+      throw new TypeError('Expected the Deno serve handler after adapter listen().');
+    }
+
+    const activeRequest = handler(new Request('https://runtime.test/termination-gate'));
+    await requestAccepted.promise;
+    let closeSettled = false;
+    const closePromise = adapter.close().then(() => {
+      closeSettled = true;
+    });
     await shutdownStarted.promise;
 
     expect(adapter.getServer()).toBeDefined();
@@ -1098,12 +1109,91 @@ describe('@fluojs/platform-deno', () => {
     }
 
     abortController.abort();
+    requestDrain.resolve();
+    await activeRequest;
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(closeSettled).toBe(false);
+    expect(adapter.getServer()).toBeDefined();
+    expect(Reflect.get(adapter, 'closeInFlight')).toBeDefined();
+
+    finished.resolve();
     await closePromise;
 
     expect(adapter.getServer()).toBeUndefined();
     expect(Reflect.get(adapter, 'closeInFlight')).toBeUndefined();
     expect(Reflect.get(adapter, 'dispatcher')).toBeUndefined();
-    expect((await adapter.handle(new Request('https://runtime.test/after-forced-close'))).status).toBe(500);
+    expect((await adapter.handle(new Request('https://runtime.test/after-termination-close'))).status).toBe(500);
+  });
+
+  it('retains Deno ownership after forced abort until active requests drain', async () => {
+    const requestAccepted = createDeferred<void>();
+    const requestDrain = createDeferred<void>();
+    const shutdownStarted = createDeferred<void>();
+    const finished = createDeferred<void>();
+    let handler: DenoServeHandler | undefined;
+    const adapter = new DenoHttpApplicationAdapter({
+      hostname: '0.0.0.0',
+      port: 3000,
+      serve: vi.fn((_options, capturedHandler) => {
+        handler = capturedHandler;
+        return {
+          finished: finished.promise,
+          shutdown: async () => {
+            shutdownStarted.resolve();
+            await new Promise<void>(() => {});
+          },
+        };
+      }),
+    });
+
+    await adapter.listen({
+      async dispatch(_request: FrameworkRequest, response: FrameworkResponse) {
+        requestAccepted.resolve();
+        await requestDrain.promise;
+        response.setStatus(204);
+      },
+    });
+
+    if (!handler) {
+      throw new TypeError('Expected the Deno serve handler after adapter listen().');
+    }
+
+    const activeRequest = handler(new Request('https://runtime.test/drain-gate'));
+    await requestAccepted.promise;
+    let closeSettled = false;
+    const closePromise = adapter.close().then(() => {
+      closeSettled = true;
+    });
+    await shutdownStarted.promise;
+
+    const abortController = Reflect.get(adapter, 'abortController');
+    if (!(abortController instanceof AbortController)) {
+      throw new TypeError('Expected the Deno adapter abort controller while close is in flight.');
+    }
+
+    abortController.abort();
+    const finishedSettled = finished.promise.then(() => undefined);
+    finished.resolve();
+    await finishedSettled;
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(closeSettled).toBe(false);
+    expect(adapter.getServer()).toBeDefined();
+    expect(Reflect.get(adapter, 'closeInFlight')).toBeDefined();
+
+    requestDrain.resolve();
+    await activeRequest;
+    await closePromise;
+
+    expect(adapter.getServer()).toBeUndefined();
+    expect(Reflect.get(adapter, 'closeInFlight')).toBeUndefined();
+    expect(Reflect.get(adapter, 'dispatcher')).toBeUndefined();
+    expect((await adapter.handle(new Request('https://runtime.test/after-drain-close'))).status).toBe(500);
   });
 
   it('aborts the Deno serve signal when in-flight drain rejects', async () => {

--- a/packages/platform-deno/src/adapter.ts
+++ b/packages/platform-deno/src/adapter.ts
@@ -539,14 +539,34 @@ function closeDenoServerWithDrain(
 ): Promise<void> {
   return (async () => {
     let closeFailure: { readonly error: unknown } | undefined;
+    const drain = waitForDrain();
+    const gracefulClose = Promise.allSettled([
+      Promise.resolve(server.shutdown()),
+      drain,
+    ]).then((results) => ({
+      kind: 'graceful' as const,
+      results,
+    }));
+    const forcedClose = abortController
+      ? waitForAbort(abortController.signal).then(() => ({ kind: 'forced' as const }))
+      : undefined;
+    const closeResult = forcedClose
+      ? await Promise.race([gracefulClose, forcedClose])
+      : await gracefulClose;
 
-    try {
-      await server.shutdown();
-      await waitForDrain();
-    } catch (error: unknown) {
-      closeFailure = { error };
-    } finally {
+    if (closeResult.kind === 'graceful') {
       abortController?.abort();
+      const rejected = closeResult.results.find((result) => result.status === 'rejected');
+
+      if (rejected?.status === 'rejected') {
+        closeFailure = { error: rejected.reason };
+      }
+    } else {
+      try {
+        await drain;
+      } catch (error: unknown) {
+        closeFailure = { error };
+      }
     }
 
     try {
@@ -561,6 +581,18 @@ function closeDenoServerWithDrain(
       throw closeFailure.error;
     }
   })();
+}
+
+function waitForAbort(signal: AbortSignal): Promise<void> {
+  if (signal.aborted) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    signal.addEventListener('abort', () => {
+      resolve();
+    }, { once: true });
+  });
 }
 
 function createDeferred<T>(): Deferred<T> {

--- a/packages/platform-deno/src/adapter.ts
+++ b/packages/platform-deno/src/adapter.ts
@@ -539,9 +539,10 @@ function closeDenoServerWithDrain(
 ): Promise<void> {
   return (async () => {
     let closeFailure: { readonly error: unknown } | undefined;
+    const shutdown = Promise.resolve(server.shutdown());
     const drain = waitForDrain();
     const gracefulClose = Promise.allSettled([
-      Promise.resolve(server.shutdown()),
+      shutdown,
       drain,
     ]).then((results) => ({
       kind: 'graceful' as const,


### PR DESCRIPTION
## Summary

Releases managed adapter ownership after a forced Deno shutdown even when \`server.shutdown()\` hangs: close() now awaits \`server.finished\` and the accepted-request drain independently of the hung graceful path, then releases ownership.

Linked context: Closes #3373

## Changes

- packages/platform-deno/src/adapter.ts: forced-abort path awaits server.finished + request drain (Promise.race with graceful close), releases ownership only after both settle.
- packages/platform-deno/src/adapter.test.ts: deferred-signal regressions — forced-abort lifecycle seam plus TWO independent retention gates (termination pending / drain pending), no timers.
- .changeset/release-deno-forced-shutdown-ownership.md: @fluojs/platform-deno patch.

## Testing

- pnpm --filter '@fluojs/platform-deno...' build — pass; typecheck — pass
- Full suite 54->55/55 twice (adapter.test.ts 161/174ms)
- Mutation proofs: production fix reverted -> regression times out (:1061); drain wait removed -> FAIL :1183; server.finished wait removed -> FAIL :1119; all reverted -> green
- Built-module driver: 'forced Deno ownership release verified'
- Read-only triad: round-1 contract blocker (mutation insensitivity) fixed; delta re-review unanimous merge at this exact head

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching \`@param\` / \`@returns\` tags where applicable.
- [x] Source \`@example\` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. (Existing ownership wording already accurate.)
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (No docs changed.)
- [ ] If platform contract docs changed... (N/A)
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests.
