### PR TITLE
Resolve #3098: Align inline comment parsing with documented dotenv behavior

### DIFF
--- a/.changeset/align-dotenv-inline-comments.md
+++ b/.changeset/align-dotenv-inline-comments.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/config': patch
+---
+
+Align built-in env-file parsing with the documented dotenv inline comment grammar. Strip an unquoted `#` comment even when no whitespace precedes it, so `VALUE=value#comment` loads as `value` instead of including the comment text, while quoted hashes such as `"value#kept"` remain part of the value across both initial loads and reloads.

--- a/packages/config/src/load.test.ts
+++ b/packages/config/src/load.test.ts
@@ -533,6 +533,57 @@ describe('loadConfig', () => {
     });
   });
 
+  it('strips unquoted inline comments that are not preceded by whitespace', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'fluo-config-adjacent-comment-'));
+    const envPath = join(cwd, '.env.dev');
+
+    writeFileSync(
+      envPath,
+      [
+        'ADJACENT=value#comment',
+        'ADJACENT_EMPTY=#comment',
+        'ADJACENT_MULTIPLE=value#first#second',
+        'SPACED=value #comment',
+        'QUOTED_DOUBLE="value#kept"#comment',
+        "QUOTED_SINGLE='value#kept'#comment",
+        'QUOTED_BACKTICK=`value#kept`#comment',
+        'ESCAPED_IN_DOUBLE="value\\#kept"',
+      ].join('\n'),
+    );
+
+    const loaded = loadConfig({ cwd, envFile: envPath, processEnv: {} });
+
+    expect(loaded).toMatchObject({
+      ADJACENT: 'value',
+      ADJACENT_EMPTY: '',
+      ADJACENT_MULTIPLE: 'value',
+      ESCAPED_IN_DOUBLE: 'value\\#kept',
+      QUOTED_BACKTICK: 'value#kept',
+      QUOTED_DOUBLE: 'value#kept',
+      QUOTED_SINGLE: 'value#kept',
+      SPACED: 'value',
+    });
+  });
+
+  it('applies adjacent inline comment stripping to manual reloads', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'fluo-config-adjacent-comment-reload-'));
+    const envPath = join(cwd, '.env.dev');
+
+    writeFileSync(envPath, 'TOKEN=initial#comment\n');
+
+    const reloader = createConfigReloader({ cwd, envFile: envPath, processEnv: {} });
+
+    try {
+      expect(reloader.current()).toMatchObject({ TOKEN: 'initial' });
+
+      writeFileSync(envPath, 'TOKEN="reloaded#kept"#comment\n');
+
+      expect(reloader.reload()).toMatchObject({ TOKEN: 'reloaded#kept' });
+    } finally {
+      reloader.close();
+    }
+  });
+
   it('expands variable interpolation in env files', () => {
     const cwd = mkdtempSync(join(tmpdir(), 'fluo-config-expand-'));
     const envPath = join(cwd, '.env.dev');

--- a/packages/config/src/load.ts
+++ b/packages/config/src/load.ts
@@ -203,7 +203,7 @@ function unquoteEnvValue(value: string): string {
 }
 
 function stripInlineEnvComment(value: string): string {
-  const commentIndex = value.search(/\s#/);
+  const commentIndex = value.indexOf('#');
   return commentIndex === -1 ? value : value.slice(0, commentIndex);
 }
 


### PR DESCRIPTION
## Summary

Align the built-in `@fluojs/config` parser with documented dotenv inline-comment behavior.

Linked context: Closes #3098

## Changes

- Strip unquoted values at the first `#`, regardless of preceding whitespace.
- Preserve embedded hashes in single-, double-, and backtick-quoted values.
- Add deterministic initial-load and manual-reload regressions.
- Add a patch Changeset for `@fluojs/config`.

## Testing

- `pnpm --filter @fluojs/config... build`
- `pnpm --filter @fluojs/config typecheck`
- `pnpm --filter @fluojs/config test` — 83 tests passed
- `pnpm --filter ...@fluojs/config test` — 36 packages / 3948 tests passed on Node v24.20.0
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`
- Built-package manual probe verified adjacent comments, quoted hashes, and empty values.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

No public exports changed.

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavior restores the existing documented dotenv parser contract; no new contract surface was added.
- [x] Intentional limitations remain explicit and unchanged.
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

Not applicable: this change is confined to the config parser and its tests.

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] No platform contract docs changed.
- [x] No platform conformance claim changed.
