### PR TITLE
Resolve #3392: synchronize client disconnect with abort-listener readiness

### DIFF
--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -3133,16 +3133,24 @@ describe('@fluojs/platform-fastify', () => {
 
   it('propagates abort signal when the client disconnects', async () => {
     const aborted = createDeferred<void>();
+    const abortListenerReady = createDeferred<void>();
 
     @Controller('/abort')
     class AbortController {
       @Get('/')
       async wait(_input: undefined, context: RequestContext) {
+        const signal = context.request.signal;
+
+        if (!signal) {
+          throw new Error('Expected the Fastify request to expose an abort signal.');
+        }
+
         await new Promise<void>((resolve) => {
-          context.request.signal?.addEventListener('abort', () => {
+          signal.addEventListener('abort', () => {
             aborted.resolve();
             resolve();
           }, { once: true });
+          abortListenerReady.resolve();
         });
 
         return { ok: true };
@@ -3171,18 +3179,18 @@ describe('@fluojs/platform-fastify', () => {
       request.on('error', () => {});
       request.end();
 
-      setTimeout(() => {
-        request.destroy();
-      }, 20);
+      await abortListenerReady.promise;
+      request.destroy();
 
-      await expect(Promise.race([
-        aborted.promise,
-        new Promise<void>((_resolve, reject) => {
-          setTimeout(() => {
-            reject(new Error('Abort signal was not propagated.'));
-          }, 2_000);
+      const abortResult = await Promise.race([
+        aborted.promise.then(() => 'aborted' as const),
+        new Promise<'timed-out'>((resolve) => {
+          AbortSignal.timeout(2_000).addEventListener('abort', () => {
+            resolve('timed-out');
+          }, { once: true });
         }),
-      ])).resolves.toBeUndefined();
+      ]);
+      expect(abortResult).toBe('aborted');
     } finally {
       request.destroy();
       await app.close();


### PR DESCRIPTION
## Summary

Synchronizes the client-disconnect abort test in `@fluojs/platform-fastify` with abort-listener **readiness**: the disconnect can no longer fire before the listener is installed.

Linked context: Closes #3392

## Changes

- `packages/platform-fastify/src/adapter.test.ts` (only file): a readiness deferred resolves immediately after `response.once('close', ...)` is installed — causally after the production listener binds, since accessing `context.request.signal` installs it synchronously — and the test awaits that readiness before `request.destroy()`. The 2s `AbortSignal.timeout` remains purely as a failure watchdog.

## Testing

- `pnpm lint` — exit 0
- `pnpm --workspace-concurrency=1 --filter '@fluojs/platform-fastify...' build` — pass
- `pnpm --filter @fluojs/platform-fastify typecheck` — pass
- `pnpm --filter @fluojs/platform-fastify test` — 74 tests, twice
- `node tooling/governance/verify-platform-consistency-governance.mjs` — pass
- Mutation proof (2/2): `response.once('close', ...)` -> `response.once('finish', ...)` severs the disconnect-to-abort wiring; both runs fail at `adapter.test.ts:3193` with `expect(abortResult).toBe('aborted')` receiving `'timed-out'` (the handler waits for an abort that never comes, so `finish` never fires either); reverted -> green twice.
- Read-only triad at this exact head: unanimous merge.

## Why the new form is stronger

The old test destroyed the request on a 20ms timer and observed both a production abort defect and the scheduling defect (disconnect before listener installation) as the same 2s timeout. The reworked test makes listener readiness a precondition, so those two causes are separated; a future failure names the right one.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Test-only; no shipped source touched (`packages/testing/src/portability/**` untouched — the case that required a changeset on #3386).

## Public export documentation

- [x] Changed public exports include a source-level summary. (N/A — test-only)
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. (N/A)
- [x] Source `@example` blocks and README scenario examples still play complementary roles. (N/A)

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. (None added.)
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (No docs changed.)
- [x] Package README alignment/conformance claims are backed by the applicable platform harness tests.
