### PR TITLE
[audit][area:foundation] Seal Container child-scope construction internals (P1)

### DIFF
--- a/.changeset/seal-di-container-construction.md
+++ b/.changeset/seal-di-container-construction.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/di': major
+---
+
+Seal `Container` child-scope construction behind `createRequestScope()`. `new Container()` continues to create a root container, but direct constructor arguments now fail at runtime and are no longer accepted by the emitted declaration. Replace direct child construction with `parent.createRequestScope()`.

--- a/book/advanced/ch05-scopes.ko.md
+++ b/book/advanced/ch05-scopes.ko.md
@@ -130,11 +130,11 @@ const singleton = await root.resolve(DefaultSingleton);
 ## 5.2 Singleton caching and the root container baseline
 singleton은 기본 lifetime이지만, Fluo의 singleton 동작은 단순한 "영원히 객체 하나"보다 더 정밀합니다. 실제로는 "문서화된 override 경로가 없는 한 root singleton cache에 token별 promise 하나"에 가깝습니다.
 
-cache field는 `path:packages/di/src/container.ts:287-313`에 선언되어 있습니다. single provider 쪽의 핵심은 `singletonCache: Map<Token, Promise<unknown>>`입니다. multi provider는 `multiSingletonCache: Map<NormalizedProvider, Promise<unknown>>`를 따로 가집니다.
+cache field와 construction boundary는 `path:packages/di/src/container.ts:292-359`에 선언되어 있습니다. single provider 쪽의 핵심은 `singletonCache: Map<Token, Promise<unknown>>`입니다. multi provider는 `multiSingletonCache: Map<NormalizedProvider, Promise<unknown>>`를 따로 가집니다.
 
 컨테이너 field를 보면 singleton, request, multi provider가 서로 다른 cache map을 갖는 이유가 바로 드러납니다.
 
-`path:packages/di/src/container.ts:287-313`
+`path:packages/di/src/container.ts:292-359`
 ```typescript
 private readonly registrations = new Map<Token, NormalizedProvider>();
 private readonly multiRegistrations = new Map<Token, NormalizedProvider[]>();
@@ -156,24 +156,38 @@ private disposed = false;
 private trackedByParent = false;
 private graphRevision = 0;
 
-constructor(
-  private readonly parent?: Container,
-  private readonly requestScopeEnabled = false,
-  singletonCache?: Map<Token, Promise<unknown>>,
-) {
-  this.singletonCache = singletonCache ?? new Map<Token, Promise<unknown>>();
+private readonly parent: Container | undefined;
+private readonly requestScopeEnabled: boolean;
+
+constructor(...construction: never[]) {
+  if (construction.length > 0) {
+    throw new ContainerResolutionError(
+      'Container child-scope construction is package-owned and cannot be invoked directly.',
+      {
+        hint: 'Construct root containers with new Container() and create child scopes with container.createRequestScope().',
+      },
+    );
+  }
+
+  const childScope = Container.#childScopeConstruction;
+
+  this.parent = childScope?.parent;
+  this.requestScopeEnabled = childScope?.requestScopeEnabled ?? false;
+  this.singletonCache = childScope?.singletonCache ?? new Map<Token, Promise<unknown>>();
 }
 ```
+
+public construction surface는 의도적으로 좁습니다. caller가 사용할 수 있는 형태는 `new Container()` 하나뿐이며, `...construction: never[]` signature는 consumer가 만족시킬 수 있는 인자 타입을 남기지 않습니다. parent, request-scope, singleton-cache wiring은 package-private construction path로만 전달되므로, emitted declaration에 대한 structural cast로도 위조할 수 없습니다.
 
 이 구조 때문에 singleton cache는 token 기준이고, multi singleton cache는 개별 normalized provider 기준입니다. request cache도 같은 분리를 반복하지만 child container의 소유물이 됩니다.
 
 root container가 singleton cache state를 소유합니다.
-`path:packages/di/src/container.ts:563-572`의 `createRequestScope()`는 `this.root().singletonCache`를 넘겨 child container를 생성합니다.
+`path:packages/di/src/container.ts:604-620`의 `createRequestScope()`는 `this.root().singletonCache`를 넘겨 child container를 생성합니다.
 즉 request scope는 singleton state를 복제하지 않습니다. 공유합니다.
 
-request child 생성 코드는 그 공유를 constructor 인자로 직접 넘깁니다.
+request child 생성 코드는 그 공유를 package-private construction path로 넘깁니다.
 
-`path:packages/di/src/container.ts:563-572`
+`path:packages/di/src/container.ts:604-620`
 ```typescript
 createRequestScope(): Container {
   if (this.isDisposedInHierarchy()) {
@@ -183,11 +197,15 @@ createRequestScope(): Container {
     );
   }
 
-  return new Container(this, true, this.root().singletonCache);
+  return Container.createChildScope({
+    parent: this,
+    requestScopeEnabled: true,
+    singletonCache: this.root().singletonCache,
+  });
 }
 ```
 
-따라서 request child는 parent와 request flag를 갖지만, singleton promise map은 root의 것을 봅니다. 빈 scope shell은 즉시 추적되지 않습니다. `path:packages/di/src/container.ts:1066-1087`의 `ensureTrackedRequestScope()`와 lazy request-cache writer는 request-owned cache state가 처음 materialize될 때 child chain을 연결합니다. 이 방식은 chapter의 ownership rule을 유지하면서 descendant invalidation과 disposal이 생성된 모든 scope object가 아니라 실제 request cache를 대상으로 동작하게 합니다.
+따라서 request child는 parent와 request flag를 갖지만, singleton promise map은 root의 것을 봅니다. construction path가 package-private이므로 그 wiring에 도달하는 경로는 `createRequestScope()`뿐이며, application 코드가 다른 컨테이너의 singleton cache를 넘겨줄 수 없습니다. 빈 scope shell은 즉시 추적되지 않습니다. `path:packages/di/src/container.ts:1153-1174`의 `ensureTrackedRequestScope()`와 lazy request-cache writer는 request-owned cache state가 처음 materialize될 때 child chain을 연결합니다. 이 방식은 chapter의 ownership rule을 유지하면서 descendant invalidation과 disposal이 생성된 모든 scope object가 아니라 실제 request cache를 대상으로 동작하게 합니다.
 
 이 구조는 resolution 단계에서 다시 강제됩니다.
 `path:packages/di/src/container.ts:963-999`의 `resolveScopedOrSingletonInstance()`는 먼저 `shouldResolveFromRoot(provider)`를 검사합니다.
@@ -299,8 +317,8 @@ return cache.get(provider.provide);
 ## 5.3 Request scope is a child container, not a flag on a provider
 request lifetime은 구조적으로 모델링됩니다. 단순히 "이 provider는 자주 다시 만들어라"라는 label이 아닙니다. Fluo는 request boundary마다 child container를 실제로 만듭니다.
 
-`path:packages/di/src/container.ts:247-263`의 `createRequestScope()`는 `new Container(this, true, this.root().singletonCache)`를 호출합니다.
-이 constructor 호출 안에 세 가지 결정이 들어 있습니다. child는 parent reference를 갖습니다. request-scope enabled 상태가 됩니다. 그리고 root singleton cache를 공유합니다.
+`path:packages/di/src/container.ts:604-620`의 `createRequestScope()`는 package-private child construction path를 호출합니다.
+이 construction 안에 세 가지 결정이 들어 있습니다. child는 parent reference를 갖습니다. request-scope enabled 상태가 됩니다. 그리고 root singleton cache를 공유합니다.
 
 즉 request scope는 root container 내부의 특별한 cache bucket이 아닙니다. 자기 own `requestCache`와 `multiRequestCache`를 가진 별도 container instance입니다. 이 field들은 `path:packages/di/src/container.ts:124-127`에 선언되어 있습니다.
 

--- a/book/advanced/ch05-scopes.ko.md
+++ b/book/advanced/ch05-scopes.ko.md
@@ -185,7 +185,7 @@ root container가 singleton cache state를 소유합니다.
 `path:packages/di/src/container.ts:604-620`의 `createRequestScope()`는 `this.root().singletonCache`를 넘겨 child container를 생성합니다.
 즉 request scope는 singleton state를 복제하지 않습니다. 공유합니다.
 
-request child 생성 코드는 그 공유를 package-private construction path로 넘깁니다.
+request child 생성 코드는 그 공유를 package-private construction path로 넘깁니다. 다음 source excerpt는 `Container` 메서드 본문입니다. 여기의 `#createChildScope` 호출은 private class-member access이므로 consumer가 복사하거나 호출할 수 있는 application code가 아닙니다.
 
 `path:packages/di/src/container.ts:604-620`
 ```typescript
@@ -197,7 +197,7 @@ createRequestScope(): Container {
     );
   }
 
-  return Container.createChildScope({
+  return Container.#createChildScope({
     parent: this,
     requestScopeEnabled: true,
     singletonCache: this.root().singletonCache,

--- a/book/advanced/ch05-scopes.ko.md
+++ b/book/advanced/ch05-scopes.ko.md
@@ -130,11 +130,11 @@ const singleton = await root.resolve(DefaultSingleton);
 ## 5.2 Singleton caching and the root container baseline
 singleton은 기본 lifetime이지만, Fluo의 singleton 동작은 단순한 "영원히 객체 하나"보다 더 정밀합니다. 실제로는 "문서화된 override 경로가 없는 한 root singleton cache에 token별 promise 하나"에 가깝습니다.
 
-cache field와 construction boundary는 `path:packages/di/src/container.ts:292-359`에 선언되어 있습니다. single provider 쪽의 핵심은 `singletonCache: Map<Token, Promise<unknown>>`입니다. multi provider는 `multiSingletonCache: Map<NormalizedProvider, Promise<unknown>>`를 따로 가집니다.
+cache field와 construction boundary는 `path:packages/di/src/container.ts:296-347`에 선언되어 있습니다. single provider 쪽의 핵심은 `singletonCache: Map<Token, Promise<unknown>>`입니다. multi provider는 `multiSingletonCache: Map<NormalizedProvider, Promise<unknown>>`를 따로 가집니다.
 
 컨테이너 field를 보면 singleton, request, multi provider가 서로 다른 cache map을 갖는 이유가 바로 드러납니다.
 
-`path:packages/di/src/container.ts:292-359`
+`path:packages/di/src/container.ts:296-347`
 ```typescript
 private readonly registrations = new Map<Token, NormalizedProvider>();
 private readonly multiRegistrations = new Map<Token, NormalizedProvider[]>();
@@ -182,12 +182,12 @@ public construction surface는 의도적으로 좁습니다. caller가 사용할
 이 구조 때문에 singleton cache는 token 기준이고, multi singleton cache는 개별 normalized provider 기준입니다. request cache도 같은 분리를 반복하지만 child container의 소유물이 됩니다.
 
 root container가 singleton cache state를 소유합니다.
-`path:packages/di/src/container.ts:604-620`의 `createRequestScope()`는 `this.root().singletonCache`를 넘겨 child container를 생성합니다.
+`path:packages/di/src/container.ts:609-622`의 `createRequestScope()`는 `this.root().singletonCache`를 넘겨 child container를 생성합니다.
 즉 request scope는 singleton state를 복제하지 않습니다. 공유합니다.
 
 request child 생성 코드는 그 공유를 package-private construction path로 넘깁니다. 다음 source excerpt는 `Container` 메서드 본문입니다. 여기의 `#createChildScope` 호출은 private class-member access이므로 consumer가 복사하거나 호출할 수 있는 application code가 아닙니다.
 
-`path:packages/di/src/container.ts:604-620`
+`path:packages/di/src/container.ts:609-622`
 ```typescript
 createRequestScope(): Container {
   if (this.isDisposedInHierarchy()) {
@@ -205,19 +205,19 @@ createRequestScope(): Container {
 }
 ```
 
-따라서 request child는 parent와 request flag를 갖지만, singleton promise map은 root의 것을 봅니다. construction path가 package-private이므로 그 wiring에 도달하는 경로는 `createRequestScope()`뿐이며, application 코드가 다른 컨테이너의 singleton cache를 넘겨줄 수 없습니다. 빈 scope shell은 즉시 추적되지 않습니다. `path:packages/di/src/container.ts:1153-1174`의 `ensureTrackedRequestScope()`와 lazy request-cache writer는 request-owned cache state가 처음 materialize될 때 child chain을 연결합니다. 이 방식은 chapter의 ownership rule을 유지하면서 descendant invalidation과 disposal이 생성된 모든 scope object가 아니라 실제 request cache를 대상으로 동작하게 합니다.
+따라서 request child는 parent와 request flag를 갖지만, singleton promise map은 root의 것을 봅니다. construction path가 package-private이므로 그 wiring에 도달하는 경로는 `createRequestScope()`뿐이며, application 코드가 다른 컨테이너의 singleton cache를 넘겨줄 수 없습니다. 빈 scope shell은 즉시 추적되지 않습니다. `path:packages/di/src/container.ts:1144-1153`의 `ensureTrackedRequestScope()`와 `path:packages/di/src/container.ts:1155-1166`의 lazy request-cache writer는 request-owned cache state가 처음 materialize될 때 child chain을 연결합니다. 이 방식은 chapter의 ownership rule을 유지하면서 descendant invalidation과 disposal이 생성된 모든 scope object가 아니라 실제 request cache를 대상으로 동작하게 합니다.
 
 이 구조는 resolution 단계에서 다시 강제됩니다.
-`path:packages/di/src/container.ts:963-999`의 `resolveScopedOrSingletonInstance()`는 먼저 `shouldResolveFromRoot(provider)`를 검사합니다.
-그리고 `path:packages/di/src/container.ts:1013-1019`의 helper는 provider가 default-scope이고, 현재 container가 request-scoped이며, provider가 local registration이 아닐 때 true를 반환합니다. 그 경우 child는 root로 위임합니다.
+`path:packages/di/src/container.ts:1032-1041`의 `resolveScopedOrSingletonInstance()`는 먼저 `cacheOwnerFor(provider)`에 cache를 소유할 container를 묻습니다.
+`path:packages/di/src/container.ts:1087-1098`의 `cacheOwnerFor()`는 local default provider를 request child에 남기고 inherited default provider를 parent/root cache owner로 위임합니다.
 
 실제 cache map 선택은 `cacheFor()`가 합니다.
-`path:packages/di/src/container.ts:1113-1134`가 핵심 규칙을 보여 줍니다.
+`path:packages/di/src/container.ts:1191-1213`가 핵심 규칙을 보여 줍니다.
 default-scope provider는 원칙적으로 root `singletonCache`를 사용합니다. 단 request child에 locally registered된 경우만 예외적으로 request cache를 사용합니다. 메서드 주석이 이 예외를 일부러 footgun으로 문서화하는 이유도 여기에 있습니다.
 
 cache 선택 규칙은 한 번만 자세히 보겠습니다. 뒤의 request, override, disposal 문단은 이 발췌를 전제로 recap만 붙입니다.
 
-`path:packages/di/src/container.ts:1113-1134`
+`path:packages/di/src/container.ts:1191-1213`
 ```typescript
 private cacheFor(provider: NormalizedProvider): Map<Token, Promise<unknown>> {
   if (provider.scope === Scope.DEFAULT) {
@@ -317,16 +317,16 @@ return cache.get(provider.provide);
 ## 5.3 Request scope is a child container, not a flag on a provider
 request lifetime은 구조적으로 모델링됩니다. 단순히 "이 provider는 자주 다시 만들어라"라는 label이 아닙니다. Fluo는 request boundary마다 child container를 실제로 만듭니다.
 
-`path:packages/di/src/container.ts:604-620`의 `createRequestScope()`는 package-private child construction path를 호출합니다.
+`path:packages/di/src/container.ts:609-622`의 `createRequestScope()`는 package-private child construction path를 호출합니다.
 이 construction 안에 세 가지 결정이 들어 있습니다. child는 parent reference를 갖습니다. request-scope enabled 상태가 됩니다. 그리고 root singleton cache를 공유합니다.
 
-즉 request scope는 root container 내부의 특별한 cache bucket이 아닙니다. 자기 own `requestCache`와 `multiRequestCache`를 가진 별도 container instance입니다. 이 field들은 `path:packages/di/src/container.ts:124-127`에 선언되어 있습니다.
+즉 request scope는 root container 내부의 특별한 cache bucket이 아닙니다. 자기 own `requestCache`와 `multiRequestCache`를 가진 별도 container instance입니다. 이 field들은 `path:packages/di/src/container.ts:302-304`에 선언되어 있습니다.
 
-request-only resolution은 `cacheFor()`와 `multiCacheFor()`에서 강제됩니다. provider scope가 `request`인데 `requestScopeEnabled`가 false이면, 컨테이너는 `container.createRequestScope()`를 사용하라는 힌트와 함께 `RequestScopeResolutionError`를 던집니다. 코드는 `path:packages/di/src/container.ts:633-645`와 `path:packages/di/src/container.ts:656-668`에 있습니다.
+request-only resolution은 `cacheFor()`와 `multiCacheFor()`에서 강제됩니다. provider scope가 `request`인데 `requestScopeEnabled`가 false이면, 컨테이너는 `container.createRequestScope()`를 사용하라는 힌트와 함께 `RequestScopeResolutionError`를 던집니다. 코드는 `path:packages/di/src/container.ts:1191-1213`와 `path:packages/di/src/container.ts:1214-1236`에 있습니다.
 
 위 `cacheFor()` 발췌가 single provider의 request guard를 이미 보여 주므로 여기서는 multi provider 쪽만 보강하면 충분합니다.
 
-`path:packages/di/src/container.ts:647-668`
+`path:packages/di/src/container.ts:1214-1236`
 ```typescript
 private multiCacheFor(provider: NormalizedProvider): Map<NormalizedProvider, Promise<unknown>> {
   if (provider.scope === Scope.DEFAULT) {
@@ -348,7 +348,7 @@ private multiCacheFor(provider: NormalizedProvider): Map<NormalizedProvider, Pro
     );
   }
 
-  return this.multiRequestCache;
+  return this.multiRequestCacheForWrite();
 }
 ```
 

--- a/book/advanced/ch05-scopes.ko.md
+++ b/book/advanced/ch05-scopes.ko.md
@@ -331,7 +331,7 @@ request-only resolution은 `cacheFor()`와 `multiCacheFor()`에서 강제됩니�
 private multiCacheFor(provider: NormalizedProvider): Map<NormalizedProvider, Promise<unknown>> {
   if (provider.scope === Scope.DEFAULT) {
     if (this.requestScopeEnabled && this.hasLocalMultiProvider(provider)) {
-      return this.multiRequestCache;
+      return this.multiRequestCacheForWrite();
     }
 
     return this.root().multiSingletonCache;

--- a/book/advanced/ch05-scopes.ko.md
+++ b/book/advanced/ch05-scopes.ko.md
@@ -320,7 +320,7 @@ request lifetime은 구조적으로 모델링됩니다. 단순히 "이 provider�
 `path:packages/di/src/container.ts:609-622`의 `createRequestScope()`는 package-private child construction path를 호출합니다.
 이 construction 안에 세 가지 결정이 들어 있습니다. child는 parent reference를 갖습니다. request-scope enabled 상태가 됩니다. 그리고 root singleton cache를 공유합니다.
 
-즉 request scope는 root container 내부의 특별한 cache bucket이 아닙니다. 자기 own `requestCache`와 `multiRequestCache`를 가진 별도 container instance입니다. 이 field들은 `path:packages/di/src/container.ts:302-304`에 선언되어 있습니다.
+즉 request scope는 root container 내부의 특별한 cache bucket이 아닙니다. 자기 own `requestCache`와 `multiRequestCache`를 가진 별도 container instance입니다. 이 field들은 `path:packages/di/src/container.ts:300-301`에 선언되어 있습니다.
 
 request-only resolution은 `cacheFor()`와 `multiCacheFor()`에서 강제됩니다. provider scope가 `request`인데 `requestScopeEnabled`가 false이면, 컨테이너는 `container.createRequestScope()`를 사용하라는 힌트와 함께 `RequestScopeResolutionError`를 던집니다. 코드는 `path:packages/di/src/container.ts:1191-1213`와 `path:packages/di/src/container.ts:1214-1236`에 있습니다.
 

--- a/book/advanced/ch05-scopes.md
+++ b/book/advanced/ch05-scopes.md
@@ -130,11 +130,11 @@ The rest of this chapter traces how this one line expands into real cache behavi
 ## 5.2 Singleton caching and the root container baseline
 Singleton is the default lifetime, but Fluo's singleton behavior is more precise than simply "one object forever." In practice, it is closer to "one promise per token in the root singleton cache unless there is a documented override path."
 
-The cache fields are declared in `path:packages/di/src/container.ts:287-313`. The key field for single providers is `singletonCache: Map<Token, Promise<unknown>>`. Multi providers have a separate `multiSingletonCache: Map<NormalizedProvider, Promise<unknown>>`.
+The cache fields and construction boundary are declared in `path:packages/di/src/container.ts:292-359`. The key field for single providers is `singletonCache: Map<Token, Promise<unknown>>`. Multi providers have a separate `multiSingletonCache: Map<NormalizedProvider, Promise<unknown>>`.
 
 Looking at the container fields immediately shows why singleton, request, and multi providers use different cache maps.
 
-`path:packages/di/src/container.ts:287-313`
+`path:packages/di/src/container.ts:292-359`
 ```typescript
 private readonly registrations = new Map<Token, NormalizedProvider>();
 private readonly multiRegistrations = new Map<Token, NormalizedProvider[]>();
