### PR TITLE
Reject colliding i18n typegen declaration names

### DIFF
--- a/.changeset/fresh-i18n-typegen-identifiers.md
+++ b/.changeset/fresh-i18n-typegen-identifiers.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/i18n': patch
+---
+
+Reject colliding catalog typegen declaration identifiers with `I18N_INVALID_OPTIONS` before emitting invalid TypeScript.

--- a/packages/i18n/README.ko.md
+++ b/packages/i18n/README.ko.md
@@ -415,7 +415,7 @@ typedI18n.translateInNamespace('admin/common', 'dashboard.title', { locale: 'en'
 
 이 helper declaration은 type-only이며 application-owned입니다. Runtime wrapper를 추가하지 않고, framework bridge를 import하지 않으며, 넓은 runtime `I18nService.translate(key: string, options)` signature도 바꾸지 않습니다.
 
-두 helper 모두 locale 간 key를 deduplicate하고 stable diff를 위해 output을 sort하며, invalid catalog shape는 `I18N_INVALID_CATALOG`, unsafe locale 또는 namespace path는 `I18N_INVALID_LOADER_OPTIONS`로 거부합니다.
+두 helper 모두 locale 간 key를 deduplicate하고 stable diff를 위해 output을 sort하며, invalid catalog shape는 `I18N_INVALID_CATALOG`, unsafe locale 또는 namespace path는 `I18N_INVALID_LOADER_OPTIONS`로 거부합니다. Custom output name은 유효하고 서로 다른 TypeScript identifier여야 하며, invalid 또는 충돌하는 name은 `I18N_INVALID_OPTIONS`로 거부합니다.
 
 ## 공개 API
 

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -415,7 +415,7 @@ typedI18n.translateInNamespace('admin/common', 'dashboard.title', { locale: 'en'
 
 These helper declarations are type-only and application-owned. They do not add runtime wrappers, do not import framework bridges, and do not change the broad runtime `I18nService.translate(key: string, options)` signature.
 
-Both helpers deduplicate keys across locales, sort output for stable diffs, reject invalid catalog shapes with `I18N_INVALID_CATALOG`, and reject unsafe locale or namespace paths with `I18N_INVALID_LOADER_OPTIONS`.
+Both helpers deduplicate keys across locales, sort output for stable diffs, reject invalid catalog shapes with `I18N_INVALID_CATALOG`, and reject unsafe locale or namespace paths with `I18N_INVALID_LOADER_OPTIONS`. Custom output names must be valid, distinct TypeScript identifiers; invalid or colliding names reject with `I18N_INVALID_OPTIONS`.
 
 ## Public API
 

--- a/packages/i18n/src/typegen.test.ts
+++ b/packages/i18n/src/typegen.test.ts
@@ -232,6 +232,17 @@ export interface I18nCatalogTypedService {
     expect(first).toContain('export type I18nCatalogKey = "alpha" | "beta" | "nested.zeta";');
   });
 
+  it('rejects colliding final declaration identifiers', () => {
+    expectI18nThrow(
+      () =>
+        generateI18nCatalogTypes([], {
+          keyTypeName: 'CatalogDeclaration',
+          namespaceTypeName: 'CatalogDeclaration',
+        }),
+      'I18N_INVALID_OPTIONS',
+    );
+  });
+
   it('fails with stable errors for invalid inputs, catalogs, namespaces, and options', async () => {
     expectI18nThrow(
       () => generateI18nCatalogTypes([{ locale: 'en', messages: { count: 1 } as unknown as I18nMessageTree }]),

--- a/packages/i18n/src/typegen.ts
+++ b/packages/i18n/src/typegen.ts
@@ -265,6 +265,18 @@ export function generateI18nCatalogTypes(
     DEFAULT_TYPED_SERVICE_TYPE_NAME,
     'Catalog typegen typedServiceTypeName',
   );
+  const generatedIdentifiers = [
+    keyTypeName,
+    namespaceTypeName,
+    keyByNamespaceTypeName,
+    namespaceKeyTypeName,
+    typedTranslateOptionsTypeName,
+    typedTranslateTypeName,
+    typedServiceTypeName,
+  ];
+  if (new Set(generatedIdentifiers).size !== generatedIdentifiers.length) {
+    throw new I18nError('Catalog typegen output identifiers must be unique.', 'I18N_INVALID_OPTIONS');
+  }
   const keys = new Set<string>();
   const namespaces = new Set<string>();
   const keysByNamespace = new Map<string, Set<string>>();


### PR DESCRIPTION
## Summary

- reject duplicate final typegen declaration identifiers before emitting invalid TypeScript
- preserve the stable `I18N_INVALID_OPTIONS` error contract
- document the constraint in EN/KO README and add a patch Changeset

## Verification

- dependency-closure build
- `@fluojs/i18n` typecheck and 99-test suite
- built-library collision driver
- Changeset release-lane gate
- exact-head contract/code/verification triad: PASS

Resolves #3291