### PR TITLE
Resolve #3367: replace README token checks with semantic contract checks

### DIFF
--- a/packages/platform-cloudflare-workers/README.ko.md
+++ b/packages/platform-cloudflare-workers/README.ko.md
@@ -119,11 +119,25 @@ Root `@fluojs/platform-cloudflare-workers` export는 application code와 first-p
 
 위의 listen, shutdown, SSE drain, websocket binding 규칙은 public lifecycle behavior입니다. 이러한 public seam type 또는 lifecycle semantic을 바꾸는 변경은 `@fluojs/platform-cloudflare-workers` release governance 대상이며, user-impacting update는 implementation, docs, tests와 함께 Changesets로 추적해야 합니다.
 
+<!-- fluo-contract: realtime-capability -->
+```json
+{
+  "realtimeCapability": {
+    "bindingInstallationVersion": 1,
+    "contract": "raw-websocket-expansion",
+    "kind": "fetch-style",
+    "mode": "request-upgrade",
+    "support": "supported",
+    "version": 1
+  }
+}
+```
+
 ## Conformance 커버리지
 
-`packages/platform-cloudflare-workers/src/adapter.test.ts`와 `packages/platform-cloudflare-workers/src/adapter-lifecycle.test.ts`는 문서화된 Worker 계약을 검증하는 package-local regression 대상입니다. 이 파일들은 shared Web dispatch delegation, Worker `env` request attachment, `executionContext.waitUntil(...)` SSE(`text/event-stream`) body tracking, body-cancellation 및 synchronous setup-failure drain, websocket upgrade binding, upgraded server-socket close tracking, pre-listen HTTP 및 websocket lifecycle guard, listen boundary 이후 websocket binding freeze, lazy entrypoint 재사용 및 timeout recovery, shutdown gating, drain 중 `listen()` rejection, HTTP와 websocket upgrade 모두에 대한 close 중 및 close 이후 JSON `503` response, reliable fake-timer cleanup, public seam source import, README parity, bounded 10초 close timeout을 검증합니다.
+`packages/platform-cloudflare-workers/src/adapter.test.ts`와 `packages/platform-cloudflare-workers/src/adapter-lifecycle.test.ts`는 문서화된 Worker 계약을 검증하는 package-local regression 대상입니다. 이 파일들은 shared Web dispatch delegation, Worker `env` request attachment, `executionContext.waitUntil(...)` SSE(`text/event-stream`) body tracking, body-cancellation 및 synchronous setup-failure drain, websocket upgrade binding, upgraded server-socket close tracking, pre-listen HTTP 및 websocket lifecycle guard, listen boundary 이후 websocket binding freeze, lazy entrypoint 재사용 및 timeout recovery, shutdown gating, drain 중 `listen()` rejection, HTTP와 websocket upgrade 모두에 대한 close 중 및 close 이후 JSON `503` response, reliable fake-timer cleanup, public seam source import, structured realtime capability contract, bounded 10초 close timeout을 검증합니다.
 
-공유 edge portability suite인 `packages/testing/src/portability/web-runtime-adapter-portability.test.ts`는 Cloudflare Workers를 Bun 및 Deno와 함께 실행해 malformed cookie 보존, query decoding, JSON/text raw-body capture, multipart raw-body 제외, SSE framing을 검증합니다. 패키지 테스트의 README parity assertion은 이 edge-runtime 커버리지 문서가 한국어 mirror와 계속 동기화되도록 확인합니다.
+공유 edge portability suite인 `packages/testing/src/portability/web-runtime-adapter-portability.test.ts`는 Cloudflare Workers를 Bun 및 Deno와 함께 실행해 malformed cookie 보존, query decoding, JSON/text raw-body capture, multipart raw-body 제외, SSE framing을 검증합니다. 패키지 테스트는 두 README locale의 structured realtime capability contract를 parse하고 machine-consumed value를 adapter capability와 비교합니다.
 
 ## 공개 API 개요
 

