### PR TITLE
Resolve #3384: synchronize startup-cancellation with retry-loop entry

### DIFF
--- a/packages/platform-express/src/adapter.test.ts
+++ b/packages/platform-express/src/adapter.test.ts
@@ -74,9 +74,11 @@ function createDeferred<T>(): {
 }
 
 async function waitForSettlement<T>(promise: Promise<T>, timeoutMs = 2_000): Promise<T> {
+  const scheduleTimeout = globalThis.setTimeout;
+  const cancelTimeout = globalThis.clearTimeout;
   let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<never>((_resolve, reject) => {
-    timeoutHandle = setTimeout(() => {
+    timeoutHandle = scheduleTimeout(() => {
       reject(new Error(`Timed out waiting for test settlement after ${String(timeoutMs)}ms.`));
     }, timeoutMs);
   });
@@ -85,7 +87,7 @@ async function waitForSettlement<T>(promise: Promise<T>, timeoutMs = 2_000): Pro
     return await Promise.race([promise, timeout]);
   } finally {
     if (timeoutHandle !== undefined) {
-      clearTimeout(timeoutHandle);
+      cancelTimeout(timeoutHandle);
     }
   }
 }
@@ -2823,8 +2825,11 @@ describe('@fluojs/platform-express', () => {
   });
 
   it('cancels retrying startup during close before a later Express bind can occur', async () => {
+    const addressInUse = createDeferred<void>();
+    const addressInUseSettlement = waitForSettlement(addressInUse.promise);
     vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
 
+    const retryDelayMs = 25;
     const blocker = createHttpServer((_request, response) => {
       response.statusCode = 200;
       response.end('blocked');
@@ -2856,18 +2861,26 @@ describe('@fluojs/platform-express', () => {
       });
     };
 
-    const adapter = new ExpressHttpApplicationAdapter(port, '127.0.0.1', 25, 20, undefined, undefined, 1024, false, 500);
+    const adapter = new ExpressHttpApplicationAdapter(port, '127.0.0.1', retryDelayMs, 20, undefined, undefined, 1024, false, 500);
     const dispatcher = {
       async dispatch() {},
     };
-    const addressInUse = createDeferred<void>();
     const laterBind = vi.fn();
     let observedAddressInUse = false;
+    const originalSetTimeout = globalThis.setTimeout;
+    const retryDelayTimer = vi.spyOn(globalThis, 'setTimeout').mockImplementation((callback, delayMs, ...args) => {
+      const timeout = originalSetTimeout(callback, delayMs, ...args);
+
+      if (delayMs === retryDelayMs && observedAddressInUse) {
+        addressInUse.resolve();
+      }
+
+      return timeout;
+    });
 
     adapter.getServer().once('error', (error) => {
       if (error instanceof Error && 'code' in error && error.code === 'EADDRINUSE') {
         observedAddressInUse = true;
-        addressInUse.resolve();
         return;
       }
 
@@ -2884,8 +2897,12 @@ describe('@fluojs/platform-express', () => {
     );
 
     try {
-      await addressInUse.promise;
+      await addressInUseSettlement;
+      expect(observedAddressInUse).toBe(true);
+      expect(vi.getTimerCount()).toBe(1);
+
       await expect(adapter.close()).resolves.toBeUndefined();
+      expect(vi.getTimerCount()).toBe(0);
       await closeBlocker();
 
       const results = await Promise.all([firstListenResult, secondListenResult]);
@@ -2895,15 +2912,13 @@ describe('@fluojs/platform-express', () => {
         expect(String(result instanceof Error ? result.message : result)).toContain('startup was cancelled');
       }
 
-      expect(observedAddressInUse).toBe(true);
-      expect(vi.getTimerCount()).toBe(0);
-
       await vi.advanceTimersByTimeAsync(60);
 
       expect(laterBind).not.toHaveBeenCalled();
     } finally {
       await adapter.close();
       await closeBlocker();
+      retryDelayTimer.mockRestore();
       vi.useRealTimers();
     }
   });

--- a/packages/platform-express/src/adapter.test.ts
+++ b/packages/platform-express/src/adapter.test.ts
@@ -2823,6 +2823,8 @@ describe('@fluojs/platform-express', () => {
   });
 
   it('cancels retrying startup during close before a later Express bind can occur', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+
     const blocker = createHttpServer((_request, response) => {
       response.statusCode = 200;
       response.end('blocked');
@@ -2858,6 +2860,20 @@ describe('@fluojs/platform-express', () => {
     const dispatcher = {
       async dispatch() {},
     };
+    const addressInUse = createDeferred<void>();
+    const laterBind = vi.fn();
+    let observedAddressInUse = false;
+
+    adapter.getServer().once('error', (error) => {
+      if (error instanceof Error && 'code' in error && error.code === 'EADDRINUSE') {
+        observedAddressInUse = true;
+        addressInUse.resolve();
+        return;
+      }
+
+      addressInUse.reject(error);
+    });
+    adapter.getServer().on('listening', laterBind);
     const firstListenResult = adapter.listen(dispatcher).then(
       () => 'listened' as const,
       (error: unknown) => error,
@@ -2868,9 +2884,7 @@ describe('@fluojs/platform-express', () => {
     );
 
     try {
-      await new Promise((resolve) => {
-        setTimeout(resolve, 10);
-      });
+      await addressInUse.promise;
       await expect(adapter.close()).resolves.toBeUndefined();
       await closeBlocker();
 
@@ -2881,27 +2895,16 @@ describe('@fluojs/platform-express', () => {
         expect(String(result instanceof Error ? result.message : result)).toContain('startup was cancelled');
       }
 
-      await new Promise((resolve) => {
-        setTimeout(resolve, 60);
-      });
+      expect(observedAddressInUse).toBe(true);
+      expect(vi.getTimerCount()).toBe(0);
 
-      await new Promise<void>((resolve, reject) => {
-        const probe = createHttpServer();
-        probe.once('error', reject);
-        probe.listen({ host: '127.0.0.1', port }, () => {
-          probe.close((error) => {
-            if (error) {
-              reject(error);
-              return;
-            }
+      await vi.advanceTimersByTimeAsync(60);
 
-            resolve();
-          });
-        });
-      });
+      expect(laterBind).not.toHaveBeenCalled();
     } finally {
       await adapter.close();
       await closeBlocker();
+      vi.useRealTimers();
     }
   });
 


### PR DESCRIPTION
## Summary

Synchronizes the platform-express startup-cancellation regression with actual retry-loop entry: the gate releases only when the real retry \`setTimeout(retryDelayMs)\` is created after an OBSERVED EADDRINUSE, then asserts exactly one active retry timer before close, zero after, and no 'listening' re-entry after fake-timer advancement.

Linked context: Closes #3384

## Changes

- packages/platform-express/src/adapter.test.ts: retry-delay-entry synchronization + timer-count assertions + rebind guard (2 test-only commits; builds on #3382/#3383 house patterns).

## Testing

- typecheck — pass; full suite 70/70 twice (adapter.test.ts 388/363ms; focused regression 20ms)
- Mutation proof (deterministic, 2/2): await addressInUseSettlement removed -> FAIL expect(observedAddressInUse).toBe(true) both runs; reverted -> green twice; verification reviewer independently re-ran the mutation
- Read-only triad: round-1 blockers (trivial timer-count pass, non-reproducible mutation) fixed; delta re-review unanimous merge at this exact head

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary. (N/A)
- [x] Changed exported functions document matching \`@param\` / \`@returns\` tags where applicable. (N/A)
- [x] Source \`@example\` blocks and README scenario examples still play complementary roles. (N/A)

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. (None added.)
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (No docs changed.)
- [ ] If platform contract docs changed... (N/A)
- [ ] Any package README alignment/conformance claims... (N/A)
