### PR TITLE
docs(cache-manager): correct bilingual cache behavior

### DIFF
--- a/book/beginner/ch17-cache.ko.md
+++ b/book/beginner/ch17-cache.ko.md
@@ -57,7 +57,7 @@ Fluo는 다양한 캐싱 백엔드에 대해 통일된 인터페이스를 제공
 이 경계는 **직렬화 프로토콜(Serialization Protocols)**에도 그대로 적용됩니다. 현재 배포된 `RedisStore`는 내부적으로 `JSON.stringify(...)`/`JSON.parse(...)`를 사용하므로, Protocol Buffers(Protobuf)나 MessagePack 같은 대체 형식은 `CacheModule`의 내장 토글이 아닙니다. 애플리케이션에 다른 직렬화 전략이 필요하다면, 공개 캐시 계약을 만족하는 커스텀 저장소로 구현해야 합니다.
 
 ### 17.2.3 Serialization and Type Safety in Fluo
-캐싱에서 흔히 겪는 골칫거리 중 하나는 가져온 데이터가 저장한 데이터와 동일한 타입인지 보장하는 것입니다. Fluo의 `CacheService`는 TypeScript 친화적인 API 표면을 제공하지만, 기본 제공 저장소가 풍부한 런타임 타입 복원을 자동으로 해주지는 않습니다. 실제로는 JSON 호환 값은 무난하게 왕복되지만, `Date` 같은 값은 애플리케이션이 직접 다시 복원하지 않는 한 직렬화된 JSON 형태로 돌아옵니다. 따라서 서비스 코드는 캐시 계층이 모든 원래 런타임 타입을 자동 복원한다고 가정하기보다, 애플리케이션이 소유하는 데이터 계약으로 캐시 값을 다루는 편이 안전합니다.
+캐싱에서 흔히 겪는 골칫거리 중 하나는 가져온 데이터가 저장한 데이터와 동일한 타입인지 보장하는 것입니다. Fluo의 `CacheService`는 TypeScript 친화적인 API 표면을 제공하지만, 실제 결과는 설정한 저장소에 따라 달라집니다. `MemoryStore`는 엔트리를 `structuredClone(...)`으로 복사하므로 `Date`, `Map`, `Set`처럼 structured clone이 가능한 값은 프로세스 안에서 같은 런타임 타입 그대로 돌아옵니다. 반면 `RedisStore`는 엔트리를 `JSON.stringify(...)`로 저장하므로, 이 경로에서는 애플리케이션이 직접 복원하지 않는 한 `Date`가 직렬화된 JSON 형태(예: ISO 문자열)로 돌아옵니다. 같은 코드가 어느 저장소에서도 동작할 수 있으므로, 캐시 값은 애플리케이션이 소유하는 데이터 계약으로 다루고 두 경로에서 동일하게 유지되어야 하는 값은 직접 정규화하세요.
 
 ## 17.3 Basic Configuration and Setup
 `AppModule`에 `CacheModule`을 등록합니다. 기본 설정은 인메모리 저장소를 사용하며, 이는 로컬 개발 환경에 적합합니다.
@@ -142,7 +142,7 @@ export class AppModule {}
 그러나 영속성은 쓰기 성능에 영향을 줄 수 있으므로 주의해야 합니다. 대부분의 Fluo 애플리케이션에서는 최대 속도를 위해 영속성이 없는 기본 모드를 선호합니다. 실패 동작은 캐시 호출 방식에 따라 달라집니다. `CacheInterceptor`가 감싼 HTTP route에서는 interceptor가 store read 실패를 cache miss로 취급하고 store write 또는 eviction 실패를 내부에 격리하므로, 캐시 저장소 오류 외에는 정상인 handler가 계속 완료될 수 있습니다. 이 route 전용 격리는 명시적인 `CacheService` operation에는 적용되지 않습니다. `get`, `set`, `remember`, `del`, `reset`은 store 작업을 기다리며, 애플리케이션이 오류를 catch하지 않으면 해당 작업 실패로 reject됩니다. 각 수동 호출 지점에서 cache가 필수인지 fail-soft여야 하는지 결정하고, 오류를 격리할 때도 log나 metric을 남기세요.
 
 ## 17.4 Automatic Response Caching
