### PR TITLE
Resolve #3336: correct the Studio route-kind changeset SemVer intent

### DIFF
--- a/.changeset/reject-unknown-studio-route-kinds.md
+++ b/.changeset/reject-unknown-studio-route-kinds.md
@@ -1,5 +1,7 @@
 ---
-'@fluojs/studio': patch
+'@fluojs/studio': major
 ---
 
 Reject unknown supplied route kinds in static and live Studio artifacts while preserving the legacy `http` default when `kind` is omitted.
+
+Migration: replace every explicit route `kind` value other than `http` or `react-page` before upgrading.

--- a/tooling/release/verify-changeset-release-lane.mjs
+++ b/tooling/release/verify-changeset-release-lane.mjs
@@ -14,7 +14,6 @@ const allowedBumpsByLane = {
 const validBumps = new Set(['patch', 'minor', 'major']);
 const publicCliFeatureAdditionVerbs = /\b(adds?|added|allows?|allowed|introduces?|introduced|exposes?|exposed|supports?|supported|enables?|enabled|provides?|provided|implements?|implemented|ships?|shipped|expands?|expanded)\b/iu;
 const nonBehaviorAdditionPhrases = /\b(adds?|added)\s+(?:(?:regression\s+)?(?:tests?|coverage|docs?|documentation)|(?:validation|guardrails?|checks?)\s+for)\b/giu;
-const studioRouteKindInputContractNarrowing = /\breject(?:s|ed|ing)?\s+(?:previously\s+)?(?:tolerated\s+)?(?:unknown|unsupported|unrecognized)\s+(?:supplied\s+)?route\s+kind(?:s)?\b/iu;
 const documentedCliSurfacePhraseMarkers = [
   {
     readme: /\b(?:generated|starter|template|lifecycle)\b/iu,
@@ -448,59 +447,6 @@ function collectPatchCliFeatureDowngradesFromVersionDeltas(versionDeltas, depend
   });
 }
 
-function describesStudioRouteKindInputContractNarrowing(text) {
-  return studioRouteKindInputContractNarrowing.test(normalizeReleaseText(text));
-}
-
-function collectPatchStudioRouteKindInputContractNarrowingsFromChangesets(intents) {
-  return intents
-    .filter(
-      (intent) =>
-        intent.packageName === '@fluojs/studio' &&
-        intent.bump === 'patch' &&
-        describesStudioRouteKindInputContractNarrowing(intent.body),
-    )
-    .map((intent) => ({
-      filePath: intent.filePath,
-      packageName: intent.packageName,
-      releaseText: normalizeReleaseText(intent.body),
-      source: 'changeset',
-    }));
-}
-
-function collectPatchStudioRouteKindInputContractNarrowingsFromVersionDeltas(versionDeltas, dependencies = {}) {
-  const { existsSync: pathExists = existsSync, readFileSync: readFile = readFileSync } = dependencies;
-
-  return versionDeltas.flatMap((delta) => {
-    if (delta.packageName !== '@fluojs/studio' || delta.bump !== 'patch') {
-      return [];
-    }
-
-    const changelogPath = packageChangelogPathForPackageJson(delta.filePath);
-    const absoluteChangelogPath = join(repoRoot, changelogPath);
-
-    if (!pathExists(absoluteChangelogPath)) {
-      return [];
-    }
-
-    const section = changelogSectionForVersion(readFile(absoluteChangelogPath, 'utf8'), delta.nextVersion);
-
-    if (!section || !describesStudioRouteKindInputContractNarrowing(section)) {
-      return [];
-    }
-
-    return [
-      {
-        changelogPath,
-        nextVersion: delta.nextVersion,
-        packageName: delta.packageName,
-        releaseText: normalizeReleaseText(section),
-        source: 'package-changelog',
-      },
-    ];
-  });
-}
-
 export function verifyChangesetReleaseLane(options = {}, dependencies = {}) {
   const baseRef = options.baseRef;
   const changesetDirectory = options.changesetDirectory ?? defaultChangesetDirectory;
@@ -526,17 +472,12 @@ export function verifyChangesetReleaseLane(options = {}, dependencies = {}) {
     ...collectPatchCliFeatureDowngradesFromChangesets(intents, dependencies),
     ...collectPatchCliFeatureDowngradesFromVersionDeltas(versionDeltas, dependencies),
   ];
-  const patchStudioRouteKindInputContractNarrowings = [
-    ...collectPatchStudioRouteKindInputContractNarrowingsFromChangesets(intents),
-    ...collectPatchStudioRouteKindInputContractNarrowingsFromVersionDeltas(versionDeltas, dependencies),
-  ];
 
   if (
     disallowed.length > 0 ||
     disallowedVersionDeltas.length > 0 ||
     dependencyOnlyMajorVersionDeltas.length > 0 ||
-    patchCliFeatureDowngrades.length > 0 ||
-    patchStudioRouteKindInputContractNarrowings.length > 0
+    patchCliFeatureDowngrades.length > 0
   ) {
     const details = disallowed
       .map((intent) => `${intent.packageName}@${intent.bump} (${intent.filePath})`)
@@ -568,20 +509,10 @@ export function verifyChangesetReleaseLane(options = {}, dependencies = {}) {
             })
             .join('\n  - ')}`
         : '',
-      patchStudioRouteKindInputContractNarrowings.length > 0
-        ? `Studio route-kind input-contract narrowing classified as patch:\n  - ${patchStudioRouteKindInputContractNarrowings
-            .map((narrowing) => {
-              const location = narrowing.source === 'changeset'
-                ? narrowing.filePath
-                : `${narrowing.changelogPath} ${narrowing.nextVersion}`;
-              return `${narrowing.packageName}@patch (${location}): ${narrowing.releaseText}`;
-            })
-            .join('\n  - ')}`
-        : '',
     ].filter((section) => section.length > 0);
 
     throw new Error(
-      `Changeset release lane check failed: the ${lane} lane only allows ${[...allowedBumps].join(', ')} changesets, package version bumps with matching major changelog evidence, public CLI feature additions classified as minor metadata, and Studio route-kind input-contract narrowing classified as major metadata:\n${sections.join('\n')}`,
+      `Changeset release lane check failed: the ${lane} lane only allows ${[...allowedBumps].join(', ')} changesets, package version bumps with matching major changelog evidence, and public CLI feature additions classified as minor metadata:\n${sections.join('\n')}`,
     );
   }
 
@@ -590,7 +521,6 @@ export function verifyChangesetReleaseLane(options = {}, dependencies = {}) {
     checkedDependencyOnlyMajorVersionDeltas: dependencyOnlyMajorVersionDeltas,
     checkedIntents: intents,
     checkedPatchCliFeatureDowngrades: patchCliFeatureDowngrades,
-    checkedPatchStudioRouteKindInputContractNarrowings: patchStudioRouteKindInputContractNarrowings,
     checkedVersionDeltas: versionDeltas,
     lane,
   };

--- a/tooling/release/verify-changeset-release-lane.mjs
+++ b/tooling/release/verify-changeset-release-lane.mjs
@@ -14,6 +14,7 @@ const allowedBumpsByLane = {
 const validBumps = new Set(['patch', 'minor', 'major']);
 const publicCliFeatureAdditionVerbs = /\b(adds?|added|allows?|allowed|introduces?|introduced|exposes?|exposed|supports?|supported|enables?|enabled|provides?|provided|implements?|implemented|ships?|shipped|expands?|expanded)\b/iu;
 const nonBehaviorAdditionPhrases = /\b(adds?|added)\s+(?:(?:regression\s+)?(?:tests?|coverage|docs?|documentation)|(?:validation|guardrails?|checks?)\s+for)\b/giu;
+const studioRouteKindInputContractNarrowing = /\breject(?:s|ed|ing)?\s+(?:previously\s+)?(?:tolerated\s+)?(?:unknown|unsupported|unrecognized)\s+(?:supplied\s+)?route\s+kind(?:s)?\b/iu;
 const documentedCliSurfacePhraseMarkers = [
   {
     readme: /\b(?:generated|starter|template|lifecycle)\b/iu,
@@ -447,6 +448,59 @@ function collectPatchCliFeatureDowngradesFromVersionDeltas(versionDeltas, depend
   });
 }
 
+function describesStudioRouteKindInputContractNarrowing(text) {
+  return studioRouteKindInputContractNarrowing.test(normalizeReleaseText(text));
+}
+
+function collectPatchStudioRouteKindInputContractNarrowingsFromChangesets(intents) {
+  return intents
+    .filter(
+      (intent) =>
+        intent.packageName === '@fluojs/studio' &&
+        intent.bump === 'patch' &&
+        describesStudioRouteKindInputContractNarrowing(intent.body),
+    )
+    .map((intent) => ({
+      filePath: intent.filePath,
+      packageName: intent.packageName,
+      releaseText: normalizeReleaseText(intent.body),
+      source: 'changeset',
+    }));
+}
+
+function collectPatchStudioRouteKindInputContractNarrowingsFromVersionDeltas(versionDeltas, dependencies = {}) {
+  const { existsSync: pathExists = existsSync, readFileSync: readFile = readFileSync } = dependencies;
+
+  return versionDeltas.flatMap((delta) => {
+    if (delta.packageName !== '@fluojs/studio' || delta.bump !== 'patch') {
+      return [];
+    }
+
+    const changelogPath = packageChangelogPathForPackageJson(delta.filePath);
+    const absoluteChangelogPath = join(repoRoot, changelogPath);
+
+    if (!pathExists(absoluteChangelogPath)) {
+      return [];
+    }
+
+    const section = changelogSectionForVersion(readFile(absoluteChangelogPath, 'utf8'), delta.nextVersion);
+
+    if (!section || !describesStudioRouteKindInputContractNarrowing(section)) {
+      return [];
+    }
+
+    return [
+      {
+        changelogPath,
+        nextVersion: delta.nextVersion,
+        packageName: delta.packageName,
+        releaseText: normalizeReleaseText(section),
+        source: 'package-changelog',
+      },
+    ];
+  });
+}
+
 export function verifyChangesetReleaseLane(options = {}, dependencies = {}) {
   const baseRef = options.baseRef;
   const changesetDirectory = options.changesetDirectory ?? defaultChangesetDirectory;
@@ -472,12 +526,17 @@ export function verifyChangesetReleaseLane(options = {}, dependencies = {}) {
     ...collectPatchCliFeatureDowngradesFromChangesets(intents, dependencies),
     ...collectPatchCliFeatureDowngradesFromVersionDeltas(versionDeltas, dependencies),
   ];
+  const patchStudioRouteKindInputContractNarrowings = [
+    ...collectPatchStudioRouteKindInputContractNarrowingsFromChangesets(intents),
+    ...collectPatchStudioRouteKindInputContractNarrowingsFromVersionDeltas(versionDeltas, dependencies),
+  ];
 
   if (
     disallowed.length > 0 ||
     disallowedVersionDeltas.length > 0 ||
     dependencyOnlyMajorVersionDeltas.length > 0 ||
-    patchCliFeatureDowngrades.length > 0
+    patchCliFeatureDowngrades.length > 0 ||
+    patchStudioRouteKindInputContractNarrowings.length > 0
   ) {
     const details = disallowed
       .map((intent) => `${intent.packageName}@${intent.bump} (${intent.filePath})`)
@@ -509,10 +568,20 @@ export function verifyChangesetReleaseLane(options = {}, dependencies = {}) {
             })
             .join('\n  - ')}`
         : '',
+      patchStudioRouteKindInputContractNarrowings.length > 0
+        ? `Studio route-kind input-contract narrowing classified as patch:\n  - ${patchStudioRouteKindInputContractNarrowings
+            .map((narrowing) => {
+              const location = narrowing.source === 'changeset'
+                ? narrowing.filePath
+                : `${narrowing.changelogPath} ${narrowing.nextVersion}`;
+              return `${narrowing.packageName}@patch (${location}): ${narrowing.releaseText}`;
+            })
+            .join('\n  - ')}`
+        : '',
     ].filter((section) => section.length > 0);
 
     throw new Error(
-      `Changeset release lane check failed: the ${lane} lane only allows ${[...allowedBumps].join(', ')} changesets, package version bumps with matching major changelog evidence, and public CLI feature additions classified as minor metadata:\n${sections.join('\n')}`,
+      `Changeset release lane check failed: the ${lane} lane only allows ${[...allowedBumps].join(', ')} changesets, package version bumps with matching major changelog evidence, public CLI feature additions classified as minor metadata, and Studio route-kind input-contract narrowing classified as major metadata:\n${sections.join('\n')}`,
     );
   }
 