--- a/packages/platform-cloudflare-workers/README.md
+++ b/packages/platform-cloudflare-workers/README.md
@@ -119,11 +119,25 @@ The root `@fluojs/platform-cloudflare-workers` export owns the Worker public sea
 
 The listen, shutdown, SSE drain, and websocket binding rules above are public lifecycle behavior. Changes to those public seam types or lifecycle semantics are release-governed for `@fluojs/platform-cloudflare-workers`; user-impacting updates must be tracked with Changesets alongside the implementation, docs, and tests.
 
+<!-- fluo-contract: realtime-capability -->
+```json
+{
+  "realtimeCapability": {
+    "bindingInstallationVersion": 1,
+    "contract": "raw-websocket-expansion",
+    "kind": "fetch-style",
+    "mode": "request-upgrade",
+    "support": "supported",
+    "version": 1
+  }
+}
+```
+
 ## Conformance Coverage
 
-`packages/platform-cloudflare-workers/src/adapter.test.ts` and `packages/platform-cloudflare-workers/src/adapter-lifecycle.test.ts` are the package-local regression targets for the documented Worker contract. They cover shared Web dispatch delegation, Worker `env` request attachment, `executionContext.waitUntil(...)` SSE (`text/event-stream`) body tracking, body-cancellation and synchronous setup-failure drains, websocket upgrade binding, upgraded server-socket close tracking, pre-listen HTTP and websocket lifecycle guards, websocket binding freeze after the listen boundary, lazy entrypoint reuse and timeout recovery, shutdown gating, drain-time `listen()` rejection, JSON `503` responses while closing and after close for both HTTP and websocket upgrades, reliable fake-timer cleanup, public seam source imports, README parity, and the bounded 10-second close timeout.
+`packages/platform-cloudflare-workers/src/adapter.test.ts` and `packages/platform-cloudflare-workers/src/adapter-lifecycle.test.ts` are the package-local regression targets for the documented Worker contract. They cover shared Web dispatch delegation, Worker `env` request attachment, `executionContext.waitUntil(...)` SSE (`text/event-stream`) body tracking, body-cancellation and synchronous setup-failure drains, websocket upgrade binding, upgraded server-socket close tracking, pre-listen HTTP and websocket lifecycle guards, websocket binding freeze after the listen boundary, lazy entrypoint reuse and timeout recovery, shutdown gating, drain-time `listen()` rejection, JSON `503` responses while closing and after close for both HTTP and websocket upgrades, reliable fake-timer cleanup, public seam source imports, the structured realtime capability contract, and the bounded 10-second close timeout.
 
-The shared edge portability suite in `packages/testing/src/portability/web-runtime-adapter-portability.test.ts` exercises Cloudflare Workers beside Bun and Deno for malformed cookie preservation, query decoding, JSON/text raw-body capture, multipart raw-body exclusion, and SSE framing. The README parity assertion in the package test keeps these documented edge-runtime coverage claims synchronized with the Korean mirror.
+The shared edge portability suite in `packages/testing/src/portability/web-runtime-adapter-portability.test.ts` exercises Cloudflare Workers beside Bun and Deno for malformed cookie preservation, query decoding, JSON/text raw-body capture, multipart raw-body exclusion, and SSE framing. The package test parses the structured realtime capability contract in both README locales and compares its machine-consumed values with the adapter capability.
 
 ## Public API Overview
 

--- a/packages/platform-cloudflare-workers/src/adapter-lifecycle.test.ts
+++ b/packages/platform-cloudflare-workers/src/adapter-lifecycle.test.ts
@@ -92,41 +92,6 @@ describe('@fluojs/platform-cloudflare-workers lifecycle regressions', () => {
     expect(source).not.toContain("from '@fluojs/runtime/internal/request-response-factory'");
   });
 