-성능을 향상시키는 가장 쉬운 방법은 전체 HTTP 응답을 캐싱하는 것입니다. Fluo는 이 목적을 위해 `CacheInterceptor`를 제공합니다. 특정 라우트에 이 인터셉터를 적용하면 아직 commit되지 않은 성공적인 GET 결과가 자동으로 캐싱되어, 이후 들어오는 동일한 요청에 대해 캐시된 내용을 즉시 반환합니다.
+성능을 향상시키는 가장 쉬운 방법은 전체 HTTP 응답을 캐싱하는 것입니다. Fluo는 이 목적을 위해 `CacheInterceptor`를 제공합니다. 특정 라우트에 이 인터셉터를 적용하면 아직 commit되지 않은 성공적인 GET 결과가 자동으로 캐싱되어, 이후 들어오는 동일한 요청에 대해 캐시된 내용을 즉시 반환합니다. 다만 interceptor는 store를 읽고 miss일 때 곧바로 handler를 호출하며 동시 miss를 합치지 않습니다. 따라서 같은 키를 동시에 miss한 요청은 각각 handler를 실행합니다.
 
 ```typescript
 import { Controller, Get, UseInterceptors } from '@fluojs/http';
@@ -155,7 +155,7 @@ export class PostsController {
   @CacheKey('popular_posts')
   @CacheTTL(600) // 10분 동안 캐싱
   async getPopular() {
-    // 이 느린 데이터베이스 쿼리는 10분에 한 번만 실행됩니다!
+    // 캐시에 저장된 뒤부터 10분 동안은 이후 요청이 캐시로 처리됩니다.
     return this.postsService.findPopular();
   }
 }
@@ -257,7 +257,7 @@ export class PostsController {
 이러한 고급 수동 패턴을 자동 응답 캐싱과 결합하면 Fluo 백엔드의 성능과 신뢰성을 함께 높이는 효율적인 데이터 계층을 만들 수 있습니다. 캐싱의 목표는 사용자에게 가능한 가장 빠른 응답을 제공하는 동시에 기본 데이터 소스의 부하를 줄이는 것임을 항상 기억하십시오. 이 레이어에서 수행하는 모든 최적화는 전반적으로 더 확장 가능하고 복원력 있는 시스템을 만드는 데 기여합니다.
 
 ### 17.5.4 Advanced Manual Patterns: Coordinating Concurrent Writers
-`CacheService`의 애플리케이션 공개 표면은 `get`, `set`, `remember`, `del`, `reset`에 집중되어 있습니다. 따라서 카운터 증가나 분산 락 같은 저장소 전용 원자 연산이 필요할 때는, 그것을 `CacheService`의 내장 애플리케이션 API로 가정하기보다 선택한 저장소의 별도 기능이나 애플리케이션 전용 조정 계층으로 다루는 편이 안전합니다.
+`CacheService`의 애플리케이션 공개 표면은 `get`, `set`, `remember`, `del`, `reset`, 그리고 `close()`를 노출하는 store로 shutdown을 전달하는 `close()` teardown 경계에 집중되어 있습니다. 따라서 카운터 증가나 분산 락 같은 저장소 전용 원자 연산이 필요할 때는, 그것을 `CacheService`의 내장 애플리케이션 API로 가정하기보다 선택한 저장소의 별도 기능이나 애플리케이션 전용 조정 계층으로 다루는 편이 안전합니다.
 
 실무에서는 이 경계를 명확히 나누는 것이 중요합니다. 캐시 계층이 자동으로 모든 동기화 문제를 해결해 준다고 기대하지 말고, 필요한 락 전략이나 원자 갱신 전략을 저장소 특성에 맞게 명시적으로 설계하십시오. 이렇게 하면 문서화된 캐시 계약을 벗어나지 않으면서도 트래픽이 높은 환경의 경쟁 상태를 별도 설계로 관리할 수 있습니다.
 

--- a/book/beginner/ch17-cache.md
+++ b/book/beginner/ch17-cache.md
@@ -57,7 +57,7 @@ The `@fluojs/cache-manager` module is built on a Provider-based architecture. Th
 That extensibility boundary matters for **serialization protocols** too. The shipped `RedisStore` uses `JSON.stringify(...)`/`JSON.parse(...)` internally, so alternative formats such as Protocol Buffers or MessagePack are not a built-in toggle on `CacheModule`. If your application needs a different serialization strategy, implement it through a custom store that still satisfies the public cache contract.
 
 ### 17.2.3 Serialization and Type Safety in Fluo
-One common pain point in caching is ensuring that retrieved data has the same type as the data that was stored. Fluo's `CacheService` provides a TypeScript-friendly API surface, but the built-in stores do not perform rich type revival for you. In practice, JSON-compatible values round-trip cleanly, while values such as `Date` return in their serialized JSON form unless your application rehydrates them explicitly. As a result, service code should treat cache values as application-owned data contracts rather than assuming the cache layer restores every original runtime type automatically.
+One common pain point in caching is ensuring that retrieved data has the same type as the data that was stored. Fluo's `CacheService` provides a TypeScript-friendly API surface, but the answer depends on the store you configured. `MemoryStore` copies entries with `structuredClone(...)`, so structured-cloneable values such as `Date`, `Map`, and `Set` come back as the same runtime types in-process. `RedisStore` persists entries with `JSON.stringify(...)`, so there a `Date` returns as its serialized JSON form (for example an ISO string) unless your application rehydrates it explicitly. Because the same code can run against either store, treat cache values as application-owned data contracts and normalize them yourself when a value must survive both paths identically.
 
 ## 17.3 Basic Configuration and Setup
 Register `CacheModule` in `AppModule`. The default configuration uses an in-memory store, which is suitable for local development.
@@ -142,7 +142,7 @@ Although caches are usually considered "volatile" storage, some providers such a
 However, persistence can affect write performance, so use it carefully. Most Fluo applications prefer the default non-persistent mode for maximum speed. Failure behavior then depends on how the cache is called. On HTTP routes wrapped by `CacheInterceptor`, the interceptor treats store read failures as cache misses and contains store write or eviction failures, so an otherwise successful handler can continue. This route-only isolation does not apply to explicit `CacheService` operations: `get`, `set`, `remember`, `del`, and `reset` await store work and reject when that work fails unless the application catches the error. Decide at each manual call site whether the cache is critical or should fail soft, and preserve logs or metrics when containing an error.
 
 ## 17.4 Automatic Response Caching
-The easiest way to improve performance is to cache entire HTTP responses. Fluo provides `CacheInterceptor` for this purpose. When this Interceptor is applied to a specific route, successful uncommitted GET results are cached automatically, and later identical requests return the cached content immediately.
+The easiest way to improve performance is to cache entire HTTP responses. Fluo provides `CacheInterceptor` for this purpose. When this Interceptor is applied to a specific route, successful uncommitted GET results are cached automatically, and later identical requests return the cached content immediately. Note that the interceptor reads the store and, on a miss, calls the handler directly: it does not coalesce concurrent misses, so simultaneous requests that all miss the same key each run the handler.
 
 ```typescript
 import { Controller, Get, UseInterceptors } from '@fluojs/http';
