### PR TITLE
Correct the i18n 2.0 HTTP migration rationale

### DIFF
--- a/.changeset/issue-3296-i18n-http-boundary.md
+++ b/.changeset/issue-3296-i18n-http-boundary.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/i18n': patch
+---
+
+Correct the 2.0 migration rationale: the optional `@fluojs/i18n/http` subpath uses `@fluojs/http`'s `RequestContext` boundary, while the root entry point remains framework-agnostic. Upgrading `@fluojs/i18n` does not require `ResponseFormatter` migration work.


### PR DESCRIPTION
## Summary

- correct the i18n 2.0 migration rationale in a patch Changeset
- explain the optional `@fluojs/i18n/http` RequestContext boundary
- clarify that the root remains framework-agnostic and no ResponseFormatter migration is required

## Verification

- `pnpm changeset status --since main`
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=main`
- `git diff --check main...HEAD`
- contract/code/verification exact-head triad: PASS

Resolves #3296