### PR TITLE
Resolve #3361: assert realtime installer error type, not just its message

### DIFF
--- a/packages/platform-bun/src/adapter.test.ts
+++ b/packages/platform-bun/src/adapter.test.ts
@@ -2461,13 +2461,25 @@ describe('@fluojs/platform-bun', () => {
   ])('rejects %s through the realtime capability installer', (_description, binding) => {
     const adapter = new BunHttpApplicationAdapter();
     const bindingInstallation = adapter.getRealtimeCapability().bindingInstallation;
+    let thrown: unknown;
 
     if (bindingInstallation === undefined) {
       throw new TypeError('Expected the Bun adapter realtime capability to expose binding installation.');
     }
 
-    expect(() => bindingInstallation.install(binding)).toThrow(
-      new TypeError('Bun realtime binding installation requires fetch and websocket host contracts.'),
+    try {
+      bindingInstallation.install(binding);
+    } catch (error: unknown) {
+      thrown = error;
+    }
+
+    if (!(thrown instanceof Error)) {
+      throw new TypeError('Expected realtime binding installation to throw an Error.');
+    }
+
+    expect(thrown).toBeInstanceOf(TypeError);
+    expect(thrown.message).toBe(
+      'Bun realtime binding installation requires fetch and websocket host contracts.',
     );
   });
 

--- a/packages/platform-bun/src/adapter.test.ts
+++ b/packages/platform-bun/src/adapter.test.ts
@@ -2449,6 +2449,28 @@ describe('@fluojs/platform-bun', () => {
     expect(() => harness.assertExposesRawWebSocketExpansionContract()).not.toThrow();
   });
 
+  it.each([
+    ['a null binding', null],
+    ['a binding without fetch', { websocket: {} }],
+    ['a binding with a non-function fetch', { fetch: 'not a function', websocket: {} }],
+    ['a binding without websocket', { fetch: (): Promise<undefined> => Promise.resolve(undefined) }],
+    [
+      'a binding with a null websocket',
+      { fetch: (): Promise<undefined> => Promise.resolve(undefined), websocket: null },
+    ],
+  ])('rejects %s through the realtime capability installer', (_description, binding) => {
+    const adapter = new BunHttpApplicationAdapter();
+    const bindingInstallation = adapter.getRealtimeCapability().bindingInstallation;
+
+    if (bindingInstallation === undefined) {
+      throw new TypeError('Expected the Bun adapter realtime capability to expose binding installation.');
+    }
+
+    expect(() => bindingInstallation.install(binding)).toThrow(
+      new TypeError('Bun realtime binding installation requires fetch and websocket host contracts.'),
+    );
+  });
+
   it('delegates websocket upgrade requests through a configured Bun websocket binding before HTTP dispatch', async () => {
     const mockBun = installMockBun();
     const adapter = new BunHttpApplicationAdapter();


### PR DESCRIPTION
## Summary

Makes the @fluojs/platform-bun invalid-realtime-installer assertions actually pin the error TYPE, not just its message.

Linked context: Closes #3361

## Changes

- packages/platform-bun/src/adapter.test.ts:2469 — each of the 5 invalid-installer cases now captures the thrown value and asserts \`toBeInstanceOf(TypeError)\` and the message as separate, independent assertions.

## Why the first attempt was not enough

The original assertions used \`toThrow(new TypeError(...))\`, which compares only the message. A plain \`Error\` carrying the identical message would have passed, so the error-class contract was never pinned. The contract reviewer blocked on exactly this, and the mutation below confirms the original form could not catch it.

## Testing

- \`pnpm --workspace-concurrency=1 --filter '@fluojs/platform-bun...' build\` — exit 0
- \`pnpm --filter @fluojs/platform-bun typecheck\` — exit 0
- \`pnpm --filter @fluojs/platform-bun test\` — exit 0, Tests 64 passed (64), twice
- \`node tooling/governance/verify-platform-consistency-governance.mjs\` — exit 0
- Mutation proof (2/2): adapter.ts:324 throws \`Error\` instead of \`TypeError\` with an unchanged message -> all 5 cases FAIL at adapter.test.ts:2480 on two consecutive runs; reverted -> 64 passed twice
- Read-only triad at this exact head: unanimous merge (delta re-review after the contract block)

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary. (N/A — test-only)
- [x] Changed exported functions document matching \`@param\` / \`@returns\` tags where applicable. (N/A)
- [x] Source \`@example\` blocks and README scenario examples still play complementary roles. (N/A)

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. (None added.)
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (No docs changed.)
- [x] Package README alignment/conformance claims are backed by the applicable platform harness tests.
