### PR TITLE
Resolve #3378: align DenoWebSocketMessage with binary payload forms

### DIFF
--- a/.changeset/issue-3378-deno-websocket-binary-forms.md
+++ b/.changeset/issue-3378-deno-websocket-binary-forms.md
@@ -1,0 +1,7 @@
+---
+"@fluojs/platform-deno": major
+---
+
+`DenoWebSocketMessage` now includes the `ArrayBuffer` and `ArrayBufferView` binary
+payload forms delivered by Deno websocket bindings. Update exhaustive handlers that
+previously covered only `Blob | string`.

--- a/packages/platform-deno/README.ko.md
+++ b/packages/platform-deno/README.ko.md
@@ -108,6 +108,14 @@ export class MyGateway {
 export class RealtimeModule {}
 ```
 
+#### Deno websocket 수신 payload
+
+`DenoWebSocketMessage`는 Deno binding이 전달할 수 있는 모든 payload form,
+`ArrayBuffer | ArrayBufferView | Blob | string`을 나타냅니다. 기존에 이 public
+union을 `Blob | string`으로 exhaustive narrowing한 handler는 `ArrayBuffer`와
+`ArrayBufferView` branch를 추가해야 합니다. `@fluojs/websockets/deno` binding은
+이미 gateway handler를 dispatch하기 전에 이 binary payload를 수용하고 normalize합니다.
+
 ## HTTPS와 런타임 이식성
 
 `https` 옵션으로 Deno TLS 인증서 자료를 전달하면 `Deno.serve`를 HTTPS 모드로 시작할 수 있습니다. 어댑터는 `https.cert`와 `https.key`를 Deno의 `cert` 및 `key`로 전달하며, 시작 로그도 `https://` listen URL을 보고하므로 Deno 패키지가 공유 HTTP 어댑터 이식성 계약과 정렬됩니다.
@@ -147,6 +155,7 @@ Advanced option에는 test 또는 non-hosted runtime을 위한 injectable `serve
 - `getRealtimeCapability()`: runtime integration을 위한 fetch-style Deno websocket upgrade capability를 보고합니다.
 - `getServer()`: adapter가 listen 중일 때 active `Deno.serve` controller를 반환합니다.
 - `configureWebSocketBinding(...)`: `listen(dispatcher)`가 server를 시작하기 전에 `@fluojs/websockets/deno` binding을 설치합니다.
+- `DenoWebSocketMessage`: 전체 수신 websocket payload union인 `ArrayBuffer | ArrayBufferView | Blob | string`입니다.
 - `https: { cert, key }`: `Deno.serve`로 전달되고 보고되는 listen URL에 반영되는 HTTPS 시작 옵션입니다.
 - Option 및 seam type: `CreateDenoFetchHandlerOptions`, `DenoServeOptions`, `DenoServeController`, `DenoServerWebSocket`, websocket binding interface, bootstrap/run option, listen-target helper.
 

--- a/packages/platform-deno/README.md
+++ b/packages/platform-deno/README.md
@@ -108,6 +108,14 @@ export class MyGateway {
 export class RealtimeModule {}
 ```
 
+#### Deno websocket inbound payloads
+
+`DenoWebSocketMessage` represents every payload form the Deno binding can deliver:
+`ArrayBuffer | ArrayBufferView | Blob | string`. Existing handlers that narrowed this
+public union exhaustively for `Blob | string` must add `ArrayBuffer` and
+`ArrayBufferView` branches. The `@fluojs/websockets/deno` binding already accepts and
+normalizes these binary payloads before it dispatches gateway handlers.
+
 ## HTTPS and Runtime Portability
 
 Pass Deno TLS certificate material through the `https` option to start `Deno.serve` in HTTPS mode. The adapter forwards `https.cert` and `https.key` to Deno as `cert` and `key`, and startup logging reports an `https://` listen URL so the Deno package stays aligned with the shared HTTP adapter portability contract.
@@ -147,6 +155,7 @@ The shared edge portability suite in `packages/testing/src/portability/web-runti
 - `getRealtimeCapability()`: Reports the fetch-style Deno websocket upgrade capability for runtime integration.
 - `getServer()`: Returns the active `Deno.serve` controller while the adapter is listening.
 - `configureWebSocketBinding(...)`: Installs the `@fluojs/websockets/deno` binding before `listen(dispatcher)` starts the server.
+- `DenoWebSocketMessage`: The full inbound websocket payload union: `ArrayBuffer | ArrayBufferView | Blob | string`.
 - `https: { cert, key }`: HTTPS startup options forwarded to `Deno.serve` and reflected in the reported listen URL.
 - Option and seam types: `CreateDenoFetchHandlerOptions`, `DenoServeOptions`, `DenoServeController`, `DenoServerWebSocket`, websocket binding interfaces, bootstrap/run options, and listen-target helpers.
 

--- a/packages/platform-deno/src/adapter.ts
+++ b/packages/platform-deno/src/adapter.ts
@@ -38,7 +38,7 @@ export interface DenoServeController {
 export type DenoApplicationSignal = 'SIGINT' | 'SIGTERM';
 
 /** Message payloads delivered through Deno server websocket bindings. */
-export type DenoWebSocketMessage = Blob | string;
+export type DenoWebSocketMessage = ArrayBuffer | ArrayBufferView | Blob | string;
 
 /** Server-side websocket shape used by the Deno platform binding seam. */
 export interface DenoServerWebSocket extends Pick<WebSocket, 'addEventListener' | 'close' | 'removeEventListener' | 'send'> {

--- a/packages/platform-deno/src/declaration-surface.test.ts
+++ b/packages/platform-deno/src/declaration-surface.test.ts
@@ -48,4 +48,17 @@ describe('@fluojs/platform-deno declaration surface', () => {
       'export declare function createDenoFetchHandler',
     );
   }, 300_000);
+
+  it('publishes all official Deno websocket binary payload forms in declarations', async () => {
+    // Given: the package manifest publishes its root declarations from dist/index.d.ts.
+    expect(existsSync(resolve(packageRootPath, 'dist/adapter.d.ts'))).toBe(true);
+
+    // When: consumers import the Deno websocket message contract from the package root.
+    const declarations = readFileSync(resolve(packageRootPath, 'dist/adapter.d.ts'), 'utf8');
+
+    // Then: the declaration accepts every binary payload form emitted by the Deno binding.
+    expect(declarations).toContain(
+      'export type DenoWebSocketMessage = ArrayBuffer | ArrayBufferView | Blob | string;',
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Aligns \`DenoWebSocketMessage\` with the binary payload forms Deno websocket bindings actually deliver.

Linked context: Closes #3378

## Changes

- packages/platform-deno/src/adapter.ts: \`DenoWebSocketMessage\` widened to \`ArrayBuffer | ArrayBufferView | Blob | string\`.
- packages/platform-deno/src/declaration-surface.test.ts: pins the emitted public union.
- packages/platform-deno/README.md, README.ko.md: consumer-facing migration guidance for exhaustive handlers.
- .changeset/issue-3378-deno-websocket-binary-forms.md: \`@fluojs/platform-deno\` **major**.

## Testing

- closure build, typecheck, platform-consistency governance — pass
- suite 57/57 twice
- Mutation proof (2/2): union narrowed to \`Blob | string\` -> FAIL declaration-surface.test.ts:56 both runs; reverted -> green twice
- Read-only triad at this exact head: all three agreed **major** is the correct bump (1.1.0; widening an inbound union is source-breaking for exhaustive consumers) and that EN/KO migration notes are equivalent

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

**Major release approval:** explicitly granted by the maintainer. Consumer-facing migration notes ship in \`packages/platform-deno/README.md\` and \`README.ko.md\`.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching \`@param\` / \`@returns\` tags where applicable.
- [x] Source \`@example\` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] Package README alignment/conformance claims are backed by the applicable platform harness tests.
