### PR TITLE
fix(di): make override batches fail atomically

### DIFF
--- a/.changeset/atomic-di-override-batches.md
+++ b/.changeset/atomic-di-override-batches.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/di': patch
+---
+
+Validate the whole `Container.override(...)` batch before mutating the graph so a rejected call leaves every earlier provider, cached instance, and disposal ownership unchanged.

--- a/docs/architecture/di-and-modules.ko.md
+++ b/docs/architecture/di-and-modules.ko.md
@@ -53,6 +53,7 @@
 - 공급자 토큰은 등록 메타데이터를 정규화하는 시점에 정의되어 있어야 합니다. `null` 또는 `undefined` inject 토큰은 유효하지 않습니다.
 - 공급자 순환 의존성 체인은 `CircularDependencyError`로 해석 실패합니다. `forwardRef(...)`는 선언 시점의 토큰 조회만 지연하며 실제 생성자 순환을 해석 가능하게 만들지 않으므로, 그런 순환은 리팩터링으로 제거해야 합니다.
 - 하나의 컨테이너 안에서 같은 토큰을 중복 등록하는 행위는 의도적인 교체가 `container.override(...)`로 수행되지 않는 한 실패해야 합니다.
+- 거부된 `container.override(...)` 배치는 어떤 등록이나 cached instance, disposal 소유권도 변경해서는 안 됩니다. 첫 번째 변경 이전에 배치 전체를 검증합니다.
 - 모듈 간 중복 공급자 토큰은 부트스트랩 시 `duplicateProviderPolicy`로 관리되며, 기본 정책은 `warn`입니다.
 - 모듈 가시성의 기본값은 비공개입니다. 교차 모듈 접근은 명시적 `exports`와 `imports`, 또는 전역 모듈의 export를 통해서만 허용됩니다.
 - 이 규칙 문서는 `@Module(...)`, `@Inject(...)`, `@Scope(...)`, `@fluojs/di`, 런타임 모듈 그래프 검증기가 정의한 현재 fluo 모델만을 다룹니다.

--- a/docs/architecture/di-and-modules.md
+++ b/docs/architecture/di-and-modules.md
@@ -53,6 +53,7 @@
 - Provider tokens MUST be defined when registration metadata is normalized. `null` or `undefined` inject tokens are invalid.
 - Circular provider dependency chains fail resolution with `CircularDependencyError`. `forwardRef(...)` only defers declaration-time token lookup; it does not make true constructor cycles resolvable, so those cycles must be removed by refactoring.
 - Duplicate registration of the same token inside one container MUST fail unless the replacement is intentional through `container.override(...)`.
+- A rejected `container.override(...)` batch MUST NOT change any registration, cached instance, or disposal ownership. The whole batch is validated before the first mutation.
 - Duplicate provider tokens across modules are governed at bootstrap by `duplicateProviderPolicy`, with `warn` as the default policy.
 - Module visibility is private by default. Cross-module access MUST pass through explicit `exports` and `imports`, or through exports from a global module.
 - This rule set covers the current fluo model defined by `@Module(...)`, `@Inject(...)`, `@Scope(...)`, `@fluojs/di`, and the runtime module-graph validator.

--- a/packages/di/README.ko.md
+++ b/packages/di/README.ko.md
@@ -100,7 +100,7 @@ direct `child.dispose()`는 이제 실패한 attempt를 포함해 attempt가 set
 
 ### provider override
 
