### PR TITLE
fix(core): expose readonly module metadata

### DIFF
--- a/.changeset/readonly-core-module-metadata.md
+++ b/.changeset/readonly-core-module-metadata.md
@@ -1,5 +1,7 @@
 ---
 "@fluojs/core": patch
+"@fluojs/config": patch
 ---
 
-Align module metadata collection types with the frozen read-only snapshots returned at runtime.
+Align module metadata collection types with the frozen read-only snapshots returned at runtime and keep the config
+module's provider assembly immutable.

--- a/.changeset/readonly-core-module-metadata.md
+++ b/.changeset/readonly-core-module-metadata.md
@@ -1,7 +1,10 @@
 ---
-"@fluojs/core": patch
+"@fluojs/core": major
 "@fluojs/config": patch
 ---
 
 Align module metadata collection types with the frozen read-only snapshots returned at runtime and keep the config
 module's provider assembly immutable.
+
+Code that intentionally derives a mutable collection from `getModuleMetadata()` must now copy the snapshot first,
+for example with `[...metadata.imports]`, instead of mutating the frozen metadata collection directly.

--- a/.changeset/readonly-core-module-metadata.md
+++ b/.changeset/readonly-core-module-metadata.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/core": patch
+---
+
+Align module metadata collection types with the frozen read-only snapshots returned at runtime.

--- a/packages/config/src/module.ts
+++ b/packages/config/src/module.ts
@@ -90,17 +90,16 @@ export class ConfigModule {
         provide: ConfigService,
         useFactory: () => createConfigServiceFromSnapshot(loadConfig(loadOptions)),
       },
