### PR TITLE
chore(runtime): align disposal release metadata with DI retry contract

### DIFF
--- a/.changeset/keep-failed-application-shutdown-terminal.md
+++ b/.changeset/keep-failed-application-shutdown-terminal.md
@@ -1,5 +1,7 @@
 ---
-"@fluojs/runtime": patch
+"@fluojs/runtime": major
 ---
 
-Preserve the documented application lifecycle state transitions and terminal operation gate, reject provider and child microservice operations once shutdown starts, and resume incomplete adapter or lifecycle-hook stages without repeating completed runtime phases. Container-managed `onDestroy()` hooks remain terminal best-effort cleanup and individual failed hooks are not retried by a later application close.
+Preserve the documented application lifecycle state transitions and terminal operation gate, reject provider and child microservice operations once shutdown starts, and resume incomplete adapter or lifecycle-hook stages without repeating completed runtime phases.
+
+Application and application-context close delegate container teardown to `Container.dispose()`, so runtime consumers inherit the `@fluojs/di` 3.x retryable failed-hook contract. In 2.x, a failed container-managed `onDestroy()` hook was attempted once. After upgrading, a later explicit application or context `close()` retries only the hooks that failed, while hooks that completed successfully remain exactly-once. Consumers must make failing cleanup hooks safe to attempt again.

--- a/packages/runtime/src/bootstrap.test.ts
+++ b/packages/runtime/src/bootstrap.test.ts
@@ -1493,6 +1493,45 @@ describe('FluoFactory.createApplicationContext', () => {
     expect(siblingOnDestroy).toHaveBeenCalledOnce();
   });
 
+  it('retries only failed container-managed onDestroy hooks on a second application close', async () => {
+    let failedAttempts = 0;
+    const failedOnDestroy = vi.fn(() => {
+      failedAttempts += 1;
+
+      if (failedAttempts === 1) {
+        throw new Error('application container destroy failed');
+      }
+    });
+    const siblingOnDestroy = vi.fn();
+
+    class FailingResource {
+      onDestroy = failedOnDestroy;
+    }
+
+    class SiblingResource {
+      onDestroy = siblingOnDestroy;
+    }
+
+    class AppModule {}
+    defineRuntimeModuleMetadata(AppModule, {
+      providers: [FailingResource, SiblingResource],
+    });
+
+    const app = await FluoFactory.create(AppModule);
+    await app.get(FailingResource);
+    await app.get(SiblingResource);
+
+    // Given: an application whose container-managed onDestroy hook fails once.
+    // When: the first close attempt reports that failure.
+    await expect(app.close()).rejects.toThrow('application container destroy failed');
+
+    // Then: a later close retries only the failed hook and reaches a stable closed application.
+    await expect(app.close()).resolves.toBeUndefined();
+    expect(failedOnDestroy).toHaveBeenCalledTimes(2);
+    expect(siblingOnDestroy).toHaveBeenCalledOnce();
+    expect(app.state).toBe('closed');
+  });
+
   it('rejects ApplicationContext.get() as soon as shutdown starts while teardown is pending', async () => {
     const shutdownCanFinish = createDeferred<void>();
 


### PR DESCRIPTION
## Summary

Align the pending `@fluojs/runtime` release metadata with the retryable failed-hook disposal contract already implemented and documented by `@fluojs/di`.

Linked context: Closes #3158

## Changes

- correct the runtime Changeset from patch to major
- replace contradictory one-shot cleanup guidance with retry-safe migration guidance
- add deterministic `Application.close()` regression coverage for retrying only failed hooks

## Testing

- dependency-closure build: PASS
- `@fluojs/runtime` typecheck and package tests: PASS
- sequential reverse-dependent suites: PASS
- exact-head contract/code/verification review: PASS / PASS / PASS

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] No public exports changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] Existing runtime and DI shutdown contracts remain aligned.
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] No platform contract docs changed.
- [x] Existing EN/KO lifecycle documentation remains synchronized.

## Maintainer note

This PR carries a major Changeset for `@fluojs/runtime` because shutdown retry guarantees are breaking release metadata under `docs/contracts/release-governance.md`; merge still requires explicit maintainer approval.