### PR TITLE
Resolve #3391: make the package-local SSE regression deterministic

### DIFF
--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -1128,50 +1128,6 @@ describe('@fluojs/platform-fastify', () => {
     }
   });
 
-  it('supports SSE streaming', async () => {
-    @Controller('/events')
-    class EventsController {
-      @Get('/')
-      stream(_input: undefined, context: RequestContext) {
-        const stream = new SseResponse(context);
-
-        stream.comment('connected');
-        stream.send({ ready: true }, { event: 'ready', id: 'evt-1' });
-        setTimeout(() => {
-          stream.close();
-        }, 10);
-
-        return stream;
-      }
-    }
-
-    class AppModule {}
-    defineModule(AppModule, {
-      controllers: [EventsController],
-    });
-
-    const app = await bootstrapFastifyApplication(AppModule, {
-      cors: false,
-      port: 0,
-    });
-
-    const port = await listenOnEphemeralPort(app);
-
-    try {
-      const response = await fetch(`http://127.0.0.1:${String(port)}/events`, {
-        headers: { accept: 'text/event-stream' },
-      });
-      const body = await response.text();
-
-      expect(response.status).toBe(200);
-      expect(response.headers.get('content-type')).toContain('text/event-stream');
-      expect(body).toContain('event: ready');
-      expect(body).toContain('data: {"ready":true}');
-    } finally {
-      await app.close();
-    }
-  });
-
   it('registers native Fastify routes while preserving fluo matching, versioning, lifecycle, and fallback semantics', async () => {
     const lifecycle: string[] = [];
 


### PR DESCRIPTION
## Summary

Removes the duplicated 10ms wall-clock SSE test in @fluojs/platform-fastify and folds its coverage into the deterministic shared portability harness the suite already runs.

Linked context: Closes #3391

## Changes

- `packages/platform-fastify/src/adapter.test.ts`: the wall-clock duplicate is gone. The shared harness pre-subscribes handler-ready, closes the stream explicitly, and uses a 2s bounded watchdog purely as a failure guard.

## Coverage is preserved, not dropped

All four assertions from the deleted test — status 200, `text/event-stream`, `event: ready`, and the JSON data frame — are asserted by the shared harness that the Fastify suite invokes (`adapter.test.ts:322` -> `packages/testing/src/portability/http-adapter-portability.ts:666`). `comment` and `id` were generated but never asserted by either version, so nothing was lost. All three reviewers verified this assertion by assertion.

## Testing

- `pnpm lint` — exit 0
- `pnpm --workspace-concurrency=1 --filter '@fluojs/platform-fastify...' build` — exit 0
- `pnpm --filter @fluojs/platform-fastify typecheck` — exit 0
- `pnpm --filter @fluojs/platform-fastify test` — pass, twice (74 tests)
- `node tooling/governance/verify-platform-consistency-governance.mjs` — exit 0
- Mutation proof (2/2): `packages/http/src/context/sse.ts` `this.stream.close()` -> `this.stream.flush?.()` fails both runs with "fastify adapter did not close the SSE response stream."; reverted -> green twice. The mutation is meaningful because Fastify's `flush()` emits headers without ending the response (`adapter.ts:940`).
- Read-only triad at this exact head: unanimous merge

## Why the replacement is stronger, not merely different

The old wall-clock test would also have caught this mutation, but only by hanging on `response.text()` until the Vitest suite timeout. The harness fails fast and names the exact close-contract violation.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

The diff touches only `packages/platform-fastify/src/adapter.test.ts`. It does not modify `packages/testing/src/portability/**`, which is why this differs from #3386, where editing that shipped harness source did require a `@fluojs/testing` patch changeset.

## Public export documentation

- [x] Changed public exports include a source-level summary. (N/A — test-only)
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. (N/A)
- [x] Source `@example` blocks and README scenario examples still play complementary roles. (N/A)

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. (None added.)
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (No docs changed.)
- [x] Package README alignment/conformance claims are backed by the applicable platform harness tests.
