### PR TITLE
Resolve #3176: complete GraphQL WebSocket transport TSDoc

### DIFF
--- a/.changeset/issue-3176-graphql-websocket-tsdoc.md
+++ b/.changeset/issue-3176-graphql-websocket-tsdoc.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/graphql": patch
+---
+
+Document the public GraphQL WebSocket transport interfaces and factory.

--- a/packages/graphql/src/node/graphql-websocket-transport.ts
+++ b/packages/graphql/src/node/graphql-websocket-transport.ts
@@ -35,6 +35,9 @@ interface GraphqlSubscribePayload {
   variables?: Record<string, unknown> | null;
 }
 
+/**
+ * Describes a GraphQL-over-WebSocket subscription forwarded to application hooks.
+ */
 export interface GraphqlNodeWebSocketSubscribeRequest {
   connectionParams?: Record<string, unknown>;
   operationId: string;
@@ -43,6 +46,9 @@ export interface GraphqlNodeWebSocketSubscribeRequest {
   socket: object;
 }
 
+/**
+ * Represents a registered Node GraphQL WebSocket transport.
+ */
 export interface GraphqlNodeWebSocketTransport {
   dispose(): Promise<void>;
 }
@@ -180,6 +186,12 @@ function createSubscribeRequest(
   };
 }
 
+/**
+ * Registers GraphQL-over-WebSocket upgrade handling for a Node HTTP/S adapter.
+ *
+ * @param options Transport dependencies and WebSocket lifecycle hooks.
+ * @returns A transport that unregisters upgrade handling and disposes WebSocket clients.
+ */
 export async function createNodeGraphqlWebSocketTransport(
   options: GraphqlNodeWebSocketTransportOptions,
 ): Promise<GraphqlNodeWebSocketTransport> {


### PR DESCRIPTION
## Summary

Complete the required public-export TSDoc for the GraphQL WebSocket transport contracts without changing runtime behavior.

Linked context: Closes #3176

## Changes

- document the exported WebSocket request and transport interfaces
- document `createNodeGraphqlWebSocketTransport` parameters and return value
- add a patch Changeset for the public package documentation update

## Testing

- `pnpm --filter @fluojs/graphql... build`
- `pnpm --filter @fluojs/graphql typecheck`
- `pnpm --filter ...@fluojs/graphql test` (13 files, 102 tests)
- `pnpm verify:public-export-tsdoc`
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=38185778b40f79c620173e6d9729f219a9e02b6a`
- exact-head contract/code/verification review triad: merge

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests.