### PR TITLE
Resolve #3390: guarantee Fastify teardown on every startup-termination path

### DIFF
--- a/.changeset/fix-fastify-bind-cancel-cleanup.md
+++ b/.changeset/fix-fastify-bind-cancel-cleanup.md
@@ -2,4 +2,4 @@
 "@fluojs/platform-fastify": patch
 ---
 
-Run Fastify `onClose` cleanup when shutdown cancels startup, including after the final port bind completes.
+Run Fastify `onClose` cleanup when shutdown cancels startup, including after the final port bind completes, without masking the startup failure when cleanup also rejects.

--- a/.changeset/fix-fastify-bind-cancel-cleanup.md
+++ b/.changeset/fix-fastify-bind-cancel-cleanup.md
@@ -2,4 +2,4 @@
 "@fluojs/platform-fastify": patch
 ---
 
-Run Fastify `onClose` cleanup when shutdown cancels startup, including after the final port bind completes, without masking the startup failure when cleanup also rejects.
+Run Fastify `onClose` cleanup when shutdown cancels startup, including after the final port bind completes, without masking the startup failure when cleanup also rejects. Mutable startup rejection objects retain their identity and expose cleanup failures through `cause`; frozen or primitive rejections instead throw a startup-first `AggregateError` because identity preservation and cleanup reachability cannot both be guaranteed.

--- a/.changeset/fix-fastify-bind-cancel-cleanup.md
+++ b/.changeset/fix-fastify-bind-cancel-cleanup.md
@@ -2,4 +2,4 @@
 "@fluojs/platform-fastify": patch
 ---
 
-Run Fastify `onClose` cleanup when shutdown cancels startup, including after the final port bind completes, without masking the startup failure when cleanup also rejects. Mutable startup rejection objects retain their identity and expose cleanup failures through `cause`; frozen or primitive rejections instead throw a startup-first `AggregateError` because identity preservation and cleanup reachability cannot both be guaranteed.
+Run Fastify `onClose` cleanup when shutdown cancels startup, including after the final port bind completes, without masking the startup failure when cleanup also rejects. Startup rejection objects retain their identity and expose cleanup failures through `cause` only when that property can be read, written, and read back; every other rejection instead throws a startup-first `AggregateError` because identity preservation and cleanup reachability cannot both be guaranteed.

--- a/.changeset/fix-fastify-bind-cancel-cleanup.md
+++ b/.changeset/fix-fastify-bind-cancel-cleanup.md
@@ -2,4 +2,4 @@
 "@fluojs/platform-fastify": patch
 ---
 
-Run Fastify `onClose` cleanup when shutdown cancels a retrying port bind.
+Run Fastify `onClose` cleanup when shutdown cancels startup, including after the final port bind completes.

--- a/.changeset/fix-fastify-bind-cancel-cleanup.md
+++ b/.changeset/fix-fastify-bind-cancel-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/platform-fastify": patch
+---
+
+Run Fastify `onClose` cleanup when shutdown cancels a retrying port bind.

--- a/packages/platform-fastify/README.ko.md
+++ b/packages/platform-fastify/README.ko.md
@@ -214,6 +214,7 @@ fluo의 Fastify 어댑터는 높은 동시성 시나리오에서 raw Node.js 어
 - **글로벌 접두사 (Global Prefix)**: 내부 경로 또는 헬스 체크 엔드포인트에 접두사가 붙지 않도록 `globalPrefixExclude`를 적절히 설정하세요.
 - **Malformed Cookie**: 잘못된 cookie header는 request 실패로 이어지지 않고 보존됩니다.
 - **HTTPS 시작**: Fastify 프로세스가 TLS를 소유한다면 Node.js `>=20.19.3 <21 || >=22.2.0 <27`에서 adapter `https` option 아래에 certificate material을 전달하세요. Infrastructure가 TLS를 종료한다면 해당 경계 뒤에서 adapter를 일반 HTTP로 유지하세요.