-    ];
-
-    if (loadOptions.watch) {
-      providers.push(
+      ...(loadOptions.watch
+        ? [
         {
           provide: CONFIG_MODULE_WATCH_OPTIONS,
           useValue: loadOptions,
         },
         ConfigModuleWatchManager,
-      );
-    }
+          ]
+        : []),
+    ];
 
     defineModuleMetadata(ConfigModuleImpl, {
       global: loadOptions.global ?? true,

--- a/packages/core/src/metadata.test.ts
+++ b/packages/core/src/metadata.test.ts
@@ -546,8 +546,13 @@ describe('metadata helpers', () => {
     expect(Object.isFrozen(metadata?.exports)).toBe(true);
     expect(metadata?.controllers).toEqual([ExampleController]);
     expect(metadata?.exports).toEqual([ExportedProvider]);
-    expect(() => metadata?.controllers?.push(class MutatedController {})).toThrow(TypeError);
-    expect(() => metadata?.exports?.push(class MutatedExport {})).toThrow(TypeError);
+    if (metadata?.controllers === undefined || metadata.exports === undefined) {
+      throw new Error('Expected frozen module collection snapshots');
+    }
+    expect(() => Reflect.apply(Array.prototype.push, metadata.controllers, [class MutatedController {}])).toThrow(
+      TypeError,
+    );
+    expect(() => Reflect.apply(Array.prototype.push, metadata.exports, [class MutatedExport {}])).toThrow(TypeError);
 
     controllers.push(class CallerMutatedController {});
     exports.push(class CallerMutatedExport {});

--- a/packages/core/src/metadata/module.ts
+++ b/packages/core/src/metadata/module.ts
@@ -80,8 +80,8 @@ function cloneModuleMetadata(metadata: ModuleMetadata): ModuleMetadata {
   };
 }
 
-function freezeCollection<T>(collection: T[] | undefined): T[] | undefined {
-  return collection ? Object.freeze(collection) as T[] : undefined;
+function freezeCollection<T>(collection: readonly T[] | undefined): readonly T[] | undefined {
+  return collection ? Object.freeze(collection) : undefined;
 }
 
 function freezeModuleMetadata(metadata: ModuleMetadata): ModuleMetadata {

--- a/packages/core/src/metadata/types.ts
+++ b/packages/core/src/metadata/types.ts
@@ -1,9 +1,9 @@
 import type { Constructor, InjectionToken, MaybePromise, MetadataPropertyKey, MetadataSource, Token } from '../types.js';
 
 /**
- * Defines the metadata collection type.
+ * Defines the read-only metadata collection type.
  */
-export type MetadataCollection<T = unknown> = T[];
+export type MetadataCollection<T = unknown> = readonly T[];
 
 /**
  * Describes the module metadata contract.

--- a/packages/core/src/module-metadata-types.test.ts
+++ b/packages/core/src/module-metadata-types.test.ts
@@ -1,0 +1,21 @@
+import { expect, expectTypeOf, it } from 'vitest';
+
+import { getModuleMetadata, Module } from './index.js';
+import type { ModuleMetadata } from './internal.js';
+
+it('models module collections as readonly frozen snapshots', () => {
+  // Given
+  class SharedModule {}
+  const imports = [SharedModule] as const;
+
+  // When
+  @Module({ imports })
+  class AppModule {}
+  const metadata: ModuleMetadata | undefined = getModuleMetadata(AppModule);
+
+  // Then
+  expectTypeOf(metadata?.imports).toEqualTypeOf<readonly unknown[] | undefined>();
+  expect(metadata?.imports).toEqual(imports);
+  expect(Object.isFrozen(metadata)).toBe(true);
+  expect(Object.isFrozen(metadata?.imports)).toBe(true);
+});

--- a/packages/core/src/module-metadata-types.test.ts
+++ b/packages/core/src/module-metadata-types.test.ts
@@ -3,10 +3,14 @@ import { expect, expectTypeOf, it } from 'vitest';
 import { getModuleMetadata, Module } from './index.js';
 import type { ModuleMetadata } from './internal.js';
 
+type HasPush<T> = T extends { push(...values: unknown[]): unknown } ? true : false;
+type ModuleImportsExcludePush = HasPush<NonNullable<ModuleMetadata['imports']>> extends false ? true : never;
+
 it('models module collections as readonly frozen snapshots', () => {
   // Given
   class SharedModule {}
   const imports = [SharedModule] as const;
+  const importsExcludePush: ModuleImportsExcludePush = true;
 
   // When
   @Module({ imports })
@@ -15,6 +19,7 @@ it('models module collections as readonly frozen snapshots', () => {
 
   // Then
   expectTypeOf(metadata?.imports).toEqualTypeOf<readonly unknown[] | undefined>();
+  expect(importsExcludePush).toBe(true);
   expect(metadata?.imports).toEqual(imports);
   expect(Object.isFrozen(metadata)).toBe(true);
   expect(Object.isFrozen(metadata?.imports)).toBe(true);


### PR DESCRIPTION
## Summary

Align ModuleMetadata collection types with the frozen readonly snapshots already returned at runtime.

Linked context: Closes #3108

## Changes

- expose MetadataCollection as readonly and accept readonly @Module inputs
- preserve runtime cloning/freezing while making freeze helpers type-correct
- keep ConfigModule provider assembly immutable
- add compile-time and runtime regression coverage
- add @fluojs/core major and @fluojs/config patch Changeset metadata with migration guidance

## Testing

- pnpm --filter '@fluojs/core...' build
- pnpm --filter @fluojs/core typecheck
- pnpm --filter @fluojs/core test
- pnpm --filter '@fluojs/config...' build
- pnpm --filter @fluojs/config typecheck
- pnpm --filter @fluojs/config test
- pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

This carries a major @fluojs/core Changeset because existing code that mutates ModuleMetadata collections must migrate to copying the frozen snapshot first, for example [...metadata.imports]. Explicit maintainer approval is required before merge.

## Public export documentation

- [x] Changed public types preserve source-level TSDoc.
- [x] No exported function documentation changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] Existing immutable-snapshot documentation remains accurate.
- [x] Runtime and type invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] No platform contract documentation changed.