### PR TITLE
docs(core): remove nonexistent Injectable examples

### DIFF
--- a/docs/guides/anti-patterns.ko.md
+++ b/docs/guides/anti-patterns.ko.md
@@ -7,16 +7,12 @@
 ### ❌ Anti-pattern
 
 ```ts
-import { Injectable } from '@fluojs/core';
-
-@Injectable()
 export class PaymentsService {
   private readonly apiKey = process.env.PAYMENTS_API_KEY;
 
   constructor(private readonly orders: OrdersService) {}
 }
 
-@Injectable()
 export class OrdersService {
   constructor(private readonly payments: PaymentsService) {}
 }
@@ -25,21 +21,33 @@ export class OrdersService {
 ### ✅ Correct
 
 ```ts
-import { Inject, Injectable } from '@fluojs/core';
-import { ConfigService } from '@fluojs/config';
+import { Inject, Module } from '@fluojs/core';
 
-@Inject(ConfigService, OrdersService)
-@Injectable()
+const PAYMENTS_API_KEY = Symbol('PAYMENTS_API_KEY');
+
+@Inject(PAYMENTS_API_KEY)
 export class PaymentsService {
-  constructor(
-    private readonly config: ConfigService,
-    private readonly orders: OrdersService,
-  ) {}
+  constructor(private readonly apiKey: string) {}
 
   getApiKey(): string {
-    return this.config.getOrThrow('PAYMENTS_API_KEY');
+    return this.apiKey;
   }
 }
+
+@Inject(PaymentsService)
+export class OrdersService {
+  constructor(private readonly payments: PaymentsService) {}
+}
+
+@Module({
+  providers: [
+    { provide: PAYMENTS_API_KEY, useValue: 'configured-at-bootstrap' },
+    PaymentsService,
+    OrdersService,
+  ],
+  exports: [OrdersService],
+})
+export class PaymentsModule {}
 ```
 
 ## Decorators
@@ -56,7 +64,6 @@ export class PaymentsService {
 ```
 
 ```ts
-@Injectable()
 export class UsersService {
   constructor(private readonly repo: UsersRepository) {}
 }
@@ -73,13 +80,18 @@ export class UsersService {
 ```
 
 ```ts
-import { Inject, Injectable } from '@fluojs/core';
+import { Inject, Module } from '@fluojs/core';
 
 @Inject(UsersRepository)
-@Injectable()
 export class UsersService {
   constructor(private readonly repo: UsersRepository) {}
 }
+
+@Module({
+  providers: [UsersRepository, UsersService],
+  exports: [UsersService],
+})
+export class UsersModule {}
 ```
 
 ## Platform Adapters

--- a/docs/guides/anti-patterns.md
+++ b/docs/guides/anti-patterns.md
@@ -7,16 +7,12 @@
 ### ❌ Anti-pattern
 
 ```ts
-import { Injectable } from '@fluojs/core';
-
-@Injectable()
 export class PaymentsService {
   private readonly apiKey = process.env.PAYMENTS_API_KEY;
 
   constructor(private readonly orders: OrdersService) {}
 }
 
-@Injectable()
 export class OrdersService {
   constructor(private readonly payments: PaymentsService) {}
 }
@@ -25,21 +21,33 @@ export class OrdersService {
 ### ✅ Correct
 
 ```ts
-import { Inject, Injectable } from '@fluojs/core';
-import { ConfigService } from '@fluojs/config';
+import { Inject, Module } from '@fluojs/core';
 
-@Inject(ConfigService, OrdersService)
-@Injectable()
+const PAYMENTS_API_KEY = Symbol('PAYMENTS_API_KEY');
+
+@Inject(PAYMENTS_API_KEY)
 export class PaymentsService {
-  constructor(
-    private readonly config: ConfigService,
-    private readonly orders: OrdersService,
-  ) {}
+  constructor(private readonly apiKey: string) {}
 
   getApiKey(): string {
-    return this.config.getOrThrow('PAYMENTS_API_KEY');
+    return this.apiKey;
   }
 }
+
+@Inject(PaymentsService)
+export class OrdersService {
+  constructor(private readonly payments: PaymentsService) {}
+}
+
+@Module({
+  providers: [
+    { provide: PAYMENTS_API_KEY, useValue: 'configured-at-bootstrap' },
+    PaymentsService,
+    OrdersService,
+  ],
+  exports: [OrdersService],
+})
+export class PaymentsModule {}
 ```
 
 ## Decorators
@@ -56,7 +64,6 @@ export class PaymentsService {
 ```
 
 ```ts
-@Injectable()
 export class UsersService {
   constructor(private readonly repo: UsersRepository) {}
 }
@@ -73,13 +80,18 @@ export class UsersService {
 ```
 
 ```ts
-import { Inject, Injectable } from '@fluojs/core';
+import { Inject, Module } from '@fluojs/core';
 
 @Inject(UsersRepository)
-@Injectable()
 export class UsersService {
   constructor(private readonly repo: UsersRepository) {}
 }
+
+@Module({
+  providers: [UsersRepository, UsersService],
+  exports: [UsersService],
+})
+export class UsersModule {}
 ```
 
 ## Platform Adapters


### PR DESCRIPTION
## Summary

Remove nonexistent Injectable usage from the canonical dependency-injection anti-pattern examples.

Linked context: Closes #3107

## Changes

- remove Injectable imports/decorators from English and Korean guides
- replace the corrected DI example with explicit symbol-token and class-level @Inject wiring
- register providers and exports through @Module
- keep the decorator migration example aligned with explicit constructor tokens

## Testing

- pnpm docs:sync-check
- pnpm docs:typecheck
- pnpm docs:build
- @fluojs/core public-api test
- manual audit: zero Injectable references remain in either canonical guide

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Examples use only shipped Inject and Module root exports.

## Behavioral contract

- [x] No runtime contracts changed.
- [x] Correct examples now match explicit DI and module registration contracts.

## Platform consistency governance (SSOT)

- [x] English/Korean mirror structure remains synchronized.
- [x] No platform contract documentation changed.