### PR TITLE
Resolve #3376: protect the pre-listen websocket binding freeze

### DIFF
--- a/packages/platform-deno/src/adapter.test.ts
+++ b/packages/platform-deno/src/adapter.test.ts
@@ -1676,6 +1676,41 @@ describe('@fluojs/platform-deno', () => {
     expect(httpResponse?.status).toBe(200);
   });
 
+  it('rejects websocket binding changes after listen and retains the original upgrade dispatch', async () => {
+    const server = createServeStub();
+    const upgraded = createUpgradeWebSocketStub();
+    const adapter = new DenoHttpApplicationAdapter({
+      hostname: '0.0.0.0',
+      port: 3000,
+      serve: server.serve,
+      upgradeWebSocket: upgraded.upgrade,
+    });
+    const originalBindingFetch = vi.fn<DenoWebSocketBinding['fetch']>(async (request, host) => host.upgrade(request).response);
+    const replacementBindingFetch = vi.fn<DenoWebSocketBinding['fetch']>(async (request, host) => host.upgrade(request).response);
+
+    adapter.configureWebSocketBinding({
+      fetch: originalBindingFetch,
+    });
+    await adapter.listen({
+      dispatch: vi.fn(async () => undefined),
+    });
+
+    expect(() => adapter.configureWebSocketBinding({
+      fetch: replacementBindingFetch,
+    })).toThrow('Deno websocket binding must be configured before Deno adapter listen() starts the server.');
+
+    const response = await server.handler?.(new Request('https://runtime.test/chat', {
+      headers: { upgrade: 'websocket' },
+    }));
+
+    expect(response?.status).toBe(200);
+    expect(originalBindingFetch).toHaveBeenCalledTimes(1);
+    expect(replacementBindingFetch).not.toHaveBeenCalled();
+    expect(upgraded.upgrade).toHaveBeenCalledTimes(1);
+
+    await adapter.close();
+  });
+
   it('keeps websocket upgrade requests on HTTP dispatch when no Deno websocket binding is configured', async () => {
     const server = createServeStub();
     const upgraded = createUpgradeWebSocketStub();


### PR DESCRIPTION
## Summary

Adds a negative regression protecting the pre-listen WebSocket binding freeze in @fluojs/platform-deno: a late \`configureWebSocketBinding()\` is rejected and the existing binding keeps serving upgrade dispatch.

Linked context: Closes #3376

## Changes

- packages/platform-deno/src/adapter.test.ts: late-binding rejection + preserved-binding upgrade dispatch regression.

## Testing

- closure build, typecheck, platform-consistency governance — pass
- suite 56/56 twice (adapter.test.ts 1.181s / 632ms)
- Mutation proof (2/2): freeze guard forced false -> FAIL adapter.test.ts:1700 documented-error assertion both runs; reverted -> green
- Read-only triad at this exact head: unanimous merge

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary. (N/A — test-only)
- [x] Changed exported functions document matching \`@param\` / \`@returns\` tags where applicable. (N/A)
- [x] Source \`@example\` blocks and README scenario examples still play complementary roles. (N/A)

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. (None added.)
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (No docs changed.)
- [ ] If platform contract docs changed... (N/A)
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests.
