### PR TITLE
Resolve #3394: parse the primary media type before detecting multipart requests

### DIFF
--- a/.changeset/fastify-media-type-parsing.md
+++ b/.changeset/fastify-media-type-parsing.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/platform-fastify": patch
+---
+
+Parse only the primary `Content-Type` media type when selecting multipart raw-body handling, so non-multipart request parameters cannot trigger the multipart path.

--- a/.changeset/fastify-media-type-parsing.md
+++ b/.changeset/fastify-media-type-parsing.md
@@ -2,4 +2,4 @@
 "@fluojs/platform-fastify": patch
 ---
 
-Parse only the primary `Content-Type` media type when selecting multipart raw-body handling, so non-multipart request parameters cannot trigger the multipart path.
+Parse only the primary `Content-Type` media type when selecting multipart raw-body handling and JSON string response serialization, so media-type parameters cannot misclassify requests or responses.

--- a/.changeset/fastify-media-type-parsing.md
+++ b/.changeset/fastify-media-type-parsing.md
@@ -2,4 +2,4 @@
 "@fluojs/platform-fastify": patch
 ---
 
-Parse only the primary `Content-Type` media type when selecting multipart raw-body handling and JSON string response serialization, so media-type parameters cannot misclassify requests or responses.
+Parse only the normalized primary `Content-Type` media type when selecting multipart raw-body handling and JSON string response serialization. Treat `application/json` and structured `+json` suffixes as JSON-compatible so media-type parameters cannot misclassify requests or responses.