@@ -155,7 +155,7 @@ export class PostsController {
   @CacheKey('popular_posts')
   @CacheTTL(600) // Cache for 10 minutes
   async getPopular() {
-    // This slow database query runs only once every 10 minutes!
+    // After a hit is stored, later requests are served from cache for 10 minutes.
     return this.postsService.findPopular();
   }
 }
@@ -257,7 +257,7 @@ On this supported route path, eviction runs only after the non-GET handler succe
 By combining these advanced manual patterns with automatic response caching, you can create a highly efficient data layer that maximizes the performance and reliability of your Fluo backend. Always remember that the goal of caching is to give users the fastest possible response while reducing load on the primary data source. Every optimization you make in this layer contributes to a more scalable and resilient system overall.
 
 ### 17.5.4 Advanced Manual Patterns: Coordinating Concurrent Writers
-The application-facing public surface of `CacheService` focuses on `get`, `set`, `remember`, `del`, and `reset`. Therefore, when you need store-specific atomic operations such as counter increments or distributed locks, it is safer to treat them as separate capabilities of the selected store or as an application-specific coordination layer, rather than assuming they are built into the `CacheService` application API.
+The application-facing public surface of `CacheService` focuses on `get`, `set`, `remember`, `del`, `reset`, and the `close()` teardown boundary that forwards shutdown to stores exposing `close()` or `dispose()`. Therefore, when you need store-specific atomic operations such as counter increments or distributed locks, it is safer to treat them as separate capabilities of the selected store or as an application-specific coordination layer, rather than assuming they are built into the `CacheService` application API.
 
 In practice, it is important to keep this boundary clear. Do not expect the cache layer to solve every synchronization problem automatically. Instead, explicitly design the required locking or atomic update strategy around the chosen store's characteristics. This lets you manage race conditions in high-traffic environments through separate design while staying within the documented cache contract.
 

