### PR TITLE
Resolve #3180: export GraphqlWebSocketLimitsOptions

### DIFF
--- a/.changeset/export-graphql-websocket-limits.md
+++ b/.changeset/export-graphql-websocket-limits.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/graphql": minor
+---
+
+Export `GraphqlWebSocketLimitsOptions` from the package root so consumers can type `subscriptions.websocket.limits` configuration.

--- a/packages/graphql/README.ko.md
+++ b/packages/graphql/README.ko.md
@@ -290,7 +290,7 @@ GraphqlModule.forRoot({
 - `Arg`: Input DTO 필드를 GraphQL 인자로 매핑하는 데코레이터.
 - `createDataLoader`, `createDataLoaderMap`, `getRequestScopedDataLoader`, `createRequestScopedDataLoaderFactory`, `DataLoader`: DataLoader factory helper와 type.
 - `listOf`, `isGraphqlListTypeRef`: list output type reference helper.
-- `GraphQLContext` 및 export되는 option/metadata type: GraphQL 실행과 module 설정을 위한 타입 정의.
+- `GraphQLContext` 및 export되는 option/metadata type: `subscriptions.websocket.limits`에 사용하는 `GraphqlWebSocketLimitsOptions`를 포함한 GraphQL 실행과 module 설정을 위한 타입 정의.
 
 지원되는 module option에는 `schema`, `context`, `plugins`, `graphiql`, `introspection`, `limits`, `subscriptions.websocket.enabled`, `subscriptions.websocket.limits`, `subscriptions.websocket.connectionInitWaitTimeoutMs`, `subscriptions.websocket.keepAliveMs`가 포함됩니다.
 

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -290,7 +290,7 @@ GraphqlModule.forRoot({
 - `Arg`: Input DTO field-to-GraphQL-argument mapping decorator.
 - `createDataLoader`, `createDataLoaderMap`, `getRequestScopedDataLoader`, `createRequestScopedDataLoaderFactory`, `DataLoader`: DataLoader factory helpers and types.
 - `listOf`, `isGraphqlListTypeRef`: Helpers for list output type references.
-- `GraphQLContext` and exported option/metadata types: Type definitions for GraphQL execution and module configuration.
+- `GraphQLContext` and exported option/metadata types: Type definitions for GraphQL execution and module configuration, including `GraphqlWebSocketLimitsOptions` for `subscriptions.websocket.limits`.
 
 Supported module options include `schema`, `context`, `plugins`, `graphiql`, `introspection`, `limits`, `subscriptions.websocket.enabled`, `subscriptions.websocket.limits`, `subscriptions.websocket.connectionInitWaitTimeoutMs`, and `subscriptions.websocket.keepAliveMs`.
 

--- a/packages/graphql/src/index.ts
+++ b/packages/graphql/src/index.ts
@@ -15,6 +15,7 @@ export type {
   GraphqlRootOutputType,
   GraphqlScalarTypeName,
   GraphqlSubscriptionsOptions,
+  GraphqlWebSocketLimitsOptions,
   GraphqlWebSocketSubscriptionsOptions,
   ResolverHandlerMetadata,
   ResolverHandlerType,

--- a/packages/graphql/src/public-api.test.ts
+++ b/packages/graphql/src/public-api.test.ts
@@ -1,4 +1,6 @@
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { beforeAll, describe, expect, expectTypeOf, it, vi } from 'vitest';
+
+import type { GraphqlWebSocketLimitsOptions } from './index.js';
 
 let graphqlPublicApi: typeof import('./index.js');
 
@@ -17,6 +19,16 @@ beforeAll(async () => {
 });
 
 describe('@fluojs/graphql public API surface', () => {
+  it('exports the documented websocket limits configuration type', () => {
+    type GivenDocumentedWebSocketLimits = {
+      maxConnections?: number;
+      maxOperationsPerConnection?: number;
+      maxPayloadBytes?: number;
+    };
+
+    expectTypeOf<GraphqlWebSocketLimitsOptions>().toEqualTypeOf<GivenDocumentedWebSocketLimits>();
+  });
+
   it('keeps websocket transport dependencies behind the enabled websocket branch', () => {
     expect(graphqlPublicApi.GraphqlModule).toHaveProperty('forRoot');
   });


### PR DESCRIPTION
## Summary

Expose the documented GraphQL WebSocket limits option type from the package root.

Linked context: Closes #3180

## Changes

- add a type-only root export for `GraphqlWebSocketLimitsOptions`
- lock the root declaration surface with a public API regression
- align EN/KO README documentation
- add a minor Changeset

## Testing

- `pnpm --filter @fluojs/graphql... build`
- `pnpm --filter @fluojs/graphql typecheck`
- `pnpm --filter ...@fluojs/graphql test` (13 files, 103 tests)
- `pnpm docs:sync-check`
- `pnpm verify:changeset-release-lane -- --lane=stable`
- exact-head contract/code/verification triad: merge

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests.