### PR TITLE
Resolve #3192: Reject ambiguous JWT key IDs before signing

### DIFF
--- a/.changeset/fix-jwt-key-id-ambiguity.md
+++ b/.changeset/fix-jwt-key-id-ambiguity.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/jwt": patch
+---
+
+Reject empty or duplicate JWT key IDs before signing or verification can select ambiguous keys.

--- a/packages/jwt/README.ko.md
+++ b/packages/jwt/README.ko.md
@@ -163,7 +163,7 @@ JWKS key는 `jwksCacheTtl` 밀리초 동안 cache되며 기본값은 `600_000`�
 
 `JwtService.verify(token, options)`는 호출 단위의 알고리즘/클레임 정책 재정의(`issuer`, `audience`, `clockSkewSeconds`, `maxAge`, `requireExp`)를 적용하더라도, 내부 JWKS client나 정적 key-resolution cache를 다시 만들지 않습니다. 호출 단위 검증은 `jwksUri`, `keys[]`, `publicKey`, `secret`, `secretOrKeyProvider` 같은 구성된 key source 자체를 교체하지는 않습니다.
 
-호환되는 키가 여러 개 설정되어 있으면 `kid`가 검증 키를 구분합니다. 호환되는 정적 키가 하나뿐이면 `kid` 없이도 토큰을 검증할 수 있고, JWKS 기반 검증은 원격 key set과 cache policy를 따릅니다.
+호환되는 키가 여러 개 설정되어 있으면 `kid`가 검증 키를 구분합니다. `keys[]`의 모든 entry는 비어 있지 않고 고유한 `kid`를 가져야 합니다. `DefaultJwtSigner`와 `DefaultJwtVerifier`는 key rotation 중 서명과 검증이 서로 다른 키를 선택하지 않도록 construction 시점에 빈 값 또는 중복 값을 `JwtConfigurationError`로 거부합니다. 호환되는 정적 키가 하나뿐이면 `kid` 없이도 토큰을 검증할 수 있고, JWKS 기반 검증은 원격 key set과 cache policy를 따릅니다.
 
 멀티테넌트 시스템에서는 발행된 토큰 header에 tenant-specific `kid`를 넣고 호환되는 key source를 미리 구성하는 방식을 권장합니다. `secretOrKeyProvider`는 decoded token header만 인자로 받으므로, request header, route param, 기타 request-context tenant hint는 JWT verifier 호출 전에 애플리케이션 수준 strategy/guard 코드에서 처리해야 합니다.
 

--- a/packages/jwt/README.md
+++ b/packages/jwt/README.md
@@ -163,7 +163,7 @@ JWKS keys are cached for `jwksCacheTtl` milliseconds (`600_000` by default) and 
 
 `JwtService.verify(token, options)` applies per-call algorithm and claim-policy overrides (`issuer`, `audience`, `clockSkewSeconds`, `maxAge`, `requireExp`) without rebuilding the underlying JWKS client or static key-resolution cache. Per-call verification does not replace configured key sources such as `jwksUri`, `keys[]`, `publicKey`, `secret`, or `secretOrKeyProvider`.
 
-When multiple compatible keys are configured, `kid` disambiguates the verification key. A single compatible static key can verify tokens without `kid`; JWKS-backed verification relies on the remote key set and its cache policy.
+When multiple compatible keys are configured, `kid` disambiguates the verification key. Every `keys[]` entry must have a non-empty, unique `kid`; `DefaultJwtSigner` and `DefaultJwtVerifier` reject empty or duplicate values with `JwtConfigurationError` during construction so key rotation cannot select different keys for signing and verification. A single compatible static key can verify tokens without `kid`; JWKS-backed verification relies on the remote key set and its cache policy.
 
 For multi-tenant systems, prefer putting a tenant-specific `kid` in issued token headers and configuring compatible key sources up front. `secretOrKeyProvider` is called with the decoded token header only, so request headers, route params, or other request-context tenant hints must be handled by application-level strategy/guard code before calling the JWT verifier.
 

