### PR TITLE
Resolve #3191: Restore JWT core provider compatibility export

### DIFF
--- a/.changeset/restore-jwt-core-provider-export.md
+++ b/.changeset/restore-jwt-core-provider-export.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/jwt": patch
+---
+
+Restore the deprecated `createJwtCoreProviders(...)` root export for existing direct module composition callers.

--- a/packages/jwt/README.ko.md
+++ b/packages/jwt/README.ko.md
@@ -218,6 +218,7 @@ Lazy loading은 import-time 안전성 속성일 뿐입니다. 서명이나 검�
 
 ### Deprecated compatibility helper
 - `normalizeRefreshTokenOptions(...)`: 기존 caller의 root import 호환성만을 위해 유지됩니다. package normalization 내부 helper를 직접 호출하기보다 `JwtModule.forRoot(...)` / `JwtModule.forRootAsync(...)`와 `RefreshTokenService`를 사용하세요.
+- `createJwtCoreProviders(...)`: 기존 direct module composition caller의 root import 호환성만을 위해 유지됩니다. registration이 published module surface와 정렬되도록 `JwtModule.forRoot(...)` / `JwtModule.forRootAsync(...)`를 사용하세요.
 
 ## 관련 패키지
 

--- a/packages/jwt/README.md
+++ b/packages/jwt/README.md
@@ -218,6 +218,7 @@ Lazy loading is an import-time safety property only. It does **not** make signin
 
 ### Deprecated compatibility helpers
 - `normalizeRefreshTokenOptions(...)`: Retained only for root-import compatibility with existing callers. Prefer `JwtModule.forRoot(...)` / `JwtModule.forRootAsync(...)` plus `RefreshTokenService` instead of calling package normalization internals.
+- `createJwtCoreProviders(...)`: Retained only for root-import compatibility with existing direct module composition callers. Prefer `JwtModule.forRoot(...)` / `JwtModule.forRootAsync(...)` so registration stays aligned with the published module surface.
 
 ## Related Packages
 

--- a/packages/jwt/src/module.test.ts
+++ b/packages/jwt/src/module.test.ts
@@ -57,8 +57,8 @@ async function createJwtApplicationContext(jwtModule: Constructor) {
 }
 
 describe('JwtModule', () => {
-  it('does not expose createJwtCoreProviders from the package root', () => {
-    expect(jwtRootExports).not.toHaveProperty('createJwtCoreProviders');
+  it('keeps createJwtCoreProviders as an explicit deprecated compatibility root export', () => {
+    expect(jwtRootExports.createJwtCoreProviders).toBeTypeOf('function');
   });
 
   it('keeps refresh-token normalization as an explicit deprecated compatibility root export', () => {

--- a/packages/jwt/src/module.ts
+++ b/packages/jwt/src/module.ts
@@ -1,4 +1,4 @@
-import { Inject, type AsyncModuleOptions, type Constructor, type InjectionToken, type MaybePromise, type Token } from '@fluojs/core';
+import { Inject, type AsyncModuleOptions, type Constructor, type InjectionToken, type MaybePromise } from '@fluojs/core';
 import { defineModuleMetadata } from '@fluojs/core/internal';
 import type { Provider } from '@fluojs/di';
 
@@ -80,6 +80,21 @@ function createJwtModuleProviders(
   }
 
   return providers;
+}
+
+/**
+ * Creates the core JWT providers for advanced direct module composition.
+ *
+ * @deprecated Prefer {@link JwtModule.forRoot} or {@link JwtModule.forRootAsync} so JWT registration stays aligned with the published module surface.
+ * @param options JWT verification and signing options used for provider registration.
+ * @returns Providers for the JWT verifier, signer, facade, and optional refresh-token service.
+ */
+export function createJwtCoreProviders(options: JwtVerifierOptions): Provider[] {
+  return createJwtModuleProviders({
+    provide: JWT_OPTIONS,
+    scope: 'singleton',
+    useValue: options,
+  }, Boolean(options.refreshToken), 'singleton');
 }
 
 /**


### PR DESCRIPTION
## Summary

Restore the deprecated `createJwtCoreProviders(...)` compatibility helper through the stable `@fluojs/jwt` root export without reviving stale provider wiring.

Linked context: Closes #3191

## Changes

- restore `createJwtCoreProviders(...)` by delegating to the current provider builder
- add source TSDoc and EN/KO deprecation guidance
- replace the removal assertion with executable root-export compatibility coverage
- add a patch Changeset for `@fluojs/jwt`

## Testing

- `pnpm --filter '@fluojs/jwt...' build`
- `pnpm --filter '@fluojs/jwt' typecheck`
- `pnpm --filter '...@fluojs/jwt' test`
- `pnpm verify:public-export-tsdoc`
- changed-file Biome lint and LSP diagnostics
- manual built root import: `compatibility-root-import:PASS providers=4`

Canonical local receipt: `.omo/lanes-v4/receipts/3191-d8260139915c.md`

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated.
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed package documentation.
- [x] No platform contract surface changed.