### PR TITLE
Resolve #3374: await shutdown abort event instead of polling

### DIFF
--- a/packages/platform-deno/src/adapter.test.ts
+++ b/packages/platform-deno/src/adapter.test.ts
@@ -1037,6 +1037,14 @@ describe('@fluojs/platform-deno', () => {
       },
     });
 
+    const signal = serveSignal;
+    if (!signal) {
+      throw new TypeError('Expected the Deno serve signal after adapter listen().');
+    }
+
+    const abortEvent = new Promise<void>((resolve) => {
+      signal.addEventListener('abort', () => resolve(), { once: true });
+    });
     const server = adapter.getServer();
     let closeSettled = false;
 
@@ -1046,9 +1054,21 @@ describe('@fluojs/platform-deno', () => {
     });
 
     // Then: the adapter retains ownership until termination, then reports the original failure.
-    await vi.waitFor(() => {
-      expect(serveSignal?.aborted).toBe(true);
-    });
+    let abortTimeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        abortEvent,
+        new Promise<never>((_resolve, reject) => {
+          abortTimeout = setTimeout(() => {
+            reject(new Error('Timed out waiting for the Deno serve signal to abort.'));
+          }, 1_000);
+        }),
+      ]);
+    } finally {
+      if (abortTimeout) {
+        clearTimeout(abortTimeout);
+      }
+    }
 
     expect(closeSettled).toBe(false);
     expect(adapter.getServer()).toBe(server);


### PR DESCRIPTION
## Summary

Awaits the Deno serve AbortSignal 'abort' event directly in the shutdown regression instead of polling wall-clock time: the subscription is attached BEFORE close(), with a 1s failure guard only.

Linked context: Closes #3374 (builds on #3373's forced-abort semantics, already merged)

## Changes

- packages/platform-deno/src/adapter.test.ts: abort-event subscription + direct await; polling removed.

## Testing

- typecheck — pass; full suite 55/55 twice (adapter.test.ts 158/129ms)
- node tooling/governance/verify-platform-consistency-governance.mjs — pass
- Mutation proof (2/2): exact abort seam disabled -> FAIL :1063 'Timed out waiting for the Deno serve signal to abort.' both runs; reverted -> green; governance re-passed
- Read-only triad at this exact head: unanimous merge (verification reviewer independently re-ran the mutation)

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary. (N/A)
- [x] Changed exported functions document matching \`@param\` / \`@returns\` tags where applicable. (N/A)
- [x] Source \`@example\` blocks and README scenario examples still play complementary roles. (N/A)

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. (None added.)
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (No docs changed.)
- [ ] If platform contract docs changed... (N/A)
- [ ] Any package README alignment/conformance claims... (N/A)
