### PR TITLE
Resolve #3351: merge mixed-case Set-Cookie writes in virtual responses

### DIFF
--- a/.changeset/quiet-cherries-dance.md
+++ b/.changeset/quiet-cherries-dance.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/testing': patch
+---
+
+Merge mixed-case virtual response `Set-Cookie` writes into one ordered header.

--- a/packages/testing/src/http.ts
+++ b/packages/testing/src/http.ts
@@ -268,8 +268,13 @@ function buildFrameworkResponse(): { response: MutableFrameworkResponse; result:
       const responseHeaders = this.headers as Record<string, string | string[]>;
 
       if (lowerName === 'set-cookie') {
-        result.headers[name] = mergeHeaderValue(result.headers[name], value);
-        responseHeaders[name] = mergeHeaderValue(responseHeaders[name], value);
+        const existingHeaderName = Object.keys(result.headers).find(
+          (headerName) => headerName.toLowerCase() === lowerName,
+        );
+        const canonicalHeaderName = existingHeaderName ?? name;
+
+        result.headers[canonicalHeaderName] = mergeHeaderValue(result.headers[canonicalHeaderName], value);
+        responseHeaders[canonicalHeaderName] = mergeHeaderValue(responseHeaders[canonicalHeaderName], value);
         return;
       }
 

--- a/packages/testing/src/module.test.ts
+++ b/packages/testing/src/module.test.ts
@@ -907,6 +907,27 @@ describe('makeRequest', () => {
       body: { ok: true },
     });
   });
+
+  it('merges mixed-case Set-Cookie writes under one ordered header', async () => {
+    const dispatcher: Dispatcher = {
+      async dispatch(_request, response) {
+        response.setHeader('Set-Cookie', 'session=alpha; Path=/; HttpOnly');
+        response.setHeader('set-cookie', 'theme=dark; Path=/');
+        response.setHeader('SET-COOKIE', 'locale=en-US; Path=/');
+        await response.send({ ok: true });
+      },
+    };
+
+    const result = await makeRequest(dispatcher, { path: '/cookies' });
+
+    expect(result.headers).toEqual({
+      'Set-Cookie': [
+        'session=alpha; Path=/; HttpOnly',
+        'theme=dark; Path=/',
+        'locale=en-US; Path=/',
+      ],
+    });
+  });
 });
 
 describe('createTestApp', () => {


### PR DESCRIPTION
## Summary

Merges mixed-case \`Set-Cookie\` writes in virtual test responses under the canonical header key, preserving write order (@fluojs/testing).

Linked context: Closes #3351

## Changes

- packages/testing/src/http.ts:270 — case-insensitive merge under the canonical key with order preserved.
- packages/testing/src/module.test.ts:908 — mixed-casing regression.
- .changeset/quiet-cherries-dance.md — @fluojs/testing patch.

## Testing

- Isolated serial run (the package's surface.test.ts spawns its own 240s build closure and is load-sensitive): closure build \`--workspace-concurrency=1\` PASS, typecheck PASS, suite 228/228 PASS
- Mutation proof (2/2): canonical-key selection broken to \`name\` -> FAIL module.test.ts:923 both runs; reverted -> green
- Read-only triad at this exact head: unanimous merge

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching \`@param\` / \`@returns\` tags where applicable.
- [x] Source \`@example\` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. (Header-merge semantics unchanged in intent; casing bug fixed.)
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (No docs changed.)
- [ ] If platform contract docs changed... (N/A)
- [ ] Any package README alignment/conformance claims... (N/A)
