### PR TITLE
Resolve #3399: expose Node HTTP server options on the platform adapter

### DIFF
--- a/.changeset/expose-node-http-server-options.md
+++ b/.changeset/expose-node-http-server-options.md
@@ -1,0 +1,6 @@
+---
+"@fluojs/platform-nodejs": minor
+"@fluojs/runtime": minor
+---
+
+Expose Node.js plain HTTP `ServerOptions` through the raw Node adapter and reject configurations that combine them with HTTPS options.

--- a/packages/platform-nodejs/README.ko.md
+++ b/packages/platform-nodejs/README.ko.md
@@ -49,18 +49,20 @@ await app.listen();
 Raw Node response는 `context.response.earlyHints`를 노출합니다. 이 optional capability를 확인한 뒤 HTTP `103` 하나마다 `write(...)`를 await하세요. 여러 write를 지원합니다. 각 write에는 비어 있지 않은 `link` value가 필요하며 Node가 허용하는 다른 informational field도 포함할 수 있습니다. Native write는 final response를 commit하거나 early field를 final header로 복사하지 않습니다. Late/native failure는 `EarlyHintsWriteError`로 reject되고 settlement 전에 연결이 끊기면 `RequestAbortedError`로 reject됩니다.
 
 ### 서버 옵션 커스텀
-어댑터는 문서화된 Node.js transport 옵션인 host/port 바인딩, HTTPS 설정, request body 제한, raw-body 보존, listen retry 설정, shutdown drain bound를 제공합니다.
+어댑터는 문서화된 Node.js transport 옵션인 host/port 바인딩, plain HTTP 또는 HTTPS 생성 설정, request body 제한, raw-body 보존, listen retry 설정, shutdown drain bound를 제공합니다.
 
 ```typescript
 const adapter = createNodejsAdapter({
-  port: 443,
-  https: {
-    key: fs.readFileSync('key.pem'),
-    cert: fs.readFileSync('cert.pem'),
+  port: 3000,
+  http: {
+    maxHeaderSize: 16_384,
+    joinDuplicateHeaders: true,
   },
   maxBodySize: 1_048_576,
 });
 ```
+
+`http`는 Node의 `node:http` `ServerOptions`를 받고 listener가 시작되기 전에 `createServer(options, handler)`로 전달합니다. `maxHeaderSize`, `insecureHTTPParser`, `joinDuplicateHeaders`, `highWaterMark` 같은 생성 시점 설정에 사용하세요. TLS에는 Node HTTPS server option이 담긴 `https`를 대신 제공하세요. `http`와 `https`는 동시에 사용할 수 없으며, 둘 다 제공하면 adapter가 server를 만들기 전에 throw하므로 어느 option도 조용히 무시되지 않습니다.
 
 `maxBodySize`는 바이트 수를 나타내는 숫자만 받습니다. 이 값은 raw Node 요청 바디가 아직 스트리밍되는 동안 바로 강제되며, 부트스트랩 시 `multipart.maxTotalSize`를 따로 재정의하지 않으면 같은 값이 멀티파트 전체 페이로드 한도의 기본값으로도 사용됩니다.
 
@@ -94,6 +96,7 @@ await app.listen();
 ## 동작 계약
 
 - `createNodejsAdapter(options)`는 Node 내장 `http` 또는 `https` 서버 primitive 위에서 fluo를 직접 실행하는 adapter-first 진입점입니다.
+- `http`는 plain HTTP server 생성용 Node `node:http` `ServerOptions`를 받고, `https`는 기존 TLS 생성 option을 유지합니다. 호출자는 두 field 중 하나만 제공해야 합니다.
 - `maxBodySize`는 0 이상의 정수 바이트 수만 받으며, raw Node 요청 바이트가 아직 스트리밍되는 동안 강제되고, 부트스트랩/실행 헬퍼에서 `multipart.maxTotalSize`를 명시적으로 제공하지 않으면 멀티파트 전체 크기 한도의 기본값이 됩니다.
 - Raw Node adapter는 대소문자가 섞인 JSON 및 multipart `content-type` 값을 normalize하고, request body가 `maxBodySize`를 넘으면 `413`을 반환하며, `x-request-id`와 `x-correlation-id` fallback을 request context와 error response에 전파하고, `getServer()` / `getRealtimeCapability()`를 통해 server-backed realtime capability를 노출합니다.
 - `bootstrapNodejsApplication(module, options)`는 raw Node 어댑터가 포함된 애플리케이션을 만들지만 리스닝은 시작하지 않으므로 이후 `app.listen()`과 `app.close()` 생명주기는 호출자가 소유합니다.
@@ -106,7 +109,7 @@ await app.listen();
 
 이 패키지는 `HttpApplicationAdapter`를 노출하며 `platform.components`에 등록되는 runtime-managed `PlatformComponent`가 아닙니다. 따라서 generic `createPlatformConformanceHarness(...)` component lifecycle 검사는 이 패키지의 지원 계약 범위에 포함되지 않고, `createHttpAdapterPortabilityHarness(...)`가 적용되는 공유 harness입니다.
 
-같은 regression target들은 package-specific public surface, type alias, adapter-first startup, lifecycle option validation, 실제로 관찰되는 listen retry, active-request bounded drain, 정상 및 실패 signal-driven shutdown, `process.env.PORT` isolation, zero/default `maxBodySize` boundary, idle keep-alive shutdown, 대소문자가 섞인 JSON 및 multipart content-type parsing, `x-correlation-id` request ID fallback, server-backed realtime capability 노출도 함께 다룹니다. Startup behavior를 바꿀 때는 README 예제 포인터를 아래 테스트 파일 및 Node.js 챕터 예제와 맞춰 유지하세요.
+같은 regression target들은 package-specific public surface, type alias, adapter-first startup, plain HTTP 생성 option과 HTTPS conflict boundary, lifecycle option validation, 실제로 관찰되는 listen retry, active-request bounded drain, 정상 및 실패 signal-driven shutdown, `process.env.PORT` isolation, zero/default `maxBodySize` boundary, idle keep-alive shutdown, 대소문자가 섞인 JSON 및 multipart content-type parsing, `x-correlation-id` request ID fallback, server-backed realtime capability 노출도 함께 다룹니다. Startup behavior를 바꿀 때는 README 예제 포인터를 아래 테스트 파일 및 Node.js 챕터 예제와 맞춰 유지하세요.
 
 ## 공개 API 개요
 
@@ -114,7 +117,7 @@ await app.listen();
 - `bootstrapNodejsApplication(module, options)`: 리스너를 시작하지 않고 애플리케이션 인스턴스를 생성합니다.
 - `runNodejsApplication(module, options)`: 생명주기 관리를 포함하여 애플리케이션을 부트스트랩하고 시작합니다.
 - `BootstrapNodejsApplicationOptions`: bootstrap-only Node.js 애플리케이션 생성 옵션입니다.
-- `NodejsAdapterOptions`: `port`, `host`, `https`, `maxBodySize`, retry 설정, raw body 보존, shutdown timeout을 포함하는 `createNodejsAdapter(...)`의 transport-level 옵션입니다.
+- `NodejsAdapterOptions`: `port`, `host`, 상호 배타적인 `http` 또는 `https` 생성 option, `maxBodySize`, retry 설정, raw body 보존, shutdown timeout을 포함하는 `createNodejsAdapter(...)`의 transport-level 옵션입니다.
 - `NodejsApplicationSignal`: `runNodejsApplication(...)` shutdown 등록이 지원하는 시그널 이름입니다.
 - `NodejsHttpApplicationAdapter`: `createNodejsAdapter(...)`가 반환하는 어댑터 인스턴스를 설명하는 타입 전용 별칭이며, `@fluojs/runtime/node`가 공개하는 어댑터 surface를 그대로 보존합니다.
 - `RunNodejsApplicationOptions`: 부트스트랩, 리스닝 시작, graceful shutdown 배선을 한 번에 수행하기 위한 옵션입니다.