--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -595,6 +595,18 @@ describe('@fluojs/platform-fastify', () => {
         return 'plain';
       }
 
+      @Header('Content-Type', ' text/plain; profile="application/json" ')
+      @Get('/string-with-json-profile')
+      getStringWithJsonProfile() {
+        return 'plain with a JSON profile';
+      }
+
+      @Header('Content-Type', ' Application/Json ; charset=utf-8 ')
+      @Get('/json-string-with-parameters')
+      getJsonStringWithParameters() {
+        return 'JSON string';
+      }
+
       @Get('/bytes')
       getBytes() {
         return Uint8Array.from([65, 66]);
@@ -637,6 +649,8 @@ describe('@fluojs/platform-fastify', () => {
       const objectResponse = await requestHttp({ path: '/responses/object', port });
       const arrayResponse = await requestHttp({ path: '/responses/array', port });
       const stringResponse = await requestHttp({ path: '/responses/string', port });
+      const stringWithJsonProfileResponse = await requestHttp({ path: '/responses/string-with-json-profile', port });
+      const jsonStringWithParametersResponse = await requestHttp({ path: '/responses/json-string-with-parameters', port });
       const bytesResponse = await requestHttp({ path: '/responses/bytes', port });
       const bufferResponse = await requestHttp({ path: '/responses/buffer', port });
       const headerResponse = await requestHttp({ path: '/responses/headers', port });
@@ -651,6 +665,8 @@ describe('@fluojs/platform-fastify', () => {
       expect(JSON.parse(arrayResponse.body)).toEqual([{ ok: true }]);
       expect(stringResponse.headers['content-type']).toContain('text/plain');
       expect(stringResponse.body).toBe('plain');
+      expect(stringWithJsonProfileResponse.body).toBe('plain with a JSON profile');
+      expect(jsonStringWithParametersResponse.body).toBe(JSON.stringify('JSON string'));
       expect(bytesResponse.headers['content-type']).toContain('application/octet-stream');
       expect(bytesResponse.body).toBe('AB');
       expect(bufferResponse.headers['content-type']).toContain('application/octet-stream');
@@ -1011,13 +1027,8 @@ describe('@fluojs/platform-fastify', () => {
     const observedMultipartRequest = createDeferred<void>();
 
     fastifyApp.addHook('preHandler', (request) => {
-      const contentType = request.headers['content-type'];
-      const primaryValue = Array.isArray(contentType) ? contentType[0] : contentType;
-
-      if (typeof primaryValue === 'string' && primaryValue.includes('multipart/form-data')) {
-        observedMultipartRawBodyStates.push(request.rawBody !== undefined);
-        observedMultipartRequest.resolve();
-      }
+      observedMultipartRawBodyStates.push(request.rawBody !== undefined);
+      observedMultipartRequest.resolve();
     });
 
     const port = await listenOnEphemeralPort(app);

--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -688,6 +688,39 @@ describe('@fluojs/platform-fastify', () => {
     }
   });
 
+  it('serializes string responses with JSON structured-suffix media types', () => {
+    const adapter = createFastifyAdapter({ port: 0 }) as FastifyHttpApplicationAdapter;
+    const requestResponseFactory = Reflect.get(adapter, 'requestResponseFactory') as {
+      createResponse(reply: FastifyReply): FrameworkResponse;
+    };
+    const headers = new Map<string, string | string[]>();
+    const sentPayloads: unknown[] = [];
+    const reply = {
+      getHeader(name: string) {
+        return headers.get(name.toLowerCase());
+      },
+      hasHeader(name: string) {
+        return headers.has(name.toLowerCase());
+      },
+      header(name: string, value: string | string[]) {
+        headers.set(name.toLowerCase(), value);
+        return this;
+      },
+      raw: {},
+      send(payload: unknown) {
+        sentPayloads.push(payload);
+        return this;
+      },
+      sent: false,
+    } as unknown as FastifyReply;
+    const response = requestResponseFactory.createResponse(reply);
+
+    response.setHeader('Content-Type', ' Application/Json-Patch+Json ; charset=utf-8 ');
+    response.send('JSON Patch string');
+
+    expect(sentPayloads).toEqual([JSON.stringify('JSON Patch string')]);
+  });
+
   it('preserves benchmark-style simple query and JSON body routes on the native request path', async () => {
     @Controller('/')
     class BenchmarkController {

--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -1034,14 +1034,7 @@ describe('@fluojs/platform-fastify', () => {
     });
 
     try {
-      await expect(Promise.race([
-        observedMultipartRequest.promise,
-        new Promise<void>((_resolve, reject) => {
-          setTimeout(() => {
-            reject(new Error('Multipart request never reached Fastify preHandler hook.'));
-          }, 2_000);
-        }),
-      ])).resolves.toBeUndefined();
+      await observedMultipartRequest.promise;
 
       expect(observedMultipartRawBodyStates).toEqual([false]);
     } finally {
@@ -1051,7 +1044,7 @@ describe('@fluojs/platform-fastify', () => {
     }
   });
 
-  it('treats multipart content-type values case-insensitively before raw-body capture', async () => {
+  it('treats multipart media types with casing, whitespace, and parameters before raw-body capture', async () => {
     @Controller('/uploads')
     class UploadController {
       @Post('/')
@@ -1078,13 +1071,8 @@ describe('@fluojs/platform-fastify', () => {
     const observedMultipartRequest = createDeferred<void>();
 
     fastifyApp.addHook('preHandler', (request) => {
-      const contentType = request.headers['content-type'];
-      const primaryValue = Array.isArray(contentType) ? contentType[0] : contentType;
-
-      if (typeof primaryValue === 'string' && primaryValue.toLowerCase().includes('multipart/form-data')) {
-        observedMultipartRawBodyStates.push(request.rawBody !== undefined);
-        observedMultipartRequest.resolve();
-      }
+      observedMultipartRawBodyStates.push(request.rawBody !== undefined);
+      observedMultipartRequest.resolve();
     });
 
     const port = await listenOnEphemeralPort(app);
@@ -1104,26 +1092,65 @@ describe('@fluojs/platform-fastify', () => {
       body,
       headers: {
         'content-length': String(Buffer.byteLength(body)),
-        'content-type': `Multipart/Form-Data; boundary=${boundary}`,
+        'content-type': `Multipart/Form-Data  ; boundary=${boundary}`,
       },
       method: 'POST',
       signal: abortController.signal,
     });
 
     try {
-      await expect(Promise.race([
-        observedMultipartRequest.promise,
-        new Promise<void>((_resolve, reject) => {
-          setTimeout(() => {
-            reject(new Error('Mixed-case multipart request never reached Fastify preHandler hook.'));
-          }, 2_000);
-        }),
-      ])).resolves.toBeUndefined();
+      await observedMultipartRequest.promise;
 
       expect(observedMultipartRawBodyStates).toEqual([false]);
     } finally {
       abortController.abort();
       await multipartRequest.catch(() => undefined);
+      await app.close();
+    }
+  });
+
+  it('captures normal JSON bodies when a parameter merely contains the multipart media type', async () => {
+    @Controller('/webhooks')
+    class WebhookController {
+      @Post('/json')
+      readJson(_input: undefined, context: RequestContext) {
+        return {
+          body: context.request.body,
+          rawBody: Buffer.from(context.request.rawBody ?? new Uint8Array()).toString('utf8'),
+        };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [WebhookController],
+    });
+
+    const app = await bootstrapFastifyApplication(AppModule, {
+      cors: false,
+      port: 0,
+      rawBody: true,
+    });
+    const port = await listenOnEphemeralPort(app);
+    const body = JSON.stringify({ event: 'payment.succeeded' });
+
+    try {
+      const response = await requestHttp({
+        body,
+        headers: {
+          'content-type': 'application/json; profile="multipart/form-data"',
+        },
+        method: 'POST',
+        path: '/webhooks/json',
+        port,
+      });
+
+      expect(response.statusCode).toBe(201);
+      expect(JSON.parse(response.body)).toEqual({
+        body: { event: 'payment.succeeded' },
+        rawBody: body,
+      });
+    } finally {
       await app.close();
     }
   });

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -1405,9 +1405,12 @@ function createRawBodyBufferChunk(chunk: unknown, encoding: BufferEncoding): Buf
 }
 
 function isMultipartRequestContentType(contentType: string | string[] | undefined): boolean {
+  return normalizePrimaryMediaType(contentType) === 'multipart/form-data';
+}
+
+function normalizePrimaryMediaType(contentType: string | string[] | undefined): string | undefined {
   const primaryValue = Array.isArray(contentType) ? contentType[0] : contentType;
-  const primaryMediaType = primaryValue?.split(';')[0]?.trim().toLowerCase();
-  return primaryMediaType === 'multipart/form-data';
+  return primaryValue?.split(';')[0]?.trim().toLowerCase();
 }
 
 function resolveListenTarget(
@@ -1604,5 +1607,5 @@ function serializeResponseBody(
 }
 
 function isJsonContentType(contentType: string | undefined): boolean {
-  return typeof contentType === 'string' && contentType.toLowerCase().includes('application/json');
+  return normalizePrimaryMediaType(contentType) === 'application/json';
 }

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -1406,7 +1406,8 @@ function createRawBodyBufferChunk(chunk: unknown, encoding: BufferEncoding): Buf
 
 function isMultipartRequestContentType(contentType: string | string[] | undefined): boolean {
   const primaryValue = Array.isArray(contentType) ? contentType[0] : contentType;
-  return typeof primaryValue === 'string' && primaryValue.toLowerCase().includes('multipart/form-data');
+  const primaryMediaType = primaryValue?.split(';')[0]?.trim().toLowerCase();
+  return primaryMediaType === 'multipart/form-data';
 }
 
 function resolveListenTarget(

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -1607,5 +1607,6 @@ function serializeResponseBody(
 }
 
 function isJsonContentType(contentType: string | undefined): boolean {
-  return normalizePrimaryMediaType(contentType) === 'application/json';
+  const normalized = normalizePrimaryMediaType(contentType);
+  return normalized === 'application/json' || normalized?.endsWith('+json') === true;
 }


### PR DESCRIPTION
## Summary

Parses the primary `Content-Type` media type before deciding whether a request is multipart or a response should be JSON-serialized, replacing naive whole-header substring matching in @fluojs/platform-fastify.

Linked context: Closes #3394

## Changes

- `normalizePrimaryMediaType()` extracts the media type before `;`, trims it, and lowercases it. Both discriminations in the package use it - there are exactly two, confirmed by a structural audit.
- Multipart requires the normalized type to equal `multipart/form-data` exactly.
- JSON matches `application/json` **or** any `+json` structured suffix, so `application/json-patch+json` and `application/merge-patch+json` keep serializing.
- A fixed `setTimeout` wait and two `Promise.race` timeout wrappers were replaced with exact deferred-event awaits; every assertion was preserved.

## Why it took three review rounds

Each round surfaced a different defect, and the last one is worth calling out:
1. The code axis found `isJsonContentType()` one function away still using `includes('application/json')`, so `text/plain; profile="application/json"` was misdetected and a string response got `JSON.stringify()`-ed.
2. Fixing that with strict equality then broke `+json` structured-suffix types - a regression introduced by the fix itself.

## Known divergence from `@fluojs/http`, deliberately left for a follow-up

`packages/http/src/dispatch/dispatch-response-policy.ts:109-111` matches on the raw header:

    contentType.toLowerCase().includes('application/json') || contentType.toLowerCase().endsWith('+json')

That is the same naive pattern this PR removes, and it is wrong in both directions: `text/plain; profile="application/json"` matches (false positive), while `application/merge-patch+json; charset=utf-8` does not (false negative, since the raw header ends with the charset parameter). This adapter is now stricter and more correct than the shared policy.

The right fix - extracting normalization plus JSON-compatibility into one `@fluojs/http/internal` helper consumed by both - changes @fluojs/http behavior for every consumer and belongs in its own issue with its own release level. It is deliberately **not** bundled into this patch. The reviewer who raised it agreed on re-adjudication.

## Testing

- `pnpm lint` — exit 0
- `pnpm --workspace-concurrency=1 --filter '@fluojs/platform-fastify...' build` — exit 0
- `pnpm --filter @fluojs/platform-fastify typecheck` — exit 0
- `pnpm --filter @fluojs/platform-fastify test` — 76 passed, twice
- `node tooling/governance/verify-platform-consistency-governance.mjs` — exit 0
- Mutation proofs (2/2 each): removing the `+json` clause fails at `adapter.test.ts:721` (mixed-case `Application/Json-Patch+Json` with parameters); reverting `isJsonContentType()` to naive `includes` fails at `:668`; reverting multipart detection fails the misclassification regression at `:1159-1163`.
- Read-only triad unanimous at this exact head.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

`@fluojs/platform-fastify` **patch**. The only requests whose handling changes are ones that were previously misclassified by parameter text; valid multipart and valid JSON behavior is unchanged.

## Public export documentation

- [x] Changed public exports include a source-level summary. (No public export signature changed.)
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] Package README alignment/conformance claims are backed by the applicable platform harness tests.
