### PR TITLE
refactor(request-pipeline): route DTO readers through core seam

### DIFF
--- a/.changeset/route-dto-readers-through-request-pipeline.md
+++ b/.changeset/route-dto-readers-through-request-pipeline.md
@@ -1,0 +1,6 @@
+---
+"@fluojs/graphql": patch
+"@fluojs/http": patch
+---
+
+Route HTTP and GraphQL DTO metadata reads through `@fluojs/core/request-pipeline` so first-party request processing remains on the documented integration seam.

--- a/packages/graphql/src/pipeline/input-pipeline.ts
+++ b/packages/graphql/src/pipeline/input-pipeline.ts
@@ -1,5 +1,5 @@
-import { type Constructor, type MetadataPropertyKey } from '@fluojs/core';
-import { getDtoValidationSchema, type DtoFieldValidationRule } from '@fluojs/core/internal';
+import type { Constructor, MetadataPropertyKey } from '@fluojs/core';
+import { getDtoValidationSchema, type DtoFieldValidationRule } from '@fluojs/core/request-pipeline';
 import { DefaultValidator } from '@fluojs/validation';
 
 import { isGraphqlListTypeRef } from '../types.js';

--- a/packages/http/src/adapters/dto-binding-plan.ts
+++ b/packages/http/src/adapters/dto-binding-plan.ts
@@ -1,4 +1,4 @@
-import { type Constructor, type MetadataPropertyKey, type MetadataSource } from '@fluojs/core';
+import type { Constructor, MetadataPropertyKey, MetadataSource } from '@fluojs/core';
 import {
   getClassValidationRules,
   getDtoBindingSchema,
@@ -6,7 +6,7 @@ import {
   type DtoBindingSchemaEntry,
   type DtoFieldBindingMetadata,
   type DtoFieldValidationRule,
-} from '@fluojs/core/internal';
+} from '@fluojs/core/request-pipeline';
 
 import { getRequestHeader } from '../header-helpers.js';
 import type { FrameworkRequest } from '../types.js';

--- a/tooling/governance/request-pipeline-import-boundary.d.mts
+++ b/tooling/governance/request-pipeline-import-boundary.d.mts
@@ -1,0 +1,3 @@
+export function enforceRequestPipelineImportBoundary(
+  readText?: (relativePath: string) => string,
+): void;

--- a/tooling/governance/request-pipeline-import-boundary.mjs
+++ b/tooling/governance/request-pipeline-import-boundary.mjs
@@ -1,0 +1,107 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+const coreInternalSpecifier = '@fluojs/core/internal';
+const coreRequestPipelineSpecifier = '@fluojs/core/request-pipeline';
+
+/**
+ * Reader and writer names owned by the `@fluojs/core/request-pipeline` seam.
+ *
+ * First-party request-pipeline consumers must reach these through the dedicated
+ * subpath instead of the broader `@fluojs/core/internal` surface.
+ */
+const requestPipelineSeamSymbols = [
+  'appendClassValidationRule',
+  'appendDtoFieldValidationRule',
+  'defineDtoFieldBindingMetadata',
+  'getClassValidationRules',
+  'getDtoBindingSchema',
+  'getDtoFieldBindingMetadata',
+  'getDtoFieldValidationRules',
+  'getDtoValidationSchema',
+];
+
+/**
+ * First-party sources that perform DTO validation or binding metadata reads.
+ */
+const requestPipelineConsumerSourcePaths = [
+  'packages/graphql/src/pipeline/input-pipeline.ts',
+  'packages/http/src/adapters/dto-binding-plan.ts',
+  'packages/openapi/src/schema-builder.ts',
+  'packages/validation/src/internal/dto-metadata-cache.ts',
+  'packages/validation/src/mapped-types.ts',
+];
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(`Request-pipeline import boundary check failed: ${message}`);
+  }
+}
+
+function defaultReadText(relativePath) {
+  return readFileSync(join(repoRoot, relativePath), 'utf8');
+}
+
+function collectImportClauses(source, specifier) {
+  const pattern = new RegExp(String.raw`import\s+([^;]*?)\s+from\s+['"]${specifier}['"]\s*;`, 'gu');
+  const clauses = [];
+  let match = pattern.exec(source);
+
+  while (match) {
+    clauses.push(match[1]);
+    match = pattern.exec(source);
+  }
+
+  return clauses;
+}
+
+function collectNamedImports(clause) {
+  const braceStart = clause.indexOf('{');
+  const braceEnd = clause.lastIndexOf('}');
+
+  if (braceStart === -1 || braceEnd <= braceStart) {
+    return [];
+  }
+
+  return clause
+    .slice(braceStart + 1, braceEnd)
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => entry.replace(/^type\s+/u, '').split(/\s+as\s+/u)[0].trim())
+    .filter(Boolean);
+}
+
+function collectImportedNames(source, specifier) {
+  return collectImportClauses(source, specifier).flatMap((clause) => collectNamedImports(clause));
+}
+
+/**
+ * Enforce that first-party request-pipeline consumers read DTO validation and
+ * binding metadata through `@fluojs/core/request-pipeline`.
+ *
+ * @param readText Optional source reader used to inject governance fixtures.
+ */
+export function enforceRequestPipelineImportBoundary(readText = defaultReadText) {
+  const seamSymbols = new Set(requestPipelineSeamSymbols);
+
+  for (const relativePath of requestPipelineConsumerSourcePaths) {
+    const source = readText(relativePath);
+    const leakedSymbols = collectImportedNames(source, coreInternalSpecifier).filter((name) => seamSymbols.has(name));
+
+    assert(
+      leakedSymbols.length === 0,
+      `${relativePath} must import ${leakedSymbols.join(', ')} from ${coreRequestPipelineSpecifier} instead of ${coreInternalSpecifier}.`,
+    );
+
+    const seamImports = collectImportedNames(source, coreRequestPipelineSpecifier).filter((name) => seamSymbols.has(name));
+
+    assert(
+      seamImports.length > 0,
+      `${relativePath} must keep reading DTO validation or binding metadata through ${coreRequestPipelineSpecifier}.`,
+    );
+  }
+}

--- a/tooling/governance/request-pipeline-import-boundary.test.ts
+++ b/tooling/governance/request-pipeline-import-boundary.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { enforceRequestPipelineImportBoundary } from './request-pipeline-import-boundary.mjs';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+function read(relativePath: string): string {
+  return readFileSync(join(repoRoot, relativePath), 'utf8');
+}
+
+function overrideFile(relativePath: string, transform: (content: string) => string): (requestedPath: string) => string {
+  return (requestedPath) => {
+    if (requestedPath !== relativePath) {
+      return read(requestedPath);
+    }
+
+    const original = read(requestedPath);
+    const mutated = transform(original);
+
+    if (mutated === original) {
+      throw new Error(
+        `Governance fixture for ${relativePath} left the source unchanged: its anchor text has drifted away from the current implementation. `
+        + 'Update the fixture so it actually breaks the seam under test, otherwise this guard is asserting nothing.',
+      );
+    }
+
+    return mutated;
+  };
+}
+
+describe('request-pipeline import boundary governance', () => {
+  it('keeps first-party DTO readers on the @fluojs/core/request-pipeline seam', () => {
+    // Given
+    const runGovernanceGuard = () => enforceRequestPipelineImportBoundary();
+
+    // When / Then
+    expect(runGovernanceGuard).not.toThrow();
+  });
+
+  it('rejects HTTP DTO binding reads routed through @fluojs/core/internal', () => {
+    // Given
+    const readWithInternalHttpImport = overrideFile('packages/http/src/adapters/dto-binding-plan.ts', (content) =>
+      content.replace("} from '@fluojs/core/request-pipeline';", "} from '@fluojs/core/internal';"));
+
+    // When
+    const runGovernanceGuard = () => enforceRequestPipelineImportBoundary(readWithInternalHttpImport);
+
+    // Then
+    expect(runGovernanceGuard).toThrow(
+      /packages\/http\/src\/adapters\/dto-binding-plan\.ts must import .*getDtoBindingSchema.* from @fluojs\/core\/request-pipeline/u,
+    );
+  });
+
+  it('rejects GraphQL input processing reads routed through @fluojs/core/internal', () => {
+    // Given
+    const readWithInternalGraphqlImport = overrideFile('packages/graphql/src/pipeline/input-pipeline.ts', (content) =>
+      content.replace("from '@fluojs/core/request-pipeline';", "from '@fluojs/core/internal';"));
+
+    // When
+    const runGovernanceGuard = () => enforceRequestPipelineImportBoundary(readWithInternalGraphqlImport);
+
+    // Then
+    expect(runGovernanceGuard).toThrow(
+      /packages\/graphql\/src\/pipeline\/input-pipeline\.ts must import getDtoValidationSchema from @fluojs\/core\/request-pipeline/u,
+    );
+  });
+
+  it('rejects dropping the request-pipeline seam read from a governed consumer', () => {
+    // Given
+    const readWithoutSeamImport = overrideFile('packages/validation/src/internal/dto-metadata-cache.ts', (content) =>
+      content.replace("} from '@fluojs/core/request-pipeline';", "} from './dto-metadata-shim.js';"));
+
+    // When
+    const runGovernanceGuard = () => enforceRequestPipelineImportBoundary(readWithoutSeamImport);
+
+    // Then
+    expect(runGovernanceGuard).toThrow(
+      /packages\/validation\/src\/internal\/dto-metadata-cache\.ts must keep reading DTO validation or binding metadata through @fluojs\/core\/request-pipeline/u,
+    );
+  });
+});