--- a/packages/platform-nodejs/README.md
+++ b/packages/platform-nodejs/README.md
@@ -49,18 +49,20 @@ await app.listen();
 Raw Node responses expose `context.response.earlyHints`. Check that optional capability, then await `write(...)` once per HTTP `103`; multiple writes are supported. Each write requires a non-empty `link` value and may include other Node-permitted informational fields. The native write does not commit the final response or copy early fields into final headers. Late/native failures reject with `EarlyHintsWriteError`, and a disconnect before settlement rejects with `RequestAbortedError`.
 
 ### Customizing Server Options
-The adapter exposes the documented Node.js transport options: host/port binding, HTTPS configuration, request body limits, raw-body preservation, listen retry settings, and shutdown drain bounds.
+The adapter exposes the documented Node.js transport options: host/port binding, plain HTTP or HTTPS construction configuration, request body limits, raw-body preservation, listen retry settings, and shutdown drain bounds.
 
 ```typescript
 const adapter = createNodejsAdapter({
-  port: 443,
-  https: {
-    key: fs.readFileSync('key.pem'),
-    cert: fs.readFileSync('cert.pem'),
+  port: 3000,
+  http: {
+    maxHeaderSize: 16_384,
+    joinDuplicateHeaders: true,
   },
   maxBodySize: 1_048_576,
 });
 ```
+
+`http` accepts Node's `node:http` `ServerOptions` and passes them to `createServer(options, handler)` before the listener starts. Use it for construction-time settings such as `maxHeaderSize`, `insecureHTTPParser`, `joinDuplicateHeaders`, or `highWaterMark`. For TLS, provide `https` with Node's HTTPS server options instead. `http` and `https` are mutually exclusive; supplying both throws before the adapter creates a server, so no option is silently ignored.
 
 `maxBodySize` accepts a byte count number. It is enforced while the raw Node request body is still streaming, and the same limit becomes the default total multipart payload cap unless you override `multipart.maxTotalSize` during bootstrap.
 
@@ -94,6 +96,7 @@ await app.listen();
 ## Behavioral Contracts
 
 - `createNodejsAdapter(options)` is the adapter-first entrypoint for running fluo directly on Node's built-in `http` or `https` server primitives.
+- `http` accepts Node `node:http` `ServerOptions` for plain HTTP server construction, while `https` keeps its existing TLS construction options; callers must supply at most one of those fields.
 - `maxBodySize` accepts a non-negative integer byte count, is enforced while raw Node request bytes are still streaming, and becomes the default multipart total-size cap unless `multipart.maxTotalSize` is explicitly provided through the bootstrap/run helpers.
 - The raw Node adapter normalizes mixed-case JSON and multipart `content-type` values, returns `413` when request bodies exceed `maxBodySize`, propagates `x-request-id` with `x-correlation-id` fallback into the request context and error responses, and exposes a server-backed realtime capability through `getServer()` / `getRealtimeCapability()`.
 - `bootstrapNodejsApplication(module, options)` creates an application with the raw Node adapter but does not start listening, so the caller owns the subsequent `app.listen()` and `app.close()` lifecycle.
@@ -106,7 +109,7 @@ await app.listen();
 
 This package exposes an `HttpApplicationAdapter`; it is not a runtime-managed `PlatformComponent` registered under `platform.components`. Therefore the generic `createPlatformConformanceHarness(...)` component lifecycle checks are outside this package's supported contract, while `createHttpAdapterPortabilityHarness(...)` is the applicable shared harness.
 
-The same regression targets also cover the package-specific public surface, type aliases, adapter-first startup, lifecycle option validation, observed listen retries, active-request bounded drain, normal and failed signal-driven shutdown, `process.env.PORT` isolation, zero and default `maxBodySize` boundaries, idle keep-alive shutdown, mixed-case JSON and multipart content-type parsing, `x-correlation-id` request ID fallback, and server-backed realtime capability exposure. Keep README example pointers aligned with those test files and the Node.js chapter examples below when changing startup behavior.
+The same regression targets also cover the package-specific public surface, type aliases, adapter-first startup, plain HTTP construction options and their HTTPS conflict boundary, lifecycle option validation, observed listen retries, active-request bounded drain, normal and failed signal-driven shutdown, `process.env.PORT` isolation, zero and default `maxBodySize` boundaries, idle keep-alive shutdown, mixed-case JSON and multipart content-type parsing, `x-correlation-id` request ID fallback, and server-backed realtime capability exposure. Keep README example pointers aligned with those test files and the Node.js chapter examples below when changing startup behavior.
 
 ## Public API Overview
 
@@ -114,7 +117,7 @@ The same regression targets also cover the package-specific public surface, type
 - `bootstrapNodejsApplication(module, options)`: Creates an application instance without starting the listener.
 - `runNodejsApplication(module, options)`: Bootstraps and starts the application with lifecycle management.
 - `BootstrapNodejsApplicationOptions`: Options for bootstrap-only Node.js application creation.
-- `NodejsAdapterOptions`: Transport-level options for `createNodejsAdapter(...)`, including `port`, `host`, `https`, `maxBodySize`, retry settings, raw body preservation, and shutdown timeout.
+- `NodejsAdapterOptions`: Transport-level options for `createNodejsAdapter(...)`, including `port`, `host`, mutually exclusive `http` or `https` construction options, `maxBodySize`, retry settings, raw body preservation, and shutdown timeout.
 - `NodejsApplicationSignal`: Supported signal names for `runNodejsApplication(...)` shutdown registration.
 - `NodejsHttpApplicationAdapter`: Type-only alias describing the adapter instances returned by `createNodejsAdapter(...)`, while preserving the public adapter surface exported from `@fluojs/runtime/node`.
 - `RunNodejsApplicationOptions`: Options for one-call bootstrap, listen, and graceful shutdown wiring.

--- a/packages/platform-nodejs/src/index.test.ts
+++ b/packages/platform-nodejs/src/index.test.ts
@@ -215,6 +215,97 @@ describe('@fluojs/platform-nodejs', () => {
     expectTypeOf<NodeHttpApplicationAdapterConstructorParameters[10]>().toEqualTypeOf<HttpServerOptions | undefined>();
   });
 