@@ -156,24 +156,38 @@ private disposed = false;
 private trackedByParent = false;
 private graphRevision = 0;
 
-constructor(
-  private readonly parent?: Container,
-  private readonly requestScopeEnabled = false,
-  singletonCache?: Map<Token, Promise<unknown>>,
-) {
-  this.singletonCache = singletonCache ?? new Map<Token, Promise<unknown>>();
+private readonly parent: Container | undefined;
+private readonly requestScopeEnabled: boolean;
+
+constructor(...construction: never[]) {
+  if (construction.length > 0) {
+    throw new ContainerResolutionError(
+      'Container child-scope construction is package-owned and cannot be invoked directly.',
+      {
+        hint: 'Construct root containers with new Container() and create child scopes with container.createRequestScope().',
+      },
+    );
+  }
+
+  const childScope = Container.#childScopeConstruction;
+
+  this.parent = childScope?.parent;
+  this.requestScopeEnabled = childScope?.requestScopeEnabled ?? false;
+  this.singletonCache = childScope?.singletonCache ?? new Map<Token, Promise<unknown>>();
 }
 ```
+
+The public construction surface is deliberately narrow. `new Container()` is the only supported caller-facing form, and the `...construction: never[]` signature leaves no argument type a consumer can satisfy. Parent, request-scope, and singleton-cache wiring travel through a package-private construction path, so a structural cast against the emitted declaration cannot forge one.
 
 Because of this structure, the singleton cache is keyed by token, while the multi singleton cache is keyed by each normalized provider. The request caches repeat the same separation, but they are owned by the child container.
 
 The root container owns singleton cache state.
-`createRequestScope()` in `path:packages/di/src/container.ts:563-572` creates the child container by passing `this.root().singletonCache`.
+`createRequestScope()` in `path:packages/di/src/container.ts:604-620` creates the child container by handing it `this.root().singletonCache`.
 So request scope does not copy singleton state. It shares it.
 
-The request child creation code passes that shared state directly as a constructor argument.
+The request child creation code passes that shared state through the package-private construction path.
 
-`path:packages/di/src/container.ts:563-572`
+`path:packages/di/src/container.ts:604-620`
 ```typescript
 createRequestScope(): Container {
   if (this.isDisposedInHierarchy()) {
@@ -183,11 +197,15 @@ createRequestScope(): Container {
     );
   }
 
-  return new Container(this, true, this.root().singletonCache);
+  return Container.createChildScope({
+    parent: this,
+    requestScopeEnabled: true,
+    singletonCache: this.root().singletonCache,
+  });
 }
 ```
 
-A request child therefore has a parent and the request flag, but it sees the root's singleton promise map. Empty scope shells are not tracked immediately. `ensureTrackedRequestScope()` and the lazy request-cache writers in `path:packages/di/src/container.ts:1066-1087` attach the child chain when request-owned cache state is first materialized. This preserves the chapter's ownership rule while making descendant invalidation and disposal operate on live request caches rather than every scope object ever created.
+A request child therefore has a parent and the request flag, but it sees the root's singleton promise map. Because the construction path is package-private, `createRequestScope()` is the only way to reach that wiring; application code cannot hand a container someone else's singleton cache. Empty scope shells are not tracked immediately. `ensureTrackedRequestScope()` and the lazy request-cache writers in `path:packages/di/src/container.ts:1153-1174` attach the child chain when request-owned cache state is first materialized. This preserves the chapter's ownership rule while making descendant invalidation and disposal operate on live request caches rather than every scope object ever created.
 
 The resolution step enforces the same structure again.
 `resolveScopedOrSingletonInstance()` in `path:packages/di/src/container.ts:963-999` first checks `shouldResolveFromRoot(provider)`.
@@ -299,8 +317,8 @@ Because `cache.set()` appears before `await`, concurrent resolves share the same
 ## 5.3 Request scope is a child container, not a flag on a provider
 Request lifetime is modeled structurally. It is not just a label that means "create this provider often." Fluo creates a real child container for each request boundary.
 
-`createRequestScope()` in `path:packages/di/src/container.ts:247-263` calls `new Container(this, true, this.root().singletonCache)`.
-That constructor call contains three decisions. The child has a parent reference. It has request-scope enabled. It shares the root singleton cache.
+`createRequestScope()` in `path:packages/di/src/container.ts:604-620` calls the package-private child construction path.
+That construction contains three decisions. The child has a parent reference. It has request-scope enabled. It shares the root singleton cache.
 
 So request scope is not a special cache bucket inside the root container. It is a separate container instance with its own `requestCache` and `multiRequestCache`. These fields are declared in `path:packages/di/src/container.ts:124-127`.
 

--- a/book/advanced/ch05-scopes.md
+++ b/book/advanced/ch05-scopes.md
@@ -320,7 +320,7 @@ Request lifetime is modeled structurally. It is not just a label that means "cre
 `createRequestScope()` in `path:packages/di/src/container.ts:609-622` calls the package-private child construction path.
 That construction contains three decisions. The child has a parent reference. It has request-scope enabled. It shares the root singleton cache.
 
-So request scope is not a special cache bucket inside the root container. It is a separate container instance with its own `requestCache` and `multiRequestCache`. These fields are declared in `path:packages/di/src/container.ts:302-304`.
+So request scope is not a special cache bucket inside the root container. It is a separate container instance with its own `requestCache` and `multiRequestCache`. These fields are declared in `path:packages/di/src/container.ts:300-301`.
 
 Request-only resolution is enforced in `cacheFor()` and `multiCacheFor()`. If the provider scope is `request` and `requestScopeEnabled` is false, the container throws `RequestScopeResolutionError` with a hint to use `container.createRequestScope()`. The code is in `path:packages/di/src/container.ts:1191-1213` and `path:packages/di/src/container.ts:1214-1236`.
 

--- a/book/advanced/ch05-scopes.md
+++ b/book/advanced/ch05-scopes.md
@@ -185,7 +185,7 @@ The root container owns singleton cache state.
 `createRequestScope()` in `path:packages/di/src/container.ts:604-620` creates the child container by handing it `this.root().singletonCache`.
 So request scope does not copy singleton state. It shares it.
 
-The request child creation code passes that shared state through the package-private construction path.
+The request child creation code passes that shared state through the package-private construction path. The following source excerpt is the body of a `Container` method: its `#createChildScope` call is a private class-member access, not application code that consumers can copy or invoke.
 
 `path:packages/di/src/container.ts:604-620`
 ```typescript
@@ -197,7 +197,7 @@ createRequestScope(): Container {
     );
   }
 
-  return Container.createChildScope({
+  return Container.#createChildScope({
     parent: this,
     requestScopeEnabled: true,
     singletonCache: this.root().singletonCache,

--- a/book/advanced/ch05-scopes.md
+++ b/book/advanced/ch05-scopes.md
@@ -331,7 +331,7 @@ The earlier `cacheFor()` excerpt already showed the request guard for single pro
 private multiCacheFor(provider: NormalizedProvider): Map<NormalizedProvider, Promise<unknown>> {
   if (provider.scope === Scope.DEFAULT) {
     if (this.requestScopeEnabled && this.hasLocalMultiProvider(provider)) {
-      return this.multiRequestCache;
+      return this.multiRequestCacheForWrite();
     }
 
     return this.root().multiSingletonCache;

--- a/book/advanced/ch05-scopes.md
+++ b/book/advanced/ch05-scopes.md
@@ -130,11 +130,11 @@ The rest of this chapter traces how this one line expands into real cache behavi
 ## 5.2 Singleton caching and the root container baseline
 Singleton is the default lifetime, but Fluo's singleton behavior is more precise than simply "one object forever." In practice, it is closer to "one promise per token in the root singleton cache unless there is a documented override path."
 
-The cache fields and construction boundary are declared in `path:packages/di/src/container.ts:292-359`. The key field for single providers is `singletonCache: Map<Token, Promise<unknown>>`. Multi providers have a separate `multiSingletonCache: Map<NormalizedProvider, Promise<unknown>>`.
+The cache fields and construction boundary are declared in `path:packages/di/src/container.ts:296-347`. The key field for single providers is `singletonCache: Map<Token, Promise<unknown>>`. Multi providers have a separate `multiSingletonCache: Map<NormalizedProvider, Promise<unknown>>`.
 
 Looking at the container fields immediately shows why singleton, request, and multi providers use different cache maps.
 
-`path:packages/di/src/container.ts:292-359`
+`path:packages/di/src/container.ts:296-347`
 ```typescript
 private readonly registrations = new Map<Token, NormalizedProvider>();
 private readonly multiRegistrations = new Map<Token, NormalizedProvider[]>();
@@ -182,12 +182,12 @@ The public construction surface is deliberately narrow. `new Container()` is the
 Because of this structure, the singleton cache is keyed by token, while the multi singleton cache is keyed by each normalized provider. The request caches repeat the same separation, but they are owned by the child container.
 
 The root container owns singleton cache state.
-`createRequestScope()` in `path:packages/di/src/container.ts:604-620` creates the child container by handing it `this.root().singletonCache`.
+`createRequestScope()` in `path:packages/di/src/container.ts:609-622` creates the child container by handing it `this.root().singletonCache`.
 So request scope does not copy singleton state. It shares it.
 
 The request child creation code passes that shared state through the package-private construction path. The following source excerpt is the body of a `Container` method: its `#createChildScope` call is a private class-member access, not application code that consumers can copy or invoke.
 
-`path:packages/di/src/container.ts:604-620`
+`path:packages/di/src/container.ts:609-622`
 ```typescript
 createRequestScope(): Container {
   if (this.isDisposedInHierarchy()) {
@@ -205,19 +205,19 @@ createRequestScope(): Container {
 }
 ```
 
-A request child therefore has a parent and the request flag, but it sees the root's singleton promise map. Because the construction path is package-private, `createRequestScope()` is the only way to reach that wiring; application code cannot hand a container someone else's singleton cache. Empty scope shells are not tracked immediately. `ensureTrackedRequestScope()` and the lazy request-cache writers in `path:packages/di/src/container.ts:1153-1174` attach the child chain when request-owned cache state is first materialized. This preserves the chapter's ownership rule while making descendant invalidation and disposal operate on live request caches rather than every scope object ever created.
+A request child therefore has a parent and the request flag, but it sees the root's singleton promise map. Because the construction path is package-private, `createRequestScope()` is the only way to reach that wiring; application code cannot hand a container someone else's singleton cache. Empty scope shells are not tracked immediately. `ensureTrackedRequestScope()` in `path:packages/di/src/container.ts:1144-1153` and the lazy request-cache writers in `path:packages/di/src/container.ts:1155-1166` attach the child chain when request-owned cache state is first materialized. This preserves the chapter's ownership rule while making descendant invalidation and disposal operate on live request caches rather than every scope object ever created.
 
 The resolution step enforces the same structure again.
-`resolveScopedOrSingletonInstance()` in `path:packages/di/src/container.ts:963-999` first checks `shouldResolveFromRoot(provider)`.
-Then the helper in `path:packages/di/src/container.ts:1013-1019` returns true when the provider has default scope, the current container is request-scoped, and the provider is not a local registration. In that case, the child delegates to the root.
+`resolveScopedOrSingletonInstance()` in `path:packages/di/src/container.ts:1032-1041` first asks `cacheOwnerFor(provider)` for the container that owns the cache.
+`cacheOwnerFor()` in `path:packages/di/src/container.ts:1087-1098` keeps local default providers in the request child and delegates inherited default providers toward the parent/root cache owner.
 
 The actual cache map is selected by `cacheFor()`.
-`path:packages/di/src/container.ts:1113-1134` shows the core rules.
+`path:packages/di/src/container.ts:1191-1213` shows the core rules.
 A default-scope provider normally uses the root `singletonCache`. The one exception is a provider locally registered in a request child, which uses the request cache. The method comment documents this exception as a footgun on purpose.
 
 We will inspect the cache selection rules closely once. The request, override, and disposal sections later recap from this excerpt.
 
-`path:packages/di/src/container.ts:1113-1134`
+`path:packages/di/src/container.ts:1191-1213`
 ```typescript
 private cacheFor(provider: NormalizedProvider): Map<Token, Promise<unknown>> {
   if (provider.scope === Scope.DEFAULT) {
@@ -317,16 +317,16 @@ Because `cache.set()` appears before `await`, concurrent resolves share the same
 ## 5.3 Request scope is a child container, not a flag on a provider
 Request lifetime is modeled structurally. It is not just a label that means "create this provider often." Fluo creates a real child container for each request boundary.
 
-`createRequestScope()` in `path:packages/di/src/container.ts:604-620` calls the package-private child construction path.
+`createRequestScope()` in `path:packages/di/src/container.ts:609-622` calls the package-private child construction path.
 That construction contains three decisions. The child has a parent reference. It has request-scope enabled. It shares the root singleton cache.
 
-So request scope is not a special cache bucket inside the root container. It is a separate container instance with its own `requestCache` and `multiRequestCache`. These fields are declared in `path:packages/di/src/container.ts:124-127`.
+So request scope is not a special cache bucket inside the root container. It is a separate container instance with its own `requestCache` and `multiRequestCache`. These fields are declared in `path:packages/di/src/container.ts:302-304`.
 
-Request-only resolution is enforced in `cacheFor()` and `multiCacheFor()`. If the provider scope is `request` and `requestScopeEnabled` is false, the container throws `RequestScopeResolutionError` with a hint to use `container.createRequestScope()`. The code is in `path:packages/di/src/container.ts:633-645` and `path:packages/di/src/container.ts:656-668`.
+Request-only resolution is enforced in `cacheFor()` and `multiCacheFor()`. If the provider scope is `request` and `requestScopeEnabled` is false, the container throws `RequestScopeResolutionError` with a hint to use `container.createRequestScope()`. The code is in `path:packages/di/src/container.ts:1191-1213` and `path:packages/di/src/container.ts:1214-1236`.
 
 The earlier `cacheFor()` excerpt already showed the request guard for single providers, so it is enough to add the multi provider side here.
 
-`path:packages/di/src/container.ts:647-668`
+`path:packages/di/src/container.ts:1214-1236`
 ```typescript
 private multiCacheFor(provider: NormalizedProvider): Map<NormalizedProvider, Promise<unknown>> {
   if (provider.scope === Scope.DEFAULT) {
@@ -348,7 +348,7 @@ private multiCacheFor(provider: NormalizedProvider): Map<NormalizedProvider, Pro
     );
   }
 
-  return this.multiRequestCache;
+  return this.multiRequestCacheForWrite();
 }
 ```
 

--- a/packages/di/README.ko.md
+++ b/packages/di/README.ko.md
@@ -102,6 +102,30 @@ direct `child.dispose()`는 이제 실패한 attempt를 포함해 attempt가 set
 
 테스트나 request-local 경계에서 기존 등록을 의도적으로 교체해야 할 때는 `override(...providers)`를 사용합니다. override는 각 토큰의 현재 provider set을 교체하고 현재 컨테이너와 이미 materialize된 request-scope 자식의 cached instance를 무효화하며, 다음 replacement resolution이 계속되기 전에 오래된 instance의 dispose가 끝나도록 보장합니다. multi provider override는 해당 토큰의 전체 multi-provider set을 교체하므로 필요한 replacement provider를 한 번에 모두 전달하세요. 같은 토큰에 single replacement와 multi replacement를 한 override 호출에서 섞으면 모호한 교체로 보고 거부합니다.
 
+### 컨테이너 생성 경계
+
+공개된 생성 형태는 `new Container()` 하나뿐이며, 항상 자신의 singleton cache를 소유하는 루트 컨테이너를 만듭니다. child request scope는 package가 소유합니다. parent 연결, request-scope flag, singleton cache 공유는 `createRequestScope()`로만 도달할 수 있는 private construction path입니다.
+
+```ts
+const root = new Container();
+const requestScope = root.createRequestScope();
+```
+
+constructor 인자 전달은 거부됩니다. emitted declaration은 할당 가능한 인자 타입을 받지 않으며, 런타임에서도 caller가 인자를 넘기면 cache ownership을 빌린 컨테이너를 만드는 대신 `ContainerResolutionError`를 던집니다.
+
+```ts
+// 거부됨: child-scope wiring은 package가 소유합니다.
+Reflect.construct(Container, [root]);
+```
+
+### 2.x에서 3.x로 컨테이너 생성 마이그레이션
+
+`@fluojs/di` 2.x에서는 caller가 child wiring을 직접 넘기는 것이 지원되는 workflow가 아니었음에도, emitted `Container` declaration이 `parent`, `requestScopeEnabled`, `singletonCache` constructor parameter를 노출했습니다. 3.x에서는 이 surface를 봉쇄합니다. constructor는 인자를 받지 않으며, 인자를 전달하면 `ContainerResolutionError`를 던집니다.
+
+인자 없는 `new Container()`와 `createRequestScope()`는 그대로이므로 지원되는 코드는 마이그레이션이 필요 없습니다. child 컨테이너를 직접 생성했다면 해당 호출을 `parent.createRequestScope()`로 바꾸세요. 동일한 parent 연결, request-scope flag, 공유 root singleton cache를 제공하면서 disposal ownership도 그대로 유지합니다.
+
+실행 가능한 근거는 `packages/di/src/container-construction-boundary.test.ts`에 있습니다.
+
 ### request scope 분리
 
 ```ts