--- a/tooling/governance/verify-platform-consistency-governance.mjs
+++ b/tooling/governance/verify-platform-consistency-governance.mjs
@@ -17,6 +17,7 @@ import { enforcePassportJsBridgeNestjsMigration } from './passport-js-bridge-nes
 import { enforcePlatformShellLifecycleContract } from './platform-shell-lifecycle-contract.mjs';
 import { enforceReactPageCatalogContract } from './react-page-catalog-contract.mjs';
 import { enforceReactRscGraduationGovernance } from './react-rsc-graduation-policy.mjs';
+import { enforceRequestPipelineImportBoundary } from './request-pipeline-import-boundary.mjs';
 import { enforceRuntimeLifecycleNestjsMigrationDocs } from './runtime-lifecycle-nestjs-migration-docs.mjs';
 
 export { enforceAdvancedBookCoreBoundaryCompanions } from './advanced-book-core-boundary.mjs';
@@ -36,6 +37,7 @@ export {
   enforceReactRscGraduationGovernance,
   enforceReactRscGraduationPolicy,
 } from './react-rsc-graduation-policy.mjs';
+export { enforceRequestPipelineImportBoundary } from './request-pipeline-import-boundary.mjs';
 export { enforceRuntimeLifecycleNestjsMigrationDocs } from './runtime-lifecycle-nestjs-migration-docs.mjs';
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
@@ -2789,6 +2791,7 @@ export function main() {
   enforceHttpCatchAllRouteGrammarDecision();
   enforceOpenApiNullableNormalizationContract();
   enforceGraphqlRuntimeBoundaryDiscoverability();
+  enforceRequestPipelineImportBoundary();
   enforcePersistenceTransactionInterceptorCompatibility();
   enforceQueueWorkerOwnershipContract();
   enforceMicroservicesSafetyGuidanceParity();


### PR DESCRIPTION
## Summary

Route HTTP and GraphQL DTO metadata readers through the documented `@fluojs/core/request-pipeline` seam instead of `@fluojs/core/internal`.

Linked context: Closes #3106

## Changes

- migrate HTTP DTO binding-plan metadata reads to the request-pipeline seam
- migrate GraphQL input-pipeline metadata reads to the same seam
- add governance enforcement for shipped request-pipeline imports
- add patch Changesets for `@fluojs/http` and `@fluojs/graphql`

## Testing

- HTTP and GraphQL dependency-closure builds: PASS
- HTTP and GraphQL typechecks/tests: PASS
- request-pipeline governance test: PASS
- Changeset release-lane gate: PASS
- sequential reverse-dependent suites: PASS
- compiled HTTP/GraphQL surface QA: PASS
- exact-head contract/code/verification review: PASS / PASS / PASS

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] No public exports changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] DTO binding behavior is preserved by regression and compiled-surface checks.

## Platform consistency governance (SSOT)

- [x] Request-pipeline import governance now covers the migrated consumers.
- [x] No platform adapter behavior changed.