--- a/packages/jwt/src/signing/key-entries.ts
+++ b/packages/jwt/src/signing/key-entries.ts
@@ -1,0 +1,23 @@
+import { JwtConfigurationError } from '../errors.js';
+import type { JwtKeyEntry } from '../types.js';
+
+/**
+ * Rejects static key entries whose IDs cannot unambiguously select one key.
+ *
+ * @param keys Static JWT key entries to validate.
+ */
+export function assertJwtKeyEntries(keys: JwtKeyEntry[] | undefined): void {
+  if (!Array.isArray(keys)) {
+    return;
+  }
+
+  const keyIds = new Set<string>();
+
+  for (const entry of keys) {
+    if (typeof entry.kid !== 'string' || entry.kid.length === 0 || keyIds.has(entry.kid)) {
+      throw new JwtConfigurationError('JWT key entries require non-empty unique kid values.');
+    }
+
+    keyIds.add(entry.kid);
+  }
+}

--- a/packages/jwt/src/signing/signer.test.ts
+++ b/packages/jwt/src/signing/signer.test.ts
@@ -3,6 +3,7 @@ import { generateKeyPairSync, sign, verify } from 'node:crypto';
 import { describe, expect, it, vi } from 'vitest';
 
 import { JwtConfigurationError } from '../errors.js';
+import type { JwtVerifierOptions } from '../types.js';
 import { DefaultJwtSigner } from './signer.js';
 import { DefaultJwtVerifier } from './verifier.js';
 
@@ -30,6 +31,43 @@ describe('DefaultJwtSigner', () => {
     expect(() => new DefaultJwtSigner({ algorithms: ['toString' as never], secret: 'secret' })).toThrow(
       'JWT signer received unsupported JWT algorithm "toString".',
     );
+  });
+
+  it('rejects empty and duplicate key IDs during construction', () => {
+    const rsa = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const ec = generateKeyPairSync('ec', { namedCurve: 'P-256' });
+    const invalidOptions: JwtVerifierOptions[] = [
+      {
+        algorithms: ['HS256'],
+        keys: [{ kid: '', secret: 'hmac-secret' }],
+      },
+      {
+        algorithms: ['RS256'],
+        keys: [
+          { kid: 'rsa-key', privateKey: rsa.privateKey },
+          { kid: 'rsa-key', privateKey: rsa.privateKey },
+        ],
+      },
+      {
+        algorithms: ['ES256'],
+        keys: [
+          { kid: 'ec-key', privateKey: ec.privateKey },
+          { kid: 'ec-key', privateKey: ec.privateKey },
+        ],
+      },
+      {
+        algorithms: ['HS256', 'RS256'],
+        keys: [
+          { kid: 'mixed-key', secret: 'hmac-secret' },
+          { kid: 'mixed-key', privateKey: rsa.privateKey },
+        ],
+      },
+    ];
+
+    for (const options of invalidOptions) {
+      expect(() => new DefaultJwtSigner(options)).toThrow(JwtConfigurationError);
+      expect(() => new DefaultJwtSigner(options)).toThrow('JWT key entries require non-empty unique kid values.');
+    }
   });
 
   it('rejects non-positive access token ttl values before issuing a token', async () => {

--- a/packages/jwt/src/signing/signer.ts
+++ b/packages/jwt/src/signing/signer.ts
@@ -3,7 +3,8 @@ import { Inject } from '@fluojs/core';
 import { JwtConfigurationError } from '../errors.js';
 import { normalizeRefreshTokenOptions } from '../refresh/refresh-token.js';
 import type { JwtAlgorithm, JwtClaims, JwtKeyEntry, JwtVerifierOptions } from '../types.js';
-import { ASYMMETRIC_HASH, assertJwtKeyEntries, HMAC_HASH, JWT_OPTIONS } from './verifier.js';
+import { assertJwtKeyEntries } from './key-entries.js';
+import { ASYMMETRIC_HASH, HMAC_HASH, JWT_OPTIONS } from './verifier.js';
 
 function encodeBase64Url(value: Buffer | string): string {
   return Buffer.from(value)

--- a/packages/jwt/src/signing/signer.ts
+++ b/packages/jwt/src/signing/signer.ts
@@ -3,7 +3,7 @@ import { Inject } from '@fluojs/core';
 import { JwtConfigurationError } from '../errors.js';
 import { normalizeRefreshTokenOptions } from '../refresh/refresh-token.js';
 import type { JwtAlgorithm, JwtClaims, JwtKeyEntry, JwtVerifierOptions } from '../types.js';
-import { ASYMMETRIC_HASH, HMAC_HASH, JWT_OPTIONS } from './verifier.js';
+import { ASYMMETRIC_HASH, assertJwtKeyEntries, HMAC_HASH, JWT_OPTIONS } from './verifier.js';
 
 function encodeBase64Url(value: Buffer | string): string {
   return Buffer.from(value)
@@ -69,6 +69,7 @@ export class DefaultJwtSigner {
 
   constructor(private readonly options: JwtVerifierOptions) {
     assertSigningAlgorithms(options.algorithms);
+    assertJwtKeyEntries(options.keys);
     this.refreshAlgorithms = this.options.algorithms.filter(
       (algorithm): algorithm is JwtAlgorithm => hasOwnAlgorithmMapping(HMAC_HASH, algorithm),
     );

--- a/packages/jwt/src/signing/verifier.test.ts
+++ b/packages/jwt/src/signing/verifier.test.ts
@@ -3,6 +3,7 @@ import { createHmac, createSign, generateKeyPairSync } from 'node:crypto';
 import { describe, expect, it, vi } from 'vitest';
 
 import { JwtConfigurationError, JwtExpiredTokenError, JwtInvalidTokenError } from '../errors.js';
+import type { JwtVerifierOptions } from '../types.js';
 import { DefaultJwtVerifier } from './verifier.js';
 
 function encodeBase64Url(value: string): string {
@@ -55,6 +56,43 @@ describe('DefaultJwtVerifier', () => {
     expect(() => new DefaultJwtVerifier({ algorithms: ['toString' as never], secret: 'secret' })).toThrow(
       'JWT verifier received unsupported JWT algorithm "toString".',
     );
+  });
+
+  it('rejects empty and duplicate key IDs during construction', () => {
+    const rsa = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const ec = generateKeyPairSync('ec', { namedCurve: 'P-256' });
+    const invalidOptions: JwtVerifierOptions[] = [
+      {
+        algorithms: ['HS256'],
+        keys: [{ kid: '', secret: 'hmac-secret' }],
+      },
+      {
+        algorithms: ['RS256'],
+        keys: [
+          { kid: 'rsa-key', publicKey: rsa.publicKey },
+          { kid: 'rsa-key', publicKey: rsa.publicKey },
+        ],
+      },
+      {
+        algorithms: ['ES256'],
+        keys: [
+          { kid: 'ec-key', publicKey: ec.publicKey },
+          { kid: 'ec-key', publicKey: ec.publicKey },
+        ],
+      },
+      {
+        algorithms: ['HS256', 'RS256'],
+        keys: [
+          { kid: 'mixed-key', secret: 'hmac-secret' },
+          { kid: 'mixed-key', publicKey: rsa.publicKey },
+        ],
+      },
+    ];
+
+    for (const options of invalidOptions) {
+      expect(() => new DefaultJwtVerifier(options)).toThrow(JwtConfigurationError);
+      expect(() => new DefaultJwtVerifier(options)).toThrow('JWT key entries require non-empty unique kid values.');
+    }
   });
 
   it('rejects tokens whose header algorithm is a prototype key', async () => {

--- a/packages/jwt/src/signing/verifier.ts
+++ b/packages/jwt/src/signing/verifier.ts
@@ -7,6 +7,7 @@ import { JwtConfigurationError, JwtExpiredTokenError, JwtInvalidTokenError } fro
 import { normalizeRefreshTokenOptions } from '../refresh/refresh-token.js';
 import type { JwtAlgorithm, JwtClaims, JwtKeyEntry, JwtPrincipal, JwtVerifierOptions } from '../types.js';
 import { JwksClient } from './jwks.js';
+import { assertJwtKeyEntries } from './key-entries.js';
 
 /**
  * Provides the resolved JWT verifier options through dependency injection.
@@ -33,27 +34,6 @@ export const ASYMMETRIC_HASH: Partial<Record<JwtAlgorithm, string>> = {
   ES384: 'sha384',
   ES512: 'sha512',
 };
-
-/**
- * Rejects static key entries whose IDs cannot unambiguously select one key.
- *
- * @param keys Static JWT key entries to validate.
- */
-export function assertJwtKeyEntries(keys: JwtKeyEntry[] | undefined): void {
-  if (!Array.isArray(keys)) {
-    return;
-  }
-
-  const keyIds = new Set<string>();
-
-  for (const entry of keys) {
-    if (typeof entry.kid !== 'string' || entry.kid.length === 0 || keyIds.has(entry.kid)) {
-      throw new JwtConfigurationError('JWT key entries require non-empty unique kid values.');
-    }
-
-    keyIds.add(entry.kid);
-  }
-}
 
 function hasOwnAlgorithmMapping(
   mappings: Partial<Record<JwtAlgorithm, string>>,

--- a/packages/jwt/src/signing/verifier.ts
+++ b/packages/jwt/src/signing/verifier.ts
@@ -34,6 +34,27 @@ export const ASYMMETRIC_HASH: Partial<Record<JwtAlgorithm, string>> = {
   ES512: 'sha512',
 };
 
+/**
+ * Rejects static key entries whose IDs cannot unambiguously select one key.
+ *
+ * @param keys Static JWT key entries to validate.
+ */
+export function assertJwtKeyEntries(keys: JwtKeyEntry[] | undefined): void {
+  if (!Array.isArray(keys)) {
+    return;
+  }
+
+  const keyIds = new Set<string>();
+
+  for (const entry of keys) {
+    if (typeof entry.kid !== 'string' || entry.kid.length === 0 || keyIds.has(entry.kid)) {
+      throw new JwtConfigurationError('JWT key entries require non-empty unique kid values.');
+    }
+
+    keyIds.add(entry.kid);
+  }
+}
+
 function hasOwnAlgorithmMapping(
   mappings: Partial<Record<JwtAlgorithm, string>>,
   alg: string | undefined,
@@ -291,6 +312,7 @@ export class DefaultJwtVerifier implements OnModuleDestroy {
 
   constructor(private readonly options: JwtVerifierOptions) {
     assertJwtAlgorithms(options.algorithms, 'JWT verifier');
+    assertJwtKeyEntries(options.keys);
     this.jwksClient = options.jwksUri
       ? new JwksClient(options.jwksUri, options.jwksCacheTtl, options.jwksRequestTimeoutMs, options.jwksCacheMaxEntries)
       : undefined;


### PR DESCRIPTION
## Summary

Duplicate or empty `kid` values let `DefaultJwtSigner` and `DefaultJwtVerifier` pick different keys for the same token, so a freshly issued token could fail its own verification. Both constructors now reject that configuration up front.

Linked context: Closes #3192

## Changes

- add a shared internal `assertJwtKeyEntries(...)` guard in `packages/jwt/src/signing/key-entries.ts`
- invoke it from both `DefaultJwtSigner` and `DefaultJwtVerifier` construction, raising `JwtConfigurationError`
- add HMAC, RSA, EC, and mixed-key constructor regression tests on both sides
- document the non-empty unique `kid` requirement in `README.md` and `README.ko.md`
- add a patch Changeset for `@fluojs/jwt`

The guard is deliberately internal: it is not re-exported from `packages/jwt/src/index.ts`, so this patch adds no new public API.

## Testing

- `pnpm --filter '@fluojs/jwt...' build` (clean dist via each package `prebuild`)
- `pnpm --filter '@fluojs/jwt' typecheck`
- `pnpm --filter '@fluojs/jwt' test` — 10 files / 132 tests
- `pnpm --filter '...@fluojs/jwt' --filter '!@fluojs/jwt' test` — `@fluojs/passport` 11 files / 123 tests
- `pnpm verify:public-export-tsdoc`, changed-file Biome lint, `changeset status`
- manual driver over the built package: `jwt-key-id-guard:PASS rejected=4 rootExport=absent`

Canonical local receipt: `.omo/lanes-v4/receipts/3192-c88d2fc5174e.md`

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated.
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed package documentation.
- [x] No platform contract surface changed.