### PR TITLE
fix(di): validate request scope across multi providers

### DIFF
--- a/.changeset/validate-singleton-scope-across-multi-providers.md
+++ b/.changeset/validate-singleton-scope-across-multi-providers.md
@@ -1,0 +1,7 @@
+---
+"@fluojs/di": minor
+---
+
+Validate singleton dependency scopes across multi-provider registrations.
+
+A singleton that injects a multi token whose contributions include a request-scoped provider now fails with `ScopeMismatchError` before any provider factory or constructor runs, instead of materializing part of the contribution set and then failing with `RequestScopeResolutionError`. The same traversal now covers alias (`useExisting`) chains that target a multi token.

--- a/book/advanced/ch04-provider-resolution.ko.md
+++ b/book/advanced/ch04-provider-resolution.ko.md
@@ -952,7 +952,7 @@ missing provider 에러는 token과 복구 hint를 같은 자리에서 구성합
 
 `RequestScopeResolutionError`는 request-scoped provider를 request scope 밖에서 resolve할 때 `cacheFor()`와 `multiCacheFor()`에서 발생합니다. 근거는 `path:packages/di/src/container.ts:958-970`과 `path:packages/di/src/container.ts:981-993`입니다. 이것은 단순 생성 실패가 아니라 아키텍처 위반을 설명하는 런타임 에러입니다.
 
-`ScopeMismatchError`는 한 단계 더 위의 검증입니다. `path:packages/di/src/container.ts:1234-1306`의 `assertSingletonDependencyScopes()`와 재귀 helper는 singleton 생성 전에 dependency graph를 순회하고, request-scoped provider에 도달하는 path를 거부합니다. 이 탐색은 effective provider, wrapper, nested dependency, class metadata를 따라가므로 alias와 transitive edge에도 동일하게 적용됩니다.
+`ScopeMismatchError`는 한 단계 더 위의 검증입니다. `path:packages/di/src/container.ts:1234-1306`의 `assertSingletonDependencyScopes()`와 재귀 helper는 singleton 생성 전에 dependency graph를 순회하고, request-scoped provider에 도달하는 path를 거부합니다. 이 탐색은 effective provider, multi-provider contribution, wrapper, nested dependency, class metadata를 따라가므로 alias, multi token, transitive edge에도 동일하게 적용됩니다.
 
 singleton dependency scope 검사는 provider 생성 전에 실행됩니다.
 
@@ -978,7 +978,7 @@ singleton dependency scope 검사는 provider 생성 전에 실행됩니다.
   }
 ```
 
-이 검사는 singleton provider가 만들어지기 전에 dependency graph를 확인합니다. 재귀 helper는 alias, nested dependency, wrapper, unregistered class metadata 뒤의 request-scoped provider도 같은 규칙으로 잡아냅니다.
+이 검사는 singleton provider가 만들어지기 전에 dependency graph를 확인합니다. 재귀 helper는 alias, multi-provider contribution, nested dependency, wrapper, unregistered class metadata 뒤의 request-scoped provider도 같은 규칙으로 잡아냅니다.
 
 `CircularDependencyError`는 의도적으로 매우 노골적입니다. `path:packages/di/src/errors.ts:106-125`의 constructor는 full chain과 함께, shared logic 분리 또는 `forwardRef()` 사용을 권장하는 first-party hint를 넣습니다. 그 복구 조언은 표준 해결 모델에 뿌리를 두고 있습니다.
 

--- a/book/advanced/ch04-provider-resolution.md
+++ b/book/advanced/ch04-provider-resolution.md
@@ -952,7 +952,7 @@ This excerpt shows that a failed Token lookup doesn't end as a simple `undefined
 
 `RequestScopeResolutionError` is raised from `cacheFor()` and `multiCacheFor()` when a request-scoped Provider is resolved outside a request Scope. The basis is `path:packages/di/src/container.ts:958-970` and `path:packages/di/src/container.ts:981-993`. This is a runtime error, but it describes an architectural violation rather than a simple construction failure.
 
-`ScopeMismatchError` is the next layer of validation. `assertSingletonDependencyScopes()` and its recursive helpers in `path:packages/di/src/container.ts:1234-1306` walk the dependency graph before singleton creation and reject a path that reaches a request-scoped Provider. Because the traversal follows effective Providers, wrappers, nested dependencies, and class metadata, the same rule applies through aliases and transitive edges.
+`ScopeMismatchError` is the next layer of validation. `assertSingletonDependencyScopes()` and its recursive helpers in `path:packages/di/src/container.ts:1234-1306` walk the dependency graph before singleton creation and reject a path that reaches a request-scoped Provider. Because the traversal follows effective Providers, multi-Provider contributions, wrappers, nested dependencies, and class metadata, the same rule applies through aliases, multi Tokens, and transitive edges.
 
 The singleton dependency Scope check runs before the Provider is created.
 
@@ -978,7 +978,7 @@ The singleton dependency Scope check runs before the Provider is created.
   }
 ```
 
-This check inspects the dependency graph before a singleton Provider is made. The recursive helpers catch request-scoped Providers behind aliases, nested dependencies, wrappers, and unregistered class metadata.
+This check inspects the dependency graph before a singleton Provider is made. The recursive helpers catch request-scoped Providers behind aliases, multi-Provider contributions, nested dependencies, wrappers, and unregistered class metadata.
 
 `CircularDependencyError` is intentionally explicit. Its constructor in `path:packages/di/src/errors.ts:106-125` includes the full chain and a first-party hint recommending shared-logic extraction or `forwardRef()` use. That recovery advice is rooted in the standard resolution model.
 

--- a/packages/di/README.ko.md
+++ b/packages/di/README.ko.md
@@ -76,6 +76,8 @@ const service = await container.resolve(UserService);
 - **request**: `createRequestScope()`마다 새로 생성됩니다.
 - **transient**: resolve할 때마다 새 인스턴스를 만듭니다.
 
+singleton provider는 request-scoped provider에 의존할 수 없습니다. 이 mismatch는 그래프의 어떤 provider factory나 constructor도 실행되기 전에 `ScopeMismatchError`를 던지며, 이 검사는 single, alias(`useExisting`), multi-provider 등록을 모두 포함합니다. singleton이 multi token을 주입받을 때도 해당 token의 contribution 중 하나라도 request scope이면 같은 방식으로 실패하므로, contribution 일부만 materialize되는 일이 없습니다.
+
 dispose 중에는 각 컨테이너가 single-provider cache와 multi-provider cache 전체에서 성공적으로 materialize된 cached instance를 실제 생성 순서의 역순으로 정리하므로, dependency보다 dependent를 먼저 종료합니다. 각 컨테이너는 자신이 소유한 살아 있는 request scope 자식을 먼저 재귀적으로 정리하므로, 루트가 아닌 request scope를 dispose해도 중첩 request scope를 닫은 뒤 자신의 request cache를 정리합니다. 이후 루트 dispose는 자식 dispose 중 하나 이상이 실패하더라도 루트가 소유한 singleton 정리를 계속 수행합니다. 자식/루트 dispose 실패가 여러 개 발생하면 `dispose()`는 모든 shutdown 실패를 확인할 수 있도록 `AggregateError`로 보고합니다.
 
 `dispose()` 시작은 `resolve()`, `register()`, `override()`, `createRequestScope()`에 대해 terminal입니다. 동시 caller는 active disposal 시도를 공유합니다. `onDestroy()` hook이 실패하면 컨테이너는 실패한 hook만 이후 명시적 `dispose()` 재시도를 위해 유지하면서 child-before-parent/root 순서와 생성 역순을 보존합니다. 성공적으로 완료된 hook은 다시 실행하지 않으며, 유지된 hook이 모두 성공한 뒤 disposal은 멱등입니다.

--- a/packages/di/README.md
+++ b/packages/di/README.md
@@ -75,6 +75,8 @@ fluo DI supports four provider shapes:
 - **Request**: Instance is created once per `createRequestScope()` call.
 - **Transient**: A new instance is created every time it is resolved.
 
+A singleton provider must not depend on a request-scoped provider. That mismatch throws `ScopeMismatchError` before any provider factory or constructor in the graph runs, and the check covers single, alias (`useExisting`), and multi-provider registrations. A singleton that injects a multi token fails the same way when any contribution under that token is request-scoped, so no partial contribution set is materialized first.
+
 During disposal, each container tears down successfully materialized cached instances in reverse creation order across single-provider and multi-provider caches, so dependents are destroyed before their dependencies. Each container first recursively tears down live request-scope children it owns, so disposing a non-root request scope also closes nested request scopes before its own request cache. Root disposal then continues with root-owned singleton cleanup even if one or more child disposals fail. When multiple child/root disposals fail, `dispose()` reports an `AggregateError` so callers can inspect every shutdown failure without losing cleanup progress.
 
 Starting `dispose()` is terminal for `resolve()`, `register()`, `override()`, and `createRequestScope()`. Concurrent callers share the active disposal attempt. If an `onDestroy()` hook fails, the container retains only that failed hook for a later explicit `dispose()` retry, preserving child-before-parent/root and reverse-creation ordering. Hooks that completed successfully are never run again, and disposal becomes idempotent after every retained hook succeeds.

--- a/packages/di/src/container-multi-provider-scope-validation-regression.test.ts
+++ b/packages/di/src/container-multi-provider-scope-validation-regression.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+
+import { Container } from './container.js';
+import { ScopeMismatchError } from './errors.js';
+import { Scope } from './types.js';
+
+describe('singleton dependency scope validation across multi providers', () => {
+  it('fails with ScopeMismatchError before any multi-provider factory runs', async () => {
+    // Given
+    const pluginToken = Symbol('plugins');
+    const factoryCalls: string[] = [];
+    const container = new Container().register(
+      {
+        multi: true,
+        provide: pluginToken,
+        useFactory: () => {
+          factoryCalls.push('singleton-plugin');
+          return 'singleton-plugin';
+        },
+      },
+      {
+        multi: true,
+        provide: pluginToken,
+        scope: Scope.REQUEST,
+        useFactory: () => {
+          factoryCalls.push('request-plugin');
+          return 'request-plugin';
+        },
+      },
+      {
+        inject: [pluginToken],
+        provide: 'PluginRegistry',
+        useFactory: (plugins: unknown) => plugins,
+      },
+    );
+
+    // When
+    const resolution = container.resolve('PluginRegistry');
+
+    // Then
+    await expect(resolution).rejects.toThrow(ScopeMismatchError);
+    expect(factoryCalls).toEqual([]);
+  });
+
+  it('reports the request-scoped multi contribution token in the scope mismatch message', async () => {
+    // Given
+    const pluginToken = Symbol('scoped-plugins');
+    const container = new Container().register(
+      {
+        multi: true,
+        provide: pluginToken,
+        scope: Scope.REQUEST,
+        useFactory: () => 'request-plugin',
+      },
+      {
+        inject: [pluginToken],
+        provide: 'ScopedPluginRegistry',
+        useFactory: (plugins: unknown) => plugins,
+      },
+    );
+
+    // When
+    const error = await container.resolve('ScopedPluginRegistry').catch((thrown: unknown) => thrown);
+
+    // Then
+    expect(error).toBeInstanceOf(ScopeMismatchError);
+    expect((error as ScopeMismatchError).message).toContain('Symbol(scoped-plugins)');
+  });
+
+  it('fails with ScopeMismatchError when an alias targets a request-scoped multi contribution', async () => {
+    // Given
+    const pluginToken = Symbol('aliased-plugins');
+    const aliasToken = Symbol('plugins-alias');
+    let factoryCalls = 0;
+    const container = new Container().register(
+      {
+        multi: true,
+        provide: pluginToken,
+        scope: Scope.REQUEST,
+        useFactory: () => {
+          factoryCalls += 1;
+          return 'request-plugin';
+        },
+      },
+      { provide: aliasToken, useExisting: pluginToken },
+      {
+        inject: [aliasToken],
+        provide: 'AliasedPluginRegistry',
+        useFactory: (plugins: unknown) => plugins,
+      },
+    );
+
+    // When
+    const resolution = container.resolve('AliasedPluginRegistry');
+
+    // Then
+    await expect(resolution).rejects.toThrow(ScopeMismatchError);
+    expect(factoryCalls).toBe(0);
+  });
+
+  it('still resolves a singleton depending on singleton-only multi contributions', async () => {
+    // Given
+    const pluginToken = Symbol('singleton-only-plugins');
+    const container = new Container().register(
+      { multi: true, provide: pluginToken, useValue: 'first' },
+      { multi: true, provide: pluginToken, useValue: 'second' },
+      {
+        inject: [pluginToken],
+        provide: 'SingletonOnlyRegistry',
+        useFactory: (plugins: unknown) => plugins,
+      },
+    );
+
+    // When
+    const plugins = await container.resolve('SingletonOnlyRegistry');
+
+    // Then
+    expect(plugins).toEqual(['first', 'second']);
+  });
+
+  it('resolves request-scoped multi contributions from a request scope container', async () => {
+    // Given
+    const pluginToken = Symbol('request-scope-plugins');
+    const root = new Container().register(
+      { multi: true, provide: pluginToken, useValue: 'singleton-plugin' },
+      { multi: true, provide: pluginToken, scope: Scope.REQUEST, useFactory: () => 'request-plugin' },
+    );
+    const requestScope = root.createRequestScope();
+
+    // When
+    const plugins = await requestScope.resolve(pluginToken);
+
+    // Then
+    expect(plugins).toEqual(['singleton-plugin', 'request-plugin']);
+  });
+});

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -1504,6 +1504,12 @@ export class Container {
     visited.add(token);
 
     try {
+      const multiRequestScopedToken = this.findRequestScopedMultiContribution(token, visited);
+
+      if (multiRequestScopedToken) {
+        return multiRequestScopedToken;
+      }
+
       const provider = this.resolveEffectiveProvider(token);
 
       if (provider) {
@@ -1528,6 +1534,40 @@ export class Container {
     } finally {
       visited.delete(token);
     }
+  }
+
+  private findRequestScopedMultiContribution(token: Token, visited: Set<Token>): Token | undefined {
+    const aliasChain = new Set<Token>();
+    let currentToken = token;
+
+    while (!aliasChain.has(currentToken)) {
+      aliasChain.add(currentToken);
+
+      for (const multiProvider of this.collectMultiProviders(currentToken)) {
+        if (multiProvider.scope === Scope.REQUEST) {
+          return multiProvider.provide;
+        }
+
+        const requestScopedToken =
+          multiProvider.type === 'existing' && multiProvider.useExisting !== undefined
+            ? this.findRequestScopedDependencyToken(multiProvider.useExisting, visited)
+            : this.findRequestScopedDependency(multiProvider.inject, visited);
+
+        if (requestScopedToken) {
+          return requestScopedToken;
+        }
+      }
+
+      const aliasProvider = this.lookupProvider(currentToken);
+
+      if (aliasProvider?.type !== 'existing' || aliasProvider.useExisting === undefined) {
+        return undefined;
+      }
+
+      currentToken = aliasProvider.useExisting;
+    }
+
+    return undefined;
   }
 
   private resolveEffectiveProvider(


### PR DESCRIPTION
## Summary

Validate singleton-to-request scope mismatches across multi-provider contributions before any provider factory materializes.

Linked context: Closes #3135

## Changes

- traverse multi-provider contributions during singleton scope validation
- cover alias chains and request-scoped class/factory contributions
- preserve singleton-only multi-provider and request-scope resolution paths
- update EN/KO DI README and book contracts
- add a consumer-facing Changeset

## Testing

- dependency-closure build: PASS
- `@fluojs/di` typecheck: PASS
- package tests: 174 PASS
- sequential reverse-dependent suites: PASS
- exact-head contract/code/verification review: PASS / PASS / PASS

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] No public exports changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] Scope mismatch behavior is documented in affected EN/KO surfaces.
- [x] Fail-before-materialization is covered by deterministic regression tests.

## Platform consistency governance (SSOT)

- [x] English/Korean mirror structure remains synchronized.
- [x] No platform adapter contract changed.