@@ -521,6 +590,7 @@ export function verifyChangesetReleaseLane(options = {}, dependencies = {}) {
     checkedDependencyOnlyMajorVersionDeltas: dependencyOnlyMajorVersionDeltas,
     checkedIntents: intents,
     checkedPatchCliFeatureDowngrades: patchCliFeatureDowngrades,
+    checkedPatchStudioRouteKindInputContractNarrowings: patchStudioRouteKindInputContractNarrowings,
     checkedVersionDeltas: versionDeltas,
     lane,
   };

--- a/tooling/release/verify-changeset-release-lane.test.ts
+++ b/tooling/release/verify-changeset-release-lane.test.ts
@@ -173,20 +173,6 @@ describe('verifyChangesetReleaseLane', () => {
     );
   });
 
-  it('rejects Studio route-kind input-contract narrowing classified as patch', () => {
-    const directory = createChangesetDirectory();
-    writeChangeset(
-      directory,
-      'reject-unknown-studio-route-kinds.md',
-      '"@fluojs/studio": patch',
-      'Reject unknown supplied route kinds in static and live Studio artifacts while preserving the legacy `http` default when `kind` is omitted.',
-    );
-
-    expect(() => verifyChangesetReleaseLane({ changesetDirectory: directory, lane: 'stable' })).toThrow(
-      /Studio route-kind input-contract narrowing classified as patch/u,
-    );
-  });
-
   it('allows patch changesets that preserve existing CLI behavior without additive feature language', () => {
     const directory = createChangesetDirectory();
     writeChangeset(
@@ -294,30 +280,6 @@ describe('verifyChangesetReleaseLane', () => {
         },
       ),
     ).toThrow(/public CLI feature additions classified as patch.*fluo inspect/us);
-  });
-
-  it('rejects generated Studio patch changelog sections that narrow route kinds', () => {
-    const directory = createChangesetDirectory();
-
-    expect(() =>
-      verifyChangesetReleaseLane(
-        { baseRef: 'origin/main', changesetDirectory: directory, lane: 'stable' },
-        {
-          collectPackageVersionDeltas: () => [
-            {
-              bump: 'patch',
-              filePath: 'packages/studio/package.json',
-              nextVersion: '1.0.9',
-              packageName: '@fluojs/studio',
-              previousVersion: '1.0.8',
-            },
-          ],
-          existsSync: (targetPath: string) => targetPath.endsWith('packages/studio/CHANGELOG.md'),
-          readFileSync: () =>
-            '# @fluojs/studio\n\n## 1.0.9\n\n### Patch Changes\n\n- Reject unknown supplied route kinds in static and live Studio artifacts.\n',
-        },
-      ),
-    ).toThrow(/Studio route-kind input-contract narrowing classified as patch.*unknown supplied route kinds/us);
   });
 
   it('allows major package version deltas with major changelog evidence', () => {

--- a/tooling/release/verify-changeset-release-lane.test.ts
+++ b/tooling/release/verify-changeset-release-lane.test.ts
@@ -173,6 +173,20 @@ describe('verifyChangesetReleaseLane', () => {
     );
   });
 
+  it('rejects Studio route-kind input-contract narrowing classified as patch', () => {
+    const directory = createChangesetDirectory();
+    writeChangeset(
+      directory,
+      'reject-unknown-studio-route-kinds.md',
+      '"@fluojs/studio": patch',
+      'Reject unknown supplied route kinds in static and live Studio artifacts while preserving the legacy `http` default when `kind` is omitted.',
+    );
+
+    expect(() => verifyChangesetReleaseLane({ changesetDirectory: directory, lane: 'stable' })).toThrow(
+      /Studio route-kind input-contract narrowing classified as patch/u,
+    );
+  });
+
   it('allows patch changesets that preserve existing CLI behavior without additive feature language', () => {
     const directory = createChangesetDirectory();
     writeChangeset(
@@ -280,6 +294,30 @@ describe('verifyChangesetReleaseLane', () => {
         },
       ),
     ).toThrow(/public CLI feature additions classified as patch.*fluo inspect/us);
+  });
+
+  it('rejects generated Studio patch changelog sections that narrow route kinds', () => {
+    const directory = createChangesetDirectory();
+
+    expect(() =>
+      verifyChangesetReleaseLane(
+        { baseRef: 'origin/main', changesetDirectory: directory, lane: 'stable' },
+        {
+          collectPackageVersionDeltas: () => [
+            {
+              bump: 'patch',
+              filePath: 'packages/studio/package.json',
+              nextVersion: '1.0.9',
+              packageName: '@fluojs/studio',
+              previousVersion: '1.0.8',
+            },
+          ],
+          existsSync: (targetPath: string) => targetPath.endsWith('packages/studio/CHANGELOG.md'),
+          readFileSync: () =>
+            '# @fluojs/studio\n\n## 1.0.9\n\n### Patch Changes\n\n- Reject unknown supplied route kinds in static and live Studio artifacts.\n',
+        },
+      ),
+    ).toThrow(/Studio route-kind input-contract narrowing classified as patch.*unknown supplied route kinds/us);
   });
 
   it('allows major package version deltas with major changelog evidence', () => {


### PR DESCRIPTION
## Summary

Corrects the SemVer intent of the Studio route-kind changeset from `patch` to `major`, with migration guidance.

Linked context: Closes #3336

## Why major

Rejecting previously-tolerated unknown route kinds **narrows the accepted input contract** of a 1.0+ package. Before #2917, `StudioRouteDescriptor.kind` was typed `string` and the parser accepted arbitrary values, so both the type and the runtime input contract narrow here — that is breaking, not a patch.

This is the distinction from #3335, which correctly shipped as `patch`: `BootstrapTimingPhase.name` was **always** a documented closed union, so accepting junk was simply a bug in the validator rather than a contract change.

Migration note included: replace every explicit route `kind` value other than `http` or `react-page` before upgrading. The legacy `http` default when `kind` is omitted is preserved.

## Scope

One file: `.changeset/reject-unknown-studio-route-kinds.md`.

An earlier revision of this PR also added a bespoke rule to `tooling/release/verify-changeset-release-lane.mjs`. **All three review axes blocked it and they were right**, for opposite reasons that together made it unfixable as designed:

- **Too narrow**: it keyed on a phrase regex, so "Stop accepting route kinds other than `http` and `react-page`" — the identical narrowing, reworded — would pass straight through. As the sole recurrence gate it granted false confidence.
- **Too broad**: it forced `major` from prose alone without consulting the public type or documented state, so a future genuine validation bug fix on an already-closed union would be wrongly blocked — contradicting the correct #3335 judgment.

Detecting this class properly needs a **structural** signal (whether a public type's accepted set actually narrowed), not changeset wording. That belongs in its own issue; the rule and its tests were removed. `git diff origin/main -- tooling/release/` is now empty.

## Testing

- `pnpm lint` — exit 0
- `git diff origin/main -- tooling/release/` — empty (removal proof)
- `pnpm exec vitest run tooling/release/verify-changeset-release-lane.test.ts` — 16/16 (18 minus exactly the two rule-specific tests)
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main` — exit 0, "163 pending package bump intent(s), 0 package version delta(s)"
- `node tooling/governance/verify-platform-consistency-governance.mjs` — exit 0
- `pnpm --filter @fluojs/studio test` — 72 passed, twice
- Read-only triad unanimous at this exact head.

**Pre-existing failure, disclosed:** `pnpm --filter @fluojs/cli test` fails 7 of 444 locally in typegen/scaffold tests. Classified with a control run — clean `main` at `199f2f91` fails 6 of 444 in the same tests, and main's CI is green — so this is a local-environment artifact of tests that spawn real builds and subprocesses, independent of this change, which touches only `.changeset/`.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

`@fluojs/studio` **major**. The changeset is still unreleased: published state on `main`, npm, and tags is `@fluojs/studio@1.0.8`. The open bot PR #2772 (`changeset-release/main`) currently holds a branch state consuming it at `1.1.0`; since that PR is unmerged it is not published history, and the bot regenerates it once this correction lands.

## Public export documentation

- [x] Changed public exports include a source-level summary. (N/A — changeset only.)
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. (N/A)
- [x] Source `@example` blocks and README scenario examples still play complementary roles. (N/A)

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] Package README alignment/conformance claims are backed by the applicable platform harness tests.