--- a/docs/architecture/caching.ko.md
+++ b/docs/architecture/caching.ko.md
@@ -9,7 +9,7 @@
 | 표면 | 현재 계약 | 소스 기준 |
 | --- | --- | --- |
 | 모듈 진입점 | 애플리케이션은 `CacheModule.forRoot(...)`로 캐시 지원을 등록합니다. 공개 옵션에는 `store`, `ttl`, `httpKeyStrategy`, `principalScopeResolver`, top-level `keyPrefix`, `redis`, `global`이 포함됩니다. | `packages/cache-manager/src/types.ts`, `packages/cache-manager/src/module.ts` |
-| 캐시 서비스 | `CacheService`는 `get`, `set`, `remember`, `del`, `reset`을 제공하는 직접 애플리케이션 캐시 파사드입니다. | `packages/cache-manager/src/service.ts` |
+| 캐시 서비스 | `CacheService`는 `get`, `set`, `remember`, `del`, `reset`과 공개 `close()` teardown 경계를 제공하는 직접 애플리케이션 캐시 파사드입니다. | `packages/cache-manager/src/service.ts` |
 | HTTP 통합 | `CacheInterceptor`는 GET read-through 캐싱을 수행하고 non-GET controller handler 이후 `@CacheEvict(...)` metadata를 소비합니다. 이 decorator는 해당 HTTP pipeline 밖의 임의 service method를 intercept하지 않습니다. | `packages/cache-manager/src/decorators.ts`, `packages/cache-manager/src/interceptor.ts` |
 | 메모리 저장소 | `MemoryStore`는 캐시 엔트리를 프로세스 내부에 보관하고, 접근 시점에 만료를 지연 정리하며, 가장 오래된 키부터 제거하면서 라이브 엔트리를 `1,000`개로 제한합니다. | `packages/cache-manager/src/stores/memory-store.ts` |
 | Redis 저장소 | `RedisStore`는 JSON 직렬화된 엔트리를 prefix가 붙은 키 공간에 저장하고, 양수 TTL에는 `EX`를 사용하며, 설정된 prefix를 scan해서 reset을 수행합니다. | `packages/cache-manager/src/stores/redis-store.ts` |
@@ -36,7 +36,7 @@
 | 무기한 엔트리 | `ttl: 0`은 만료 없음 의미입니다. 메모리 저장소는 이런 엔트리에 `expiresAt`을 두지 않고, Redis 저장소는 `EX` 없이 기록합니다. | `packages/cache-manager/src/service.ts`, `packages/cache-manager/src/stores/memory-store.ts`, `packages/cache-manager/src/stores/redis-store.ts` |
 | GET 전용 응답 캐싱 | `CacheInterceptor`는 `GET` 요청에 대해서만 read-through 캐싱을 수행합니다. GET이 아닌 요청은 캐시 읽기와 쓰기를 건너뜁니다. | `packages/cache-manager/src/interceptor.ts` |
 | 캐시 가능한 응답 형태 | 인터셉터는 나중에 재생할 수 있는 성공한 GET 결과만 캐싱합니다. 핸들러가 `undefined`, `SseResponse`, 2xx가 아닌 status, 이미 커밋된 응답을 반환한 경우 캐싱하지 않습니다. | `packages/cache-manager/src/interceptor.ts` |
-| read-through 중복 제거 | `CacheService.remember(...)`는 key별 in-flight promise 맵으로 동시 miss를 중복 제거합니다. | `packages/cache-manager/src/service.ts` |
+| read-through 중복 제거 | `CacheService.remember(...)`는 key별 in-flight promise 맵으로 동시 miss를 중복 제거하며, 그 범위는 하나의 `CacheService` 인스턴스입니다. `CacheInterceptor`는 동시 GET miss를 합치지 않으며 각 miss가 handler를 호출합니다. | `packages/cache-manager/src/service.ts`, `packages/cache-manager/src/interceptor.ts` |
 
 ## 무효화 규칙
 

