### PR TITLE
Resolve #3174: register GraphQL middleware through module metadata

### DIFF
--- a/.changeset/register-graphql-middleware-metadata.md
+++ b/.changeset/register-graphql-middleware-metadata.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/graphql": patch
+---
+
+Fix GraphQL endpoint middleware registration through module metadata so `GraphqlModule.forRoot()` consistently dispatches requests through the application pipeline.

--- a/packages/graphql/src/module.test.ts
+++ b/packages/graphql/src/module.test.ts
@@ -3,7 +3,6 @@ import { Inject, Scope } from '@fluojs/core';
 import type { MiddlewareContext, Next } from '@fluojs/http';
 import { bootstrapModule, defineModule } from '@fluojs/runtime';
 import { APPLICATION_LOGGER, COMPILED_MODULES, HTTP_APPLICATION_ADAPTER, RUNTIME_CONTAINER } from '@fluojs/runtime/internal';
-import { bootstrapNodeApplication } from '@fluojs/runtime/node';
 import { IsInt, MinLength } from '@fluojs/validation';
 import { GraphQLObjectType, GraphQLSchema, GraphQLString, GraphQLUnionType } from 'graphql';
 import { describe, expect, it } from 'vitest';

--- a/packages/graphql/src/module.test.ts
+++ b/packages/graphql/src/module.test.ts
@@ -1,7 +1,9 @@
 import { createRequire } from 'node:module';
 import { Inject, Scope } from '@fluojs/core';
 import type { MiddlewareContext, Next } from '@fluojs/http';
-import { defineModule } from '@fluojs/runtime';
+import { bootstrapModule, defineModule } from '@fluojs/runtime';
+import { APPLICATION_LOGGER, COMPILED_MODULES, HTTP_APPLICATION_ADAPTER, RUNTIME_CONTAINER } from '@fluojs/runtime/internal';
+import { bootstrapNodeApplication } from '@fluojs/runtime/node';
 import { IsInt, MinLength } from '@fluojs/validation';
 import { GraphQLObjectType, GraphQLSchema, GraphQLString, GraphQLUnionType } from 'graphql';
 import { describe, expect, it } from 'vitest';
@@ -10,6 +12,7 @@ import { WebSocket } from 'ws';
 import { Arg, Mutation, Query, Resolver, Subscription } from './decorators.js';
 import { GraphqlModule } from './module.js';
 import { createGraphqlNetworkFixture } from './network.test-fixture.js';
+import { GraphqlLifecycleService } from './service.js';
 import { GRAPHQL_OPERATION_CONTAINER, type GraphQLContext, listOf } from './types.js';
 
 type GraphqlInstanceOf = (value: unknown, constructor: { prototype?: { [Symbol.toStringTag]?: string } }) => boolean;