+  it('preserves positional Node adapter constructor values through their runtime behavior', async () => {
+    const blocker = createServer();
+    await new Promise<void>((resolve) => {
+      blocker.listen(0, '127.0.0.1', resolve);
+    });
+    const blockerAddress = blocker.address();
+    if (!blockerAddress || typeof blockerAddress === 'string') {
+      throw new Error('Failed to bind a positional constructor test port.');
+    }
+
+    const retryAdapter = new NodeHttpApplicationAdapter(
+      blockerAddress.port,
+      '127.0.0.1',
+      1,
+      2,
+      true,
+      undefined,
+      undefined,
+      32,
+      false,
+      61,
+      { maxHeaderSize: 32_768 },
+    );
+    const retryServerListen = vi.spyOn(retryAdapter.getServer(), 'listen');
+    const dispatcher: Dispatcher = {
+      async dispatch(_request, response) {
+        await response.send('ok');
+      },
+    };
+
+    try {
+      await expect(retryAdapter.listen(dispatcher)).rejects.toMatchObject({ code: 'EADDRINUSE' });
+      expect(retryServerListen).toHaveBeenCalledTimes(3);
+    } finally {
+      retryServerListen.mockRestore();
+      await retryAdapter.close();
+      await new Promise<void>((resolve, reject) => {
+        blocker.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          resolve();
+        });
+      });
+    }
+
+    let observedRawBody: Uint8Array | undefined;
+    const adapter = new NodeHttpApplicationAdapter(
+      0,
+      '127.0.0.1',
+      1,
+      2,
+      true,
+      undefined,
+      undefined,
+      32,
+      false,
+      61,
+      { maxHeaderSize: 32_768 },
+    );
+
+    try {
+      await adapter.listen({
+        async dispatch(request, response) {
+          observedRawBody = request.rawBody;
+          await response.send('compressible response'.repeat(64));
+        },
+      });
+      const listeningPort = getBoundPort(adapter.getServer());
+
+      const oversizedResponse = await fetch(`http://127.0.0.1:${String(listeningPort)}`, {
+        body: 'x'.repeat(48),
+        method: 'POST',
+      });
+      expect(oversizedResponse.status).toBe(413);
+
+      const response = await fetch(`http://127.0.0.1:${String(listeningPort)}`, {
+        body: 'body',
+        headers: { 'accept-encoding': 'gzip' },
+        method: 'POST',
+      });
+      expect(response.headers.get('content-encoding')).toBe('gzip');
+      expect(observedRawBody).toBeUndefined();
+      expect(Reflect.get(adapter.getServer(), 'maxHeaderSize')).toBe(32_768);
+    } finally {
+      await adapter.close();
+    }
+  });
+
   it('keeps advanced process and compression utilities off the primary platform startup surface', () => {
     expect(platformNodejsApi).not.toHaveProperty('compressNodeResponse');
     expect(platformNodejsApi).not.toHaveProperty('createNodeResponseCompression');

--- a/packages/platform-nodejs/src/index.test.ts
+++ b/packages/platform-nodejs/src/index.test.ts
@@ -248,6 +248,23 @@ describe('@fluojs/platform-nodejs', () => {
     );
   });
 
+  it('passes plain HTTP construction options and rejects HTTPS pairing through the platform adapter', async () => {
+    const adapter = createNodejsAdapter({
+      http: { maxHeaderSize: 32_768 },
+    });
+
+    try {
+      expect(Reflect.get(adapter.getServer(), 'maxHeaderSize')).toBe(32_768);
+    } finally {
+      await adapter.close();
+    }
+
+    expect(() => createNodejsAdapter({
+      http: { maxHeaderSize: 32_768 },
+      https: {},
+    })).toThrow('Plain HTTP and HTTPS server options cannot be used together.');
+  });
+
   it('rejects listen through the package adapter after retryLimit is exhausted', async () => {
     const blocker = createServer();
     await new Promise<void>((resolve) => {

--- a/packages/platform-nodejs/src/index.test.ts
+++ b/packages/platform-nodejs/src/index.test.ts
@@ -1,12 +1,14 @@
 import { type AddressInfo, createServer } from 'node:net';
+import type { ServerOptions as HttpServerOptions } from 'node:http';
+import type { ServerOptions as HttpsServerOptions } from 'node:https';
 import { Controller, type Dispatcher, FromBody, Get, Post, type RequestContext, RequestDto } from '@fluojs/http';
-import { defineModule, FluoFactory } from '@fluojs/runtime';
+import { defineModule, FluoFactory, type MultipartOptions } from '@fluojs/runtime';
 import {
   type BootstrapNodeApplicationOptions,
   bootstrapNodeApplication,
   type NodeApplicationSignal,
   type NodeHttpAdapterOptions,
-  type NodeHttpApplicationAdapter,
+  NodeHttpApplicationAdapter,
   type RunNodeApplicationOptions,
   runNodeApplication,
 } from '@fluojs/runtime/node';
@@ -23,6 +25,10 @@ import {
   type RunNodejsApplicationOptions,
   runNodejsApplication,
 } from './index.js';
+
+type NodeHttpApplicationAdapterConstructorParameters = ConstructorParameters<
+  typeof NodeHttpApplicationAdapter
+>;
 
 function getBoundPort(server: { address(): AddressInfo | string | null }): number {
   const address = server.address();
@@ -193,6 +199,20 @@ describe('@fluojs/platform-nodejs', () => {
     expectTypeOf<NodejsApplicationSignal>().toEqualTypeOf<NodeApplicationSignal>();
     expectTypeOf<NodejsHttpApplicationAdapter>().toEqualTypeOf<NodeHttpApplicationAdapter>();
     expectTypeOf<RunNodejsApplicationOptions>().toEqualTypeOf<RunNodeApplicationOptions>();
+  });
+
+  it('preserves the Node adapter constructor parameter order for positional consumers', () => {
+    expectTypeOf<NodeHttpApplicationAdapterConstructorParameters[0]>().toEqualTypeOf<number>();
+    expectTypeOf<NodeHttpApplicationAdapterConstructorParameters[1]>().toEqualTypeOf<string | undefined>();
+    expectTypeOf<NodeHttpApplicationAdapterConstructorParameters[2]>().toEqualTypeOf<number | undefined>();
+    expectTypeOf<NodeHttpApplicationAdapterConstructorParameters[3]>().toEqualTypeOf<number | undefined>();
+    expectTypeOf<NodeHttpApplicationAdapterConstructorParameters[4]>().toEqualTypeOf<boolean | undefined>();
+    expectTypeOf<NodeHttpApplicationAdapterConstructorParameters[5]>().toEqualTypeOf<HttpsServerOptions | undefined>();
+    expectTypeOf<NodeHttpApplicationAdapterConstructorParameters[6]>().toEqualTypeOf<MultipartOptions | undefined>();
+    expectTypeOf<NodeHttpApplicationAdapterConstructorParameters[7]>().toEqualTypeOf<number | undefined>();
+    expectTypeOf<NodeHttpApplicationAdapterConstructorParameters[8]>().toEqualTypeOf<boolean | undefined>();
+    expectTypeOf<NodeHttpApplicationAdapterConstructorParameters[9]>().toEqualTypeOf<number | undefined>();
+    expectTypeOf<NodeHttpApplicationAdapterConstructorParameters[10]>().toEqualTypeOf<HttpServerOptions | undefined>();
   });
 
   it('keeps advanced process and compression utilities off the primary platform startup surface', () => {

--- a/packages/runtime/src/node/internal-node.ts
+++ b/packages/runtime/src/node/internal-node.ts
@@ -147,12 +147,12 @@ export class NodeHttpApplicationAdapter implements HttpApplicationAdapter {
     private readonly retryDelayMs = 150,
     private readonly retryLimit = 20,
     compression = false,
-    private readonly httpOptions: HttpServerOptions | undefined,
     private readonly httpsOptions: HttpsServerOptions | undefined,
     multipartOptions?: MultipartOptions,
     maxBodySize = 1 * 1024 * 1024,
     preserveRawBody = false,
     private readonly shutdownTimeoutMs = DEFAULT_SHUTDOWN_TIMEOUT_MS,
+    private readonly httpOptions?: HttpServerOptions,
   ) {
     validateNodeLifecycleOptions({
       retryDelayMs: this.retryDelayMs,
@@ -287,12 +287,12 @@ export function createNodeHttpAdapter(options: NodeHttpAdapterOptions = {}, comp
     options.retryDelayMs,
     options.retryLimit,
     compression,
-    options.http,
     options.https,
     multipartOptions,
     resolveNodeMaxBodySize(options.maxBodySize),
     options.rawBody,
     options.shutdownTimeoutMs,
+    options.http,
   );
 }
 

--- a/packages/runtime/src/node/internal-node.ts
+++ b/packages/runtime/src/node/internal-node.ts
@@ -1,7 +1,7 @@
 import {
   createServer as createHttpServer,
-  type RequestListener,
   type ServerOptions as HttpServerOptions,
+  type RequestListener,
   type ServerResponse,
 } from 'node:http';
 import { createServer as createHttpsServer, type ServerOptions as HttpsServerOptions } from 'node:https';

--- a/packages/runtime/src/node/internal-node.ts
+++ b/packages/runtime/src/node/internal-node.ts
@@ -1,4 +1,9 @@
-import { createServer as createHttpServer, type RequestListener, type ServerResponse } from 'node:http';
+import {
+  createServer as createHttpServer,
+  type RequestListener,
+  type ServerOptions as HttpServerOptions,
+  type ServerResponse,
+} from 'node:http';
 import { createServer as createHttpsServer, type ServerOptions as HttpsServerOptions } from 'node:https';
 import type { AddressInfo, Socket } from 'node:net';
 
@@ -61,6 +66,7 @@ import {
  */
 export interface NodeHttpAdapterOptions {
   host?: string;
+  http?: HttpServerOptions;
   https?: HttpsServerOptions;
   maxBodySize?: number;
   port?: number;
@@ -91,6 +97,7 @@ export interface BootstrapNodeApplicationOptions extends Omit<CreateApplicationO
   globalPrefix?: string;
   globalPrefixExclude?: readonly string[];
   host?: string;
+  http?: HttpServerOptions;
   https?: HttpsServerOptions;
   logger?: ApplicationLogger;
   maxBodySize?: number;
@@ -140,6 +147,7 @@ export class NodeHttpApplicationAdapter implements HttpApplicationAdapter {
     private readonly retryDelayMs = 150,
     private readonly retryLimit = 20,
     compression = false,
+    private readonly httpOptions: HttpServerOptions | undefined,
     private readonly httpsOptions: HttpsServerOptions | undefined,
     multipartOptions?: MultipartOptions,
     maxBodySize = 1 * 1024 * 1024,
@@ -157,7 +165,7 @@ export class NodeHttpApplicationAdapter implements HttpApplicationAdapter {
       maxBodySize,
       preserveRawBody,
     );
-    this.server = createNodeServer(this.httpsOptions, (request, response) => {
+    this.server = createNodeServer(this.httpOptions, this.httpsOptions, (request, response) => {
       void this.handleRequest(request, response);
     });
     this.listenLifecycle = new NodeListenLifecycle(this.server, {
@@ -279,6 +287,7 @@ export function createNodeHttpAdapter(options: NodeHttpAdapterOptions = {}, comp
     options.retryDelayMs,
     options.retryLimit,
     compression,
+    options.http,
     options.https,
     multipartOptions,
     resolveNodeMaxBodySize(options.maxBodySize),
@@ -352,9 +361,18 @@ export {
 };
 
 function createNodeServer(
+  httpOptions: HttpServerOptions | undefined,
   httpsOptions: HttpsServerOptions | undefined,
   handler: NodeRequestListener,
 ): NodeServer {
+  if (httpOptions && httpsOptions) {
+    throw new Error('Plain HTTP and HTTPS server options cannot be used together.');
+  }
+
+  if (httpOptions) {
+    return createHttpServer(httpOptions, handler);
+  }
+
   return httpsOptions ? createHttpsServer(httpsOptions, handler) : createHttpServer(handler);
 }
 


### PR DESCRIPTION
## Summary

Exposes plain-HTTP `node:http.ServerOptions` on the Node.js platform adapter (`http` option), forwarded through every construction path, with `http` + `https` rejected synchronously before server creation.

Linked context: Closes #3399

## Changes

- `@fluojs/runtime`: `NodeHttpApplicationAdapter` gains `httpOptions` as an **optional trailing** constructor parameter; the factory forwards `options.http` as the last argument.
- `@fluojs/platform-nodejs`: `http` option accepted and documented (EN/KO README).
- Positional behavioral regression pinning every constructor slot with distinct observable semantics.

## Review history worth knowing

The read-only triad ran three rounds at exact heads:
- R1: the contract axis caught `httpOptions` inserted **mid-list** in the public constructor — source-breaking on a 2.0.1 package while the changesets said minor. Code and verification axes had approved; the ordering defect was invisible to tests.
- R2: moved to the trailing position (source-compatible; minor correct). The added positional **type** regression was then found insufficient: same-type slots (`retryDelayMs`/`retryLimit`, `maxBodySize`/`shutdownTimeoutMs`, `compression`/`preserveRawBody`) could swap without failing any type assertion.
- R3: replaced with a positional **behavioral** regression — each slot carries a distinct value asserted by real semantics (3 retries observed, 413 on a 48-byte body over `maxBodySize: 32`, gzip response, raw body disabled, `maxHeaderSize: 32768` on a real native server). Unanimous merge.

## Testing

- `pnpm lint` — exit 0
- serial platform closure build — pass
- `@fluojs/platform-nodejs` + `@fluojs/runtime` typecheck — pass
- `pnpm --filter @fluojs/platform-nodejs test` — 45 tests, twice
- `node tooling/governance/verify-platform-consistency-governance.mjs` — pass
- Swap mutation proofs (2/2 each): `retryDelayMs`/`retryLimit` fails at `index.test.ts:250` (expected 3 calls, got 2); `maxBodySize`/`shutdownTimeoutMs` at `:294` (expected 413, got 200); `compression`/`preserveRawBody` at `:301` (expected gzip, got null). HTTP-forwarding removal fails the real-server assertion ("expected undefined to be 32768").
- Read-only triad unanimous at this exact head.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

`@fluojs/runtime` **minor**, `@fluojs/platform-nodejs` **minor** — additive optional API only; the trailing position keeps every existing positional call site compiling with identical semantics.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] Package README alignment/conformance claims are backed by the applicable platform harness tests.
