### PR TITLE
Resolve #3381: cover rejected Early Hints writes on the real Express listener

### DIFF
--- a/packages/platform-express/src/adapter.test.ts
+++ b/packages/platform-express/src/adapter.test.ts
@@ -339,6 +339,142 @@ describe('@fluojs/platform-express', () => {
     }
   });
 
+  it('rejects Early Hints written after final response commit on a real listener', async () => {
+    const lateWrite = createDeferred<void>();
+    const responseCommitted = createDeferred<void>();
+    void lateWrite.promise.catch(() => {});
+
+    @Controller('/early-hints-after-commit')
+    class EarlyHintsAfterCommitController {
+      @Get('/')
+      async render(_input: undefined, context: RequestContext) {
+        const earlyHints = context.response.earlyHints;
+
+        if (!earlyHints) {
+          throw new Error('Expected the Express response to support Early Hints.');
+        }
+
+        const rawResponse = context.response.raw;
+
+        if (!isExpressResponse(rawResponse)) {
+          throw new Error('Expected the Express response to expose its raw response.');
+        }
+
+        rawResponse.once('finish', () => {
+          responseCommitted.resolve();
+          void earlyHints.write({
+            link: '</late.css>; rel=preload; as=style',
+          }).then(lateWrite.resolve, lateWrite.reject);
+        });
+
+        await context.response.send({ ok: true });
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, { controllers: [EarlyHintsAfterCommitController] });
+
+    const adapter = createExpressAdapter({
+      host: '127.0.0.1',
+      port: 0,
+    }) as ExpressHttpApplicationAdapter;
+    const app = await FluoFactory.create(AppModule, { adapter });
+
+    try {
+      await app.listen();
+      const response = await requestHttp({
+        path: '/early-hints-after-commit',
+        port: getBoundPort(adapter.getServer()),
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body)).toEqual({ ok: true });
+      await expect(waitForSettlement(responseCommitted.promise)).resolves.toBeUndefined();
+      await expect(waitForSettlement(lateWrite.promise)).rejects.toMatchObject({
+        code: 'EARLY_HINTS_WRITE_FAILED',
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('rejects Early Hints written after client disconnect on a real listener', async () => {
+    const handlerReady = createDeferred<void>();
+    const disconnectedWrite = createDeferred<void>();
+    const releaseHandler = createDeferred<void>();
+    void disconnectedWrite.promise.catch(() => {});
+
+    @Controller('/early-hints-after-disconnect')
+    class EarlyHintsAfterDisconnectController {
+      @Get('/')
+      async render(_input: undefined, context: RequestContext) {
+        const earlyHints = context.response.earlyHints;
+
+        if (!earlyHints) {
+          throw new Error('Expected the Express response to support Early Hints.');
+        }
+
+        const rawResponse = context.response.raw;
+
+        if (!isExpressResponse(rawResponse)) {
+          throw new Error('Expected the Express response to expose its raw response.');
+        }
+
+        rawResponse.once('close', () => {
+          void earlyHints.write({
+            link: '</disconnected.css>; rel=preload; as=style',
+          }).then(disconnectedWrite.resolve, disconnectedWrite.reject);
+        });
+        handlerReady.resolve();
+        await releaseHandler.promise;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, { controllers: [EarlyHintsAfterDisconnectController] });
+
+    const adapter = createExpressAdapter({
+      host: '127.0.0.1',
+      port: 0,
+    }) as ExpressHttpApplicationAdapter;
+    const app = await FluoFactory.create(AppModule, { adapter });
+    let request: ReturnType<typeof httpRequest> | undefined;
+
+    try {
+      await app.listen();
+      request = httpRequest({
+        host: '127.0.0.1',
+        path: '/early-hints-after-disconnect',
+        port: getBoundPort(adapter.getServer()),
+      });
+      request.on('error', (error) => {
+        if (!request?.destroyed) {
+          disconnectedWrite.reject(error);
+        }
+      });
+      request.end();
+
+      const handlerReadySettlement = waitForSettlement(handlerReady.promise);
+      void handlerReadySettlement.catch(() => {
+        releaseHandler.resolve();
+      });
+      await expect(handlerReadySettlement).resolves.toBeUndefined();
+      request.destroy();
+
+      const disconnectedWriteSettlement = waitForSettlement(disconnectedWrite.promise);
+      void disconnectedWriteSettlement.catch(() => {
+        releaseHandler.resolve();
+      });
+      await expect(disconnectedWriteSettlement).rejects.toMatchObject({
+        code: 'REQUEST_ABORTED',
+      });
+    } finally {
+      releaseHandler.resolve();
+      request?.destroy();
+      await app.close();
+    }
+  });
+
   it('documents Express host compatibility without promising native middleware translation', () => {
     const packageReadme = readFileSync(new URL('../README.md', import.meta.url), 'utf8');
     const packageReadmeKo = readFileSync(new URL('../README.ko.md', import.meta.url), 'utf8');


### PR DESCRIPTION
## Summary

Adds real-listener regressions for REJECTED Early Hints writes in @fluojs/platform-express.

Linked context: Closes #3381

## Changes

- packages/platform-express/src/adapter.test.ts:
  - an Early Hints write after the final response finishes is rejected with \`EARLY_HINTS_WRITE_FAILED\`
  - a write after client close is rejected with \`REQUEST_ABORTED\`

Both subscribe to the real \`finish\`/\`close\` events before triggering the cause, gate ordering with a handler-ready deferred, and use bounded watchdogs only — no sleeps, polling, or timer-turn ordering.

## Testing

- \`pnpm --workspace-concurrency=1 --filter '@fluojs/platform-express...' build\` — exit 0
- \`pnpm --filter @fluojs/platform-express typecheck\` — exit 0
- \`pnpm --filter @fluojs/platform-express test\` — exit 0, Tests 73 passed (73), twice
- \`node tooling/governance/verify-platform-consistency-governance.mjs\` — exit 0
- Mutation proofs (2/2 each): final-commit seam broken -> FAIL adapter.test.ts:395 both runs; disconnect seam broken -> FAIL adapter.test.ts:470 both runs; reverted -> green twice
- Read-only triad at this exact head: unanimous merge

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary. (N/A — test-only)
- [x] Changed exported functions document matching \`@param\` / \`@returns\` tags where applicable. (N/A)
- [x] Source \`@example\` blocks and README scenario examples still play complementary roles. (N/A)

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. (None added; the pinned rejection reasons match the documented Early Hints contract.)
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (No docs changed.)
- [x] Package README alignment/conformance claims are backed by the applicable platform harness tests.