-테스트나 request-local 경계에서 기존 등록을 의도적으로 교체해야 할 때는 `override(...providers)`를 사용합니다. override는 각 토큰의 현재 provider set을 교체하고 현재 컨테이너와 이미 materialize된 request-scope 자식의 cached instance를 무효화하며, 다음 replacement resolution이 계속되기 전에 오래된 instance의 dispose가 끝나도록 보장합니다. multi provider override는 해당 토큰의 전체 multi-provider set을 교체하므로 필요한 replacement provider를 한 번에 모두 전달하세요. 같은 토큰에 single replacement와 multi replacement를 한 override 호출에서 섞으면 모호한 교체로 보고 거부합니다.
+테스트나 request-local 경계에서 기존 등록을 의도적으로 교체해야 할 때는 `override(...providers)`를 사용합니다. override는 각 토큰의 현재 provider set을 교체하고 현재 컨테이너와 이미 materialize된 request-scope 자식의 cached instance를 무효화하며, 다음 replacement resolution이 계속되기 전에 오래된 instance의 dispose가 끝나도록 보장합니다. multi provider override는 해당 토큰의 전체 multi-provider set을 교체하므로 필요한 replacement provider를 한 번에 모두 전달하세요. 같은 토큰에 single replacement와 multi replacement를 한 override 호출에서 섞으면 모호한 교체로 보고 거부합니다. override 호출은 원자적입니다. 배치 전체를 검증한 뒤에야 등록과 캐시를 변경하므로, 거부된 호출은 모든 provider와 cached instance, disposal 소유권을 호출 이전 상태 그대로 남깁니다.
 
 ### request scope 분리
 
