### PR TITLE
Resolve #3099: Make published config declarations self-contained

### DIFF
--- a/.changeset/self-contained-config-declarations.md
+++ b/.changeset/self-contained-config-declarations.md
@@ -1,0 +1,7 @@
+---
+"@fluojs/config": patch
+---
+
+Make the published `@fluojs/config` declarations self-contained for consumers without Node ambient types.
+
+`ConfigModuleOptions.processEnv` is now typed as the package-owned `ConfigProcessEnv` (`Record<string, string | undefined>`) instead of the ambient `NodeJS.ProcessEnv` namespace, which the package never declared through `@types/node`. Strict TypeScript consumers compiling without Node types no longer fail to resolve the package root declaration. Accepted values and runtime behavior are unchanged, and `process.env` stays assignable because the structural type matches.

--- a/packages/config/src/load.ts
+++ b/packages/config/src/load.ts
@@ -5,6 +5,7 @@ import { snapshotConfigLoadOptions } from './options.js';
 import type {
   ConfigDictionary,
   ConfigLoadOptions,
+  ConfigProcessEnv,
   ConfigReloadErrorListener,
   ConfigReloader,
   ConfigReloadListener,
@@ -346,7 +347,7 @@ function parseEnvContent(content: string, safeProcessEnv: Record<string, string>
   return expandEnvVariables(parseDotenvContent(content), safeProcessEnv);
 }
 
-function sanitizeProcessEnv(processEnv: NodeJS.ProcessEnv): Record<string, string> {
+function sanitizeProcessEnv(processEnv: ConfigProcessEnv): Record<string, string> {
   return Object.fromEntries(
     Object.entries(processEnv).filter((entry): entry is [string, string] => entry[1] !== undefined),
   );

--- a/packages/config/src/options.ts
+++ b/packages/config/src/options.ts
@@ -1,16 +1,16 @@
 import { cloneConfigDictionary } from './clone.js';
-import type { ConfigDictionary, ConfigLoadOptions, ConfigModuleOptions, ConfigSchema } from './types.js';
+import type { ConfigDictionary, ConfigLoadOptions, ConfigModuleOptions, ConfigProcessEnv, ConfigSchema } from './types.js';
 
 function snapshotConfigDictionary(value: ConfigDictionary | undefined): ConfigDictionary | undefined {
   return value === undefined ? undefined : cloneConfigDictionary(value);
 }
 
-function snapshotProcessEnv(processEnv: NodeJS.ProcessEnv | undefined): NodeJS.ProcessEnv | undefined {
+function snapshotProcessEnv(processEnv: ConfigProcessEnv | undefined): ConfigProcessEnv | undefined {
   if (processEnv === undefined) {
     return undefined;
   }
 
-  const snapshot: NodeJS.ProcessEnv = {};
+  const snapshot: ConfigProcessEnv = {};
 
   for (const [key, value] of Object.entries(processEnv)) {
     if (value !== undefined) {

--- a/packages/config/src/published-declaration-consumer.test.ts
+++ b/packages/config/src/published-declaration-consumer.test.ts
@@ -1,0 +1,121 @@
+import { execFile } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+import ts from 'typescript';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+const packageRootPath = fileURLToPath(new URL('..', import.meta.url));
+const repoRootPath = fileURLToPath(new URL('../../..', import.meta.url));
+const buildClosureScriptPath = fileURLToPath(
+  new URL('../../../tooling/scripts/run-workspace-build-closure.mjs', import.meta.url),
+);
+const declarationRootPath = resolve(packageRootPath, 'dist/index.d.ts');
+const declarationTypesPath = resolve(packageRootPath, 'dist/types.d.ts');
+const requiredArtifactPaths = [declarationRootPath, declarationTypesPath] as const;
+
+/**
+ * Typechecks the published root declaration the way a strict consumer without Node
+ * ambient types does: `types: []` removes every automatically included `@types/*`
+ * package, so any leaked `NodeJS.*` reference fails to resolve.
+ */
+function collectCleanConsumerDiagnostics(): readonly ts.Diagnostic[] {
+  const consumerEntryPath = resolve(packageRootPath, 'dist/__fluo-clean-consumer__.ts');
+  const consumerEntrySource = [
+    "import type { ConfigModuleOptions } from './index.js';",
+    '',
+    'export const processEnv: ConfigModuleOptions[\'processEnv\'] = { PORT: \'3000\', UNSET: undefined };',
+    '',
+  ].join('\n');
+  const compilerOptions: ts.CompilerOptions = {
+    declaration: false,
+    esModuleInterop: true,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    noEmit: true,
+    skipLibCheck: false,
+    strict: true,
+    target: ts.ScriptTarget.ES2022,
+    // A clean consumer has no ambient Node types available.
+    types: [],
+  };
+  const host = ts.createCompilerHost(compilerOptions, true);
+  const originalGetSourceFile = host.getSourceFile.bind(host);
+
+  host.fileExists = ((fileName: string) =>
+    resolve(fileName) === consumerEntryPath || ts.sys.fileExists(fileName)) as typeof host.fileExists;
+  host.readFile = ((fileName: string) =>
+    resolve(fileName) === consumerEntryPath ? consumerEntrySource : ts.sys.readFile(fileName)) as typeof host.readFile;
+  host.getSourceFile = ((fileName: string, languageVersionOrOptions, ...rest) =>
+    resolve(fileName) === consumerEntryPath
+      ? ts.createSourceFile(fileName, consumerEntrySource, languageVersionOrOptions, true, ts.ScriptKind.TS)
+      : originalGetSourceFile(fileName, languageVersionOrOptions, ...rest)) as typeof host.getSourceFile;
+
+  const program = ts.createProgram([consumerEntryPath], compilerOptions, host);
+
+  return ts.getPreEmitDiagnostics(program);
+}
+
+function formatDiagnostics(diagnostics: readonly ts.Diagnostic[]): string {
+  return ts.formatDiagnostics(diagnostics, {
+    getCanonicalFileName: (filePath) => filePath,
+    getCurrentDirectory: () => repoRootPath,
+    getNewLine: () => '\n',
+  });
+}
+
+describe('@fluojs/config published declaration consumer surface', () => {
+  beforeAll(async () => {
+    if (requiredArtifactPaths.every((artifactPath) => existsSync(artifactPath))) {
+      return;
+    }
+
+    await execFileAsync(process.execPath, [buildClosureScriptPath, '@fluojs/config'], {
+      cwd: repoRootPath,
+      env: process.env,
+    });
+  }, 300_000);
+
+  it('does not declare @types/node as a dependency or peer dependency', () => {
+    // Given: the manifest publishes root declarations without any Node types contract.
+    const manifest = JSON.parse(readFileSync(resolve(packageRootPath, 'package.json'), 'utf8')) as {
+      readonly dependencies?: Record<string, string>;
+      readonly peerDependencies?: Record<string, string>;
+    };
+
+    // Then: consumers never inherit ambient Node types from this package.
+    expect(manifest.dependencies ?? {}).not.toHaveProperty('@types/node');
+    expect(manifest.peerDependencies ?? {}).not.toHaveProperty('@types/node');
+  });
+
+  it('typechecks the published root declaration without ambient Node types', () => {
+    // Given: a strict consumer program compiled with `types: []`.
+    // When: the published root declaration is resolved through the package entry.
+    const diagnostics = collectCleanConsumerDiagnostics();
+
+    // Then: no declaration member depends on an unresolvable ambient Node namespace.
+    expect(formatDiagnostics(diagnostics)).toBe('');
+  }, 60_000);
+
+  it('keeps the published process-env option structurally self-contained', () => {
+    // Given: the emitted root declaration graph, ignoring documentation prose.
+    const declarationSourceFile = ts.createSourceFile(
+      declarationTypesPath,
+      readFileSync(declarationTypesPath, 'utf8'),
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    );
+    const declarationCode = ts
+      .createPrinter({ newLine: ts.NewLineKind.LineFeed, removeComments: true })
+      .printFile(declarationSourceFile);
+
+    // Then: the option is expressed with package-owned structural types only.
+    expect(declarationCode).not.toMatch(/\bNodeJS\b/);
+    expect(declarationCode).toContain('processEnv?: ConfigProcessEnv;');
+    expect(declarationCode).toContain('type ConfigProcessEnv = Record<string, string | undefined>;');
+  });
+});

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -6,6 +6,15 @@ import type { StandardSchemaV1 } from '@standard-schema/spec';
 export type ConfigDictionary = Record<string, unknown>;
 
 /**
+ * Structural process-environment snapshot accepted by `@fluojs/config`.
+ *
+ * Declared by this package instead of the ambient `NodeJS.ProcessEnv` namespace so the
+ * published declarations resolve for strict consumers without Node ambient types. A
+ * `NodeJS.ProcessEnv` value remains assignable because it has the same structure.
+ */
+export type ConfigProcessEnv = Record<string, string | undefined>;
+
+/**
  * Standard Schema v1-compatible config validator accepted by `@fluojs/config` loaders.
  *
  * @typeParam Input Raw merged config shape consumed by the schema validator.
@@ -42,7 +51,7 @@ export type DotValue<T, K extends string> = K extends keyof T
 export interface ConfigModuleOptions {
   envFile?: string;
   envFilePath?: string;
-  processEnv?: NodeJS.ProcessEnv;
+  processEnv?: ConfigProcessEnv;
   schema?: ConfigSchema;
   defaults?: ConfigDictionary;
   /** Highest-precedence values applied after defaults, env files, and `processEnv`. */

--- a/tooling/governance/config-nestjs-migration-docs.mjs
+++ b/tooling/governance/config-nestjs-migration-docs.mjs
@@ -11,7 +11,12 @@ const requirements = [
   ]],
   ['packages/config/src/module.ts', ['static forRoot(options?: ConfigModuleOptions)', 'global: loadOptions.global ?? true']],
   ['packages/config/src/service.ts', ["const parts = key.split('.');", 'current = current[part];']],
-  ['packages/config/src/types.ts', ['processEnv?: NodeJS.ProcessEnv', 'schema?: ConfigSchema', 'global?: boolean']],
+  ['packages/config/src/types.ts', [
+    'export type ConfigProcessEnv = Record<string, string | undefined>',
+    'processEnv?: ConfigProcessEnv',
+    'schema?: ConfigSchema',
+    'global?: boolean',
+  ]],
   ['packages/config/README.md', [
     '### NestJS Registration Migration',
     'ConfigModule.forRootAsync(...)',

--- a/tooling/governance/config-nestjs-migration-docs.test.ts
+++ b/tooling/governance/config-nestjs-migration-docs.test.ts
@@ -35,7 +35,8 @@ describe('NestJS config migration documentation', () => {
     expect(moduleSource).toContain('static forRoot(options?: ConfigModuleOptions)');
     expect(moduleSource).toContain('global: loadOptions.global ?? true');
     expect(serviceSource).toContain("const parts = key.split('.');");
-    expect(typesSource).toContain('processEnv?: NodeJS.ProcessEnv');
+    expect(typesSource).toContain('export type ConfigProcessEnv = Record<string, string | undefined>');
+    expect(typesSource).toContain('processEnv?: ConfigProcessEnv');
     expect(typesSource).toContain('schema?: ConfigSchema');
     expect(typesSource).toContain('global?: boolean');
     expect(englishReadme).toContain('### NestJS Registration Migration');


### PR DESCRIPTION
## Summary

Make published `@fluojs/config` declarations self-contained for strict consumers without ambient Node types.

Linked context: Closes #3099

## Changes

- Add the package-owned structural `ConfigProcessEnv` type.
- Replace the public `NodeJS.ProcessEnv` reference without changing runtime behavior.
- Add a clean-consumer declaration regression compiled with `types: []`.
- Add a patch Changeset for `@fluojs/config`.

## Testing

- `pnpm --filter @fluojs/config... build`
- `pnpm --filter @fluojs/config typecheck`
- `pnpm --filter @fluojs/config test` — 84 tests passed
- Clean-consumer declaration compilation with `types: []`
- Exact-head reverse-dependent gate passed under Node v24.20.0
- `pnpm verify:public-export-tsdoc`
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable, or are not functions.
- [x] Source `@example` blocks and README scenario examples remain complementary.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] Accepted values and runtime behavior are unchanged.
- [x] Intentional limitations remain explicit and unchanged.
- [x] The published declaration invariant is covered by a non-vacuous regression test.

## Platform consistency governance (SSOT)

Not applicable: no platform contract changed.

- [x] SSOT English/Korean mirror structure remains synchronized.
- [x] No platform contract docs changed.
- [x] No platform conformance claim changed.