@@ -431,6 +434,24 @@ class UnionOutputResolver {
 }
 
 describe('@fluojs/graphql', () => {
+  it('registers GraphQL middleware through module metadata', () => {
+    // Given: GraphQL module options for an application endpoint.
+    const graphqlModule = GraphqlModule.forRoot();
+
+    // When: the runtime compiles the generated module metadata.
+    const bootstrap = bootstrapModule(graphqlModule, {
+      validationTokens: [
+        APPLICATION_LOGGER,
+        COMPILED_MODULES,
+        HTTP_APPLICATION_ADAPTER,
+        RUNTIME_CONTAINER,
+      ],
+    });
+
+    // Then: the DI-managed lifecycle service is declared as package middleware.
+    expect(bootstrap.modules[0]?.definition.middleware).toEqual([GraphqlLifecycleService]);
+  });
+
   it('requests an operating system assigned port for network tests', async () => {
     expect(await findAvailablePort()).toBeGreaterThan(0);
   });

--- a/packages/graphql/src/module.ts
+++ b/packages/graphql/src/module.ts
@@ -38,7 +38,7 @@ export class GraphqlModule {
 
     return defineModule(GraphqlRootModule, {
       controllers: [GraphqlEndpointController],
-      middleware: [],
+      middleware: [GraphqlLifecycleService],
       providers: createGraphqlProviders(options),
     });
   }

--- a/packages/graphql/src/service.ts
+++ b/packages/graphql/src/service.ts
@@ -292,10 +292,9 @@ async function loadGraphqlDeps(): Promise<GraphqlDeps> {
  * Boots the GraphQL runtime, middleware, and subscription transports for the active adapter.
  */
 @Inject(RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER, HTTP_APPLICATION_ADAPTER, GRAPHQL_INTERNAL_MODULE_OPTIONS_TOKEN)
-export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplicationShutdown {
+export class GraphqlLifecycleService implements Middleware, OnApplicationBootstrap, OnApplicationShutdown {
   private allowedCrossRealmGraphqlObjects: WeakSet<object> | undefined;
   private graphQLErrorConstructor: typeof GraphQLErrorType | undefined;
-  private middlewareRegistered = false;
   private readonly operationContainers = new WeakMap<Request, Container>();
   private readonly requestContexts = new WeakMap<Request, GraphqlRequestContext>();
   private readonly websocketOperationContainers = new Map<object, Map<string, Container>>();
@@ -305,50 +304,48 @@ export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplic
   private subscribeGraphqlOperation: typeof subscribeGraphql | undefined;
   private yoga: YogaLike | undefined;
 
-  private readonly middleware: Middleware = {
-    handle: async (context: MiddlewareContext, next: Next) => {
-      if (!isGraphqlPath(context.request.path)) {
-        await next();
-        return;
+  async handle(context: MiddlewareContext, next: Next): Promise<void> {
+    if (!isGraphqlPath(context.request.path)) {
+      await next();
+      return;
+    }
+
+    const yoga = this.yoga;
+
+    if (!yoga) {
+      this.logger.error('GraphQL middleware was invoked before GraphQL Yoga initialization.', undefined, 'GraphqlLifecycleService');
+      context.response.setStatus(500);
+      await context.response.send({
+        errors: [{ message: 'GraphQL server not initialized.' }],
+      });
+      return;
+    }
+
+    try {
+      const fetchRequest = toFetchRequest(context.request);
+      this.requestContexts.set(fetchRequest, {
+        principal: context.requestContext.principal,
+        request: context.request,
+      });
+      try {
+        const fetchResponse = await yoga.fetch(fetchRequest);
+
+        await writeFetchResponse(fetchResponse, context.response);
+      } finally {
+        this.requestContexts.delete(fetchRequest);
+        await this.disposeOperationContainer(fetchRequest);
       }
+    } catch (error) {
+      this.logger.error('Failed to process GraphQL request.', error, 'GraphqlLifecycleService');
 
-      const yoga = this.yoga;
-
-      if (!yoga) {
-        this.logger.error('GraphQL middleware was invoked before GraphQL Yoga initialization.', undefined, 'GraphqlLifecycleService');
+      if (!context.response.committed) {
         context.response.setStatus(500);
         await context.response.send({
-          errors: [{ message: 'GraphQL server not initialized.' }],
+          errors: [{ message: 'Internal server error.' }],
         });
-        return;
       }
-
-      try {
-        const fetchRequest = toFetchRequest(context.request);
-        this.requestContexts.set(fetchRequest, {
-          principal: context.requestContext.principal,
-          request: context.request,
-        });
-        try {
-          const fetchResponse = await yoga.fetch(fetchRequest);
-
-          await writeFetchResponse(fetchResponse, context.response);
-        } finally {
-          this.requestContexts.delete(fetchRequest);
-          await this.disposeOperationContainer(fetchRequest);
-        }
-      } catch (error) {
-        this.logger.error('Failed to process GraphQL request.', error, 'GraphqlLifecycleService');
-
-        if (!context.response.committed) {
-          context.response.setStatus(500);
-          await context.response.send({
-            errors: [{ message: 'Internal server error.' }],
-          });
-        }
-      }
-    },
-  };
+    }
+  }
 
   constructor(
     private readonly runtimeContainer: Container,
@@ -359,7 +356,7 @@ export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplic
   ) {}
 
   async onApplicationBootstrap(): Promise<void> {
-    if (this.middlewareRegistered) {
+    if (this.yoga) {
       return;
     }
 
@@ -392,9 +389,6 @@ export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplic
       });
 
       await this.registerWebSocketTransport();
-
-      this.registerMiddleware();
-      this.middlewareRegistered = true;
     } catch (error) {
       try {
         await this.resetGraphqlRuntimeState();
@@ -412,8 +406,6 @@ export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplic
 
   private async resetGraphqlRuntimeState(): Promise<void> {
     await this.unregisterWebSocketTransport();
-    this.unregisterMiddleware();
-    this.middlewareRegistered = false;
     this.executeGraphqlOperation = undefined;
     this.graphQLErrorConstructor = undefined;
     this.releaseGraphqlInstanceOfPatch?.();
@@ -461,42 +453,6 @@ export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplic
 
   private discoverResolverDescriptors(): ResolverDescriptor[] {
     return discoverResolverDescriptors(this.compiledModules, this.options);
-  }
-
-  private registerMiddleware(): void {
-    for (const compiledModule of this.compiledModules) {
-      if (!compiledModule.providerTokens.has(GraphqlLifecycleService)) {
-        continue;
-      }
-
-      const middleware = compiledModule.definition.middleware ?? [];
-
-      if (!middleware.includes(this.middleware)) {
-        compiledModule.definition.middleware = [...middleware, this.middleware];
-        continue;
-      }
-
-      compiledModule.definition.middleware = [...middleware];
-    }
-  }
-
-  private unregisterMiddleware(): void {
-    for (const compiledModule of this.compiledModules) {
-      if (!compiledModule.providerTokens.has(GraphqlLifecycleService)) {
-        continue;
-      }
-
-      const middleware = compiledModule.definition.middleware ?? [];
-      const remaining = [];
-
-      for (const entry of middleware) {
-        if (entry !== this.middleware) {
-          remaining.push(entry);
-        }
-      }
-
-      compiledModule.definition.middleware = remaining;
-    }
   }
 
   private buildGraphqlContext(


### PR DESCRIPTION
## Summary

Register GraphQL middleware through module metadata and DI ownership instead of mutating compiled definitions during bootstrap.

Linked context: Closes #3174

## Changes

- declare `GraphqlLifecycleService` as module middleware and provider
- remove compiled-definition middleware mutation and unregister compensation
- preserve repeated application bootstrap and route behavior
- add a patch Changeset

## Testing

- dependency build and GraphQL typecheck
- focused middleware metadata regression
- bounded GraphQL suite: 13 files, 103 tests
- stable Changeset verifier
- exact-head contract/code/verification triad: merge

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests.