### PR TITLE
test(core): cover public error behavior

### DIFF
--- a/packages/core/src/errors.test.ts
+++ b/packages/core/src/errors.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+
+import { FluoCodeError, FluoError, formatTokenName, InvariantError } from './errors.js';
+
+class DatabaseError extends FluoCodeError {
+  constructor(message: string) {
+    super(message, 'DATABASE_ERROR');
+  }
+}
+
+describe('public core errors', () => {
+  it('preserves the default code, name, metadata, and Error cause', () => {
+    // Given
+    const cause = new Error('connection refused');
+    const meta = { operation: 'connect' };
+
+    // When
+    const error = new FluoError('database unavailable', { cause, meta });
+
+    // Then
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe('FluoError');
+    expect(error.message).toBe('database unavailable');
+    expect(error.code).toBe('FLUO_ERROR');
+    expect(error.cause).toBe(cause);
+    expect(error.meta).toBe(meta);
+  });
+
+  it('preserves a non-Error cause without making it enumerable', () => {
+    // Given
+    const cause = { reason: 'offline' };
+
+    // When
+    const error = new FluoError('database unavailable', {
+      cause,
+      code: 'DATABASE_UNAVAILABLE',
+    });
+
+    // Then
+    expect(error.code).toBe('DATABASE_UNAVAILABLE');
+    expect(error.cause).toBe(cause);
+    expect(Object.keys(error)).not.toContain('cause');
+  });
+
+  it('uses the fixed invariant code and subclass name', () => {
+    // Given
+    const meta = { invariant: 'container-ready' };
+
+    // When
+    const error = new InvariantError('container is not ready', { meta });
+
+    // Then
+    expect(error.name).toBe('InvariantError');
+    expect(error.code).toBe('INVARIANT_ERROR');
+    expect(error.meta).toBe(meta);
+  });
+
+  it('uses the code supplied by a FluoCodeError subclass', () => {
+    // Given
+    const message = 'database unavailable';
+
+    // When
+    const error = new DatabaseError(message);
+
+    // Then
+    expect(error.name).toBe('DatabaseError');
+    expect(error.code).toBe('DATABASE_ERROR');
+    expect(error.message).toBe(message);
+  });
+});
+
+describe('formatTokenName', () => {
+  it.each([
+    [class UserService {}, 'UserService'],
+    [Symbol('user'), 'Symbol(user)'],
+    ['user', 'user'],
+    [42, '42'],
+    [true, 'true'],
+    [null, 'null'],
+    [undefined, 'undefined'],
+  ])('formats %s as %s', (token, expected) => {
+    // Given
+    const injectionToken = token;
+
+    // When
+    const formatted = formatTokenName(injectionToken);
+
+    // Then
+    expect(formatted).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary

Add executable regression coverage for the public @fluojs/core error primitives and token formatter.

Linked context: Closes #3102

## Changes

- exercise FluoError default/custom codes, Error and non-Error causes, and metadata
- exercise InvariantError and FluoCodeError subclass names/codes
- exercise function, symbol, string, numeric, boolean, null, and undefined token formatting

## Testing

- pnpm --filter '@fluojs/core...' build
- pnpm --filter @fluojs/core typecheck
- pnpm --filter @fluojs/core test
- focused errors.test.ts: 11 passed

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

## Public export documentation

- [x] No public exports changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] No platform contract documentation changed.