### PR TITLE
Restore remote i18n loader timeout, TTL, and error contracts

### DIFF
--- a/.changeset/restore-i18n-remote-loader-contracts.md
+++ b/.changeset/restore-i18n-remote-loader-contracts.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/i18n": patch
+---
+
+Restore remote loader timeout validation, successful-load TTL caching, and provider error propagation contracts.

--- a/packages/i18n/README.ko.md
+++ b/packages/i18n/README.ko.md
@@ -346,11 +346,11 @@ const loader = createRemoteI18nLoader({
 const common = await loader.load('en', 'common');
 ```
 
-Provider는 validated `locale`, `namespace`, 그리고 loader timeout과 optional per-call cancellation을 결합한 `AbortSignal`을 받습니다. Provider는 raw object message tree 또는 JSON string을 반환할 수 있습니다. `undefined`와 `null`은 missing catalog로 취급되어 `I18N_MISSING_CATALOG`를 throw합니다. Malformed JSON과 invalid message tree shape는 `I18N_INVALID_CATALOG`, provider failure는 `I18N_LOADER_FAILED`, timeout은 `I18N_LOADER_TIMEOUT`, caller cancellation은 `I18N_LOADER_ABORTED`로 보고됩니다. 반환된 catalog는 항상 detached immutable `I18nMessageTree` snapshot입니다.
+Provider는 validated `locale`, `namespace`, 그리고 loader timeout과 optional per-call cancellation을 결합한 `AbortSignal`을 받습니다. `timeoutMs`는 runtime timer가 정확하게 표현할 수 있는 최대 지연값인 `2_147_483_647` 이하의 양의 정수여야 합니다. Provider는 raw object message tree 또는 JSON string을 반환할 수 있습니다. `undefined`와 `null`은 missing catalog로 취급되어 `I18N_MISSING_CATALOG`를 throw합니다. Malformed JSON과 invalid message tree shape는 `I18N_INVALID_CATALOG`, provider가 throw한 `I18nError` instance는 변경 없이 다시 throw되며 그 외 provider failure는 `I18N_LOADER_FAILED`, timeout은 `I18N_LOADER_TIMEOUT`, caller cancellation은 `I18N_LOADER_ABORTED`로 보고됩니다. 반환된 catalog는 항상 detached immutable `I18nMessageTree` snapshot입니다.
 
 Remote loader는 기본적으로 cache하지 않습니다. 모든 `load(locale, namespace)` 호출은 provider를 호출하고 그 provider result를 snapshot합니다. Memory, HTTP, CDN, database 또는 stale-while-revalidate caching이 필요한 애플리케이션은 cache invalidation이 application boundary에서 명시적으로 유지되도록 provider 내부 또는 provider wrapper에서 구현해야 합니다.
 
-First-party in-memory policy가 필요한 애플리케이션은 loader를 명시적으로 wrap할 수 있습니다. Cache entry는 caller가 custom key를 제공하지 않는 한 `(locale, namespace, version)`으로 keying되며, `invalidate(...)` / `clear()`가 invalidation을 application-owned 상태로 유지합니다.
+First-party in-memory policy가 필요한 애플리케이션은 loader를 명시적으로 wrap할 수 있습니다. Cache entry는 caller가 custom key를 제공하지 않는 한 `(locale, namespace, version)`으로 keying되고 successful load 이후에만 TTL을 시작하며, `invalidate(...)` / `clear()`가 invalidation을 application-owned 상태로 유지합니다.
 
 ```ts
 import { createCachedRemoteI18nLoader, createRemoteI18nLoader } from '@fluojs/i18n/loaders/remote';

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -346,11 +346,11 @@ const loader = createRemoteI18nLoader({
 const common = await loader.load('en', 'common');
 ```
 
-The provider receives the validated `locale`, `namespace`, and an `AbortSignal` that combines the loader timeout with optional per-call cancellation. Providers may return a raw object message tree or a JSON string. `undefined` and `null` are treated as missing catalogs and throw `I18N_MISSING_CATALOG`; malformed JSON and invalid message tree shapes throw `I18N_INVALID_CATALOG`; provider failures are wrapped as `I18N_LOADER_FAILED`; timeouts throw `I18N_LOADER_TIMEOUT`; caller cancellation throws `I18N_LOADER_ABORTED`. Returned catalogs are always detached immutable `I18nMessageTree` snapshots.
+The provider receives the validated `locale`, `namespace`, and an `AbortSignal` that combines the loader timeout with optional per-call cancellation. `timeoutMs` must be a positive integer no greater than `2_147_483_647`, the largest delay that the runtime timer can represent truthfully. Providers may return a raw object message tree or a JSON string. `undefined` and `null` are treated as missing catalogs and throw `I18N_MISSING_CATALOG`; malformed JSON and invalid message tree shapes throw `I18N_INVALID_CATALOG`; provider-thrown `I18nError` instances are rethrown unchanged, while other provider failures are wrapped as `I18N_LOADER_FAILED`; timeouts throw `I18N_LOADER_TIMEOUT`; caller cancellation throws `I18N_LOADER_ABORTED`. Returned catalogs are always detached immutable `I18nMessageTree` snapshots.
 
 The remote loader never caches by default: every `load(locale, namespace)` call invokes the provider and snapshots that provider result. Applications that need memory, HTTP, CDN, database, or stale-while-revalidate caching should implement it inside the provider or in a wrapper around the provider so cache invalidation remains explicit at the application boundary.
 
-Applications that want a first-party in-memory policy can wrap the loader explicitly. Cache entries are keyed by `(locale, namespace, version)` unless the caller provides a custom key, and `invalidate(...)` / `clear()` keep invalidation application-owned:
+Applications that want a first-party in-memory policy can wrap the loader explicitly. Cache entries are keyed by `(locale, namespace, version)` unless the caller provides a custom key, begin their TTL only after a successful load, and keep invalidation application-owned through `invalidate(...)` / `clear()`:
 
 ```ts
 import { createCachedRemoteI18nLoader, createRemoteI18nLoader } from '@fluojs/i18n/loaders/remote';

--- a/packages/i18n/src/loaders/remote.test.ts
+++ b/packages/i18n/src/loaders/remote.test.ts
@@ -102,6 +102,27 @@ describe('@fluojs/i18n/loaders/remote', () => {
     expect(providerCalls).toBe(2);
   });
 
+  it('starts a cache entry TTL after its catalog load succeeds', async () => {
+    let now = 1_000;
+    let providerCalls = 0;
+    const loader: I18nLoader = {
+      load: async () => {
+        providerCalls += 1;
+        now = 1_050;
+        return { title: `Welcome ${providerCalls}` };
+      },
+    };
+    const cached = createCachedRemoteI18nLoader({ loader, now: () => now, ttlMs: 100 });
+
+    await expect(cached.load('en', 'common')).resolves.toEqual({ title: 'Welcome 1' });
+    now = 1_149;
+    await expect(cached.load('en', 'common')).resolves.toEqual({ title: 'Welcome 1' });
+    now = 1_150;
+    await expect(cached.load('en', 'common')).resolves.toEqual({ title: 'Welcome 2' });
+
+    expect(providerCalls).toBe(2);
+  });
+
   it('separates default cache entries by caller-owned catalog version', async () => {
     let providerCalls = 0;
     const loader = new RemoteI18nLoader({
@@ -175,13 +196,14 @@ describe('@fluojs/i18n/loaders/remote', () => {
   });
 
   it('preserves provider-thrown i18n errors without remapping', async () => {
+    const providerError = new I18nError('backend reported a missing catalog', 'I18N_MISSING_CATALOG');
     const loader = new RemoteI18nLoader({
       provider: () => {
-        throw new I18nError('backend reported a missing catalog', 'I18N_MISSING_CATALOG');
+        throw providerError;
       },
     });
 
-    await expectI18nRejection(() => loader.load('en', 'common'), 'I18N_MISSING_CATALOG');
+    await expect(loader.load('en', 'common')).rejects.toBe(providerError);
   });
 
   it('aborts provider work and rejects with a stable timeout code', async () => {
@@ -250,6 +272,7 @@ describe('@fluojs/i18n/loaders/remote', () => {
 
     expectI18nThrow(() => new RemoteI18nLoader({ provider: undefined } as unknown as { readonly provider: () => unknown }), 'I18N_INVALID_LOADER_OPTIONS');
     expectI18nThrow(() => new RemoteI18nLoader({ provider: () => ({}), timeoutMs: 0 }), 'I18N_INVALID_LOADER_OPTIONS');
+    expectI18nThrow(() => new RemoteI18nLoader({ provider: () => ({}), timeoutMs: 2_147_483_648 }), 'I18N_INVALID_LOADER_OPTIONS');
     await expectI18nRejection(() => loader.load('../en', 'common'), 'I18N_INVALID_LOADER_OPTIONS');
     await expectI18nRejection(() => loader.load('en', '.'), 'I18N_INVALID_LOADER_OPTIONS');
     await expectI18nRejection(() => loader.load('en', 'common.json'), 'I18N_INVALID_LOADER_OPTIONS');

--- a/packages/i18n/src/loaders/remote.ts
+++ b/packages/i18n/src/loaders/remote.ts
@@ -11,6 +11,7 @@ import {
 export type { I18nLoader, I18nLoaderLoadOptions } from './shared.js';
 
 const DEFAULT_TIMEOUT_MS = 10_000;
+const MAX_TIMEOUT_MS = 2_147_483_647;
 
 /**
  * Request metadata passed to a remote catalog provider.
@@ -82,8 +83,11 @@ function validateTimeout(timeoutMs: unknown): number {
     return DEFAULT_TIMEOUT_MS;
   }
 
-  if (typeof timeoutMs !== 'number' || !Number.isInteger(timeoutMs) || timeoutMs <= 0) {
-    throw new I18nError('Remote i18n loader timeoutMs must be a positive integer when provided.', 'I18N_INVALID_LOADER_OPTIONS');
+  if (typeof timeoutMs !== 'number' || !Number.isInteger(timeoutMs) || timeoutMs <= 0 || timeoutMs > MAX_TIMEOUT_MS) {
+    throw new I18nError(
+      `Remote i18n loader timeoutMs must be a positive integer no greater than ${MAX_TIMEOUT_MS} when provided.`,
+      'I18N_INVALID_LOADER_OPTIONS',
+    );
   }
 
   return timeoutMs;
@@ -286,7 +290,7 @@ export class CachedRemoteI18nLoader implements CachedI18nLoader {
     }
 
     const catalog = await this.loader.load(locale, namespace, options);
-    this.cache.set(cacheKey, { catalog, expiresAt: currentTime + this.ttlMs });
+    this.cache.set(cacheKey, { catalog, expiresAt: this.now() + this.ttlMs });
     return catalog;
   }
 


### PR DESCRIPTION
## Summary

- start cached remote-loader TTL after successful load completion
- reject timeout values above the Node timer ceiling
- preserve stable loader/provider error semantics
- synchronize EN/KO docs and add a patch Changeset

## Verification

- dependency-closure build and typecheck
- focused timeout test plus two consecutive serial 99-test full-suite passes
- built-library TTL/timeout driver
- docs parity and Changeset release-lane gates
- exact-head contract/code/verification triad: PASS

Resolves #3290