### PR TITLE
Resolve #3398: run custom-method portability through the real Node listener

### DIFF
--- a/packages/platform-nodejs/src/index.test.ts
+++ b/packages/platform-nodejs/src/index.test.ts
@@ -118,6 +118,10 @@ const nodejsPortabilityHarness = createHttpAdapterPortabilityHarness<
 
 describe('@fluojs/platform-nodejs', () => {
   describe('adapter portability', () => {
+    it('executes QUERY and extension methods through the real Node listener', async () => {
+      await nodejsPortabilityHarness.assertSupportsCustomHttpRouteMethods();
+    });
+
     it('supports HTTP-owned JSON and HTML error representations', async () => {
       await nodejsPortabilityHarness.assertSupportsHttpErrorRepresentations();
     });

--- a/packages/platform-nodejs/test-types/testing-http-adapter-portability.d.ts
+++ b/packages/platform-nodejs/test-types/testing-http-adapter-portability.d.ts
@@ -41,6 +41,7 @@ declare module '@fluojs/testing/http-adapter-portability' {
     assertReportsConfiguredHostInStartupLogs(): Promise<void>;
     assertReportsHttpsStartupUrl(https: { cert: string; key: string }): Promise<void>;
     assertSettlesStreamDrainWaitOnClose(): Promise<void>;
+    assertSupportsCustomHttpRouteMethods(): Promise<void>;
     assertSupportsHttpErrorRepresentations(): Promise<void>;
     assertSupportsSseStreaming(): Promise<void>;
   }


### PR DESCRIPTION
## Summary

Runs the shared custom HTTP method (QUERY/PURGE) body portability assertions through the REAL Node listener for @fluojs/platform-nodejs.

Linked context: Closes #3398

## Changes

- packages/platform-nodejs/src/index.test.ts: portability harness assertions on the real listener.
- packages/platform-nodejs/test-types/testing-http-adapter-portability.d.ts: test-support declaration (outside src/, not shipped).

## Testing

- closure build, typecheck, platform-consistency governance — pass
- suite 42/42 twice
- Mutation proof (2/2): listener forced to GET for all methods -> FAIL http-adapter-portability.ts:429 ('QUERY ... received 404') both runs; reverted -> green
- Read-only triad at this exact head: unanimous merge

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary. (N/A — test-only)
- [x] Changed exported functions document matching \`@param\` / \`@returns\` tags where applicable. (N/A)
- [x] Source \`@example\` blocks and README scenario examples still play complementary roles. (N/A)

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. (None added.)
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (No docs changed.)
- [ ] If platform contract docs changed... (N/A)
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests.
