### PR TITLE
Resolve #3365: install Cloudflare realtime bindings through the canonical capability

### DIFF
--- a/.changeset/expose-cloudflare-workers-binding-installation.md
+++ b/.changeset/expose-cloudflare-workers-binding-installation.md
@@ -1,0 +1,6 @@
+---
+'@fluojs/platform-cloudflare-workers': minor
+'@fluojs/websockets': patch
+---
+
+Expose Cloudflare Workers WebSocket binding installation through the versioned realtime capability and use it from the first-party WebSocket integration.

--- a/packages/platform-cloudflare-workers/README.ko.md
+++ b/packages/platform-cloudflare-workers/README.ko.md
@@ -92,7 +92,7 @@ export class EdgeGateway {}
 export class RealtimeModule {}
 ```
 
-Bootstrap 전에 application module graph에 `RealtimeModule`을 import하세요. Application bootstrap 중 `CloudflareWorkersWebSocketModule`이 gateway를 발견하고 `app.listen()`이 binding을 freeze하기 전에 Worker adapter binding을 구성합니다. Listen boundary 이후에는 binding을 추가하거나 교체하지 마세요.
+Bootstrap 전에 application module graph에 `RealtimeModule`을 import하세요. Application bootstrap 중 `CloudflareWorkersWebSocketModule`이 gateway를 발견하고 `app.listen()`이 binding을 freeze하기 전에 versioned realtime capability를 통해 Worker adapter binding을 설치합니다. `configureWebSocketBinding()`은 compatibility facade로 유지됩니다. Listen boundary 이후에는 binding을 추가하거나 교체하지 마세요.
 
 ### 엣지 네이티브 미들웨어
 표준 fluo 미들웨어(CORS, Global Prefix 등)는 Worker bootstrap helper를 통해 완전히 지원되며 Cloudflare 환경에 최적화되어 있습니다. `createCloudflareWorkerAdapter(...)`는 adapter가 소유하는 parsing 및 websocket-pair 옵션만 받습니다. Routing 및 middleware 옵션은 `bootstrapCloudflareWorkerApplication(...)` 또는 `createCloudflareWorkerEntrypoint(...)`에 전달하세요.

--- a/packages/platform-cloudflare-workers/README.md
+++ b/packages/platform-cloudflare-workers/README.md
@@ -92,7 +92,7 @@ export class EdgeGateway {}
 export class RealtimeModule {}
 ```
 
-Import `RealtimeModule` into the application module graph before bootstrap. During application bootstrap, `CloudflareWorkersWebSocketModule` discovers the gateway and configures the Worker adapter binding before `app.listen()` freezes it; do not add or replace the binding after the listen boundary.
+Import `RealtimeModule` into the application module graph before bootstrap. During application bootstrap, `CloudflareWorkersWebSocketModule` discovers the gateway and installs the Worker adapter binding through its versioned realtime capability before `app.listen()` freezes it; `configureWebSocketBinding()` remains a compatibility facade. Do not add or replace the binding after the listen boundary.
 
 ### Edge-Native Middleware
 Standard fluo middleware (CORS, Global Prefix, etc.) is fully supported through Worker bootstrap helpers and optimized for the Cloudflare environment. `createCloudflareWorkerAdapter(...)` only accepts adapter-owned parsing and websocket-pair options; pass routing and middleware options to `bootstrapCloudflareWorkerApplication(...)` or `createCloudflareWorkerEntrypoint(...)` instead.

--- a/packages/platform-cloudflare-workers/src/adapter.test.ts
+++ b/packages/platform-cloudflare-workers/src/adapter.test.ts
@@ -177,14 +177,20 @@ describe('@fluojs/platform-cloudflare-workers', () => {
 
   it('exposes a supported fetch-style raw websocket expansion contract for Worker runtimes', async () => {
     const adapter = createCloudflareWorkerAdapter();
+    const capability = adapter.getRealtimeCapability();
+    const { bindingInstallation, ...contract } = capability;
 
-    expect(adapter.getRealtimeCapability()).toEqual({
+    expect(contract).toEqual({
       contract: 'raw-websocket-expansion',
       kind: 'fetch-style',
       mode: 'request-upgrade',
       reason:
         'Cloudflare Workers exposes WebSocketPair isolate-local request-upgrade hosting. Use @fluojs/websockets/cloudflare-workers for the official raw websocket binding.',
       support: 'supported',
+      version: 1,
+    });
+    expect(bindingInstallation).toEqual({
+      install: expect.any(Function),
       version: 1,
     });
   });
@@ -312,8 +318,16 @@ describe('@fluojs/platform-cloudflare-workers', () => {
     const replacementBinding = {
       fetch: vi.fn<CloudflareWorkerWebSocketBinding['fetch']>(async () => new Response(null, { status: 426 })),
     };
+    const installation = adapter.getRealtimeCapability().bindingInstallation;
 
-    adapter.configureWebSocketBinding(initialBinding);
+    if (!installation) {
+      throw new Error('Expected the Cloudflare Workers adapter to expose websocket binding installation.');
+    }
+
+    expect(() => installation.install({})).toThrow(
+      'Cloudflare Workers websocket binding installation requires a binding with a fetch(request, host) function.',
+    );
+    installation.install(initialBinding);
     await adapter.listen({
       async dispatch(_request: FrameworkRequest, response: FrameworkResponse) {
         response.setStatus(204);
@@ -321,12 +335,13 @@ describe('@fluojs/platform-cloudflare-workers', () => {
     });
 
     try {
-      expect(() => adapter.configureWebSocketBinding(replacementBinding)).toThrow(
+      expect(() => installation.install(replacementBinding)).toThrow(
         'Cloudflare Workers websocket binding must be configured before listen() starts accepting Worker requests.',
       );
-      expect(() => adapter.configureWebSocketBinding(undefined)).toThrow(
+      expect(() => installation.install(undefined)).toThrow(
         'Cloudflare Workers websocket binding must be configured before listen() starts accepting Worker requests.',
       );
+      expect(() => installation.install(initialBinding)).not.toThrow();
       expect(() => adapter.configureWebSocketBinding(initialBinding)).not.toThrow();
     } finally {
       await adapter.close();

--- a/packages/platform-cloudflare-workers/src/adapter.ts
+++ b/packages/platform-cloudflare-workers/src/adapter.ts
@@ -36,6 +36,8 @@ const WEBSOCKET_CLOSED_READY_STATE = 3;
 const ADAPTER_CLOSE_SETTLED = Symbol('CloudflareWorkerAdapterCloseSettled');
 const WEBSOCKET_BINDING_RECONFIGURATION_MESSAGE =
   'Cloudflare Workers websocket binding must be configured before listen() starts accepting Worker requests.';
+const WEBSOCKET_BINDING_INSTALLATION_MESSAGE =
+  'Cloudflare Workers websocket binding installation requires a binding with a fetch(request, host) function.';
 type CloudflareWorkerCorsInput = false | string | string[] | CorsOptions;
 type WebRequestResponseFactory = NonNullable<DispatchWebRequestOptions['factory']>;
 
@@ -183,7 +185,18 @@ export class CloudflareWorkerHttpApplicationAdapter
   getRealtimeCapability() {
     return createFetchStyleHttpAdapterRealtimeCapability(
       'Cloudflare Workers exposes WebSocketPair isolate-local request-upgrade hosting. Use @fluojs/websockets/cloudflare-workers for the official raw websocket binding.',
-      { support: 'supported' },
+      {
+        bindingInstallation: {
+          install: (binding) => {
+            if (binding !== undefined && !isCloudflareWorkerWebSocketBinding(binding)) {
+              throw new Error(WEBSOCKET_BINDING_INSTALLATION_MESSAGE);
+            }
+
+            this.configureWebSocketBinding(binding);
+          },
+        },
+        support: 'supported',
+      },
     );
   }
 
@@ -520,6 +533,13 @@ function validateNonNegativeIntegerOption(name: string, value: number | undefine
 
 function isWebSocketUpgradeRequest(request: Request): boolean {
   return request.headers.get('upgrade')?.toLowerCase() === 'websocket';
+}
+
+function isCloudflareWorkerWebSocketBinding(binding: unknown): binding is CloudflareWorkerWebSocketBinding {
+  return typeof binding === 'object'
+    && binding !== null
+    && 'fetch' in binding
+    && typeof binding.fetch === 'function';
 }
 
 function createWebSocketCloseLifecycle(socket: CloudflareWorkerWebSocket): Promise<void> {

--- a/packages/websockets/src/cloudflare-workers/cloudflare-workers-service.ts
+++ b/packages/websockets/src/cloudflare-workers/cloudflare-workers-service.ts
@@ -21,7 +21,6 @@ import type { WebSocketGatewayDescriptor, WebSocketRoomService, WebSocketUpgrade
 import type {
   CloudflareWorkerWebSocket,
   CloudflareWorkerWebSocketBinding,
-  CloudflareWorkerWebSocketBindingHost,
   CloudflareWorkerWebSocketMessage,
   WebSocketModuleOptions,
 } from './cloudflare-workers-types.js';
@@ -62,12 +61,6 @@ const DEFAULT_MAX_WEBSOCKET_PAYLOAD_BYTES = 1_048_576;
 const DEFAULT_WEBSOCKET_SHUTDOWN_TIMEOUT_MS = 5_000;
 const LIFECYCLE_LOG_CONTEXT = 'WebSocketGatewayLifecycleService';
 const WEBSOCKET_OPEN_READY_STATE = 1;
-
-function hasCloudflareWorkerWebSocketBindingHost(
-  adapter: HttpApplicationAdapter,
-): adapter is HttpApplicationAdapter & CloudflareWorkerWebSocketBindingHost {
-  return 'configureWebSocketBinding' in adapter && typeof adapter.configureWebSocketBinding === 'function';
-}
 
 function isWebSocketUpgradeRequest(request: Request): boolean {
   return request.headers.get('upgrade')?.toLowerCase() === 'websocket';
@@ -131,19 +124,19 @@ export class CloudflareWorkersWebSocketGatewayLifecycleService
 
     assertNoFetchStyleServerBackedGatewayOptIn(descriptors, 'cloudflare-workers');
 
-    resolveSupportedFetchStyleRealtimeCapability(this.adapter, {
+    const capability = resolveSupportedFetchStyleRealtimeCapability(this.adapter, {
       packageSubpath: 'cloudflare-workers',
       platformPackage: '@fluojs/platform-cloudflare-workers',
       runtimeName: 'Cloudflare Workers',
     });
 
-    if (!hasCloudflareWorkerWebSocketBindingHost(this.adapter)) {
+    if (!capability.bindingInstallation) {
       throw new Error(
-        'Cloudflare Workers WebSocket gateway bootstrap requires the selected adapter to expose Cloudflare websocket binding configuration. Use @fluojs/platform-cloudflare-workers with @fluojs/websockets/cloudflare-workers.',
+        'Cloudflare Workers WebSocket gateway bootstrap requires the selected adapter to expose websocket binding installation through its realtime capability. Use @fluojs/platform-cloudflare-workers with @fluojs/websockets/cloudflare-workers.',
       );
     }
 
-    this.adapter.configureWebSocketBinding(this.createBinding(descriptors));
+    capability.bindingInstallation.install(this.createBinding(descriptors));
   }
 
   async onApplicationShutdown(): Promise<void> {

--- a/packages/websockets/src/cloudflare-workers/cloudflare-workers.test.ts
+++ b/packages/websockets/src/cloudflare-workers/cloudflare-workers.test.ts
@@ -17,7 +17,6 @@ import {
   CloudflareWorkersWebSocketModule,
   type CloudflareWorkerWebSocket,
   type CloudflareWorkerWebSocketBinding,
-  type CloudflareWorkerWebSocketBindingHost,
   type CloudflareWorkerWebSocketMessage,
   type CloudflareWorkerWebSocketUpgradeResult,
 } from './cloudflare-workers.js';
@@ -193,16 +192,18 @@ class TestWorkerServer {
   }
 }
 
-class TestWorkerAdapter implements HttpApplicationAdapter, CloudflareWorkerWebSocketBindingHost {
+class TestWorkerAdapter implements HttpApplicationAdapter {
   private binding?: CloudflareWorkerWebSocketBinding;
   private server?: TestWorkerServer;
 
-  configureWebSocketBinding(binding: CloudflareWorkerWebSocketBinding | undefined): void {
-    this.binding = binding;
-  }
-
   getRealtimeCapability() {
     return {
+      bindingInstallation: {
+        install: (binding: unknown | undefined) => {
+          this.binding = binding as CloudflareWorkerWebSocketBinding | undefined;
+        },
+        version: 1 as const,
+      },
       contract: 'raw-websocket-expansion' as const,
       kind: 'fetch-style' as const,
       mode: 'request-upgrade' as const,


### PR DESCRIPTION
## Summary

Gives Cloudflare Workers a first-class realtime binding-installation capability instead of duck-typing the Cloudflare runtime, and routes the websockets integration through it.

Linked context: Closes #3365

## Changes

- packages/platform-cloudflare-workers/src/adapter.ts: \`bindingInstallation\` v1 installer on the canonical realtime capability, with runtime validation, delegating to the existing frozen-binding policy.
- packages/websockets: integration consumes the capability rather than Cloudflare duck typing.
- EN/KO README updates; changesets (\`platform-cloudflare-workers\` minor, \`websockets\` patch).

## Testing

- typecheck, cfw suite twice, platform-consistency governance — pass
- @fluojs/websockets suite twice plus the built-adapter driver
- Mutation proofs (2/2 each): installer removed -> FAIL adapter.test.ts:192; integration installer call removed -> FAIL cloudflare-workers.test.ts:380; reverted -> green
- Read-only triad at this exact head: unanimous merge (changeset SemVer correct, EN/KO equivalent, no sleeps/polling/timer-turn ordering)

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching \`@param\` / \`@returns\` tags where applicable.
- [x] Source \`@example\` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] Package README alignment/conformance claims are backed by the applicable platform harness tests.