@@ -201,7 +201,7 @@ it('uses a mock database', async () => {
 |---|---|---|
 | `Container` | Root export | 메인 DI 컨테이너 클래스입니다. |
 | `container.register(...providers)` | `Container` instance method | 하나 이상의 프로바이더를 등록합니다. |
-| `container.override(...providers)` | `Container` instance method | 기존 provider를 교체하고 cached instance를 무효화하며 다음 replacement resolution이 계속되기 전에 오래된 instance dispose가 settle되도록 보장합니다. |
+| `container.override(...providers)` | `Container` instance method | 호출 단위로 원자적으로 기존 provider를 교체하고 cached instance를 무효화하며 다음 replacement resolution이 계속되기 전에 오래된 instance dispose가 settle되도록 보장합니다. |
 | `container.resolve<T>(token)` | `Container` instance method | 토큰을 인스턴스로 비동기 해석합니다. |
 | `container.inspectResolutionState()` | `Container` instance method | snapshot read-only map view, frozen provider record, controlled cache adoption을 통해 cache ownership을 보존해야 하는 testing/tooling helper를 위한 지원 대상 framework-owned container introspection seam을 노출합니다. 애플리케이션 코드는 `has(...)`와 `resolve(...)`를 우선 사용하세요. |
 | `container.createRequestScope()` | `Container` instance method | 요청 스코프 의존성을 위한 자식 컨테이너를 생성합니다. |

--- a/packages/di/README.md
+++ b/packages/di/README.md
@@ -99,7 +99,7 @@ Direct `child.dispose()` now detaches the request child from its parent after th
 
 ### Provider Overrides
 
-Use `override(...providers)` when a test or request-local boundary needs to replace existing registrations deliberately. Overrides replace the current provider set for each token, invalidate cached instances in the current container and already-materialized request-scope descendants, and dispose stale instances before the next replacement resolution continues. Multi-provider overrides replace the full multi-provider set for that token, so pass every replacement provider together; mixing single and multi replacements for the same token in one override call is rejected as ambiguous.
+Use `override(...providers)` when a test or request-local boundary needs to replace existing registrations deliberately. Overrides replace the current provider set for each token, invalidate cached instances in the current container and already-materialized request-scope descendants, and dispose stale instances before the next replacement resolution continues. Multi-provider overrides replace the full multi-provider set for that token, so pass every replacement provider together; mixing single and multi replacements for the same token in one override call is rejected as ambiguous. An override call is atomic: the whole batch is validated before any registration or cache changes, so a rejected call leaves every provider, cached instance, and disposal ownership exactly as it was.
 
 ### Request Scoping
 Isolated containers can be created to handle per-request state without polluting the root container.
@@ -201,7 +201,7 @@ Ensure all required providers are registered in the container. If you use `creat
 |---|---|---|
 | `Container` | Root export | The main DI container class. |
 | `container.register(...providers)` | `Container` instance method | Registers one or more providers. |
-| `container.override(...providers)` | `Container` instance method | Replaces existing providers, invalidates cached instances, and ensures stale instance disposal settles before the next replacement resolution continues. |
+| `container.override(...providers)` | `Container` instance method | Replaces existing providers atomically per call, invalidates cached instances, and ensures stale instance disposal settles before the next replacement resolution continues. |
 | `container.resolve<T>(token)` | `Container` instance method | Asynchronously resolves a token to an instance. |
 | `container.inspectResolutionState()` | `Container` instance method | Exposes the supported framework-owned container introspection seam for testing/tooling helpers that must preserve cache ownership through snapshot read-only map views, frozen provider records, and controlled cache adoption. Prefer `has(...)` and `resolve(...)` for application code. |
 | `container.createRequestScope()` | `Container` instance method | Creates a child container for request-scoped dependencies. |

--- a/packages/di/src/container-override-atomicity-regression.test.ts
+++ b/packages/di/src/container-override-atomicity-regression.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+
+import { Container } from './container.js';
+import { DuplicateProviderError, ScopeMismatchError } from './errors.js';
+import { Scope } from './types.js';
+
+describe('Container override batch atomicity regressions', () => {
+  it('leaves earlier single registrations unchanged when a later token group is ambiguous', async () => {
+    // Given
+    const stable = Symbol('stable-single');
+    const ambiguous = Symbol('ambiguous-multi');
+    const container = new Container().register(
+      { provide: stable, useValue: 'original' },
+      { provide: ambiguous, useValue: 'original-multi', multi: true },
+    );
+
+    // When
+    expect(() =>
+      container.override(
+        { provide: stable, useValue: 'replacement' },
+        { provide: ambiguous, useValue: 'replacement-multi', multi: true },
+        { provide: ambiguous, useValue: 'replacement-single' },
+      ),
+    ).toThrow(DuplicateProviderError);
+
+    // Then
+    await expect(container.resolve<string>(stable)).resolves.toBe('original');
+    await expect(container.resolve<string[]>(ambiguous)).resolves.toEqual(['original-multi']);
+  });
+
+  it('leaves earlier multi registrations unchanged when a later token group is duplicated', async () => {
+    // Given
+    const stable = Symbol('stable-multi');
+    const duplicated = Symbol('duplicated-single');
+    const container = new Container().register(
+      { provide: stable, useValue: 'original-a', multi: true },
+      { provide: stable, useValue: 'original-b', multi: true },
+      { provide: duplicated, useValue: 'original' },
+    );
+
+    // When
+    expect(() =>
+      container.override(
+        { provide: stable, useValue: 'replacement-a', multi: true },
+        { provide: duplicated, useValue: 'replacement-one' },
+        { provide: duplicated, useValue: 'replacement-two' },
+      ),
+    ).toThrow(DuplicateProviderError);
+
+    // Then
+    await expect(container.resolve<string[]>(stable)).resolves.toEqual(['original-a', 'original-b']);
+    await expect(container.resolve<string>(duplicated)).resolves.toBe('original');
+  });
+
+  it('keeps cached singleton instances and disposal ownership when a batch is rejected', async () => {
+    // Given
+    const stable = Symbol('stable-cached');
+    const ambiguous = Symbol('ambiguous-cached');
+    const destroyed: string[] = [];
+
+    class CachedService {
+      onDestroy(): void {
+        destroyed.push('cached');
+      }
+    }
+
+    const container = new Container().register(
+      { provide: stable, useClass: CachedService },
+      { provide: ambiguous, useValue: 'original-multi', multi: true },
+    );
+    const cachedInstance = await container.resolve<CachedService>(stable);
+
+    // When
+    expect(() =>
+      container.override(
+        { provide: stable, useValue: new CachedService() },
+        { provide: ambiguous, useValue: 'replacement-multi', multi: true },
+        { provide: ambiguous, useValue: 'replacement-single' },
+      ),
+    ).toThrow(DuplicateProviderError);
+
+    // Then
+    await expect(container.resolve<CachedService>(stable)).resolves.toBe(cachedInstance);
+    expect(destroyed).toEqual([]);
+    expect(container.inspectResolutionState().singletonCache.has(stable)).toBe(true);
+  });
+
+  it('leaves earlier registrations unchanged when a later group introduces a request-scope singleton', async () => {
+    // Given
+    const stable = Symbol('stable-request-scope');
+    const introduced = Symbol('introduced-singleton');
+    const root = new Container().register({ provide: stable, useValue: 'original' });
+    const requestScope = root.createRequestScope();
+
+    // When
+    expect(() =>
+      requestScope.override(
+        { provide: stable, useValue: 'replacement' },
+        { provide: introduced, scope: Scope.DEFAULT, useValue: 'new-singleton' },
+      ),
+    ).toThrow(ScopeMismatchError);
+
+    // Then
+    await expect(requestScope.resolve<string>(stable)).resolves.toBe('original');
+    expect(requestScope.has(introduced)).toBe(false);
+  });
+});

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -379,11 +379,16 @@ export class Container {
    * set — the whole set is replaced. If you need to preserve other entries, re-register them
    * together with the replacement in one `override()` call.
    *
+   * **Batch atomicity**: the whole batch is validated before any registration or cache is touched,
+   * so a rejected `override()` call leaves every provider, cached instance, and disposal ownership
+   * exactly as it was before the call.
+   *
    * @param providers Provider definitions that should replace existing registrations for each token.
    * @returns The same container instance for fluent override chains.
    * @throws {ContainerResolutionError} When called after the container was disposed.
    * @throws {ScopeMismatchError} When a request-scope override would introduce a new singleton token.
    * @throws {InvalidProviderError} When a provider definition is structurally invalid.
+   * @throws {DuplicateProviderError} When one token mixes single and multi replacements or repeats a single replacement.
    */
   override(...providers: Provider[]): this {
     if (this.isDisposedInHierarchy()) {
@@ -424,6 +429,8 @@ export class Container {
       }
     }
 
+    const plannedOverrides = new Map<Token, { containsMultiProvider: boolean; firstProvider: NormalizedProvider; normalizedProviders: NormalizedProvider[] }>();
+
     for (const [token, normalizedProviders] of normalizedByToken) {
       const firstProvider = normalizedProviders[0];
 
@@ -441,6 +448,10 @@ export class Container {
         throw new DuplicateProviderError(token);
       }
 
+      plannedOverrides.set(token, { containsMultiProvider, firstProvider, normalizedProviders });
+    }
+
+    for (const [token, { containsMultiProvider, firstProvider, normalizedProviders }] of plannedOverrides) {
       this.invalidateAffectedCachedEntriesInHierarchy(token);
       this.registrations.delete(token);
       this.multiRegistrations.delete(token);


### PR DESCRIPTION
## Summary

Make `Container.override(...providers)` validate the entire batch before mutating registrations, caches, or disposal ownership.

Linked context: Closes #3126

## Changes

- split override validation from graph mutation with a preflight plan
- preserve prior single/multi registrations and cached singleton ownership when a later token is invalid
- document batch atomicity in EN/KO package and architecture contracts
- add focused regression coverage and a patch Changeset

## Testing

- dependency-closure build: PASS
- `@fluojs/di` typecheck: PASS
- package tests: 173 PASS
- sequential reverse-dependent suites: PASS
- exact-head contract/code/verification review: PASS / PASS / PASS

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Updated `Container.override()` contract and throws documentation.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New batch atomicity contract is documented in affected EN/KO surfaces.
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] English/Korean mirror structure remains synchronized.
- [x] No platform adapter contract changed.