@@ -199,12 +223,12 @@ it('uses a mock database', async () => {
 
 | Surface | 종류 | 설명 |
 |---|---|---|
-| `Container` | Root export | 메인 DI 컨테이너 클래스입니다. |
+| `Container` | Root export | 메인 DI 컨테이너 클래스입니다. `new Container()`는 인자를 받지 않고 루트 컨테이너를 만들며, child request scope는 package가 소유하고 `createRequestScope()`로 생성합니다. constructor 인자를 전달하면 `ContainerResolutionError`를 던집니다. |
 | `container.register(...providers)` | `Container` instance method | 하나 이상의 프로바이더를 등록합니다. |
 | `container.override(...providers)` | `Container` instance method | 기존 provider를 교체하고 cached instance를 무효화하며 다음 replacement resolution이 계속되기 전에 오래된 instance dispose가 settle되도록 보장합니다. |
 | `container.resolve<T>(token)` | `Container` instance method | 토큰을 인스턴스로 비동기 해석합니다. |
 | `container.inspectResolutionState()` | `Container` instance method | snapshot read-only map view, frozen provider record, controlled cache adoption을 통해 cache ownership을 보존해야 하는 testing/tooling helper를 위한 지원 대상 framework-owned container introspection seam을 노출합니다. 애플리케이션 코드는 `has(...)`와 `resolve(...)`를 우선 사용하세요. |
-| `container.createRequestScope()` | `Container` instance method | 요청 스코프 의존성을 위한 자식 컨테이너를 생성합니다. |
+| `container.createRequestScope()` | `Container` instance method | 요청 스코프 의존성을 위한 자식 컨테이너를 생성합니다. parent에 연결되고 request scope가 활성화되며 root singleton cache를 공유하는 컨테이너를 얻는 유일한 지원 경로입니다. |
 | `container.has(token)` | `Container` instance method | 컨테이너나 부모에 토큰이 등록되어 있는지 확인합니다. |
 | `container.hasRequestScopedDependency(token)` | `Container` instance method | 토큰 해석 시 provider 그래프에 request-scoped 의존성이나 순환이 있어 request-scope 컨테이너가 필요할 수 있는지 확인합니다. |
 | `container.dispose()` | `Container` instance method | parent/root cache보다 request child를 먼저 정리하고 active 시도를 공유하며, 이후 명시적 호출에서 실패한 `onDestroy()` hook만 재시도합니다. |

--- a/packages/di/README.md
+++ b/packages/di/README.md
@@ -101,6 +101,30 @@ Direct `child.dispose()` now detaches the request child from its parent after th
 
 Use `override(...providers)` when a test or request-local boundary needs to replace existing registrations deliberately. Overrides replace the current provider set for each token, invalidate cached instances in the current container and already-materialized request-scope descendants, and dispose stale instances before the next replacement resolution continues. Multi-provider overrides replace the full multi-provider set for that token, so pass every replacement provider together; mixing single and multi replacements for the same token in one override call is rejected as ambiguous.
 
+### Container Construction Boundary
+
+`new Container()` is the only supported public construction form, and it always creates a root container that owns its own singleton cache. Child request scopes are package-owned: parent linkage, the request-scope flag, and singleton-cache sharing use a private construction path reachable only through `createRequestScope()`.
+
+```typescript
+const root = new Container();
+const requestScope = root.createRequestScope();
+```
+
+Supplying constructor arguments is rejected. The emitted declaration accepts no assignable argument type, and at runtime a caller-supplied argument throws `ContainerResolutionError` rather than producing a container with borrowed cache ownership.
+
+```typescript
+// Rejected: child-scope wiring is package-owned.
+Reflect.construct(Container, [root]);
+```
+
+### Migrating container construction from 2.x to 3.x
+
+In `@fluojs/di` 2.x, the emitted `Container` declaration exposed `parent`, `requestScopeEnabled`, and `singletonCache` constructor parameters even though caller-supplied child wiring was never a supported application workflow. In 3.x that surface is sealed: the constructor accepts no arguments, and passing any argument throws `ContainerResolutionError`.
+
+Zero-argument `new Container()` and `createRequestScope()` are unchanged, so supported code needs no migration. If you constructed child containers directly, replace that call with `parent.createRequestScope()`, which supplies the same parent linkage, request-scope flag, and shared root singleton cache while keeping disposal ownership intact.
+
+Executable evidence lives in `packages/di/src/container-construction-boundary.test.ts`.
+
 ### Request Scoping
 Isolated containers can be created to handle per-request state without polluting the root container.
 
@@ -199,12 +223,12 @@ Ensure all required providers are registered in the container. If you use `creat
 
 | Surface | Kind | Description |
 |---|---|---|
-| `Container` | Root export | The main DI container class. |
+| `Container` | Root export | The main DI container class. `new Container()` takes no arguments and creates a root container; child request scopes are package-owned and created with `createRequestScope()`. Supplying constructor arguments throws `ContainerResolutionError`. |
 | `container.register(...providers)` | `Container` instance method | Registers one or more providers. |
 | `container.override(...providers)` | `Container` instance method | Replaces existing providers, invalidates cached instances, and ensures stale instance disposal settles before the next replacement resolution continues. |
 | `container.resolve<T>(token)` | `Container` instance method | Asynchronously resolves a token to an instance. |
 | `container.inspectResolutionState()` | `Container` instance method | Exposes the supported framework-owned container introspection seam for testing/tooling helpers that must preserve cache ownership through snapshot read-only map views, frozen provider records, and controlled cache adoption. Prefer `has(...)` and `resolve(...)` for application code. |
-| `container.createRequestScope()` | `Container` instance method | Creates a child container for request-scoped dependencies. |
+| `container.createRequestScope()` | `Container` instance method | Creates a child container for request-scoped dependencies. This is the only supported path to parent-linked, request-scope-enabled containers that share the root singleton cache. |
 | `container.has(token)` | `Container` instance method | Checks if a token is registered in the container or its parents. |
 | `container.hasRequestScopedDependency(token)` | `Container` instance method | Checks whether resolving a token may require a request-scope container because its provider graph contains request-scoped dependencies or is cyclic. |
 | `container.dispose()` | `Container` instance method | Disposes request children before parent/root caches, shares an active attempt, and retries only failed `onDestroy()` hooks on a later explicit call. |

--- a/packages/di/package.json
+++ b/packages/di/package.json
@@ -42,7 +42,7 @@
   "scripts": {
     "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
     "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
-    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
+    "typecheck": "pnpm exec tsc -p tsconfig.typecheck.json --noEmit",
     "test": "pnpm exec vitest run -c vitest.config.ts",
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },

--- a/packages/di/src/container-construction-boundary.test.ts
+++ b/packages/di/src/container-construction-boundary.test.ts
@@ -40,6 +40,19 @@ describe('Container construction boundary', () => {
     expect(construct).toThrow(ContainerResolutionError);
   });
 
+  it('keeps the child-scope factory inaccessible to external runtime callers', () => {
+    // Given
+    const root = new Container();
+
+    // When
+    const childScopeFactory = Reflect.get(Container, 'createChildScope');
+    const construct = (): object => Reflect.construct(Container, [root, true, new Map()]);
+
+    // Then
+    expect(childScopeFactory).toBeUndefined();
+    expect(construct).toThrow(ContainerResolutionError);
+  });
+
   it('keeps createRequestScope() as the supported child-scope path', async () => {
     // Given
     const singletonToken = Symbol('shared-singleton');

--- a/packages/di/src/container-construction-boundary.test.ts
+++ b/packages/di/src/container-construction-boundary.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import { Container } from './container.js';
+import { ContainerResolutionError } from './errors.js';
+import { Scope } from './types.js';
+
+describe('Container construction boundary', () => {
+  it('supports zero-argument root construction', async () => {
+    // Given
+    const token = Symbol('root-value');
+    const container = new Container().register({ provide: token, useValue: 'root' });
+
+    // When
+    const resolved = await container.resolve<string>(token);
+
+    // Then
+    expect(resolved).toBe('root');
+  });
+
+  it('rejects caller-supplied child-scope constructor arguments', () => {
+    // Given
+    const root = new Container();
+
+    // When
+    const construct = (): object => Reflect.construct(Container, [root, true, new Map()]);
+
+    // Then
+    expect(construct).toThrow(ContainerResolutionError);
+    expect(construct).toThrow(/createRequestScope\(\)/);
+  });
+
+  it('rejects a caller-supplied parent even without cache wiring', () => {
+    // Given
+    const root = new Container();
+
+    // When
+    const construct = (): object => Reflect.construct(Container, [root]);
+
+    // Then
+    expect(construct).toThrow(ContainerResolutionError);
+  });
+
+  it('keeps createRequestScope() as the supported child-scope path', async () => {
+    // Given
+    const singletonToken = Symbol('shared-singleton');
+    const requestToken = Symbol('request-scoped');
+    const root = new Container().register(
+      { provide: singletonToken, useFactory: () => ({ id: 'singleton' }) },
+      { provide: requestToken, scope: Scope.REQUEST, useFactory: () => ({ id: 'request' }) },
+    );
+
+    // When
+    const firstScope = root.createRequestScope();
+    const secondScope = root.createRequestScope();
+    const rootSingleton = await root.resolve(singletonToken);
+    const firstSingleton = await firstScope.resolve(singletonToken);
+    const secondSingleton = await secondScope.resolve(singletonToken);
+    const firstRequestInstance = await firstScope.resolve(requestToken);
+    const secondRequestInstance = await secondScope.resolve(requestToken);
+
+    // Then
+    expect(firstSingleton).toBe(rootSingleton);
+    expect(secondSingleton).toBe(rootSingleton);
+    expect(firstRequestInstance).not.toBe(secondRequestInstance);
+    await expect(root.resolve(requestToken)).rejects.toThrow();
+  });
+
+  it('keeps request-scope disposal terminal after the parent is disposed', async () => {
+    // Given
+    const root = new Container();
+    const scope = root.createRequestScope();
+
+    // When
+    await root.dispose();
+
+    // Then
+    expect(() => scope.createRequestScope()).toThrow(ContainerResolutionError);
+  });
+});

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -345,7 +345,7 @@ export class Container {
     this.singletonCache = childScope?.singletonCache ?? new Map<Token, Promise<unknown>>();
   }
 
-  private static createChildScope(construction: ChildScopeConstruction): Container {
+  static #createChildScope(construction: ChildScopeConstruction): Container {
     const parentConstruction = Container.#childScopeConstruction;
     Container.#childScopeConstruction = construction;
 
@@ -614,7 +614,7 @@ export class Container {
       );
     }
 
-    return Container.createChildScope({
+    return Container.#createChildScope({
       parent: this,
       requestScopeEnabled: true,
       singletonCache: this.root().singletonCache,

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -37,6 +37,12 @@ interface StaleDisposalTask {
 
 type DisposalAttemptOrigin = 'direct' | 'parent';
 
+interface ChildScopeConstruction {
+  readonly parent: Container;
+  readonly requestScopeEnabled: boolean;
+  readonly singletonCache: Map<Token, Promise<unknown>>;
+}
+
 /**
  * Controlled cache adoption seam for framework-owned testing and tooling that
  * need synchronous helpers to preserve container-owned singleton disposal.
@@ -286,6 +292,8 @@ function linkPendingResolution(
  */
 // allow: SIZE_OK — Container is the package's existing DI lifecycle state machine.
 export class Container {
+  static #childScopeConstruction: ChildScopeConstruction | undefined;
+
   private readonly registrations = new Map<Token, NormalizedProvider>();
   private readonly multiRegistrations = new Map<Token, NormalizedProvider[]>();
   private readonly multiOverriddenTokens = new Set<Token>();
@@ -308,12 +316,44 @@ export class Container {
   private trackedByParent = false;
   private graphRevision = 0;
 
-  constructor(
-    private readonly parent?: Container,
-    private readonly requestScopeEnabled = false,
-    singletonCache?: Map<Token, Promise<unknown>>,
-  ) {
-    this.singletonCache = singletonCache ?? new Map<Token, Promise<unknown>>();
+  private readonly parent: Container | undefined;
+  private readonly requestScopeEnabled: boolean;
+
+  /**
+   * Creates a root container that owns its own singleton cache.
+   *
+   * Child request scopes are package-owned and must be created with
+   * {@link Container.createRequestScope}; caller-supplied parent, request-scope,
+   * or singleton-cache wiring is rejected.
+   *
+   * @throws {ContainerResolutionError} When any constructor argument is supplied.
+   */
+  constructor(...construction: never[]) {
+    if (construction.length > 0) {
+      throw new ContainerResolutionError(
+        'Container child-scope construction is package-owned and cannot be invoked directly.',
+        {
+          hint: 'Construct root containers with new Container() and create child scopes with container.createRequestScope().',
+        },
+      );
+    }
+
+    const childScope = Container.#childScopeConstruction;
+
+    this.parent = childScope?.parent;
+    this.requestScopeEnabled = childScope?.requestScopeEnabled ?? false;
+    this.singletonCache = childScope?.singletonCache ?? new Map<Token, Promise<unknown>>();
+  }
+
+  private static createChildScope(construction: ChildScopeConstruction): Container {
+    const parentConstruction = Container.#childScopeConstruction;
+    Container.#childScopeConstruction = construction;
+
+    try {
+      return new Container();
+    } finally {
+      Container.#childScopeConstruction = parentConstruction;
+    }
   }
 
   /**
@@ -574,7 +614,11 @@ export class Container {
       );
     }
 
-    return new Container(this, true, this.root().singletonCache);
+    return Container.createChildScope({
+      parent: this,
+      requestScopeEnabled: true,
+      singletonCache: this.root().singletonCache,
+    });
   }
 
   /**

--- a/packages/di/tsconfig.typecheck.json
+++ b/packages/di/tsconfig.typecheck.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": [
+    "src/**/*.ts",
+    "typecheck/**/*.ts"
+  ]
+}

--- a/packages/di/typecheck/container-construction-boundary.ts
+++ b/packages/di/typecheck/container-construction-boundary.ts
@@ -1,0 +1,6 @@
+import type { Container } from '@fluojs/di';
+
+type AssertNever<Value extends never> = Value;
+type ConstructorArguments = ConstructorParameters<typeof Container>;
+
+export type ContainerConstructorArgumentsAreUnassignable = AssertNever<ConstructorArguments[number]>;


### PR DESCRIPTION
Closes #3157

## Summary
- seal external `Container` construction while preserving internal child-scope ownership
- lock the emitted declaration boundary with a compile-time negative fixture
- synchronize EN/KO documentation, migration guidance, and source excerpts

## Verification
- `@fluojs/di` build, typecheck, and 175 tests pass
- docs locale parity, typecheck, and production build pass
- lint and stable Changeset lane checks pass
- contract/code/verification exact-head reviewers: PASS/PASS/PASS

## Release
- includes a major `@fluojs/di` Changeset with migration guidance