### PR TITLE
Resolve #3362: assert stopActiveConnections forwarding to Bun server.stop()

### DIFF
--- a/packages/platform-bun/src/adapter.test.ts
+++ b/packages/platform-bun/src/adapter.test.ts
@@ -1749,6 +1749,31 @@ describe('@fluojs/platform-bun', () => {
     }
   });
 
+  it.each([
+    ['true', true],
+    ['false', false],
+    ['the default undefined value', undefined],
+  ])('forwards stopActiveConnections=%s to Bun server shutdown', async (_description, stopActiveConnections) => {
+    const mockBun = installMockBun();
+    const adapter = new BunHttpApplicationAdapter({ stopActiveConnections });
+
+    await adapter.listen({
+      async dispatch(_request: FrameworkRequest, response: FrameworkResponse) {
+        response.setStatus(204);
+      },
+    });
+
+    const server = mockBun.lastServer;
+
+    if (server === undefined) {
+      throw new TypeError('Expected the Bun adapter to create a server.');
+    }
+
+    await adapter.close();
+
+    expect(server.stop).toHaveBeenCalledWith(stopActiveConnections);
+  });
+
   it('keeps close pending and server state until Bun termination and request drain settle', async () => {
     const mockBun = installMockBun();
     const adapter = createBunAdapter() as BunHttpApplicationAdapter;


### PR DESCRIPTION
## Summary

Pins that \`stopActiveConnections\` is forwarded verbatim to Bun's \`server.stop()\`.

Linked context: Closes #3362

## Changes

- packages/platform-bun/src/adapter.test.ts:1752 — parameterized cases asserting \`true\`, \`false\`, and the omitted (default) form each reach \`server.stop()\` exactly as given. The assertions compare argument length too, so an explicit \`false\` is distinguished from a no-argument call.

## Testing

- \`pnpm --workspace-concurrency=1 --filter '@fluojs/platform-bun...' build\` — exit 0
- \`pnpm --filter @fluojs/platform-bun typecheck\` — exit 0
- \`pnpm --filter @fluojs/platform-bun test\` — exit 0, Tests 67 passed (67), twice
- \`node tooling/governance/verify-platform-consistency-governance.mjs\` — exit 0
- Mutation proof (2/2): \`server.stop(stopActiveConnections)\` -> \`server.stop()\` fails twice at adapter.test.ts:1774; reverted -> green twice
- Read-only triad at this exact head: unanimous merge

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary. (N/A — test-only)
- [x] Changed exported functions document matching \`@param\` / \`@returns\` tags where applicable. (N/A)
- [x] Source \`@example\` blocks and README scenario examples still play complementary roles. (N/A)

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. (None added; the test pins the documented shutdown option pass-through.)
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (No docs changed.)
- [x] Package README alignment/conformance claims are backed by the applicable platform harness tests.
