### PR TITLE
Resolve #3375: synchronize timed-out drain coverage with close settlement

### DIFF
--- a/packages/platform-deno/src/adapter.test.ts
+++ b/packages/platform-deno/src/adapter.test.ts
@@ -1184,9 +1184,8 @@ describe('@fluojs/platform-deno', () => {
     const activeRequest = handler(new Request('https://runtime.test/drain-gate'));
     await requestAccepted.promise;
     let closeSettled = false;
-    const closePromise = adapter.close().then(() => {
-      closeSettled = true;
-    });
+    const settlementOrder: string[] = [];
+    const closePromise = adapter.close();
     await shutdownStarted.promise;
 
     const abortController = Reflect.get(adapter, 'abortController');
@@ -1196,22 +1195,27 @@ describe('@fluojs/platform-deno', () => {
 
     abortController.abort();
     const closeSettlement = adapter.close();
-    let closeSettlementReached = false;
     void closeSettlement.then(() => {
-      closeSettlementReached = true;
+      closeSettled = true;
+      settlementOrder.push('close-settled');
     });
-    requestDrain.resolve();
-    await activeRequest;
+    const finishedSettled = finished.promise.then(() => {
+      settlementOrder.push('server-finished');
+    });
+    finished.resolve();
+    await finishedSettled;
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
 
     expect(closeSettled).toBe(false);
     expect(adapter.getServer()).toBeDefined();
     expect(Reflect.get(adapter, 'closeInFlight')).toBeDefined();
+    expect(settlementOrder).toEqual(['server-finished']);
 
-    try {
-      expect(closeSettlementReached).toBe(false);
-    } finally {
-      finished.resolve();
-    }
+    settlementOrder.push('request-drain-released');
+    requestDrain.resolve();
+    await activeRequest;
     let closeSettlementTimeout: ReturnType<typeof setTimeout> | undefined;
     try {
       await Promise.race([
@@ -1228,6 +1232,8 @@ describe('@fluojs/platform-deno', () => {
       }
     }
 
+    expect(closeSettled).toBe(true);
+    expect(settlementOrder).toEqual(['server-finished', 'request-drain-released', 'close-settled']);
     expect(adapter.getServer()).toBeUndefined();
     expect(Reflect.get(adapter, 'closeInFlight')).toBeUndefined();
     expect(Reflect.get(adapter, 'dispatcher')).toBeUndefined();

--- a/packages/platform-deno/src/adapter.test.ts
+++ b/packages/platform-deno/src/adapter.test.ts
@@ -1195,25 +1195,44 @@ describe('@fluojs/platform-deno', () => {
     }
 
     abortController.abort();
-    const finishedSettled = finished.promise.then(() => undefined);
-    finished.resolve();
-    await finishedSettled;
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    const closeSettlement = adapter.close();
+    let closeSettlementReached = false;
+    void closeSettlement.then(() => {
+      closeSettlementReached = true;
+    });
+    requestDrain.resolve();
+    await activeRequest;
 
     expect(closeSettled).toBe(false);
     expect(adapter.getServer()).toBeDefined();
     expect(Reflect.get(adapter, 'closeInFlight')).toBeDefined();
 
-    requestDrain.resolve();
-    await activeRequest;
-    await closePromise;
+    try {
+      expect(closeSettlementReached).toBe(false);
+    } finally {
+      finished.resolve();
+    }
+    let closeSettlementTimeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        closeSettlement,
+        new Promise<never>((_resolve, reject) => {
+          closeSettlementTimeout = setTimeout(() => {
+            reject(new Error('Timed out waiting for the Deno close settlement after active requests drained.'));
+          }, 1_000);
+        }),
+      ]);
+    } finally {
+      if (closeSettlementTimeout) {
+        clearTimeout(closeSettlementTimeout);
+      }
+    }
 
     expect(adapter.getServer()).toBeUndefined();
     expect(Reflect.get(adapter, 'closeInFlight')).toBeUndefined();
     expect(Reflect.get(adapter, 'dispatcher')).toBeUndefined();
     expect((await adapter.handle(new Request('https://runtime.test/after-drain-close'))).status).toBe(500);
+    await closePromise;
   });
 
   it('aborts the Deno serve signal when in-flight drain rejects', async () => {


### PR DESCRIPTION
## Summary

Synchronizes the platform-deno timed-out drain coverage with real close settlement: subscribes to the second close()'s actual settlement, and pins — with an order recorder — that the joined close cannot settle before server.finished NOR before the request drain releases (restored active-drain gate as an independent scenario). Timer turns removed; 1s timeouts remain failure guards only.

Linked context: Closes #3375 (completes the deno chain #3373 -> #3374 -> #3375)

## Changes

- packages/platform-deno/src/adapter.test.ts: settlement subscription + server-finished/request-drain-released/close-settled order pinning (2 test-only commits).

## Testing

- typecheck — pass; full suite 55/55 twice (adapter.test.ts 114/115ms)
- node tooling/governance/verify-platform-consistency-governance.mjs — pass
- Mutation proofs (2/2 each): await drain removed -> FAIL :1211; closeInFlight join removed -> FAIL :1211; verification reviewer independently reproduced via in-memory transform
- Read-only triad: round-1 blocker (lost drain-gate scenario) fixed; final round unanimous merge at this exact head (the setImmediate-boundary concern was withdrawn after determinism re-judgment: pure promise-chain path gated on an unresolved deferred cannot settle across the macrotask boundary)

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary. (N/A)
- [x] Changed exported functions document matching \`@param\` / \`@returns\` tags where applicable. (N/A)
- [x] Source \`@example\` blocks and README scenario examples still play complementary roles. (N/A)

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. (None added.)
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (No docs changed.)
- [ ] If platform contract docs changed... (N/A)
- [ ] Any package README alignment/conformance claims... (N/A)