--- a/docs/architecture/caching.md
+++ b/docs/architecture/caching.md
@@ -9,7 +9,7 @@ This document defines the current cache contract across `@fluojs/cache-manager`,
 | Surface | Current contract | Source anchor |
 | --- | --- | --- |
 | Module entrypoint | Applications register cache support through `CacheModule.forRoot(...)`. Public options include `store`, `ttl`, `httpKeyStrategy`, `principalScopeResolver`, top-level `keyPrefix`, `redis`, and `global`. | `packages/cache-manager/src/types.ts`, `packages/cache-manager/src/module.ts` |
-| Cache service | `CacheService` is the direct application cache facade with `get`, `set`, `remember`, `del`, and `reset`. | `packages/cache-manager/src/service.ts` |
+| Cache service | `CacheService` is the direct application cache facade with `get`, `set`, `remember`, `del`, `reset`, and the public `close()` teardown boundary. | `packages/cache-manager/src/service.ts` |
 | HTTP integration | `CacheInterceptor` performs GET read-through caching and consumes `@CacheEvict(...)` metadata after non-GET controller handlers. The decorator does not intercept arbitrary service methods outside that HTTP pipeline. | `packages/cache-manager/src/decorators.ts`, `packages/cache-manager/src/interceptor.ts` |
 | Memory store | `MemoryStore` keeps cache entries in-process, sweeps expirations lazily on access, and caps live entries at `1,000` by evicting the oldest keys. | `packages/cache-manager/src/stores/memory-store.ts` |
 | Redis store | `RedisStore` stores JSON-serialized entries under a prefixed key space, uses `EX` for positive TTL values, and resets by scanning the configured prefix. | `packages/cache-manager/src/stores/redis-store.ts` |
@@ -36,7 +36,7 @@ This document defines the current cache contract across `@fluojs/cache-manager`,
 | No-expiry entries | `ttl: 0` means no expiration. The memory store omits `expiresAt` for such entries, and the Redis store writes without `EX`. | `packages/cache-manager/src/service.ts`, `packages/cache-manager/src/stores/memory-store.ts`, `packages/cache-manager/src/stores/redis-store.ts` |
 | GET-only response caching | `CacheInterceptor` only performs read-through caching for `GET` requests. Non-GET requests skip cache reads and writes. | `packages/cache-manager/src/interceptor.ts` |
 | Cacheable response shape | The interceptor caches only replayable successful GET results. It skips caching when the handler returns `undefined`, an `SseResponse`, a non-2xx status, or a response that is already committed. | `packages/cache-manager/src/interceptor.ts` |
-| Read-through deduplication | `CacheService.remember(...)` deduplicates concurrent misses per key through an in-flight promise map. | `packages/cache-manager/src/service.ts` |
+| Read-through deduplication | `CacheService.remember(...)` deduplicates concurrent misses per key through an in-flight promise map, scoped to one `CacheService` instance. `CacheInterceptor` does not coalesce concurrent GET misses; each miss invokes the handler. | `packages/cache-manager/src/service.ts`, `packages/cache-manager/src/interceptor.ts` |
 
 ## Invalidation Rules
 


### PR DESCRIPTION
## Summary

Correct the bilingual cache learning path so it accurately distinguishes `CacheInterceptor` miss behavior from `CacheService.remember()` coalescing, documents store-specific value cloning/serialization, and includes the public `CacheService.close()` lifecycle boundary.

Linked context: Closes #3110

## Changes

- Correct concurrent-miss behavior in the EN/KO cache chapter.
- Distinguish `MemoryStore` structured cloning from `RedisStore` JSON serialization.
- Add the `CacheService.close()` teardown boundary to the EN/KO chapter and architecture contract.

## Testing

- `pnpm verify:docs`
- `pnpm verify:platform-consistency-governance`
- exact-head contract/code/verification review triad: PASS

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Docs-only correction of existing behavior; no runtime or package API change.

## Public export documentation

- [x] No public exports changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] Existing behavioral claims now match the implementation.
- [x] Intentional limitations are explicitly stated.
- [x] Runtime invariants are covered by the existing cache-manager tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] No platform conformance claim was added.