### PR TITLE
fix(studio): make file loading failure-safe

### DIFF
--- a/.changeset/tiny-seals-listen.md
+++ b/.changeset/tiny-seals-listen.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/studio': patch
+---
+
+Make static diagnostics file loading failure-safe and ensure the latest selected file wins over slower reads.

--- a/packages/studio/src/features/file-loader/ui/FileDropZone.test.ts
+++ b/packages/studio/src/features/file-loader/ui/FileDropZone.test.ts
@@ -1,0 +1,153 @@
+// @vitest-environment happy-dom
+
+import { act, createElement, useReducer } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { initialStudioState } from '../../../entities/studio/model.js';
+import { studioReducer } from '../../live-connection/model/reducer.js';
+import { FileDropZone } from './FileDropZone.js';
+
+let root: Root | undefined;
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  root?.unmount();
+  root = undefined;
+  document.body.innerHTML = '';
+});
+
+function FileDropZoneHarness() {
+  const [state, dispatch] = useReducer(studioReducer, initialStudioState);
+
+  return createElement(
+    'div',
+    undefined,
+    createElement(FileDropZone, { dispatch, state }),
+    createElement('output', { id: 'loaded-json' }, state.staticReport.rawJson),
+  );
+}
+
+function renderFileDropZone(): void {
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  document.body.innerHTML = '<div id="app"></div>';
+  const app = document.querySelector<HTMLDivElement>('#app');
+  if (!app) {
+    throw new Error('Expected the Studio app root to be rendered.');
+  }
+
+  const renderedRoot = createRoot(app);
+  root = renderedRoot;
+  act(() => {
+    renderedRoot.render(createElement(FileDropZoneHarness));
+  });
+}
+
+function getFileInput(): HTMLInputElement {
+  const fileInput = document.querySelector<HTMLInputElement>('#file-input');
+  if (!fileInput) {
+    throw new Error('Expected the Studio file input to be rendered.');
+  }
+
+  return fileInput;
+}
+
+function selectFile(fileInput: HTMLInputElement, file: File): void {
+  Object.defineProperty(fileInput, 'files', {
+    configurable: true,
+    value: [file],
+  });
+  fileInput.dispatchEvent(new Event('change', { bubbles: true }));
+}
+
+function staticPayload(componentId: string): string {
+  return JSON.stringify({
+    components: [
+      {
+        dependencies: [],
+        details: {},
+        health: { status: 'healthy' },
+        id: componentId,
+        kind: 'queue',
+        ownership: {
+          externallyManaged: false,
+          ownsResources: true,
+        },
+        readiness: {
+          critical: true,
+          status: 'ready',
+        },
+        state: 'ready',
+        telemetry: {
+          namespace: 'fluo.test',
+          tags: {},
+        },
+      },
+    ],
+    diagnostics: [],
+    generatedAt: '2026-08-30T00:00:00.000Z',
+    health: { status: 'healthy' },
+    readiness: {
+      critical: true,
+      status: 'ready',
+    },
+  });
+}
+
+describe('FileDropZone', () => {
+  it('shows a file read failure when the selected diagnostics file is unreadable', async () => {
+    // Given
+    renderFileDropZone();
+    let rejectRead = (_error: Error): void => {};
+    const unreadableFile = new File([], 'unreadable.json', { type: 'application/json' });
+    Object.defineProperty(unreadableFile, 'text', {
+      value: () => new Promise<string>((_resolve, reject) => {
+        rejectRead = reject;
+      }),
+    });
+
+    // When
+    await act(async () => {
+      selectFile(getFileInput(), unreadableFile);
+      rejectRead(new Error('File access was denied.'));
+      await Promise.resolve();
+    });
+
+    // Then
+    expect(document.querySelector('#drop-zone')?.textContent).toContain('File access was denied.');
+  });
+
+  it('keeps the most recently selected diagnostics file when older reads resolve later', async () => {
+    // Given
+    renderFileDropZone();
+    let resolveOlderRead = (_content: string): void => {};
+    const olderFile = new File([], 'older.json', { type: 'application/json' });
+    Object.defineProperty(olderFile, 'text', {
+      value: () => new Promise<string>((resolve) => {
+        resolveOlderRead = resolve;
+      }),
+    });
+    let resolveNewerRead = (_content: string): void => {};
+    const newerFile = new File([], 'newer.json', { type: 'application/json' });
+    Object.defineProperty(newerFile, 'text', {
+      value: () => new Promise<string>((resolve) => {
+        resolveNewerRead = resolve;
+      }),
+    });
+    const newerPayload = staticPayload('newer.default');
+
+    // When
+    await act(async () => {
+      selectFile(getFileInput(), olderFile);
+      selectFile(getFileInput(), newerFile);
+      resolveNewerRead(newerPayload);
+      await Promise.resolve();
+    });
+    await act(async () => {
+      resolveOlderRead(staticPayload('stale.default'));
+      await Promise.resolve();
+    });
+
+    // Then
+    expect(document.querySelector('#loaded-json')?.textContent).toBe(newerPayload);
+  });
+});

--- a/packages/studio/src/features/file-loader/ui/FileDropZone.tsx
+++ b/packages/studio/src/features/file-loader/ui/FileDropZone.tsx
@@ -1,4 +1,4 @@
-import type { ChangeEvent, Dispatch, DragEvent } from 'react';
+import { useRef, type ChangeEvent, type Dispatch, type DragEvent } from 'react';
 import { parseStudioPayload, renderMermaid } from '../../../contracts.js';
 import type { StudioAction } from '../../../entities/studio/actions.js';
 import type { StudioDashboardState } from '../../../entities/studio/model.js';
@@ -31,18 +31,31 @@ async function copyToClipboard(text: string): Promise<void> {
  * Provides File Drop Zone behavior for the Studio devtool.
  */
 export function FileDropZone({ dispatch, state }: FileDropZoneProps) {
+  const latestFileLoad = useRef(0);
   const snapshot = selectStaticSnapshot(state);
   const rawJson = state.staticReport.rawJson;
 
   async function handleFile(file: File): Promise<void> {
-    const raw = await file.text();
+    const fileLoad = latestFileLoad.current + 1;
+    latestFileLoad.current = fileLoad;
+
     try {
+      const raw = await file.text();
+      const parsed = parseStudioPayload(raw);
+      if (fileLoad !== latestFileLoad.current) {
+        return;
+      }
+
       dispatch({
         message: 'Diagnostics file loaded successfully.',
-        parsed: parseStudioPayload(raw),
+        parsed,
         type: 'static-payload',
       });
     } catch (error) {
+      if (fileLoad !== latestFileLoad.current) {
+        return;
+      }
+
       dispatch({
         message: error instanceof Error ? error.message : 'Failed to parse diagnostics file.',
         type: 'file-error',


### PR DESCRIPTION
## Summary

Make Studio static file loading surface read failures to users and ensure the latest selected artifact wins when reads complete out of order.

Linked context: Closes #3342

## Changes

- guard `File.text()` and parsing in the file-load operation
- ignore stale success and failure completions with a generation token
- add deterministic rejected-read and reverse-resolution regressions
- add an `@fluojs/studio` patch Changeset

## Testing

- dependency-closure build
- `@fluojs/studio` typecheck
- focused FileDropZone tests: 2/2
- Studio suite: 70/70
- CLI reverse-dependent suite: 444/444
- leaf contract/code/verification triad: PASS

## Release impact

- [x] This PR has consumer-visible release impact and includes a Changeset.
- [ ] This PR has no consumer-visible release impact.