### PR TITLE
Resolve #3335: make Studio timing validators honor BootstrapTimingPhase

### DIFF
--- a/.changeset/issue-3335-studio-bootstrap-timing-phase.md
+++ b/.changeset/issue-3335-studio-bootstrap-timing-phase.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/studio': patch
+---
+
+Reject timing diagnostics that use bootstrap phase names outside the published contract.

--- a/packages/studio/README.ko.md
+++ b/packages/studio/README.ko.md
@@ -119,6 +119,8 @@ Studio는 여전히 fluo CLI가 내보낸 JSON 파일을 소비합니다. 런타
 
 Studio는 주로 CLI가 실행하는 sidecar와 browser viewer이지만, 배포된 패키지는 도구/자동화가 사용할 수 있는 계약도 함께 공개합니다. `@fluojs/studio`를 snapshot parsing, filtering, Mermaid graph rendering, live Studio event validation 의미론의 canonical owner로 취급합니다. Root `@fluojs/studio` export는 `@fluojs/studio/contracts`의 helper function과 public type을 다시 export합니다.
 
+Bootstrap timing phase 이름은 `bootstrap_module`, `register_runtime_tokens`, `resolve_lifecycle_instances`, `run_bootstrap_lifecycle`, `create_dispatcher`만 허용하며, 그 밖의 모든 값은 static payload와 live timing event에서 거부됩니다.
+
 | 규격 | 설명 |
 |---|---|
 | `parseStudioPayload(rawJson)` | raw snapshot JSON, standalone timing JSON, snapshot+timing envelope, `fluo inspect --report` artifact를 받아 parsed payload와 원본 JSON string을 반환합니다. |

--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -119,6 +119,8 @@ This file-first path is the compatibility and migration fallback for CI, support
 
 Studio is primarily a CLI-launched sidecar and browser viewer, but the published package also exposes documented contracts used by tooling and automation. Treat `@fluojs/studio` as the canonical owner of snapshot parsing, filtering, Mermaid graph rendering, and live Studio event validation semantics. The root `@fluojs/studio` export re-exports the helper functions and public types from `@fluojs/studio/contracts`.
 
+Bootstrap timing phase names accept only `bootstrap_module`, `register_runtime_tokens`, `resolve_lifecycle_instances`, `run_bootstrap_lifecycle`, and `create_dispatcher`; all other values are rejected in static payloads and live timing events.
+
 | Contract | Description |
 |---|---|
 | `parseStudioPayload(rawJson)` | Accepts raw snapshot JSON, standalone timing JSON, snapshot+timing envelopes, and `fluo inspect --report` artifacts; returns the parsed payload plus the original JSON string. |

--- a/packages/studio/src/contracts.test.ts
+++ b/packages/studio/src/contracts.test.ts
@@ -294,43 +294,52 @@ describe('Studio live contracts', () => {
     ).toThrow('Invalid Studio live graph node payload.');
   });
 
-  it('rejects unknown BootstrapTimingPhase names across static and live timing payloads', () => {
-    const unknownPhaseTiming = {
-      phases: [{ durationMs: 1.25, name: 'unknown_bootstrap_phase' }],
-      totalMs: 1.25,
-      version: 1,
-    };
-    const eventBase = {
-      emittedAt: '2026-05-28T00:00:02.000Z',
-      epoch: 'epoch-1',
-      eventId: 'epoch-1:unknown-phase',
-      sequence: 3,
-      source: { appId: 'app-test', runtime: 'node' as const },
-      version: 1,
-    };
-    const snapshotEvent = {
-      ...eventBase,
-      payload: { ...liveSnapshot, timing: unknownPhaseTiming },
-      type: 'snapshot' as const,
-    };
-    const timingEvent = {
-      ...eventBase,
-      eventId: 'epoch-1:unknown-phase-timing',
-      payload: unknownPhaseTiming,
-      type: 'timing' as const,
-    };
+  const unknownPhaseTiming = {
+    phases: [{ durationMs: 1.25, name: 'unknown_bootstrap_phase' }],
+    totalMs: 1.25,
+    version: 1,
+  };
+  const unknownPhaseEventBase = {
+    emittedAt: '2026-05-28T00:00:02.000Z',
+    epoch: 'epoch-1',
+    eventId: 'epoch-1:unknown-phase',
+    sequence: 3,
+    source: { appId: 'app-test', runtime: 'node' as const },
+    version: 1,
+  };
+  const unknownPhaseSnapshotEvent = {
+    ...unknownPhaseEventBase,
+    payload: { ...liveSnapshot, timing: unknownPhaseTiming },
+    type: 'snapshot' as const,
+  };
+  const unknownPhaseTimingEvent = {
+    ...unknownPhaseEventBase,
+    eventId: 'epoch-1:unknown-phase-timing',
+    payload: unknownPhaseTiming,
+    type: 'timing' as const,
+  };
 
+  it('rejects unknown BootstrapTimingPhase names in static timing payloads', () => {
     expect(() => parseStudioPayload(JSON.stringify(unknownPhaseTiming))).toThrow(
       'Invalid phase entry in bootstrap timing payload.',
     );
-    expect(() => parseStudioLiveEvent(JSON.stringify(snapshotEvent))).toThrow(
+  });
+
+  it('rejects unknown BootstrapTimingPhase names in live snapshot events', () => {
+    expect(() => parseStudioLiveEvent(JSON.stringify(unknownPhaseSnapshotEvent))).toThrow(
       'Invalid phase entry in bootstrap timing payload.',
     );
-    expect(isStudioLiveEvent(snapshotEvent)).toBe(false);
-    expect(() => parseStudioLiveEvent(JSON.stringify(timingEvent))).toThrow(
+  });
+
+  it('rejects unknown BootstrapTimingPhase names in timing events', () => {
+    expect(() => parseStudioLiveEvent(JSON.stringify(unknownPhaseTimingEvent))).toThrow(
       'Invalid phase entry in bootstrap timing payload.',
     );
-    expect(isStudioLiveEvent(timingEvent)).toBe(false);
+  });
+
+  it('returns false for unknown BootstrapTimingPhase names in Studio live event guards', () => {
+    expect(isStudioLiveEvent(unknownPhaseSnapshotEvent)).toBe(false);
+    expect(isStudioLiveEvent(unknownPhaseTimingEvent)).toBe(false);
   });
 
   it('rejects request events with body-like fields before UI state consumes them', () => {

--- a/packages/studio/src/contracts.test.ts
+++ b/packages/studio/src/contracts.test.ts
@@ -294,6 +294,45 @@ describe('Studio live contracts', () => {
     ).toThrow('Invalid Studio live graph node payload.');
   });
 
+  it('rejects unknown BootstrapTimingPhase names across static and live timing payloads', () => {
+    const unknownPhaseTiming = {
+      phases: [{ durationMs: 1.25, name: 'unknown_bootstrap_phase' }],
+      totalMs: 1.25,
+      version: 1,
+    };
+    const eventBase = {
+      emittedAt: '2026-05-28T00:00:02.000Z',
+      epoch: 'epoch-1',
+      eventId: 'epoch-1:unknown-phase',
+      sequence: 3,
+      source: { appId: 'app-test', runtime: 'node' as const },
+      version: 1,
+    };
+    const snapshotEvent = {
+      ...eventBase,
+      payload: { ...liveSnapshot, timing: unknownPhaseTiming },
+      type: 'snapshot' as const,
+    };
+    const timingEvent = {
+      ...eventBase,
+      eventId: 'epoch-1:unknown-phase-timing',
+      payload: unknownPhaseTiming,
+      type: 'timing' as const,
+    };
+
+    expect(() => parseStudioPayload(JSON.stringify(unknownPhaseTiming))).toThrow(
+      'Invalid phase entry in bootstrap timing payload.',
+    );
+    expect(() => parseStudioLiveEvent(JSON.stringify(snapshotEvent))).toThrow(
+      'Invalid phase entry in bootstrap timing payload.',
+    );
+    expect(isStudioLiveEvent(snapshotEvent)).toBe(false);
+    expect(() => parseStudioLiveEvent(JSON.stringify(timingEvent))).toThrow(
+      'Invalid phase entry in bootstrap timing payload.',
+    );
+    expect(isStudioLiveEvent(timingEvent)).toBe(false);
+  });
+
   it('rejects request events with body-like fields before UI state consumes them', () => {
     const event = {
       emittedAt: '2026-05-28T00:00:02.000Z',

--- a/packages/studio/src/contracts.test.ts
+++ b/packages/studio/src/contracts.test.ts
@@ -15,7 +15,7 @@ import type {
   PlatformSnapshot as RuntimePlatformSnapshot,
 } from '@fluojs/runtime';
 import type { Root } from 'react-dom/client';
-import { afterEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { bootstrapStudioApp } from './app/bootstrap.js';
 import {
   applyFilters,
@@ -42,7 +42,7 @@ type Exact<Left, Right> =
       : false
     : false;
 
-function assertExactContract<Condition extends true>(): void {}
+function assertExactContract<Condition extends true>(...condition: Condition[]): void { void condition; }
 
 const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const packageCommandTimeoutMs = 120_000;

--- a/packages/studio/src/contracts.ts
+++ b/packages/studio/src/contracts.ts
@@ -417,6 +417,14 @@ function isStudioRequestStatus(value: unknown): value is StudioRequestStatus {
     || value === 'finished';
 }
 
+function isBootstrapTimingPhaseName(value: unknown): value is BootstrapTimingPhase['name'] {
+  return value === 'bootstrap_module'
+    || value === 'register_runtime_tokens'
+    || value === 'resolve_lifecycle_instances'
+    || value === 'run_bootstrap_lifecycle'
+    || value === 'create_dispatcher';
+}
+
 function validateStudioGraphNode(value: unknown): StudioGraphNode {
   if (!isRecord(value) || !isStudioGraphNodeKind(value.kind)) {
     throw new Error('Invalid Studio live graph node payload.');
@@ -894,7 +902,7 @@ function validateTiming(value: unknown): BootstrapTimingDiagnostics | null {
   }
 
   for (const phase of value.phases) {
-    if (!isRecord(phase) || typeof phase.name !== 'string' || typeof phase.durationMs !== 'number') {
+    if (!isRecord(phase) || !isBootstrapTimingPhaseName(phase.name) || typeof phase.durationMs !== 'number') {
       throw new Error('Invalid phase entry in bootstrap timing payload.');
     }
   }

--- a/packages/studio/src/contracts.ts
+++ b/packages/studio/src/contracts.ts
@@ -417,12 +417,16 @@ function isStudioRequestStatus(value: unknown): value is StudioRequestStatus {
     || value === 'finished';
 }
 
+const bootstrapTimingPhaseNames = {
+  bootstrap_module: true,
+  register_runtime_tokens: true,
+  resolve_lifecycle_instances: true,
+  run_bootstrap_lifecycle: true,
+  create_dispatcher: true,
+} satisfies Record<BootstrapTimingPhase['name'], true>;
+
 function isBootstrapTimingPhaseName(value: unknown): value is BootstrapTimingPhase['name'] {
-  return value === 'bootstrap_module'
-    || value === 'register_runtime_tokens'
-    || value === 'resolve_lifecycle_instances'
-    || value === 'run_bootstrap_lifecycle'
-    || value === 'create_dispatcher';
+  return typeof value === 'string' && Object.hasOwn(bootstrapTimingPhaseNames, value);
 }
 
 function validateStudioGraphNode(value: unknown): StudioGraphNode {


### PR DESCRIPTION
## Summary

Makes Studio timing validation honor `BootstrapTimingPhase`: only the five contract phases are accepted, and the accepted set is type-tied to the union so the contract and the validator cannot drift apart.

Linked context: Closes #3335

## Changes

- `packages/studio/src/contracts.ts`: the validator's accepted set is declared `satisfies Record<BootstrapTimingPhase['name'], true>`, so adding a phase to the union fails typecheck on the missing key and removing one fails on the excess key — drift is caught in **both** directions.
- Regressions covering the static payload, the live snapshot, timing events, and `isStudioLiveEvent`.
- EN/KO READMEs document the five phases and the rejection behavior.

## Testing

- `pnpm lint` — exit 0
- `pnpm --workspace-concurrency=1 --filter '@fluojs/studio...' build` — exit 0
- `pnpm --filter @fluojs/studio typecheck` — exit 0
- `pnpm --filter @fluojs/studio test` — 69 passed, twice
- `pnpm --filter @fluojs/cli test` — 26 files / 444 tests passed (direct reverse dependent)
- `node tooling/governance/verify-platform-consistency-governance.mjs` — exit 0
- Studio runtime-neutral governance test from #3334 — 2 passed
- Executed the published `dist/contracts.js` directly: an unknown phase is rejected in the **shipped artifact**, not only in source
- Mutation proof (2/2): removing the validation seam fails `packages/studio/src/contracts.test.ts:323` on two consecutive runs; reverted -> green twice. Drift guard proven with TS1360/2344 diagnostics.
- Read-only triad unanimous at this exact head.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

`@fluojs/studio` **patch**. `BootstrapTimingPhase` was always the documented closed union, so accepting arbitrary phase strings was the bug; tightening to the contract is a fix, not a new restriction.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] Package README alignment/conformance claims are backed by the applicable platform harness tests.

`#3334`'s runtime-neutral diagnostics contract and symmetric `Exact<>` drift assertions are untouched; no `package.json` or dependency edge changed, so the workspace closure order is unaffected.