+- **시작 및 종료 실패**: startup과 Fastify `onClose`가 모두 실패하면, `cause`를 읽고 쓰고 다시 읽을 수 있는 경우에만 caller는 원래 startup rejection과 `cause`의 close failure를 받습니다. 그 외에는 caller가 startup rejection을 `errors[0]`, close failure를 `errors[1]`로 갖는 startup-first `AggregateError`를 받습니다.
 
 ## 관련 패키지
 

--- a/packages/platform-fastify/README.md
+++ b/packages/platform-fastify/README.md
@@ -214,6 +214,7 @@ The same file also covers Fastify-specific native route registration with wildca
 - **Global Prefix**: Use `globalPrefixExclude` to prevent the prefix from being applied to internal routes or health check endpoints.
 - **Malformed Cookies**: Malformed cookie headers are preserved rather than failing the request.
 - **HTTPS startup**: Use Node.js `>=20.19.3 <21 || >=22.2.0 <27` and pass certificate material under the adapter `https` option when the Fastify process owns TLS. If TLS is terminated by infrastructure, keep the adapter on plain HTTP behind that boundary.
+- **Startup and shutdown failures**: When startup and Fastify `onClose` both fail, callers receive the original startup rejection with the close failure in `cause` only when `cause` can be read, written, and read back. Otherwise, callers receive a startup-first `AggregateError` whose `errors[0]` is the startup rejection and whose `errors[1]` is the close failure.
 
 ## Related Packages
 

--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -2729,6 +2729,41 @@ describe('@fluojs/platform-fastify', () => {
     }
   });
 
+  it('preserves plugin registration failure when Fastify onClose also fails during shutdown', async () => {
+    const adapter = new FastifyHttpApplicationAdapter(0, '127.0.0.1', 25, 20, undefined, undefined, 1024, false, 500);
+    const fastifyApp: FastifyInstance = Reflect.get(adapter, 'app');
+    const pluginStarted = createDeferred<void>();
+    const allowPluginFailure = createDeferred<void>();
+    const pluginError = new Error('plugin rejected during startup');
+    const closeError = new Error('onClose rejected during shutdown');
+    fastifyApp.addHook('onClose', async () => {
+      throw closeError;
+    });
+    fastifyApp.register(async () => {
+      pluginStarted.resolve();
+      await allowPluginFailure.promise;
+      throw pluginError;
+    });
+    const listenResult = adapter.listen({ async dispatch() {} }).then(
+      () => 'listened' as const,
+      (error: unknown) => error,
+    );
+
+    try {
+      await pluginStarted.promise;
+
+      const closeResult = adapter.close();
+      allowPluginFailure.resolve();
+
+      await expect(closeResult).rejects.toBe(pluginError);
+      expect(Reflect.get(pluginError, 'cause')).toBe(closeError);
+      await expect(listenResult).resolves.toBe(pluginError);
+    } finally {
+      allowPluginFailure.resolve();
+      await adapter.close();
+    }
+  });
+
   it('clears the fastify shutdown timer once close settles', async () => {
     vi.useFakeTimers();
 

--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -2601,9 +2601,9 @@ describe('@fluojs/platform-fastify', () => {
       const onCloseResult = await Promise.race([
         onCloseObserved.promise.then((): 'closed' => 'closed'),
         new Promise<'timed-out'>((resolve) => {
-          AbortSignal.timeout(1_000).addEventListener('abort', () => {
+          setTimeout(() => {
             resolve('timed-out');
-          }, { once: true });
+          }, 1_000);
         }),
       ]);
       expect(onCloseResult).toBe('closed');
@@ -2625,6 +2625,64 @@ describe('@fluojs/platform-fastify', () => {
           resolve();
         });
       });
+    }
+  });
+
+  it('runs Fastify onClose hooks when shutdown races final bind completion', async () => {
+    const adapter = new FastifyHttpApplicationAdapter(0, '127.0.0.1', 25, 20, undefined, undefined, 1024, false, 500);
+    const fastifyApp: FastifyInstance = Reflect.get(adapter, 'app');
+    const originalListen = fastifyApp.listen.bind(fastifyApp);
+    const bindCompleted = createDeferred<void>();
+    const allowListenToSettle = createDeferred<void>();
+    const onCloseObserved = createDeferred<void>();
+    fastifyApp.addHook('onClose', async () => {
+      onCloseObserved.resolve();
+    });
+    const listenSpy = vi.spyOn(fastifyApp, 'listen').mockImplementation(async (options) => {
+      const url = await originalListen(options);
+      bindCompleted.resolve();
+      await allowListenToSettle.promise;
+      return url;
+    });
+    const dispatcher = { async dispatch() {} };
+    const listenResult = adapter.listen(dispatcher).then(
+      () => 'listened' as const,
+      (error: unknown) => error,
+    );
+
+    try {
+      await bindCompleted.promise;
+
+      const abortController = Reflect.get(adapter, 'listenAbortController') as AbortController | undefined;
+      if (!abortController) {
+        throw new Error('Expected an active Fastify startup abort controller.');
+      }
+
+      abortController.signal.addEventListener('abort', () => {
+        fastifyApp.server.close();
+      }, { once: true });
+
+      const closeResult = adapter.close();
+      expect((adapter.getServer() as { listening?: boolean }).listening).toBe(false);
+
+      allowListenToSettle.resolve();
+      const onCloseResult = await Promise.race([
+        onCloseObserved.promise.then((): 'closed' => 'closed'),
+        new Promise<'timed-out'>((resolve) => {
+          AbortSignal.timeout(1_000).addEventListener('abort', () => {
+            resolve('timed-out');
+          }, { once: true });
+        }),
+      ]);
+      expect(onCloseResult).toBe('closed');
+      await expect(closeResult).resolves.toBeUndefined();
+
+      const result = await listenResult;
+      expect(result).toBeInstanceOf(Error);
+      expect(String(result instanceof Error ? result.message : result)).toContain('startup was cancelled');
+    } finally {
+      allowListenToSettle.resolve();
+      listenSpy.mockRestore();
     }
   });
 

