### PR TITLE
Resolve #3358: cover rejected realtime binding evaluation during shutdown

### DIFF
--- a/packages/platform-bun/src/adapter.test.ts
+++ b/packages/platform-bun/src/adapter.test.ts
@@ -2147,6 +2147,73 @@ describe('@fluojs/platform-bun', () => {
     expect(order).toEqual(['binding-released', 'close-settled']);
   });
 
+  it('drains a rejected realtime binding during close and clears public state', async () => {
+    const mockBun = installMockBun();
+    const adapter = new BunHttpApplicationAdapter();
+    const bindingStarted = createDeferred<void>();
+    const bindingRelease = createDeferred<void>();
+    const bindingError = new Error('Realtime binding rejected.');
+    const order: string[] = [];
+    let closePromise: Promise<void> | undefined;
+    let closeSettled = false;
+    let responsePromise: Promise<Response | undefined> | undefined;
+
+    adapter.configureRealtimeBinding({
+      fetch: async () => {
+        bindingStarted.resolve();
+        await bindingRelease.promise;
+        return undefined;
+      },
+      websocket: {},
+    });
+
+    await adapter.listen({
+      dispatch: vi.fn(async () => undefined),
+    });
+
+    const server = mockBun.lastServer;
+
+    try {
+      if (!server) {
+        throw new TypeError('Expected the Bun adapter test server to be available after listen().');
+      }
+
+      const acceptedResponsePromise = Promise.resolve(server.fetch(new Request('http://127.0.0.1:3000/realtime')));
+      responsePromise = acceptedResponsePromise;
+      await waitForSettlement(bindingStarted.promise);
+
+      closePromise = adapter.close();
+      void closePromise.then(
+        () => {
+          order.push('close-settled');
+        },
+        () => {
+          order.push('close-rejected');
+        },
+      );
+
+      order.push('binding-rejected');
+      bindingRelease.reject(bindingError);
+
+      await expect(waitForSettlement(acceptedResponsePromise)).rejects.toBe(bindingError);
+      await expect(waitForSettlement(closePromise)).resolves.toBeUndefined();
+      closeSettled = true;
+
+      expect(order).toEqual(['binding-rejected', 'close-settled']);
+      expect(adapter.getServer()).toBeUndefined();
+    } finally {
+      bindingRelease.reject(bindingError);
+      if (closePromise === undefined) {
+        await adapter.close();
+      } else if (closeSettled) {
+        await waitForSettlement(Promise.allSettled([
+          responsePromise ?? Promise.resolve(undefined),
+          closePromise,
+        ]));
+      }
+    }
+  });
+
   it('drains an accepted request through a delayed websocket upgrade without HTTP fallback', async () => {
     const mockBun = installMockBun();
     const adapter = new BunHttpApplicationAdapter();


### PR DESCRIPTION
## Summary

Adds shutdown coverage for a REJECTED realtime binding on @fluojs/platform-bun: request error propagation, drain completion, and adapter state cleanup are pinned with deferred gates.

Linked context: Closes #3358

## Changes

- packages/platform-bun/src/adapter.test.ts: rejected-binding shutdown regression (house deferred-gate patterns; bounded timeouts only as failure guards).

## Testing

- typecheck — pass; full suite 59/59 twice (adapter.test.ts 117/151ms)
- Mutation proof: finally { release(); } removed -> FAIL :2194 close-settlement; reverted -> green
- Read-only triad at this exact head: unanimous merge

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary. (N/A)
- [x] Changed exported functions document matching \`@param\` / \`@returns\` tags where applicable. (N/A)
- [x] Source \`@example\` blocks and README scenario examples still play complementary roles. (N/A)

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. (None added.)
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (No docs changed.)
- [ ] If platform contract docs changed... (N/A)
- [ ] Any package README alignment/conformance claims... (N/A)
