### PR TITLE
Resolve #3171: preserve downstream streaming errors during upstream cancellation

### DIFF
--- a/.changeset/preserve-graphql-stream-errors.md
+++ b/.changeset/preserve-graphql-stream-errors.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/graphql": patch
+---
+
+Preserve downstream streaming failures when best-effort upstream cancellation cleanup also fails.

--- a/packages/graphql/README.ko.md
+++ b/packages/graphql/README.ko.md
@@ -252,6 +252,7 @@ GraphqlModule.forRoot({
 - `graphiql` 기본값은 `false`입니다. `introspection`은 명시하지 않으면 `graphiql` 설정을 따르므로, production 앱은 기본적으로 비공개 상태를 유지하고 로컬 GraphiQL 세션만 opt in할 수 있습니다.
 - `limits`에는 request validation budget을 전달하거나 `false`를 전달할 수 있습니다. `false`는 fluo 밖에서 동등한 제어를 적용할 때만 사용하세요.
 - Streaming GraphQL 응답은 downstream response stream이 닫히거나 오류를 내면 upstream fetch body를 cancel하므로 SSE subscription 리소스를 즉시 해제합니다.
+- Downstream streaming 실패와 upstream cancellation cleanup 실패가 동시에 발생하면 downstream 실패가 계속 관찰 가능하며 cancellation cleanup은 best-effort로 처리됩니다.
 - GraphQL 스키마 해석 이후 bootstrap이 실패하면 원래 오류를 다시 던지기 전에 실패한 service의 cross-realm GraphQL object allowlist만 제거합니다. 다른 활성 GraphQL 애플리케이션이 하나도 남지 않은 경우에만 package의 process-wide `graphql/jsutils/instanceOf` 패치를 원복합니다.
 - 각 활성 GraphQL 애플리케이션은 자체 cross-realm GraphQL object allowlist를 소유합니다. Shutdown도 같은 release 규칙을 따르므로, 다른 실행 중인 애플리케이션은 process-wide `instanceOf` 패치를 유지하고 자신의 object만 허용합니다.
 - WebSocket 구독 경로에는 별도의 전송 budget이 기본 적용됩니다: 동시 연결 `100`, 최대 payload 크기 `64 KiB`, 연결당 활성 operation `25`개입니다.

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -252,6 +252,7 @@ GraphqlModule.forRoot({
 - `graphiql` defaults to `false`. `introspection` follows `graphiql` unless set explicitly, so production apps stay private by default while local GraphiQL sessions can opt in.
 - `limits` accepts request validation budgets or `false`; use `false` only when equivalent controls exist outside fluo.
 - Streaming GraphQL responses cancel the upstream fetch body when the downstream response stream closes or errors, so SSE subscription resources are released promptly.
+- If downstream streaming fails while upstream cancellation cleanup also fails, the downstream failure remains observable and cancellation cleanup is best-effort.
 - Bootstrap failures after GraphQL schema resolution remove only the failed service's cross-realm GraphQL object allowlist before rethrowing. The package restores its process-wide `graphql/jsutils/instanceOf` patch only when no other active GraphQL application remains.
 - Each active GraphQL application owns its cross-realm GraphQL object allowlist. Shutdown follows the same release rule, so another running application retains the process-wide `instanceOf` patch and only its own objects remain allowed.
 - WebSocket subscriptions use separate transport budgets by default: `100` concurrent connections, `64 KiB` maximum payload size, and `25` active operations per connection.

--- a/packages/graphql/src/transport/transport.test.ts
+++ b/packages/graphql/src/transport/transport.test.ts
@@ -161,17 +161,31 @@ describe('writeFetchResponse', () => {
     expect(cancel).toHaveBeenCalledOnce();
   });
 
-  it('preserves the downstream backpressure error when upstream cancellation also fails', async () => {
+  it('waits for upstream cancellation before preserving the downstream backpressure error', async () => {
     // Given
     const cancellationError = new Error('upstream cancellation failed');
+    let releaseCancellation: (() => void) | undefined;
+    const cancellationReleased = new Promise<void>((resolve) => {
+      releaseCancellation = resolve;
+    });
+    let notifyCancellationStarted: (() => void) | undefined;
+    const cancellationStarted = new Promise<void>((resolve) => {
+      notifyCancellationStarted = resolve;
+    });
+    let notifyCancellationFinished: (() => void) | undefined;
+    const cancellationFinished = new Promise<void>((resolve) => {
+      notifyCancellationFinished = resolve;
+    });
     const cancel = vi.fn(async () => {
+      notifyCancellationStarted?.();
+      await cancellationReleased;
+      notifyCancellationFinished?.();
       throw cancellationError;
     });
     const fetchResponse = new Response(new ReadableStream<Uint8Array>({
       cancel,
       start(controller) {
         controller.enqueue(new TextEncoder().encode('chunk-1'));
-        controller.enqueue(new TextEncoder().encode('chunk-2'));
       },
     }), {
       headers: { 'content-type': 'text/event-stream' },
@@ -186,8 +200,8 @@ describe('writeFetchResponse', () => {
     }
     const waitForDrain = stream.waitForDrain;
 
-    if (!waitForDrain) {
-      throw new Error('Expected waitForDrain mock to exist.');
+    if (!waitForDrain || !releaseCancellation || !notifyCancellationFinished) {
+      throw new Error('Expected stream drain and cancellation controls to exist.');
     }
 
     vi.mocked(stream.write).mockReturnValueOnce(false);
@@ -195,8 +209,18 @@ describe('writeFetchResponse', () => {
 
     // When
     const write = writeFetchResponse(fetchResponse, frameworkResponse);
+    await cancellationStarted;
+    releaseCancellation();
+    const firstSettlement = await Promise.race([
+      write.then(
+        () => 'write',
+        () => 'write',
+      ),
+      cancellationFinished.then(() => 'cancellation'),
+    ]);
 
     // Then
+    expect(firstSettlement).toBe('cancellation');
     await expect(write).rejects.toBe(downstreamError);
     expect(cancel).toHaveBeenCalledOnce();
   });

--- a/packages/graphql/src/transport/transport.test.ts
+++ b/packages/graphql/src/transport/transport.test.ts
@@ -1,6 +1,5 @@
-import { describe, expect, it, vi } from 'vitest';
-
 import type { FrameworkResponse } from '@fluojs/http';
+import { describe, expect, it, vi } from 'vitest';
 
 import { writeFetchResponse } from './transport.js';
 
@@ -159,6 +158,46 @@ describe('writeFetchResponse', () => {
 
     await expect(writeFetchResponse(fetchResponse, frameworkResponse)).rejects.toBe(downstreamError);
 
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it('preserves the downstream backpressure error when upstream cancellation also fails', async () => {
+    // Given
+    const cancellationError = new Error('upstream cancellation failed');
+    const cancel = vi.fn(async () => {
+      throw cancellationError;
+    });
+    const fetchResponse = new Response(new ReadableStream<Uint8Array>({
+      cancel,
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('chunk-1'));
+        controller.enqueue(new TextEncoder().encode('chunk-2'));
+      },
+    }), {
+      headers: { 'content-type': 'text/event-stream' },
+      status: 200,
+    });
+    const frameworkResponse = createFrameworkResponseMock();
+    const stream = frameworkResponse.stream;
+    const downstreamError = new Error('downstream closed with error');
+
+    if (!stream) {
+      throw new Error('Expected stream mock to exist.');
+    }
+    const waitForDrain = stream.waitForDrain;
+
+    if (!waitForDrain) {
+      throw new Error('Expected waitForDrain mock to exist.');
+    }
+
+    vi.mocked(stream.write).mockReturnValueOnce(false);
+    vi.mocked(waitForDrain).mockRejectedValueOnce(downstreamError);
+
+    // When
+    const write = writeFetchResponse(fetchResponse, frameworkResponse);
+
+    // Then
+    await expect(write).rejects.toBe(downstreamError);
     expect(cancel).toHaveBeenCalledOnce();
   });
 

--- a/packages/graphql/src/transport/transport.ts
+++ b/packages/graphql/src/transport/transport.ts
@@ -186,7 +186,10 @@ async function writeFetchResponseStream(body: ReadableStream<Uint8Array>, stream
       }
     }
   } catch (error) {
-    void cancelUnreadBody().catch(() => {});
+    await cancelUnreadBody().then(
+      () => undefined,
+      () => undefined,
+    );
     throw error;
   } finally {
     removeCloseListener?.();

--- a/packages/graphql/src/transport/transport.ts
+++ b/packages/graphql/src/transport/transport.ts
@@ -186,7 +186,7 @@ async function writeFetchResponseStream(body: ReadableStream<Uint8Array>, stream
       }
     }
   } catch (error) {
-    await cancelUnreadBody();
+    void cancelUnreadBody().catch(() => {});
     throw error;
   } finally {
     removeCloseListener?.();


### PR DESCRIPTION
## Summary

Keep the original downstream streaming failure observable when best-effort upstream cancellation cleanup also fails.

Linked context: Closes #3171

## Changes

- treat `cancelUnreadBody()` in the streaming error path as best-effort so its rejection no longer replaces the downstream error
- still await cancellation before rethrowing, so upstream resources are released first
- document the best-effort cleanup contract in EN/KO README
- add a patch Changeset

## Testing

- GraphQL typecheck
- focused transport regressions (deterministic promise synchronisation, no timing sleeps)
- bounded full GraphQL suite: 13 files, 103 tests
- docs locale parity
- stable Changeset verifier

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests.