### PR TITLE
Resolve #3385: await close finalizer cleanup in close-timeout regression

### DIFF
--- a/packages/platform-express/src/adapter.test.ts
+++ b/packages/platform-express/src/adapter.test.ts
@@ -2461,11 +2461,10 @@ describe('@fluojs/platform-express', () => {
 
     expect(closeCallCount).toBe(1);
     expect(Reflect.get(adapter, 'dispatcher')).toBe(dispatcher);
+    const closeInFlight: Promise<void> = Reflect.get(adapter, 'closeInFlight');
 
     deferred.resolve();
-    await new Promise((resolve) => {
-      setTimeout(resolve, 0);
-    });
+    await waitForSettlement(closeInFlight);
 
     expect(Reflect.get(adapter, 'dispatcher')).toBeUndefined();
   });


### PR DESCRIPTION
## Summary

Makes the platform-express close-timeout cleanup regression observe finalizer completion: the test awaits the closeInFlight finalizer via bounded waitForSettlement (failure guard only) instead of guessing with timers.

Linked context: Closes #3385 (completes the express determinism chain #3382 -> #3384 -> #3385)

## Changes

- packages/platform-express/src/adapter.test.ts: closeInFlight settlement await; timer guessing removed.

## Testing

- typecheck — pass; full suite 70/70 twice (adapter.test.ts 359/375ms)
- Mutation proof (2/2): dispatcher cleanup seam disabled -> FAIL :2469 both runs; reverted -> green; verification reviewer re-ran the mutation
- Read-only triad at this exact head: unanimous merge

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary. (N/A)
- [x] Changed exported functions document matching \`@param\` / \`@returns\` tags where applicable. (N/A)
- [x] Source \`@example\` blocks and README scenario examples still play complementary roles. (N/A)

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. (None added.)
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (No docs changed.)
- [ ] If platform contract docs changed... (N/A)
- [ ] Any package README alignment/conformance claims... (N/A)
