### PR TITLE
Resolve #3355: fix Chapter 14 learning-objectives TOC links

### DIFF
--- a/book/advanced/toc.ko.md
+++ b/book/advanced/toc.ko.md
@@ -177,7 +177,7 @@
 ## 파트 5. 테스트와 진단
 
 - [챕터 14. 이식성 테스트와 적합성 검증](ch14-portability-testing.ko.md)
-  - [이 챕터에서 배우는 것](ch14-portability-testing.ko.md#what-you-will-learn-in-this-chapter)
+  - [이 챕터에서 배우는 것](ch14-portability-testing.ko.md#learning-objectives)
   - [사전 요구사항](ch14-portability-testing.ko.md#prerequisites)
   - [14.1 이식성의 도전 과제](ch14-portability-testing.ko.md#141-the-portability-challenge)
   - [14.2 적합성 vs 이식성](ch14-portability-testing.ko.md#142-conformance-vs-portability)

--- a/book/advanced/toc.md
+++ b/book/advanced/toc.md
@@ -177,7 +177,7 @@
 ## Part 5. Testing and Diagnostics
 
 - [Chapter 14. Portability Testing and Conformance Verification](ch14-portability-testing.md)
-  - [What You Will Learn in This Chapter](ch14-portability-testing.md#what-you-will-learn-in-this-chapter)
+  - [What You Will Learn in This Chapter](ch14-portability-testing.md#learning-objectives)
   - [Prerequisites](ch14-portability-testing.md#prerequisites)
   - [14.1 The Portability Challenge](ch14-portability-testing.md#141-the-portability-challenge)
   - [14.2 Conformance vs Portability](ch14-portability-testing.md#142-conformance-vs-portability)


### PR DESCRIPTION
## Summary

Fix the broken Chapter 14 learning-objectives links in the English and Korean advanced-book tables of contents.

Linked context: Closes #3355

## Changes

- Point the English Chapter 14 TOC entry to `#learning-objectives`.
- Point the Korean companion TOC entry to the same live anchor.

## Testing

- `pnpm verify:docs`
- Manual EN/KO `#learning-objectives` anchor validation
- `git diff --check main...HEAD`
- Local contract/code/verification reviewer triad: merge

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

## Public export documentation

- [x] No public exports changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed.
- [x] No runtime behavior changed.

## Platform consistency governance (SSOT)

- [x] English/Korean mirror navigation remains synchronized.
- [x] No platform contract changed.