--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -2806,6 +2806,100 @@ describe('@fluojs/platform-fastify', () => {
     }
   });
 
+  it('keeps both failures reachable when the startup cause setter discards writes', async () => {
+    const adapter = new FastifyHttpApplicationAdapter(0, '127.0.0.1', 25, 20, undefined, undefined, 1024, false, 500);
+    const fastifyApp: FastifyInstance = Reflect.get(adapter, 'app');
+    const pluginStarted = createDeferred<void>();
+    const allowPluginFailure = createDeferred<void>();
+    const pluginError = {};
+    const closeError = new Error('onClose rejected during shutdown');
+    Object.defineProperty(pluginError, 'cause', {
+      get: () => undefined,
+      set: () => {},
+    });
+    fastifyApp.addHook('onClose', async () => {
+      throw closeError;
+    });
+    fastifyApp.register(async () => {
+      pluginStarted.resolve();
+      await allowPluginFailure.promise;
+      throw pluginError;
+    });
+    const listenResult = adapter.listen({ async dispatch() {} }).then(
+      () => 'listened' as const,
+      (error: unknown) => error,
+    );
+
+    try {
+      await pluginStarted.promise;
+
+      const closeResult = adapter.close();
+      allowPluginFailure.resolve();
+
+      const closeFailure = await closeResult.then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      if (!(closeFailure instanceof AggregateError)) {
+        throw new Error('Expected shutdown to preserve both failures in an AggregateError.');
+      }
+
+      expect(closeFailure.errors).toEqual([pluginError, closeError]);
+      await expect(listenResult).resolves.toBe(pluginError);
+    } finally {
+      allowPluginFailure.resolve();
+      await adapter.close();
+    }
+  });
+
+  it('keeps both failures reachable when the startup cause getter throws', async () => {
+    const adapter = new FastifyHttpApplicationAdapter(0, '127.0.0.1', 25, 20, undefined, undefined, 1024, false, 500);
+    const fastifyApp: FastifyInstance = Reflect.get(adapter, 'app');
+    const pluginStarted = createDeferred<void>();
+    const allowPluginFailure = createDeferred<void>();
+    const pluginError = {};
+    const causeGetterError = new Error('startup cause getter rejected');
+    const closeError = new Error('onClose rejected during shutdown');
+    Object.defineProperty(pluginError, 'cause', {
+      get: () => {
+        throw causeGetterError;
+      },
+    });
+    fastifyApp.addHook('onClose', async () => {
+      throw closeError;
+    });
+    fastifyApp.register(async () => {
+      pluginStarted.resolve();
+      await allowPluginFailure.promise;
+      throw pluginError;
+    });
+    const listenResult = adapter.listen({ async dispatch() {} }).then(
+      () => 'listened' as const,
+      (error: unknown) => error,
+    );
+
+    try {
+      await pluginStarted.promise;
+
+      const closeResult = adapter.close();
+      allowPluginFailure.resolve();
+
+      const closeFailure = await closeResult.then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      if (!(closeFailure instanceof AggregateError)) {
+        throw new Error('Expected shutdown to preserve both failures in an AggregateError.');
+      }
+
+      expect(closeFailure.errors).toEqual([pluginError, closeError]);
+      await expect(listenResult).resolves.toBe(pluginError);
+    } finally {
+      allowPluginFailure.resolve();
+      await adapter.close();
+    }
+  });
+
   it('preserves a mutable non-Error startup rejection when Fastify onClose also fails during shutdown', async () => {
     const adapter = new FastifyHttpApplicationAdapter(0, '127.0.0.1', 25, 20, undefined, undefined, 1024, false, 500);
     const fastifyApp: FastifyInstance = Reflect.get(adapter, 'app');

--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -2563,7 +2563,7 @@ describe('@fluojs/platform-fastify', () => {
     expect(Reflect.get(adapter, 'dispatcher')).toBeUndefined();
   });
 
-  it('cancels retrying startup during close before a later port bind can occur', async () => {
+  it('runs Fastify onClose hooks when close cancels retrying startup', async () => {
     const blocker = createServer();
     await new Promise<void>((resolve, reject) => {
       blocker.once('error', reject);
@@ -2576,6 +2576,10 @@ describe('@fluojs/platform-fastify', () => {
     const fastifyApp: FastifyInstance = Reflect.get(adapter, 'app');
     const originalListen = fastifyApp.listen.bind(fastifyApp);
     const retryObserved = createDeferred<void>();
+    const onCloseObserved = createDeferred<void>();
+    fastifyApp.addHook('onClose', async () => {
+      onCloseObserved.resolve();
+    });
     const listenSpy = vi.spyOn(fastifyApp, 'listen').mockImplementation(async (options) => {
       try {
         return await originalListen(options);
@@ -2593,6 +2597,16 @@ describe('@fluojs/platform-fastify', () => {
     try {
       await retryObserved.promise;
       await expect(adapter.close()).resolves.toBeUndefined();
+
+      const onCloseResult = await Promise.race([
+        onCloseObserved.promise.then((): 'closed' => 'closed'),
+        new Promise<'timed-out'>((resolve) => {
+          AbortSignal.timeout(1_000).addEventListener('abort', () => {
+            resolve('timed-out');
+          }, { once: true });
+        }),
+      ]);
+      expect(onCloseResult).toBe('closed');
 
       const result = await listenResult;
       expect(result).toBeInstanceOf(Error);

--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -2764,6 +2764,83 @@ describe('@fluojs/platform-fastify', () => {
     }
   });
 
+  it('keeps a frozen startup error primary when Fastify onClose also fails during shutdown', async () => {
+    const adapter = new FastifyHttpApplicationAdapter(0, '127.0.0.1', 25, 20, undefined, undefined, 1024, false, 500);
+    const fastifyApp: FastifyInstance = Reflect.get(adapter, 'app');
+    const pluginStarted = createDeferred<void>();
+    const allowPluginFailure = createDeferred<void>();
+    const pluginError = Object.freeze(new Error('frozen plugin rejected during startup'));
+    const closeError = new Error('onClose rejected during shutdown');
+    fastifyApp.addHook('onClose', async () => {
+      throw closeError;
+    });
+    fastifyApp.register(async () => {
+      pluginStarted.resolve();
+      await allowPluginFailure.promise;
+      throw pluginError;
+    });
+    const listenResult = adapter.listen({ async dispatch() {} }).then(
+      () => 'listened' as const,
+      (error: unknown) => error,
+    );
+
+    try {
+      await pluginStarted.promise;
+
+      const closeResult = adapter.close();
+      allowPluginFailure.resolve();
+
+      const closeFailure = await closeResult.then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      if (!(closeFailure instanceof AggregateError)) {
+        throw new Error('Expected shutdown to preserve both failures in an AggregateError.');
+      }
+
+      expect(closeFailure.errors).toEqual([pluginError, closeError]);
+      await expect(listenResult).resolves.toBe(pluginError);
+    } finally {
+      allowPluginFailure.resolve();
+      await adapter.close();
+    }
+  });
+
+  it('preserves a mutable non-Error startup rejection when Fastify onClose also fails during shutdown', async () => {
+    const adapter = new FastifyHttpApplicationAdapter(0, '127.0.0.1', 25, 20, undefined, undefined, 1024, false, 500);
+    const fastifyApp: FastifyInstance = Reflect.get(adapter, 'app');
+    const pluginStarted = createDeferred<void>();
+    const allowPluginFailure = createDeferred<void>();
+    const pluginError = { message: 'plugin rejected during startup' };
+    const closeError = new Error('onClose rejected during shutdown');
+    fastifyApp.addHook('onClose', async () => {
+      throw closeError;
+    });
+    fastifyApp.register(async () => {
+      pluginStarted.resolve();
+      await allowPluginFailure.promise;
+      throw pluginError;
+    });
+    const listenResult = adapter.listen({ async dispatch() {} }).then(
+      () => 'listened' as const,
+      (error: unknown) => error,
+    );
+
+    try {
+      await pluginStarted.promise;
+
+      const closeResult = adapter.close();
+      allowPluginFailure.resolve();
+
+      await expect(closeResult).rejects.toBe(pluginError);
+      expect(Reflect.get(pluginError, 'cause')).toBe(closeError);
+      await expect(listenResult).resolves.toBe(pluginError);
+    } finally {
+      allowPluginFailure.resolve();
+      await adapter.close();
+    }
+  });
+
   it('clears the fastify shutdown timer once close settles', async () => {
     vi.useFakeTimers();
 

--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -2686,6 +2686,49 @@ describe('@fluojs/platform-fastify', () => {
     }
   });
 
+  it('runs Fastify onClose hooks when shutdown races plugin registration failure', async () => {
+    const adapter = new FastifyHttpApplicationAdapter(0, '127.0.0.1', 25, 20, undefined, undefined, 1024, false, 500);
+    const fastifyApp: FastifyInstance = Reflect.get(adapter, 'app');
+    const pluginStarted = createDeferred<void>();
+    const allowPluginFailure = createDeferred<void>();
+    const onCloseObserved = createDeferred<void>();
+    const pluginError = new Error('plugin rejected during startup');
+    fastifyApp.addHook('onClose', async () => {
+      onCloseObserved.resolve();
+    });
+    fastifyApp.register(async () => {
+      pluginStarted.resolve();
+      await allowPluginFailure.promise;
+      throw pluginError;
+    });
+    const listenResult = adapter.listen({ async dispatch() {} }).then(
+      () => 'listened' as const,
+      (error: unknown) => error,
+    );
+
+    try {
+      await pluginStarted.promise;
+
+      const closeResult = adapter.close();
+      allowPluginFailure.resolve();
+      await expect(closeResult).rejects.toBe(pluginError);
+
+      const onCloseResult = await Promise.race([
+        onCloseObserved.promise.then((): 'closed' => 'closed'),
+        new Promise<'timed-out'>((resolve) => {
+          AbortSignal.timeout(1_000).addEventListener('abort', () => {
+            resolve('timed-out');
+          }, { once: true });
+        }),
+      ]);
+      expect(onCloseResult).toBe('closed');
+      await expect(listenResult).resolves.toBe(pluginError);
+    } finally {
+      allowPluginFailure.resolve();
+      await adapter.close();
+    }
+  });
+
   it('clears the fastify shutdown timer once close settles', async () => {
     vi.useFakeTimers();
 

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -299,15 +299,28 @@ export class FastifyHttpApplicationAdapter implements HttpApplicationAdapter {
             throw closeError;
           }
 
-          if (startupError instanceof Error) {
+          if (
+            (typeof startupError === 'object' && startupError !== null) ||
+            typeof startupError === 'function'
+          ) {
             const existingCause = Reflect.get(startupError, 'cause');
-            Reflect.set(
+            const closeFailure = existingCause === undefined
+              ? closeError
+              : new AggregateError([existingCause, closeError], 'Fastify startup and shutdown both failed.');
+            const causeAttached = Reflect.set(
               startupError,
               'cause',
-              existingCause === undefined
-                ? closeError
-                : new AggregateError([existingCause, closeError], 'Fastify startup and shutdown both failed.'),
+              closeFailure,
             );
+
+            // Mutable rejection objects preserve identity. Primitives and values with an unassignable
+            // cause cannot both preserve identity and expose the close failure, so use startup-first errors.
+            if (!causeAttached) {
+              startupError = new AggregateError(
+                [startupError, closeError],
+                'Fastify startup and shutdown both failed.',
+              );
+            }
           } else {
             startupError = new AggregateError(
               [startupError, closeError],

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -303,19 +303,26 @@ export class FastifyHttpApplicationAdapter implements HttpApplicationAdapter {
             (typeof startupError === 'object' && startupError !== null) ||
             typeof startupError === 'function'
           ) {
-            const existingCause = Reflect.get(startupError, 'cause');
-            const closeFailure = existingCause === undefined
-              ? closeError
-              : new AggregateError([existingCause, closeError], 'Fastify startup and shutdown both failed.');
-            const causeAttached = Reflect.set(
-              startupError,
-              'cause',
-              closeFailure,
-            );
+            try {
+              const existingCause = Reflect.get(startupError, 'cause');
+              const closeFailure = existingCause === undefined
+                ? closeError
+                : new AggregateError([existingCause, closeError], 'Fastify startup and shutdown both failed.');
+              const causeAttached = Reflect.set(
+                startupError,
+                'cause',
+                closeFailure,
+              );
 
-            // Mutable rejection objects preserve identity. Primitives and values with an unassignable
-            // cause cannot both preserve identity and expose the close failure, so use startup-first errors.
-            if (!causeAttached) {
+              if (!causeAttached || Reflect.get(startupError, 'cause') !== closeFailure) {
+                startupError = new AggregateError(
+                  [startupError, closeError],
+                  'Fastify startup and shutdown both failed.',
+                );
+              }
+            } catch {
+              // Mutable rejection objects preserve identity only when cause can be read, written, and
+              // read back. Every other rejection value uses startup-first errors to expose both failures.
               startupError = new AggregateError(
                 [startupError, closeError],
                 'Fastify startup and shutdown both failed.',

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -284,7 +284,7 @@ export class FastifyHttpApplicationAdapter implements HttpApplicationAdapter {
       await ignoreCancelledListen(this.listenInFlight);
     }
 
-    if (!this.app.server.listening) {
+    if (this.appClosed) {
       return;
     }
 

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -44,10 +44,10 @@ import {
 } from '@fluojs/runtime/internal/request-response-factory';
 import {
   cloneHeaderValue,
-  createNodeEarlyHintsCapability,
   createDeferredFrameworkRequestShell,
   createMemoizedAsyncValue,
   createMemoizedValue,
+  createNodeEarlyHintsCapability,
   parseQueryParamsFromSearch,
   snapshotSimpleQueryRecord,
   splitRawRequestUrl,
@@ -281,6 +281,8 @@ export class FastifyHttpApplicationAdapter implements HttpApplicationAdapter {
   private async closeApplication(): Promise<void> {
     let startupError: unknown;
     let startupFailed = false;
+    let closeError: unknown;
+    let closeFailed = false;
 
     try {
       if (this.listenInFlight) {
@@ -294,46 +296,9 @@ export class FastifyHttpApplicationAdapter implements HttpApplicationAdapter {
       if (!this.appClosed) {
         try {
           await this.app.close();
-        } catch (closeError: unknown) {
-          if (!startupFailed) {
-            throw closeError;
-          }
-
-          if (
-            (typeof startupError === 'object' && startupError !== null) ||
-            typeof startupError === 'function'
-          ) {
-            try {
-              const existingCause = Reflect.get(startupError, 'cause');
-              const closeFailure = existingCause === undefined
-                ? closeError
-                : new AggregateError([existingCause, closeError], 'Fastify startup and shutdown both failed.');
-              const causeAttached = Reflect.set(
-                startupError,
-                'cause',
-                closeFailure,
-              );
-
-              if (!causeAttached || Reflect.get(startupError, 'cause') !== closeFailure) {
-                startupError = new AggregateError(
-                  [startupError, closeError],
-                  'Fastify startup and shutdown both failed.',
-                );
-              }
-            } catch {
-              // Mutable rejection objects preserve identity only when cause can be read, written, and
-              // read back. Every other rejection value uses startup-first errors to expose both failures.
-              startupError = new AggregateError(
-                [startupError, closeError],
-                'Fastify startup and shutdown both failed.',
-              );
-            }
-          } else {
-            startupError = new AggregateError(
-              [startupError, closeError],
-              'Fastify startup and shutdown both failed.',
-            );
-          }
+        } catch (error: unknown) {
+          closeError = error;
+          closeFailed = true;
         } finally {
           this.appClosed = true;
         }
@@ -341,7 +306,49 @@ export class FastifyHttpApplicationAdapter implements HttpApplicationAdapter {
     }
 
     if (startupFailed) {
+      if (closeFailed) {
+        if (
+          (typeof startupError === 'object' && startupError !== null) ||
+          typeof startupError === 'function'
+        ) {
+          try {
+            const existingCause = Reflect.get(startupError, 'cause');
+            const closeFailure = existingCause === undefined
+              ? closeError
+              : new AggregateError([existingCause, closeError], 'Fastify startup and shutdown both failed.');
+            const causeAttached = Reflect.set(
+              startupError,
+              'cause',
+              closeFailure,
+            );
+
+            if (!causeAttached || Reflect.get(startupError, 'cause') !== closeFailure) {
+              startupError = new AggregateError(
+                [startupError, closeError],
+                'Fastify startup and shutdown both failed.',
+              );
+            }
+          } catch {
+            // Mutable rejection objects preserve identity only when cause can be read, written, and
+            // read back. Every other rejection value uses startup-first errors to expose both failures.
+            startupError = new AggregateError(
+              [startupError, closeError],
+              'Fastify startup and shutdown both failed.',
+            );
+          }
+        } else {
+          startupError = new AggregateError(
+            [startupError, closeError],
+            'Fastify startup and shutdown both failed.',
+          );
+        }
+      }
+
       throw startupError;
+    }
+
+    if (closeFailed) {
+      throw closeError;
     }
   }
 

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -279,19 +279,19 @@ export class FastifyHttpApplicationAdapter implements HttpApplicationAdapter {
   }
 
   private async closeApplication(): Promise<void> {
-    if (this.listenInFlight) {
-      this.listenAbortController?.abort();
-      await ignoreCancelledListen(this.listenInFlight);
-    }
-
-    if (this.appClosed) {
-      return;
-    }
-
     try {
-      await this.app.close();
+      if (this.listenInFlight) {
+        this.listenAbortController?.abort();
+        await ignoreCancelledListen(this.listenInFlight);
+      }
     } finally {
-      this.appClosed = true;
+      if (!this.appClosed) {
+        try {
+          await this.app.close();
+        } finally {
+          this.appClosed = true;
+        }
+      }
     }
   }
 

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -279,19 +279,49 @@ export class FastifyHttpApplicationAdapter implements HttpApplicationAdapter {
   }
 
   private async closeApplication(): Promise<void> {
+    let startupError: unknown;
+    let startupFailed = false;
+
     try {
       if (this.listenInFlight) {
         this.listenAbortController?.abort();
         await ignoreCancelledListen(this.listenInFlight);
       }
+    } catch (error: unknown) {
+      startupError = error;
+      startupFailed = true;
     } finally {
       if (!this.appClosed) {
         try {
           await this.app.close();
+        } catch (closeError: unknown) {
+          if (!startupFailed) {
+            throw closeError;
+          }
+
+          if (startupError instanceof Error) {
+            const existingCause = Reflect.get(startupError, 'cause');
+            Reflect.set(
+              startupError,
+              'cause',
+              existingCause === undefined
+                ? closeError
+                : new AggregateError([existingCause, closeError], 'Fastify startup and shutdown both failed.'),
+            );
+          } else {
+            startupError = new AggregateError(
+              [startupError, closeError],
+              'Fastify startup and shutdown both failed.',
+            );
+          }
         } finally {
           this.appClosed = true;
         }
       }
+    }
+
+    if (startupFailed) {
+      throw startupError;
     }
   }
 


### PR DESCRIPTION
## Summary

Guarantees Fastify teardown on every startup-termination path, and preserves both the startup error and any close error when shutdown also fails.

Linked context: Closes #3390

## Changes

- `packages/platform-fastify/src/adapter.ts`: `closeApplication()` closes from a `finally`, so teardown runs no matter which error propagates. `closeInFlight` coalesces concurrent calls and `appClosed` keeps the real close to exactly once.
- Error preservation: when startup and Fastify `onClose` both fail, the startup rejection's `cause` is read, written, and read back. If that round-trips, the original rejection is preserved with the close error exposed as `cause`. If any read/write/read-back throws, or the write-back does not verify, an `AggregateError` is returned with the startup error at `errors[0]` and the close error at `errors[1]`.
- `packages/platform-fastify/src/adapter.test.ts`: regressions for the final-bind race, a plugin rejection racing shutdown, a frozen Error, a non-`Error` rejection, a setter that discards writes, and a throwing getter.
- EN/KO README document the failure mode; `@fluojs/platform-fastify` patch changeset.

## Review history

Six rounds, six distinct defects — every one found by review, none by CI:

1. teardown was conditional on a live listener
2. `ignoreCancelledListen()` re-throws non-cancellation startup errors, so a plugin/configuration rejection overlapping shutdown escaped teardown
3. a rejecting teardown replaced the original startup error
4. the `Reflect.set` return value was ignored — frozen errors silently dropped the close error, and non-`Error` rejections lost identity
5. an accessor whose setter discards the write returns `true` anyway, and a throwing `cause` getter let that error escape, losing both
6. resolved by read-write-read verification with a startup-first `AggregateError` fallback

A residual risk remains only for deliberately adversarial stateful accessors or revocable Proxies, which cannot arise from normal Fastify or application errors; the reviewer judged it not worth blocking on, and preserving arbitrary object identity while proving permanent reachability is not possible in general.

## Testing

- `pnpm --workspace-concurrency=1 --filter '@fluojs/platform-fastify...' build` — exit 0
- `pnpm --filter @fluojs/platform-fastify typecheck` — exit 0
- `pnpm --filter @fluojs/platform-fastify test` — exit 0, Tests 72 passed (72), twice
- `node tooling/governance/verify-platform-consistency-governance.mjs` — exit 0
- Mutation proofs (2/2 each): removing the write-back comparison fails the setter-discard regression twice; changing the fallback catch to rethrow fails the throwing-getter regression twice; reverted -> both pass twice. Earlier proofs (unconditional close, final-bind, retrying-bind) still hold.
- Read-only triad at this exact head: unanimous merge

## Note for the sibling PR (#3393)

#3393 fixes the `configureFastify` rejection leak in the same file and is blocked on the race this PR resolves. It rebases on top of this one, keeping `configureFastify`, `fastifyConfigurationInFlight`, and configuration-state reset, and dropping the then-redundant `fastifyConfigurationFailed` flag and its dedicated catch. Do not reintroduce a listener-conditional early return.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] Package README alignment/conformance claims are backed by the applicable platform harness tests.
