### PR TITLE
Resolve #3170: retain GraphQL cleanup ownership and retry failed teardown

### DIFF
--- a/.changeset/retain-graphql-cleanup-ownership.md
+++ b/.changeset/retain-graphql-cleanup-ownership.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/graphql': patch
+---
+
+Retain failed GraphQL HTTP and WebSocket cleanup owners for shutdown retry, and report every remaining teardown failure together.

--- a/packages/graphql/README.ko.md
+++ b/packages/graphql/README.ko.md
@@ -205,6 +205,7 @@ class UserResolver {
 - Object field resolver는 root resolver와 같은 provider scope 및 operation container를 사용합니다. `@Parent()`와 `@Context()`는 positional method argument만 제어합니다.
 - GraphQL operation 범위 DataLoader helper는 같은 `GraphQLContext` operation 경계를 사용하므로 loader cache는 하나의 GraphQL operation 안에서만 공유됩니다.
 - 애플리케이션 shutdown은 WebSocket transport를 등록 해제하고, 살아 있는 WebSocket client를 닫으며, 아직 활성 상태인 WebSocket operation container를 정상 operation 완료 때와 같은 request-scoped provider teardown 경로로 dispose합니다.
+- HTTP operation-container, WebSocket operation-container 또는 WebSocket transport teardown이 실패하면 소유자를 이후 `Application.close()` 재시도까지 보존합니다. Shutdown은 남은 모든 cleanup 실패를 함께 보고하며, 이미 성공한 cleanup은 반복하지 않습니다.
 
 ```typescript
 import { Inject, Scope } from '@fluojs/core';

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -205,6 +205,7 @@ class UserResolver {
 - Object field resolvers use the same provider scope and operation container as root resolvers; `@Parent()` and `@Context()` only control positional method arguments.
 - GraphQL-operation-scoped DataLoader helpers use the same `GraphQLContext` operation boundary, so loader caches are shared only within one GraphQL operation.
 - Application shutdown unregisters the websocket transport, closes live websocket clients, and disposes any still-active websocket operation containers through the same request-scoped provider teardown path used when an operation completes normally.
+- Failed HTTP operation-container, websocket operation-container, or websocket transport teardown retains its owner for a later `Application.close()` retry. Shutdown reports every remaining cleanup failure together and never repeats cleanup that already succeeded.
 
 ```typescript
 import { Inject, Scope } from '@fluojs/core';

--- a/packages/graphql/src/cleanup-retry.test.ts
+++ b/packages/graphql/src/cleanup-retry.test.ts
@@ -1,7 +1,7 @@
-import { createServer } from 'node:net';
-
 import { Inject, Scope } from '@fluojs/core';
+import type { Application } from '@fluojs/runtime';
 import { defineModule } from '@fluojs/runtime';
+import { HTTP_APPLICATION_ADAPTER } from '@fluojs/runtime/internal';
 import { bootstrapNodeApplication } from '@fluojs/runtime/node';
 import { describe, expect, it } from 'vitest';
 import { WebSocket } from 'ws';
@@ -18,29 +18,16 @@ type GraphqlWebSocketMessage = {
   type: string;
 };
 
-async function findAvailablePort(): Promise<number> {
-  return await new Promise<number>((resolve, reject) => {
-    const server = createServer();
+async function resolveListeningPort(app: Application): Promise<number> {
+  const adapter = await app.get(HTTP_APPLICATION_ADAPTER);
+  const server = adapter.getServer?.() as { address?: () => unknown } | undefined;
+  const address = server?.address?.();
 
-    server.once('error', reject);
-    server.listen(0, () => {
-      const address = server.address();
+  if (!address || typeof address !== 'object' || !('port' in address)) {
+    throw new Error('Failed to resolve the listening port of the bootstrapped application.');
+  }
 
-      if (!address || typeof address === 'string') {
-        reject(new Error('Failed to resolve available port.'));
-        return;
-      }
-
-      server.close((error?: Error) => {
-        if (error) {
-          reject(error);
-          return;
-        }
-
-        resolve(address.port);
-      });
-    });
-  });
+  return (address as { port: number }).port;
 }
 
 function onceGraphqlWebSocketMessage(socket: WebSocket): Promise<GraphqlWebSocketMessage> {
@@ -187,10 +174,11 @@ describe('GraphQL cleanup retry ownership', () => {
       providers: [RetriedOperationScope, RetriedOperationResolver],
     });
 
-    const port = await findAvailablePort();
-    const app = await bootstrapNodeApplication(AppModule, { cors: false, port });
+    const app = await bootstrapNodeApplication(AppModule, { cors: false, port: 0 });
 
     await app.listen();
+
+    const port = await resolveListeningPort(app);
 
     const socket = await connectGraphqlWebSocket(port);
     const firstMessages = readGraphqlWebSocketMessages(socket, 2);

--- a/packages/graphql/src/cleanup-retry.test.ts
+++ b/packages/graphql/src/cleanup-retry.test.ts
@@ -1,0 +1,250 @@
+import { createServer } from 'node:net';
+
+import { Inject, Scope } from '@fluojs/core';
+import { defineModule } from '@fluojs/runtime';
+import { bootstrapNodeApplication } from '@fluojs/runtime/node';
+import { describe, expect, it } from 'vitest';
+import { WebSocket } from 'ws';
+
+import { Resolver, Subscription } from './decorators.js';
+import { GraphqlModule } from './module.js';
+
+type GraphqlWebSocketMessage = {
+  id?: string;
+  payload?: {
+    data?: Record<string, unknown>;
+    errors?: Array<{ message?: string }>;
+  };
+  type: string;
+};
+
+async function findAvailablePort(): Promise<number> {
+  return await new Promise<number>((resolve, reject) => {
+    const server = createServer();
+
+    server.once('error', reject);
+    server.listen(0, () => {
+      const address = server.address();
+
+      if (!address || typeof address === 'string') {
+        reject(new Error('Failed to resolve available port.'));
+        return;
+      }
+
+      server.close((error?: Error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve(address.port);
+      });
+    });
+  });
+}
+
+function onceGraphqlWebSocketMessage(socket: WebSocket): Promise<GraphqlWebSocketMessage> {
+  return new Promise((resolve, reject) => {
+    const handleClose = (code: number, reason: Buffer) => {
+      reject(new Error(`WebSocket closed before message: ${String(code)} ${reason.toString('utf8')}`));
+    };
+    const handleMessage = (data: unknown) => {
+      socket.off('close', handleClose);
+
+      if (typeof data === 'string') {
+        resolve(JSON.parse(data) as GraphqlWebSocketMessage);
+        return;
+      }
+
+      if (data instanceof ArrayBuffer) {
+        resolve(JSON.parse(Buffer.from(data).toString('utf8')) as GraphqlWebSocketMessage);
+        return;
+      }
+
+      if (ArrayBuffer.isView(data)) {
+        resolve(
+          JSON.parse(Buffer.from(data.buffer, data.byteOffset, data.byteLength).toString('utf8')) as GraphqlWebSocketMessage,
+        );
+        return;
+      }
+
+      reject(new Error(`Unsupported websocket message payload: ${String(data)}`));
+    };
+
+    socket.once('close', handleClose);
+    socket.once('error', reject);
+    socket.once('message', handleMessage);
+  });
+}
+
+function readGraphqlWebSocketMessages(socket: WebSocket, count: number): Promise<GraphqlWebSocketMessage[]> {
+  return new Promise((resolve, reject) => {
+    const messages: GraphqlWebSocketMessage[] = [];
+    const handleClose = (code: number, reason: Buffer) => {
+      cleanup();
+      reject(new Error(`WebSocket closed before collecting ${String(count)} messages: ${String(code)} ${reason.toString('utf8')}`));
+    };
+    const handleError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const handleMessage = (data: unknown) => {
+      if (typeof data === 'string') {
+        messages.push(JSON.parse(data) as GraphqlWebSocketMessage);
+      } else if (data instanceof ArrayBuffer) {
+        messages.push(JSON.parse(Buffer.from(data).toString('utf8')) as GraphqlWebSocketMessage);
+      } else if (ArrayBuffer.isView(data)) {
+        messages.push(
+          JSON.parse(Buffer.from(data.buffer, data.byteOffset, data.byteLength).toString('utf8')) as GraphqlWebSocketMessage,
+        );
+      } else {
+        cleanup();
+        reject(new Error(`Unsupported websocket message payload: ${String(data)}`));
+        return;
+      }
+
+      if (messages.length === count) {
+        cleanup();
+        resolve(messages);
+      }
+    };
+    const cleanup = () => {
+      socket.off('close', handleClose);
+      socket.off('error', handleError);
+      socket.off('message', handleMessage);
+    };
+
+    socket.on('close', handleClose);
+    socket.on('error', handleError);
+    socket.on('message', handleMessage);
+  });
+}
+
+async function connectGraphqlWebSocket(port: number): Promise<WebSocket> {
+  const socket = await new Promise<WebSocket>((resolve, reject) => {
+    const openedSocket = new WebSocket(`ws://127.0.0.1:${String(port)}/graphql`, 'graphql-transport-ws');
+
+    openedSocket.once('open', () => resolve(openedSocket));
+    openedSocket.once('error', reject);
+  });
+  const acknowledgement = onceGraphqlWebSocketMessage(socket);
+
+  socket.send(JSON.stringify({ type: 'connection_init' }));
+  await expect(acknowledgement).resolves.toEqual({ type: 'connection_ack' });
+
+  return socket;
+}
+
+function onceWebSocketClosed(socket: WebSocket): Promise<void> {
+  return new Promise((resolve) => {
+    socket.once('close', () => resolve());
+  });
+}
+
+describe('GraphQL cleanup retry ownership', () => {
+  it('creates a fresh websocket operation scope when completed cleanup fails for the same operation id', async () => {
+    let createdScopes = 0;
+    let destroyAttempts = 0;
+
+    @Inject()
+    @Scope('request')
+    class RetriedOperationScope {
+      readonly id = ++createdScopes;
+
+      onDestroy(): void {
+        destroyAttempts += 1;
+
+        if (destroyAttempts === 1) {
+          throw new Error('first operation cleanup fails');
+        }
+      }
+    }
+
+    @Inject(RetriedOperationScope)
+    @Scope('request')
+    @Resolver('RetriedOperationResolver')
+    class RetriedOperationResolver {
+      constructor(private readonly scope: RetriedOperationScope) {}
+
+      @Subscription()
+      async *scopeId(): AsyncGenerator<string, void, void> {
+        yield String(this.scope.id);
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [
+        GraphqlModule.forRoot({
+          resolvers: [RetriedOperationResolver],
+          subscriptions: {
+            websocket: {
+              enabled: true,
+            },
+          },
+        }),
+      ],
+      providers: [RetriedOperationScope, RetriedOperationResolver],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapNodeApplication(AppModule, { cors: false, port });
+
+    await app.listen();
+
+    const socket = await connectGraphqlWebSocket(port);
+    const firstMessages = readGraphqlWebSocketMessages(socket, 2);
+    socket.send(JSON.stringify({
+      id: 'retryable-operation',
+      payload: {
+        query: 'subscription { scopeId }',
+      },
+      type: 'subscribe',
+    }));
+    await expect(firstMessages).resolves.toEqual([
+      {
+        id: 'retryable-operation',
+        payload: {
+          data: {
+            scopeId: '1',
+          },
+        },
+        type: 'next',
+      },
+      {
+        id: 'retryable-operation',
+        type: 'complete',
+      },
+    ]);
+
+    const secondMessages = readGraphqlWebSocketMessages(socket, 2);
+    socket.send(JSON.stringify({
+      id: 'retryable-operation',
+      payload: {
+        query: 'subscription { scopeId }',
+      },
+      type: 'subscribe',
+    }));
+    await expect(secondMessages).resolves.toEqual([
+      {
+        id: 'retryable-operation',
+        payload: {
+          data: {
+            scopeId: '2',
+          },
+        },
+        type: 'next',
+      },
+      {
+        id: 'retryable-operation',
+        type: 'complete',
+      },
+    ]);
+
+    const closed = onceWebSocketClosed(socket);
+    socket.close();
+    await closed;
+    await expect(app.close()).resolves.toBeUndefined();
+    expect(destroyAttempts).toBe(3);
+  });
+});

--- a/packages/graphql/src/node/graphql-websocket-transport.test.ts
+++ b/packages/graphql/src/node/graphql-websocket-transport.test.ts
@@ -1,0 +1,99 @@
+import { createServer, type Server } from 'node:http';
+
+import type { HttpApplicationAdapter } from '@fluojs/http';
+import { execute, subscribe } from 'graphql';
+import { describe, expect, it } from 'vitest';
+import { WebSocket } from 'ws';
+
+import { createNodeGraphqlWebSocketTransport } from './graphql-websocket-transport.js';
+
+function listen(server: Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, () => {
+      const address = server.address();
+
+      if (!address || typeof address === 'string') {
+        reject(new Error('Expected an HTTP server address.'));
+        return;
+      }
+
+      resolve(address.port);
+    });
+  });
+}
+
+function openWebSocket(port: number): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const socket = new WebSocket(`ws://127.0.0.1:${String(port)}/graphql`, 'graphql-transport-ws');
+
+    socket.once('open', () => resolve(socket));
+    socket.once('error', reject);
+  });
+}
+
+function onceClosed(socket: WebSocket): Promise<void> {
+  return new Promise((resolve) => {
+    socket.once('close', () => resolve());
+  });
+}
+
+describe('Node GraphQL websocket transport cleanup', () => {
+  it('aggregates current disconnect failures once and allows a successful dispose retry', async () => {
+    const server = createServer();
+    const adapter: HttpApplicationAdapter = {
+      async close() {},
+      getServer: () => server,
+      async listen() {},
+    };
+    const disconnectErrors = [new Error('disconnect cleanup one'), new Error('disconnect cleanup two')];
+    let observedDisconnects = 0;
+    let resolveObservedDisconnects: (() => void) | undefined;
+    const disconnectsObserved = new Promise<void>((resolve) => {
+      resolveObservedDisconnects = resolve;
+    });
+    const transport = await createNodeGraphqlWebSocketTransport({
+      adapter,
+      execute,
+      onComplete() {},
+      onDisconnect: async () => {
+        const error = disconnectErrors.shift();
+
+        if (!error) {
+          return;
+        }
+
+        observedDisconnects += 1;
+
+        if (observedDisconnects === 2) {
+          resolveObservedDisconnects?.();
+        }
+
+        throw error;
+      },
+      onSubscribe: async () => {
+        throw new Error('No subscription is expected in this transport cleanup test.');
+      },
+      subscribe,
+    });
+    const port = await listen(server);
+    const firstSocket = await openWebSocket(port);
+    const secondSocket = await openWebSocket(port);
+    const firstClosed = onceClosed(firstSocket);
+    const secondClosed = onceClosed(secondSocket);
+
+    firstSocket.close();
+    secondSocket.close();
+
+    await Promise.all([disconnectsObserved, firstClosed, secondClosed]);
+    await expect(transport.dispose()).rejects.toSatisfy((error: unknown) => {
+      if (!(error instanceof AggregateError)) {
+        return false;
+      }
+
+      return error.errors.some((item) => item instanceof Error && item.message === 'disconnect cleanup one') &&
+        error.errors.some((item) => item instanceof Error && item.message === 'disconnect cleanup two');
+    });
+    await expect(transport.dispose()).resolves.toBeUndefined();
+  });
+});

--- a/packages/graphql/src/node/graphql-websocket-transport.ts
+++ b/packages/graphql/src/node/graphql-websocket-transport.ts
@@ -50,6 +50,11 @@ export interface GraphqlNodeWebSocketSubscribeRequest {
  * Represents a registered Node GraphQL WebSocket transport.
  */
 export interface GraphqlNodeWebSocketTransport {
+  /**
+   * Releases websocket listeners, clients, and GraphQL protocol resources.
+   *
+   * @returns A promise that resolves when cleanup completes or rejects with all current cleanup failures.
+   */
   dispose(): Promise<void>;
 }
 
@@ -110,6 +115,15 @@ function closeWebSocketServer(server: WebSocketServer): Promise<void> {
       resolve();
     });
   });
+}
+
+function collectCleanupError(errors: unknown[], error: unknown): void {
+  if (error instanceof AggregateError) {
+    errors.push(...error.errors);
+    return;
+  }
+
+  errors.push(error);
 }
 
 function resolveUpgradeServer(adapter: HttpApplicationAdapter): NodeUpgradeServer {
@@ -197,7 +211,10 @@ export async function createNodeGraphqlWebSocketTransport(
 ): Promise<GraphqlNodeWebSocketTransport> {
   const upgradeServer = resolveUpgradeServer(options.adapter);
   const disconnectErrors: unknown[] = [];
+  const disconnectedSockets = new Set<object>();
   const pendingDisconnects = new Set<Promise<void>>();
+  let websocketDisposableDisposed = false;
+  let websocketServerClosed = false;
   const websocketServer = new WebSocketServer({
     handleProtocols: (protocols: Set<string>) => handleProtocols(protocols),
     maxPayload: options.limits?.maxPayloadBytes ?? 0,
@@ -205,6 +222,11 @@ export async function createNodeGraphqlWebSocketTransport(
   });
   const upgradeListener = createUpgradeListener(websocketServer, options.limits);
   const trackDisconnect = (socketKey: object) => {
+    if (disconnectedSockets.has(socketKey)) {
+      return;
+    }
+
+    disconnectedSockets.add(socketKey);
     const pendingDisconnect = Promise.resolve(options.onDisconnect(socketKey))
       .catch((error: unknown) => {
         disconnectErrors.push(error);
@@ -224,8 +246,8 @@ export async function createNodeGraphqlWebSocketTransport(
       onComplete: async (context: GraphqlWebSocketContext, message: CompleteMessage) => {
         await options.onComplete(context.extra.socket, message.id);
       },
-      onDisconnect: async (context: GraphqlWebSocketContext) => {
-        await options.onDisconnect(context.extra.socket);
+      onDisconnect: (context: GraphqlWebSocketContext) => {
+        trackDisconnect(context.extra.socket);
       },
       onSubscribe: async (context: GraphqlWebSocketContext, message: SubscribeMessage) =>
         options.onSubscribe(createSubscribeRequest(context, message)),
@@ -240,7 +262,7 @@ export async function createNodeGraphqlWebSocketTransport(
 
   return {
     async dispose() {
-      let disposeError: unknown;
+      const cleanupErrors = disconnectErrors.splice(0, disconnectErrors.length);
 
       websocketServer.off('connection', trackConnection);
       upgradeServer.off('upgrade', upgradeListener);
@@ -250,33 +272,37 @@ export async function createNodeGraphqlWebSocketTransport(
       }
 
       const disconnectResults = await Promise.allSettled(pendingDisconnects);
-      for (const error of disconnectErrors) {
-        disposeError ??= error;
-      }
+      cleanupErrors.push(...disconnectErrors.splice(0, disconnectErrors.length));
       for (const result of disconnectResults) {
         if (result.status === 'rejected') {
-          disposeError ??= result.reason;
+          collectCleanupError(cleanupErrors, result.reason);
         }
       }
 
-      try {
-        await websocketDisposable.dispose();
-      } catch (error) {
-        disposeError = error;
+      if (!websocketDisposableDisposed) {
+        try {
+          await websocketDisposable.dispose();
+          websocketDisposableDisposed = true;
+        } catch (error) {
+          collectCleanupError(cleanupErrors, error);
+        }
       }
 
-      try {
-        await closeWebSocketServer(websocketServer);
-      } catch (error) {
-        disposeError ??= error;
+      if (!websocketServerClosed) {
+        try {
+          await closeWebSocketServer(websocketServer);
+          websocketServerClosed = true;
+        } catch (error) {
+          collectCleanupError(cleanupErrors, error);
+        }
       }
 
-      if (disposeError instanceof Error) {
-        throw disposeError;
+      if (cleanupErrors.length === 1) {
+        throw cleanupErrors[0];
       }
 
-      if (disposeError !== undefined) {
-        throw new Error(String(disposeError));
+      if (cleanupErrors.length > 1) {
+        throw new AggregateError(cleanupErrors, 'Failed to dispose GraphQL websocket transport resources.');
       }
     },
   };

--- a/packages/graphql/src/node/graphql-websocket-transport.ts
+++ b/packages/graphql/src/node/graphql-websocket-transport.ts
@@ -119,7 +119,14 @@ function closeWebSocketServer(server: WebSocketServer): Promise<void> {
 
 function collectCleanupError(errors: unknown[], error: unknown): void {
   if (error instanceof AggregateError) {
-    errors.push(...error.errors);
+    for (const nested of error.errors) {
+      collectCleanupError(errors, nested);
+    }
+
+    return;
+  }
+
+  if (errors.includes(error)) {
     return;
   }
 
@@ -215,12 +222,18 @@ export async function createNodeGraphqlWebSocketTransport(
   const pendingDisconnects = new Set<Promise<void>>();
   let websocketDisposableDisposed = false;
   let websocketServerClosed = false;
+  let inFlightDispose: Promise<void> | undefined;
   const websocketServer = new WebSocketServer({
     handleProtocols: (protocols: Set<string>) => handleProtocols(protocols),
     maxPayload: options.limits?.maxPayloadBytes ?? 0,
     noServer: true,
   });
   const upgradeListener = createUpgradeListener(websocketServer, options.limits);
+  const drainDisconnectErrors = (cleanupErrors: unknown[]): void => {
+    for (const error of disconnectErrors.splice(0, disconnectErrors.length)) {
+      collectCleanupError(cleanupErrors, error);
+    }
+  };
   const trackDisconnect = (socketKey: object) => {
     if (disconnectedSockets.has(socketKey)) {
       return;
@@ -260,9 +273,10 @@ export async function createNodeGraphqlWebSocketTransport(
   websocketServer.on('connection', trackConnection);
   upgradeServer.on('upgrade', upgradeListener);
 
-  return {
-    async dispose() {
-      const cleanupErrors = disconnectErrors.splice(0, disconnectErrors.length);
+  const runDispose = async (): Promise<void> => {
+      const cleanupErrors: unknown[] = [];
+
+      drainDisconnectErrors(cleanupErrors);
 
       websocketServer.off('connection', trackConnection);
       upgradeServer.off('upgrade', upgradeListener);
@@ -271,13 +285,17 @@ export async function createNodeGraphqlWebSocketTransport(
         client.terminate();
       }
 
-      const disconnectResults = await Promise.allSettled(pendingDisconnects);
-      cleanupErrors.push(...disconnectErrors.splice(0, disconnectErrors.length));
-      for (const result of disconnectResults) {
-        if (result.status === 'rejected') {
-          collectCleanupError(cleanupErrors, result.reason);
+      while (pendingDisconnects.size > 0) {
+        const disconnectResults = await Promise.allSettled([...pendingDisconnects]);
+
+        for (const result of disconnectResults) {
+          if (result.status === 'rejected') {
+            collectCleanupError(cleanupErrors, result.reason);
+          }
         }
       }
+
+      drainDisconnectErrors(cleanupErrors);
 
       if (!websocketDisposableDisposed) {
         try {
@@ -297,6 +315,18 @@ export async function createNodeGraphqlWebSocketTransport(
         }
       }
 
+      while (pendingDisconnects.size > 0) {
+        const lateDisconnectResults = await Promise.allSettled([...pendingDisconnects]);
+
+        for (const result of lateDisconnectResults) {
+          if (result.status === 'rejected') {
+            collectCleanupError(cleanupErrors, result.reason);
+          }
+        }
+      }
+
+      drainDisconnectErrors(cleanupErrors);
+
       if (cleanupErrors.length === 1) {
         throw cleanupErrors[0];
       }
@@ -304,6 +334,15 @@ export async function createNodeGraphqlWebSocketTransport(
       if (cleanupErrors.length > 1) {
         throw new AggregateError(cleanupErrors, 'Failed to dispose GraphQL websocket transport resources.');
       }
+  };
+
+  return {
+    async dispose() {
+      inFlightDispose ??= runDispose().finally(() => {
+        inFlightDispose = undefined;
+      });
+
+      await inFlightDispose;
     },
   };
 }

--- a/packages/graphql/src/service-lifecycle.test.ts
+++ b/packages/graphql/src/service-lifecycle.test.ts
@@ -1,0 +1,105 @@
+import { Container } from '@fluojs/di';
+import type { HttpApplicationAdapter } from '@fluojs/http';
+import type { ApplicationLogger, CompiledModule } from '@fluojs/runtime';
+import { describe, expect, it, vi } from 'vitest';
+
+import { GraphqlLifecycleService } from './service.js';
+import type { GraphqlModuleOptions } from './types.js';
+
+function createService(options: GraphqlModuleOptions, runtimeContainer: Container): GraphqlLifecycleService {
+  const logger: ApplicationLogger = {
+    debug() {},
+    error() {},
+    log() {},
+    warn() {},
+  };
+  const adapter: HttpApplicationAdapter = {
+    async close() {},
+    async listen() {},
+  };
+
+  return new GraphqlLifecycleService(runtimeContainer, [] as CompiledModule[], logger, adapter, options);
+}
+
+function getLifecycleMethod(service: GraphqlLifecycleService, name: string): Function {
+  const method = Reflect.get(service, name);
+
+  if (typeof method !== 'function') {
+    throw new Error(`Expected ${name} to be a GraphqlLifecycleService method.`);
+  }
+
+  return method;
+}
+
+describe('GraphqlLifecycleService cleanup ownership', () => {
+  it('retries failed HTTP operation cleanup during a later shutdown', async () => {
+    const runtimeContainer = new Container();
+    const operationContainer = runtimeContainer.createRequestScope();
+    const dispose = vi.spyOn(operationContainer, 'dispose')
+      .mockRejectedValueOnce(new Error('first HTTP disposal fails'))
+      .mockResolvedValueOnce(undefined);
+    vi.spyOn(runtimeContainer, 'createRequestScope').mockReturnValue(operationContainer);
+    const service = createService({}, runtimeContainer);
+    const request = new Request('http://localhost/graphql');
+    const getOrCreateOperationContainer = getLifecycleMethod(service, 'getOrCreateOperationContainer');
+    const disposeOperationContainer = getLifecycleMethod(service, 'disposeOperationContainer');
+
+    Reflect.apply(getOrCreateOperationContainer, service, [request]);
+    await Reflect.apply(disposeOperationContainer, service, [request]);
+
+    await expect(service.onApplicationShutdown()).resolves.toBeUndefined();
+    expect(dispose).toHaveBeenCalledTimes(2);
+  });
+
+  it('disposes a websocket operation container when custom context creation fails', async () => {
+    const contextError = new Error('custom websocket context fails');
+    const runtimeContainer = new Container();
+    const operationContainer = runtimeContainer.createRequestScope();
+    const dispose = vi.spyOn(operationContainer, 'dispose').mockResolvedValue(undefined);
+    vi.spyOn(runtimeContainer, 'createRequestScope').mockReturnValue(operationContainer);
+    const service = createService(
+      {
+        context: () => {
+          throw contextError;
+        },
+      },
+      runtimeContainer,
+    );
+    const handleWebSocketSubscribe = getLifecycleMethod(service, 'handleWebSocketSubscribe');
+    Reflect.set(service, 'yoga', {});
+
+    await expect(
+      Reflect.apply(handleWebSocketSubscribe, service, [
+        {
+          operationId: 'context-failure',
+          payload: { query: 'subscription { ping }' },
+          request: {
+            cookies: {},
+            headers: {},
+            method: 'GET',
+            params: {},
+            path: '/graphql',
+            query: {},
+            url: '/graphql',
+          },
+          socket: {},
+        },
+      ]),
+    ).rejects.toThrow(contextError);
+
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+
+  it('retains a failed websocket transport for shutdown retry and reports the failure', async () => {
+    const dispose = vi.fn()
+      .mockRejectedValueOnce(new Error('first websocket transport disposal fails'))
+      .mockResolvedValueOnce(undefined);
+    const service = createService({}, new Container());
+    Reflect.set(service, 'websocketTransport', { dispose });
+
+    await expect(service.onApplicationShutdown()).rejects.toBeInstanceOf(AggregateError);
+    await expect(service.onApplicationShutdown()).resolves.toBeUndefined();
+
+    expect(dispose).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/graphql/src/service.ts
+++ b/packages/graphql/src/service.ts
@@ -69,7 +69,14 @@ const DEFAULT_GRAPHQL_WEBSOCKET_LIMITS: GraphqlWebSocketLimits = {
 
 function collectCleanupError(errors: unknown[], error: unknown): void {
   if (error instanceof AggregateError) {
-    errors.push(...error.errors);
+    for (const nested of error.errors) {
+      collectCleanupError(errors, nested);
+    }
+
+    return;
+  }
+
+  if (errors.includes(error)) {
     return;
   }
 
@@ -307,6 +314,8 @@ export class GraphqlLifecycleService implements Middleware, OnApplicationBootstr
   private readonly operationContainers = new Map<Request, Container>();
   private readonly requestContexts = new WeakMap<Request, GraphqlRequestContext>();
   private readonly failedWebsocketOperationContainers = new Map<object, Set<Container>>();
+  private readonly websocketContainerDisposals = new Map<Container, Promise<unknown>>();
+  private websocketContainersAttemptedInCurrentCleanup: Set<Container> | undefined;
   private readonly websocketOperationContainers = new Map<object, Map<string, Container>>();
   private websocketTransport: GraphqlNodeWebSocketTransport | undefined;
   private executeGraphqlOperation: typeof executeGraphql | undefined;
@@ -417,10 +426,14 @@ export class GraphqlLifecycleService implements Middleware, OnApplicationBootstr
   private async resetGraphqlRuntimeState(): Promise<void> {
     const cleanupErrors: unknown[] = [];
 
+    this.websocketContainersAttemptedInCurrentCleanup = new Set<Container>();
+
     try {
       await this.unregisterWebSocketTransport();
     } catch (error) {
       collectCleanupError(cleanupErrors, error);
+    } finally {
+      this.websocketContainersAttemptedInCurrentCleanup = undefined;
     }
 
     try {
@@ -680,15 +693,46 @@ export class GraphqlLifecycleService implements Middleware, OnApplicationBootstr
       this.websocketOperationContainers.delete(socketKey);
     }
 
-    try {
-      await operationContainer.dispose();
-    } catch (error) {
-      const failedContainers = this.failedWebsocketOperationContainers.get(socketKey) ?? new Set<Container>();
-      failedContainers.add(operationContainer);
-      this.failedWebsocketOperationContainers.set(socketKey, failedContainers);
-      this.logger.error('Failed to dispose GraphQL websocket operation container.', error, 'GraphqlLifecycleService');
-      return error;
+    return await this.disposeWebSocketContainerOnce(socketKey, operationContainer);
+  }
+
+  private async disposeWebSocketContainerOnce(socketKey: object, operationContainer: Container): Promise<unknown> {
+    const inFlight = this.websocketContainerDisposals.get(operationContainer);
+
+    if (inFlight) {
+      return await inFlight;
     }
+
+    const attempted = this.websocketContainersAttemptedInCurrentCleanup;
+
+    if (attempted?.has(operationContainer)) {
+      return undefined;
+    }
+
+    attempted?.add(operationContainer);
+
+    const disposal = operationContainer
+      .dispose()
+      .then(
+        () => {
+          this.failedWebsocketOperationContainers.get(socketKey)?.delete(operationContainer);
+          return undefined;
+        },
+        (error: unknown) => {
+          const failedContainers = this.failedWebsocketOperationContainers.get(socketKey) ?? new Set<Container>();
+          failedContainers.add(operationContainer);
+          this.failedWebsocketOperationContainers.set(socketKey, failedContainers);
+          this.logger.error('Failed to dispose GraphQL websocket operation container.', error, 'GraphqlLifecycleService');
+          return error;
+        },
+      )
+      .finally(() => {
+        this.websocketContainerDisposals.delete(operationContainer);
+      });
+
+    this.websocketContainerDisposals.set(operationContainer, disposal);
+
+    return await disposal;
   }
 
   private async disposeAllWebSocketOperationContainers(socketKey: object): Promise<void> {
@@ -696,12 +740,10 @@ export class GraphqlLifecycleService implements Middleware, OnApplicationBootstr
     const failedContainers = this.failedWebsocketOperationContainers.get(socketKey);
 
     for (const operationContainer of [...(failedContainers ?? [])]) {
-      try {
-        await operationContainer.dispose();
-        failedContainers?.delete(operationContainer);
-      } catch (error) {
-        this.logger.error('Failed to retry GraphQL websocket operation container cleanup.', error, 'GraphqlLifecycleService');
-        collectCleanupError(cleanupErrors, error);
+      const cleanupError = await this.disposeWebSocketContainerOnce(socketKey, operationContainer);
+
+      if (cleanupError !== undefined) {
+        collectCleanupError(cleanupErrors, cleanupError);
       }
     }
 

--- a/packages/graphql/src/service.ts
+++ b/packages/graphql/src/service.ts
@@ -306,6 +306,7 @@ export class GraphqlLifecycleService implements Middleware, OnApplicationBootstr
   private graphQLErrorConstructor: typeof GraphQLErrorType | undefined;
   private readonly operationContainers = new Map<Request, Container>();
   private readonly requestContexts = new WeakMap<Request, GraphqlRequestContext>();
+  private readonly failedWebsocketOperationContainers = new Map<object, Set<Container>>();
   private readonly websocketOperationContainers = new Map<object, Map<string, Container>>();
   private websocketTransport: GraphqlNodeWebSocketTransport | undefined;
   private executeGraphqlOperation: typeof executeGraphql | undefined;
@@ -554,7 +555,12 @@ export class GraphqlLifecycleService implements Middleware, OnApplicationBootstr
       }
     }
 
-    for (const socketKey of [...this.websocketOperationContainers.keys()]) {
+    const socketKeys = new Set([
+      ...this.websocketOperationContainers.keys(),
+      ...this.failedWebsocketOperationContainers.keys(),
+    ]);
+
+    for (const socketKey of socketKeys) {
       try {
         await this.disposeAllWebSocketOperationContainers(socketKey);
       } catch (error) {
@@ -668,30 +674,44 @@ export class GraphqlLifecycleService implements Middleware, OnApplicationBootstr
       return;
     }
 
-    try {
-      await operationContainer.dispose();
-    } catch (error) {
-      this.logger.error('Failed to dispose GraphQL websocket operation container.', error, 'GraphqlLifecycleService');
-      return error;
-    }
-
     socketContainers?.delete(operationId);
 
     if (socketContainers && socketContainers.size === 0) {
       this.websocketOperationContainers.delete(socketKey);
     }
+
+    try {
+      await operationContainer.dispose();
+    } catch (error) {
+      const failedContainers = this.failedWebsocketOperationContainers.get(socketKey) ?? new Set<Container>();
+      failedContainers.add(operationContainer);
+      this.failedWebsocketOperationContainers.set(socketKey, failedContainers);
+      this.logger.error('Failed to dispose GraphQL websocket operation container.', error, 'GraphqlLifecycleService');
+      return error;
+    }
   }
 
   private async disposeAllWebSocketOperationContainers(socketKey: object): Promise<void> {
-    const socketContainers = this.websocketOperationContainers.get(socketKey);
+    const cleanupErrors: unknown[] = [];
+    const failedContainers = this.failedWebsocketOperationContainers.get(socketKey);
 
-    if (!socketContainers) {
-      return;
+    for (const operationContainer of [...(failedContainers ?? [])]) {
+      try {
+        await operationContainer.dispose();
+        failedContainers?.delete(operationContainer);
+      } catch (error) {
+        this.logger.error('Failed to retry GraphQL websocket operation container cleanup.', error, 'GraphqlLifecycleService');
+        collectCleanupError(cleanupErrors, error);
+      }
     }
 
-    const cleanupErrors: unknown[] = [];
+    if (failedContainers?.size === 0) {
+      this.failedWebsocketOperationContainers.delete(socketKey);
+    }
 
-    for (const operationId of [...socketContainers.keys()]) {
+    const socketContainers = this.websocketOperationContainers.get(socketKey);
+
+    for (const operationId of [...(socketContainers?.keys() ?? [])]) {
       const cleanupError = await this.disposeWebSocketOperationContainer(socketKey, operationId);
 
       if (cleanupError !== undefined) {

--- a/packages/graphql/src/service.ts
+++ b/packages/graphql/src/service.ts
@@ -67,6 +67,15 @@ const DEFAULT_GRAPHQL_WEBSOCKET_LIMITS: GraphqlWebSocketLimits = {
   maxPayloadBytes: 64 * 1024,
 };
 
+function collectCleanupError(errors: unknown[], error: unknown): void {
+  if (error instanceof AggregateError) {
+    errors.push(...error.errors);
+    return;
+  }
+
+  errors.push(error);
+}
+
 function buildFrameworkRequestFromFetchRequest(request: Request): FrameworkRequest {
   const requestUrl = new URL(request.url);
 
@@ -295,7 +304,7 @@ async function loadGraphqlDeps(): Promise<GraphqlDeps> {
 export class GraphqlLifecycleService implements Middleware, OnApplicationBootstrap, OnApplicationShutdown {
   private allowedCrossRealmGraphqlObjects: WeakSet<object> | undefined;
   private graphQLErrorConstructor: typeof GraphQLErrorType | undefined;
-  private readonly operationContainers = new WeakMap<Request, Container>();
+  private readonly operationContainers = new Map<Request, Container>();
   private readonly requestContexts = new WeakMap<Request, GraphqlRequestContext>();
   private readonly websocketOperationContainers = new Map<object, Map<string, Container>>();
   private websocketTransport: GraphqlNodeWebSocketTransport | undefined;
@@ -405,7 +414,23 @@ export class GraphqlLifecycleService implements Middleware, OnApplicationBootstr
   }
 
   private async resetGraphqlRuntimeState(): Promise<void> {
-    await this.unregisterWebSocketTransport();
+    const cleanupErrors: unknown[] = [];
+
+    try {
+      await this.unregisterWebSocketTransport();
+    } catch (error) {
+      collectCleanupError(cleanupErrors, error);
+    }
+
+    try {
+      await this.disposeAllOperationContainers();
+    } catch (error) {
+      collectCleanupError(cleanupErrors, error);
+    }
+
+    if (cleanupErrors.length > 0) {
+      throw new AggregateError(cleanupErrors, 'Failed to clean up GraphQL runtime resources.');
+    }
     this.executeGraphqlOperation = undefined;
     this.graphQLErrorConstructor = undefined;
     this.releaseGraphqlInstanceOfPatch?.();
@@ -499,7 +524,9 @@ export class GraphqlLifecycleService implements Middleware, OnApplicationBootstr
       },
       keepAliveMs: this.options.subscriptions?.websocket?.keepAliveMs,
       limits: this.resolveWebSocketLimits(),
-      onComplete: (socketKey, operationId) => this.disposeWebSocketOperationContainer(socketKey, operationId),
+      onComplete: async (socketKey, operationId) => {
+        await this.disposeWebSocketOperationContainer(socketKey, operationId);
+      },
       onDisconnect: (socketKey) => this.disposeAllWebSocketOperationContainers(socketKey),
       onSubscribe: (request) => this.handleWebSocketSubscribe(request),
       subscribe: (args: ExecutionArgs) => {
@@ -513,18 +540,30 @@ export class GraphqlLifecycleService implements Middleware, OnApplicationBootstr
   }
 
   private async unregisterWebSocketTransport(): Promise<void> {
+    const cleanupErrors: unknown[] = [];
     if (this.websocketTransport) {
       try {
         await this.websocketTransport.dispose();
       } catch (error) {
         this.logger.error('Failed to dispose GraphQL websocket transport.', error, 'GraphqlLifecycleService');
+        collectCleanupError(cleanupErrors, error);
+      }
+
+      if (cleanupErrors.length === 0) {
+        this.websocketTransport = undefined;
       }
     }
 
-    this.websocketTransport = undefined;
+    for (const socketKey of [...this.websocketOperationContainers.keys()]) {
+      try {
+        await this.disposeAllWebSocketOperationContainers(socketKey);
+      } catch (error) {
+        collectCleanupError(cleanupErrors, error);
+      }
+    }
 
-    for (const socketKey of this.websocketOperationContainers.keys()) {
-      await this.disposeAllWebSocketOperationContainers(socketKey);
+    if (cleanupErrors.length > 0) {
+      throw new AggregateError(cleanupErrors, 'Failed to dispose GraphQL websocket resources.');
     }
   }
 
@@ -547,17 +586,17 @@ export class GraphqlLifecycleService implements Middleware, OnApplicationBootstr
 
     const fetchRequest = toFetchRequest(request.request);
     const operationContainer = this.getOrCreateWebSocketOperationContainer(request.socket, request.operationId);
-    const graphqlContext = this.buildGraphqlContext(
-      fetchRequest,
-      {
-        connectionParams: request.connectionParams,
-        request: request.request,
-        socket: request.socket,
-      },
-      operationContainer,
-    );
 
     try {
+      const graphqlContext = this.buildGraphqlContext(
+        fetchRequest,
+        {
+          connectionParams: request.connectionParams,
+          request: request.request,
+          socket: request.socket,
+        },
+        operationContainer,
+      );
       const { contextFactory, parse, schema, validate } = yoga.getEnveloped({
         request: fetchRequest,
         [GRAPHQL_CONTEXT_OVERRIDE]: graphqlContext,
@@ -621,7 +660,7 @@ export class GraphqlLifecycleService implements Middleware, OnApplicationBootstr
     return created;
   }
 
-  private async disposeWebSocketOperationContainer(socketKey: object, operationId: string): Promise<void> {
+  private async disposeWebSocketOperationContainer(socketKey: object, operationId: string): Promise<unknown> {
     const socketContainers = this.websocketOperationContainers.get(socketKey);
     const operationContainer = socketContainers?.get(operationId);
 
@@ -629,16 +668,17 @@ export class GraphqlLifecycleService implements Middleware, OnApplicationBootstr
       return;
     }
 
-    socketContainers?.delete(operationId);
-
-    if (socketContainers && socketContainers.size === 0) {
-      this.websocketOperationContainers.delete(socketKey);
-    }
-
     try {
       await operationContainer.dispose();
     } catch (error) {
       this.logger.error('Failed to dispose GraphQL websocket operation container.', error, 'GraphqlLifecycleService');
+      return error;
+    }
+
+    socketContainers?.delete(operationId);
+
+    if (socketContainers && socketContainers.size === 0) {
+      this.websocketOperationContainers.delete(socketKey);
     }
   }
 
@@ -649,14 +689,18 @@ export class GraphqlLifecycleService implements Middleware, OnApplicationBootstr
       return;
     }
 
-    this.websocketOperationContainers.delete(socketKey);
+    const cleanupErrors: unknown[] = [];
 
-    for (const operationContainer of socketContainers.values()) {
-      try {
-        await operationContainer.dispose();
-      } catch (error) {
-        this.logger.error('Failed to dispose GraphQL websocket operation container.', error, 'GraphqlLifecycleService');
+    for (const operationId of [...socketContainers.keys()]) {
+      const cleanupError = await this.disposeWebSocketOperationContainer(socketKey, operationId);
+
+      if (cleanupError !== undefined) {
+        collectCleanupError(cleanupErrors, cleanupError);
       }
+    }
+
+    if (cleanupErrors.length > 0) {
+      throw new AggregateError(cleanupErrors, 'Failed to dispose GraphQL websocket operation containers.');
     }
   }
 
@@ -672,19 +716,36 @@ export class GraphqlLifecycleService implements Middleware, OnApplicationBootstr
     return created;
   }
 
-  private async disposeOperationContainer(request: Request): Promise<void> {
+  private async disposeOperationContainer(request: Request): Promise<unknown> {
     const operationContainer = this.operationContainers.get(request);
 
     if (!operationContainer) {
       return;
     }
 
-    this.operationContainers.delete(request);
-
     try {
       await operationContainer.dispose();
     } catch (error) {
       this.logger.error('Failed to dispose GraphQL operation container.', error, 'GraphqlLifecycleService');
+      return error;
+    }
+
+    this.operationContainers.delete(request);
+  }
+
+  private async disposeAllOperationContainers(): Promise<void> {
+    const cleanupErrors: unknown[] = [];
+
+    for (const request of [...this.operationContainers.keys()]) {
+      const cleanupError = await this.disposeOperationContainer(request);
+
+      if (cleanupError !== undefined) {
+        collectCleanupError(cleanupErrors, cleanupError);
+      }
+    }
+
+    if (cleanupErrors.length > 0) {
+      throw new AggregateError(cleanupErrors, 'Failed to dispose GraphQL operation containers.');
     }
   }
 }

--- a/packages/graphql/src/teardown-aggregate.test.ts
+++ b/packages/graphql/src/teardown-aggregate.test.ts
@@ -1,0 +1,238 @@
+import { createServer } from 'node:net';
+
+import { Inject, Scope } from '@fluojs/core';
+import { defineModule } from '@fluojs/runtime';
+import { bootstrapNodeApplication } from '@fluojs/runtime/node';
+import { describe, expect, it } from 'vitest';
+import { WebSocket } from 'ws';
+
+import { Query, Resolver, Subscription } from './decorators.js';
+import { GraphqlModule } from './module.js';
+
+type GraphqlWebSocketMessage = {
+  id?: string;
+  payload?: {
+    data?: Record<string, unknown>;
+  };
+  type: string;
+};
+
+async function findAvailablePort(): Promise<number> {
+  return await new Promise<number>((resolve, reject) => {
+    const server = createServer();
+
+    server.once('error', reject);
+    server.listen(0, () => {
+      const address = server.address();
+
+      if (!address || typeof address === 'string') {
+        reject(new Error('Failed to resolve available port.'));
+        return;
+      }
+
+      server.close((error?: Error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve(address.port);
+      });
+    });
+  });
+}
+
+async function postGraphql(port: number, query: string): Promise<unknown> {
+  const response = await fetch(`http://127.0.0.1:${String(port)}/graphql`, {
+    body: JSON.stringify({ query }),
+    headers: {
+      'content-type': 'application/json',
+    },
+    method: 'POST',
+  });
+
+  return await response.json();
+}
+
+function readGraphqlWebSocketMessages(socket: WebSocket, count: number): Promise<GraphqlWebSocketMessage[]> {
+  return new Promise((resolve, reject) => {
+    const messages: GraphqlWebSocketMessage[] = [];
+    const handleClose = (code: number, reason: Buffer) => {
+      cleanup();
+      reject(new Error(`WebSocket closed before collecting ${String(count)} messages: ${String(code)} ${reason.toString('utf8')}`));
+    };
+    const handleError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const handleMessage = (data: unknown) => {
+      if (typeof data === 'string') {
+        messages.push(JSON.parse(data) as GraphqlWebSocketMessage);
+      } else if (data instanceof ArrayBuffer) {
+        messages.push(JSON.parse(Buffer.from(data).toString('utf8')) as GraphqlWebSocketMessage);
+      } else if (ArrayBuffer.isView(data)) {
+        messages.push(
+          JSON.parse(Buffer.from(data.buffer, data.byteOffset, data.byteLength).toString('utf8')) as GraphqlWebSocketMessage,
+        );
+      } else {
+        cleanup();
+        reject(new Error(`Unsupported websocket message payload: ${String(data)}`));
+        return;
+      }
+
+      if (messages.length === count) {
+        cleanup();
+        resolve(messages);
+      }
+    };
+    const cleanup = () => {
+      socket.off('close', handleClose);
+      socket.off('error', handleError);
+      socket.off('message', handleMessage);
+    };
+
+    socket.on('close', handleClose);
+    socket.on('error', handleError);
+    socket.on('message', handleMessage);
+  });
+}
+
+async function connectGraphqlWebSocket(port: number): Promise<WebSocket> {
+  const socket = await new Promise<WebSocket>((resolve, reject) => {
+    const openedSocket = new WebSocket(`ws://127.0.0.1:${String(port)}/graphql`, 'graphql-transport-ws');
+
+    openedSocket.once('open', () => resolve(openedSocket));
+    openedSocket.once('error', reject);
+  });
+  const acknowledgement = readGraphqlWebSocketMessages(socket, 1);
+
+  socket.send(JSON.stringify({ type: 'connection_init' }));
+  await expect(acknowledgement).resolves.toEqual([{ type: 'connection_ack' }]);
+
+  return socket;
+}
+
+function onceWebSocketClosed(socket: WebSocket): Promise<void> {
+  return new Promise((resolve) => {
+    socket.once('close', () => resolve());
+  });
+}
+
+describe('GraphQL teardown error aggregation', () => {
+  it('reports HTTP and websocket cleanup failures together and retries their owners', async () => {
+    let cleanupShouldFail = true;
+
+    @Inject()
+    @Scope('request')
+    class HttpCleanupFailure {
+      onDestroy(): void {
+        if (cleanupShouldFail) {
+          throw new Error('HTTP operation cleanup failed');
+        }
+      }
+    }
+
+    @Inject()
+    @Scope('request')
+    class WebSocketCleanupFailure {
+      onDestroy(): void {
+        if (cleanupShouldFail) {
+          throw new Error('websocket operation cleanup failed');
+        }
+      }
+    }
+
+    @Inject(HttpCleanupFailure)
+    @Scope('request')
+    @Resolver('HttpCleanupFailureResolver')
+    class HttpCleanupFailureResolver {
+      constructor(private readonly cleanupFailure: HttpCleanupFailure) {}
+
+      @Query()
+      httpCleanup(): string {
+        return this.cleanupFailure.constructor.name;
+      }
+    }
+
+    @Inject(WebSocketCleanupFailure)
+    @Scope('request')
+    @Resolver('WebSocketCleanupFailureResolver')
+    class WebSocketCleanupFailureResolver {
+      constructor(private readonly cleanupFailure: WebSocketCleanupFailure) {}
+
+      @Subscription()
+      async *websocketCleanup(): AsyncGenerator<string, void, void> {
+        yield this.cleanupFailure.constructor.name;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [
+        GraphqlModule.forRoot({
+          resolvers: [HttpCleanupFailureResolver, WebSocketCleanupFailureResolver],
+          subscriptions: {
+            websocket: {
+              enabled: true,
+            },
+          },
+        }),
+      ],
+      providers: [
+        HttpCleanupFailure,
+        WebSocketCleanupFailure,
+        HttpCleanupFailureResolver,
+        WebSocketCleanupFailureResolver,
+      ],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapNodeApplication(AppModule, { cors: false, port });
+
+    await app.listen();
+    await expect(postGraphql(port, '{ httpCleanup }')).resolves.toEqual({
+      data: {
+        httpCleanup: 'HttpCleanupFailure',
+      },
+    });
+
+    const socket = await connectGraphqlWebSocket(port);
+    const subscriptionMessages = readGraphqlWebSocketMessages(socket, 2);
+    socket.send(JSON.stringify({
+      id: 'teardown-errors',
+      payload: {
+        query: 'subscription { websocketCleanup }',
+      },
+      type: 'subscribe',
+    }));
+    await expect(subscriptionMessages).resolves.toEqual([
+      {
+        id: 'teardown-errors',
+        payload: {
+          data: {
+            websocketCleanup: 'WebSocketCleanupFailure',
+          },
+        },
+        type: 'next',
+      },
+      {
+        id: 'teardown-errors',
+        type: 'complete',
+      },
+    ]);
+
+    const socketClosed = onceWebSocketClosed(socket);
+    await expect(app.close()).rejects.toSatisfy((error: unknown) => {
+      if (!(error instanceof AggregateError)) {
+        return false;
+      }
+
+      return error.errors.some((item) => item instanceof Error && item.message === 'HTTP operation cleanup failed') &&
+        error.errors.some((item) => item instanceof Error && item.message === 'websocket operation cleanup failed');
+    });
+    await socketClosed;
+
+    cleanupShouldFail = false;
+    await expect(app.close()).resolves.toBeUndefined();
+  });
+});

--- a/packages/graphql/src/teardown-aggregate.test.ts
+++ b/packages/graphql/src/teardown-aggregate.test.ts
@@ -1,7 +1,7 @@
-import { createServer } from 'node:net';
-
 import { Inject, Scope } from '@fluojs/core';
+import type { Application } from '@fluojs/runtime';
 import { defineModule } from '@fluojs/runtime';
+import { HTTP_APPLICATION_ADAPTER } from '@fluojs/runtime/internal';
 import { bootstrapNodeApplication } from '@fluojs/runtime/node';
 import { describe, expect, it } from 'vitest';
 import { WebSocket } from 'ws';
@@ -17,29 +17,16 @@ type GraphqlWebSocketMessage = {
   type: string;
 };
 
-async function findAvailablePort(): Promise<number> {
-  return await new Promise<number>((resolve, reject) => {
-    const server = createServer();
+async function resolveListeningPort(app: Application): Promise<number> {
+  const adapter = await app.get(HTTP_APPLICATION_ADAPTER);
+  const server = adapter.getServer?.() as { address?: () => unknown } | undefined;
+  const address = server?.address?.();
 
-    server.once('error', reject);
-    server.listen(0, () => {
-      const address = server.address();
+  if (!address || typeof address !== 'object' || !('port' in address)) {
+    throw new Error('Failed to resolve the listening port of the bootstrapped application.');
+  }
 
-      if (!address || typeof address === 'string') {
-        reject(new Error('Failed to resolve available port.'));
-        return;
-      }
-
-      server.close((error?: Error) => {
-        if (error) {
-          reject(error);
-          return;
-        }
-
-        resolve(address.port);
-      });
-    });
-  });
+  return (address as { port: number }).port;
 }
 
 async function postGraphql(port: number, query: string): Promise<unknown> {
@@ -186,10 +173,11 @@ describe('GraphQL teardown error aggregation', () => {
       ],
     });
 
-    const port = await findAvailablePort();
-    const app = await bootstrapNodeApplication(AppModule, { cors: false, port });
+    const app = await bootstrapNodeApplication(AppModule, { cors: false, port: 0 });
 
     await app.listen();
+
+    const port = await resolveListeningPort(app);
     await expect(postGraphql(port, '{ httpCleanup }')).resolves.toEqual({
       data: {
         httpCleanup: 'HttpCleanupFailure',
@@ -227,8 +215,15 @@ describe('GraphQL teardown error aggregation', () => {
         return false;
       }
 
-      return error.errors.some((item) => item instanceof Error && item.message === 'HTTP operation cleanup failed') &&
-        error.errors.some((item) => item instanceof Error && item.message === 'websocket operation cleanup failed');
+      const hasNestedAggregate = error.errors.some((item) => item instanceof AggregateError);
+      const messages = error.errors
+        .map((item) => (item instanceof Error ? item.message : String(item)))
+        .sort();
+
+      return !hasNestedAggregate &&
+        messages.includes('HTTP operation cleanup failed') &&
+        messages.includes('websocket operation cleanup failed') &&
+        messages.length === new Set(messages).size;
     });
     await socketClosed;
 


### PR DESCRIPTION
## Summary

Keep ownership of GraphQL request and subscription resources whose cleanup fails, retry only the failed owners, and report every teardown failure exactly once.

Linked context: Closes #3170

## Changes

- retain failed HTTP and websocket cleanup owners separately from active operation IDs, so a legal same-ID resubscribe gets a fresh request scope
- serialize websocket transport disposal behind a single in-flight attempt and drain pending disconnects until quiescent, so late close events cannot escape
- consume transport disconnect errors per attempt and skip resources that were already disposed successfully
- flatten nested `AggregateError`s and drop duplicate leaves, and attempt each failed container at most once per close so retries move to the next attempt
- document the retry contract in EN/KO README and add a patch Changeset

## Testing

- GraphQL typecheck
- focused regressions through real HTTP middleware and a real WebSocket transport, including same-ID resubscribe after failed cleanup, reject-once then successful retry, and duplicate-free multi-owner aggregation
- bounded full GraphQL suite: 17 files, 108 tests
- docs locale parity, platform consistency governance, stable Changeset verifier
- real-boundary tests bind the application to port 0 and read the listening port from the adapter, removing the released-port race

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests.