### PR TITLE
Harden i18n catalog snapshots against prototype keys and cycles

### DIFF
--- a/.changeset/harden-i18n-catalog-snapshots.md
+++ b/.changeset/harden-i18n-catalog-snapshots.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/i18n': patch
+---
+
+Preserve prototype-colliding message keys and report cyclic catalogs with `I18N_INVALID_CATALOG`.

--- a/packages/i18n/src/catalog.ts
+++ b/packages/i18n/src/catalog.ts
@@ -16,20 +16,17 @@ export function isPlainObject(value: unknown): value is Record<string, unknown> 
   return prototype === Object.prototype || prototype === null;
 }
 
-/**
- * Creates a detached immutable message tree from untrusted catalog-like input.
- *
- * @param value Catalog-like value to validate and snapshot.
- * @param path Diagnostic path used in validation errors.
- * @returns A frozen message tree detached from caller-owned data.
- */
-export function snapshotMessageTree(value: unknown, path: string): I18nMessageTree {
+function snapshotMessageTreeAtPath(value: unknown, path: string, ancestors: Set<object>): I18nMessageTree {
   if (!isPlainObject(value)) {
     throw new I18nError(`${path} must be a plain object message tree.`, 'I18N_INVALID_CATALOG');
   }
 
-  const snapshot: Record<string, string | I18nMessageTree> = {};
+  if (ancestors.has(value)) {
+    throw new I18nError(`${path} contains a cyclic message tree.`, 'I18N_INVALID_CATALOG');
+  }
 
+  ancestors.add(value);
+  const snapshot: Record<string, string | I18nMessageTree> = Object.create(null);
   for (const [key, entry] of Object.entries(value)) {
     if (key.trim() === '') {
       throw new I18nError(`${path} contains an empty message key segment.`, 'I18N_INVALID_CATALOG');
@@ -41,14 +38,26 @@ export function snapshotMessageTree(value: unknown, path: string): I18nMessageTr
     }
 
     if (isPlainObject(entry)) {
-      snapshot[key] = snapshotMessageTree(entry, `${path}.${key}`);
+      snapshot[key] = snapshotMessageTreeAtPath(entry, `${path}.${key}`, ancestors);
       continue;
     }
 
     throw new I18nError(`${path}.${key} must be a string or nested message tree.`, 'I18N_INVALID_CATALOG');
   }
 
+  ancestors.delete(value);
   return Object.freeze(snapshot);
+}
+
+/**
+ * Creates a detached immutable message tree from untrusted catalog-like input.
+ *
+ * @param value Catalog-like value to validate and snapshot.
+ * @param path Diagnostic path used in validation errors.
+ * @returns A frozen message tree detached from caller-owned data.
+ */
+export function snapshotMessageTree(value: unknown, path: string): I18nMessageTree {
+  return snapshotMessageTreeAtPath(value, path, new Set<object>());
 }
 
 /**

--- a/packages/i18n/src/index.test.ts
+++ b/packages/i18n/src/index.test.ts
@@ -240,6 +240,27 @@ describe('@fluojs/i18n root public surface', () => {
     expect(service.snapshotOptions().supportedLocales).toEqual(['en', 'ko']);
   });
 
+  it('preserves own __proto__ message keys in core catalog snapshots', () => {
+    // Given: a plain-object catalog with an own message key that collides with Object.prototype.
+    const messages: I18nMessageCatalogs['en'] = {};
+    Object.defineProperty(messages, '__proto__', { enumerable: true, value: 'Prototype-safe' });
+
+    // When: the core service captures its catalog snapshot.
+    const service = createI18n({ catalogs: { en: messages }, defaultLocale: 'en' });
+
+    // Then: the valid own key remains available for translation.
+    expect(service.translate('__proto__', { locale: 'en' })).toBe('Prototype-safe');
+  });
+
+  it('rejects cyclic core catalogs with the stable invalid catalog code', () => {
+    // Given: a catalog whose nested tree refers to itself.
+    const messages: Record<string, string | I18nMessageCatalogs['en']> = {};
+    messages.self = messages;
+
+    // When/Then: core registration reports the documented catalog error instead of overflowing recursion.
+    expectI18nCode(() => createI18n({ catalogs: { en: messages }, defaultLocale: 'en' }), 'I18N_INVALID_CATALOG');
+  });
+
   it('fails with stable errors for invalid catalogs, locale config, and translation options', () => {
     const invalidCatalogs = {
       en: {

--- a/packages/i18n/src/loaders/remote.test.ts
+++ b/packages/i18n/src/loaders/remote.test.ts
@@ -59,6 +59,31 @@ describe('@fluojs/i18n/loaders/remote', () => {
     expect(Object.isFrozen(catalog.nested)).toBe(true);
   });
 
+  it('preserves own __proto__ message keys from remote provider catalogs', async () => {
+    // Given: a provider result with an own message key that collides with Object.prototype.
+    const providerCatalog: I18nMessageTree = {};
+    Object.defineProperty(providerCatalog, '__proto__', { enumerable: true, value: 'Prototype-safe' });
+    const loader = createRemoteI18nLoader({ provider: () => providerCatalog });
+
+    // When: the remote loader snapshots that catalog.
+    const catalog = await loader.load('en', 'common');
+
+    // Then: the valid own key remains a frozen catalog entry.
+    expect(Object.hasOwn(catalog, '__proto__')).toBe(true);
+    expect(catalog.__proto__).toBe('Prototype-safe');
+    expect(Object.isFrozen(catalog)).toBe(true);
+  });
+
+  it('rejects cyclic remote provider catalogs with the stable invalid catalog code', async () => {
+    // Given: a provider result whose nested catalog tree refers to itself.
+    const providerCatalog: Record<string, string | I18nMessageTree> = {};
+    providerCatalog.self = providerCatalog;
+    const loader = createRemoteI18nLoader({ provider: () => providerCatalog });
+
+    // When/Then: loader validation reports the documented error instead of overflowing recursion.
+    await expectI18nRejection(() => loader.load('en', 'common'), 'I18N_INVALID_CATALOG');
+  });
+
   it('loads remote JSON string catalogs into immutable message trees', async () => {
     const loader = new RemoteI18nLoader({
       provider: () => JSON.stringify({ title: 'Welcome' }),

--- a/packages/i18n/src/typegen.test.ts
+++ b/packages/i18n/src/typegen.test.ts
@@ -86,6 +86,27 @@ describe('@fluojs/i18n/typegen', () => {
     expect(output).toContain('readonly "admin/common": "cancel" | "nested.save";');
   });
 
+  it('includes own __proto__ message keys in generated catalog declarations', () => {
+    // Given: an in-memory catalog with an own key that collides with Object.prototype.
+    const messages: I18nMessageTree = {};
+    Object.defineProperty(messages, '__proto__', { enumerable: true, value: 'Prototype-safe' });
+
+    // When: typegen snapshots and traverses the catalog.
+    const output = generateI18nCatalogTypes([{ locale: 'en', messages }]);
+
+    // Then: the valid own key appears in the generated union.
+    expect(output).toContain('export type I18nCatalogKey = "__proto__";');
+  });
+
+  it('rejects cyclic in-memory catalogs with the stable invalid catalog code', () => {
+    // Given: an in-memory catalog whose nested tree refers to itself.
+    const messages: Record<string, string | I18nMessageTree> = {};
+    messages.self = messages;
+
+    // When/Then: typegen validation reports the documented error instead of overflowing recursion.
+    expectI18nThrow(() => generateI18nCatalogTypes([{ locale: 'en', messages }]), 'I18N_INVALID_CATALOG');
+  });
+
   it('reads locale namespace files from disk using deterministic namespace paths', async () => {
     await writeCatalog('ko', 'common/actions', { save: '저장' });
     await writeCatalog('en', 'common/actions', { cancel: 'Cancel', save: 'Save' });


### PR DESCRIPTION
## Summary

- preserve valid own keys such as `__proto__` in null-prototype snapshots
- reject cyclic catalog graphs with `I18N_INVALID_CATALOG`
- cover core, remote-loader, and typegen ingestion paths
- add a patch Changeset

## Verification

- dependency-closure build and typecheck
- serial `@fluojs/i18n` suite: 104/104
- built-library prototype-key/cycle driver
- Changeset release-lane gate
- exact-head contract/code/verification triad: PASS

Resolves #3289