-  it('keeps Worker README lifecycle and public API claims mirrored across English and Korean docs', () => {
-    const englishReadme = readFileSync(new URL('../README.md', import.meta.url), 'utf8');
-    const koreanReadme = readFileSync(new URL('../README.ko.md', import.meta.url), 'utf8');
-    const sharedPublicSymbols = [
-      'CloudflareWorkerHttpApplicationAdapter',
-      'CloudflareWorkerHandler',
-      'CloudflareWorkerApplication',
-      'CloudflareWorkerEntrypoint',
-      'CloudflareWorkerWebSocketBinding',
-      'CloudflareWorkerWebSocketPair',
-      'CloudflareWorkerWebSocketUpgradeResult',
-    ];
-    const pairedLifecycleClaims = [
-      ['executionContext.waitUntil(...)', 'executionContext.waitUntil(...)'],
-      ['SSE (`text/event-stream`) response bodies', 'SSE(`text/event-stream`) response body'],
-      ['WebSocket upgrades', 'WebSocket upgrade'],
-      ['Cloudflare Workers adapter cannot listen while shutdown is still draining.',
-        'Cloudflare Workers adapter cannot listen while shutdown is still draining.'],
-      ['bounded 10-second drain window', '최대 10초의 bounded drain window'],
-      ['JSON `503` shutdown response', 'JSON `503` shutdown response'],
-      ['public seam', 'public seam'],
-      ['Changesets', 'Changesets'],
-    ];
-
-    for (const symbol of sharedPublicSymbols) {
-      expect(englishReadme).toContain(symbol);
-      expect(koreanReadme).toContain(symbol);
-    }
-
-    for (const [englishClaim, koreanClaim] of pairedLifecycleClaims) {
-      expect(englishReadme).toContain(englishClaim);
-      expect(koreanReadme).toContain(koreanClaim);
-    }
-  });
-
   it('rejects Worker websocket binding reconfiguration after the listen boundary even after close', async () => {
     const adapter = new CloudflareWorkerHttpApplicationAdapter({
       createWebSocketPair: createWebSocketPairStub(),

--- a/packages/platform-cloudflare-workers/src/adapter.test.ts
+++ b/packages/platform-cloudflare-workers/src/adapter.test.ts
@@ -30,6 +30,68 @@ function createExecutionContext(): CloudflareWorkerExecutionContext {
   };
 }
 
+type DocumentedRealtimeCapability = {
+  readonly bindingInstallationVersion: number;
+  readonly contract: string;
+  readonly kind: string;
+  readonly mode: string;
+  readonly support: string;
+  readonly version: number;
+};
+
+const REALTIME_CAPABILITY_DOCUMENTATION_ANCHOR = '<!-- fluo-contract: realtime-capability -->';
+
+function isDocumentedRealtimeCapability(value: unknown): value is DocumentedRealtimeCapability {
+  if (value === null || typeof value !== 'object') {
+    return false;
+  }
+
+  return (
+    typeof Reflect.get(value, 'bindingInstallationVersion') === 'number'
+    && typeof Reflect.get(value, 'contract') === 'string'
+    && typeof Reflect.get(value, 'kind') === 'string'
+    && typeof Reflect.get(value, 'mode') === 'string'
+    && typeof Reflect.get(value, 'support') === 'string'
+    && typeof Reflect.get(value, 'version') === 'number'
+  );
+}
+
+function readDocumentedRealtimeCapability(readme: string, locale: string): DocumentedRealtimeCapability {
+  const anchorOffset = readme.indexOf(REALTIME_CAPABILITY_DOCUMENTATION_ANCHOR);
+
+  if (anchorOffset === -1) {
+    throw new Error(
+      `${locale} README is missing the ${REALTIME_CAPABILITY_DOCUMENTATION_ANCHOR} documentation contract anchor.`,
+    );
+  }
+
+  const payloadStart = readme.indexOf('```json\n', anchorOffset);
+  const payloadEnd = payloadStart === -1 ? -1 : readme.indexOf('\n```', payloadStart);
+
+  if (payloadStart === -1 || payloadEnd === -1) {
+    throw new Error(`${locale} README realtime capability documentation contract must contain a JSON code block.`);
+  }
+
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(readme.slice(payloadStart + '```json\n'.length, payloadEnd));
+  } catch {
+    throw new Error(`${locale} README realtime capability documentation contract must contain valid JSON.`);
+  }
+
+  if (
+    !parsed
+    || typeof parsed !== 'object'
+    || !('realtimeCapability' in parsed)
+    || !isDocumentedRealtimeCapability(parsed.realtimeCapability)
+  ) {
+    throw new Error(`${locale} README realtime capability documentation contract has an invalid shape.`);
+  }
+
+  return parsed.realtimeCapability;
+}
+
 function createMockWorkerWebSocket(): CloudflareWorkerWebSocket {
   const listeners = {
     close: [] as Array<(event: Event) => void>,
@@ -99,18 +161,26 @@ describe('@fluojs/platform-cloudflare-workers', () => {
     expect(() => createCloudflareWorkerAdapter({ maxBodySize: 1.5 })).toThrow(/maxBodySize/i);
   });
 
-  it('keeps edge runtime README conformance coverage aligned across English and Korean docs', () => {
+  it('keeps the machine-consumed realtime capability contract synchronized with both READMEs', () => {
     const englishReadme = readFileSync(new URL('../README.md', import.meta.url), 'utf8');
     const koreanReadme = readFileSync(new URL('../README.ko.md', import.meta.url), 'utf8');
+    const capability = createCloudflareWorkerAdapter().getRealtimeCapability();
 
-    for (const readme of [englishReadme, koreanReadme]) {
-      expect(readme).toContain('Cloudflare Workers');
-      expect(readme).toContain('executionContext.waitUntil(...)');
-      expect(readme).toContain('10');
-      expect(readme).toContain('503');
-      expect(readme).toContain('packages/platform-cloudflare-workers/src/adapter.test.ts');
-      expect(readme).toContain('packages/testing/src/portability/web-runtime-adapter-portability.test.ts');
+    if (!capability.bindingInstallation) {
+      throw new Error('Expected the Cloudflare Workers adapter to expose websocket binding installation.');
     }
+
+    const expectedDocumentationContract = {
+      bindingInstallationVersion: capability.bindingInstallation.version,
+      contract: capability.contract,
+      kind: capability.kind,
+      mode: capability.mode,
+      support: capability.support,
+      version: capability.version,
+    };
+
+    expect(readDocumentedRealtimeCapability(englishReadme, 'English')).toEqual(expectedDocumentationContract);
+    expect(readDocumentedRealtimeCapability(koreanReadme, 'Korean')).toEqual(expectedDocumentationContract);
   });
 
   it('keeps the Worker adapter runtime import path free of the HTTP root barrel', () => {


### PR DESCRIPTION
## Summary

Replaces bilingual README token checks with semantic contract checks that compare the documented realtime capability against the ACTUAL adapter capability.

Linked context: Closes #3367

## Changes

- packages/platform-cloudflare-workers/README.md and README.ko.md: the realtime capability contract is now a structured block.
- packages/platform-cloudflare-workers/src/adapter.test.ts: compares that block against \`createCloudflareWorkerAdapter().getRealtimeCapability()\` (adapter.test.ts:164) and pins the runtime contract independently (adapter.test.ts:248). Missing anchors, missing or malformed JSON blocks, and wrong shapes all throw explicitly (adapter.test.ts:59) — there is no vacuous-pass path.
- The old prose-substring assertions were removed; lifecycle, SSE drain, websocket, shutdown/503, and public-seam execution checks are all retained.

## Why this matters

Token checks pass while the contract drifts. Mutation proof (2/2): changing \`"bindingInstallationVersion": 1\` to \`2\` in README.md fails the new semantic check twice (expected 1, received 2), while the OLD token checks **passed** under that same drift.

## Testing

- \`pnpm --workspace-concurrency=1 --filter '@fluojs/platform-cloudflare-workers...' build\` — exit 0
- \`pnpm --filter @fluojs/platform-cloudflare-workers typecheck\` — exit 0
- \`pnpm --filter @fluojs/platform-cloudflare-workers test\` — exit 0, Tests 36 passed (36), twice
- \`node tooling/governance/verify-platform-consistency-governance.mjs\` — exit 0
- Read-only triad at this exact head: unanimous merge

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary. (N/A — docs and tests only)
- [x] Changed exported functions document matching \`@param\` / \`@returns\` tags where applicable. (N/A)
- [x] Source \`@example\` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] Package README alignment/conformance claims are backed by the applicable platform harness tests.
