### PR TITLE
Centralize i18n message and locale resolution internals

### DIFF
--- a/.changeset/issue-3292-i18n-resolution-seams.md
+++ b/.changeset/issue-3292-i18n-resolution-seams.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/i18n": patch
+---
+
+Centralize internal catalog provenance and locale resolver-chain resolution without changing public i18n behavior.

--- a/packages/i18n/src/adapters.test.ts
+++ b/packages/i18n/src/adapters.test.ts
@@ -321,4 +321,28 @@ describe('@fluojs/i18n/adapters locale adapter surface', () => {
       }),
     ).toEqual({ locale: 'ko', source: 'accept-language' });
   });
+
+  it('keeps resolver-chain provenance parity after invalid candidates', () => {
+    const adapterContext: TransportContext = {};
+    const httpContext = createMockHttpContext();
+    const unsupportedAdapter: LocaleAdapterResolver<TransportContext> = () => ({ locale: 'fr', source: 'unsupported' });
+    const selectedAdapter: LocaleAdapterResolver<TransportContext> = () => ({ locale: 'ko', source: 'selected' });
+    const unsupportedHttp: HttpLocaleResolver = () => ({ locale: 'fr', source: 'unsupported' });
+    const selectedHttp: HttpLocaleResolver = () => ({ locale: 'ko', source: 'selected' });
+
+    expect(
+      resolveLocale(adapterContext, {
+        defaultLocale: 'en',
+        resolvers: [unsupportedAdapter, selectedAdapter],
+        supportedLocales: ['en', 'ko'],
+      }),
+    ).toEqual({ locale: 'ko', source: 'selected' });
+    expect(
+      resolveHttpLocale(httpContext, {
+        defaultLocale: 'en',
+        resolvers: [unsupportedHttp, selectedHttp],
+        supportedLocales: ['en', 'ko'],
+      }),
+    ).toEqual({ locale: 'ko', source: 'selected' });
+  });
 });

--- a/packages/i18n/src/adapters.ts
+++ b/packages/i18n/src/adapters.ts
@@ -2,11 +2,11 @@ import {
   type AcceptLanguageLocalePolicyOptions,
   isSupportedLocale,
   isValidLocale,
-  normalizeLocaleResolverResult,
   parseLocalePreferences,
   resolveSupportedLocale,
   selectLocaleFromAcceptLanguagePolicy,
 } from './locale-resolution.js';
+import { resolveLocaleResolverChain } from './resolver-chain.js';
 import type { I18nLocale } from './types.js';
 
 /**
@@ -181,27 +181,10 @@ export function getAdapterLocale<TContext>(
  * @throws {TypeError} When the configured default locale is invalid or unsupported.
  */
 export function resolveLocale<TContext>(context: TContext, options: ResolveLocaleOptions<TContext>): LocaleAdapterContext {
-  if (!isValidLocale(options.defaultLocale)) {
-    throw new TypeError('defaultLocale must be a syntactically valid locale string.');
-  }
-
-  if (!isSupportedLocale(options.defaultLocale, options.supportedLocales)) {
-    throw new TypeError('defaultLocale must be listed in supportedLocales when supportedLocales is provided.');
-  }
-
-  for (const resolver of options.resolvers ?? []) {
-    const result = normalizeLocaleResolverResult(
-      resolver({ context, defaultLocale: options.defaultLocale, supportedLocales: options.supportedLocales }),
-    );
-
-    if (result === undefined || !isValidLocale(result.locale) || !isSupportedLocale(result.locale, options.supportedLocales)) {
-      continue;
-    }
-
-    return Object.freeze({ locale: result.locale, source: result.source });
-  }
-
-  return Object.freeze({ locale: options.defaultLocale, source: 'default' });
+  return resolveLocaleResolverChain<LocaleAdapterResolverInput<TContext>>(
+    { context, defaultLocale: options.defaultLocale, supportedLocales: options.supportedLocales },
+    options,
+  );
 }
 
 /**

--- a/packages/i18n/src/http.ts
+++ b/packages/i18n/src/http.ts
@@ -7,13 +7,11 @@ import {
 } from '@fluojs/http';
 import {
   type AcceptLanguageLocalePolicyOptions,
-  isSupportedLocale,
-  isValidLocale,
-  normalizeLocaleResolverResult,
   parseLocalePreferences,
   resolveSupportedLocale,
   selectLocaleFromAcceptLanguagePolicy,
 } from './locale-resolution.js';
+import { resolveLocaleResolverChain } from './resolver-chain.js';
 import type { I18nLocale } from './types.js';
 
 /**
@@ -212,27 +210,11 @@ export function createAcceptLanguageLocalePolicyResolver(
  * @throws {TypeError} When the configured default locale is invalid or unsupported.
  */
 export function resolveHttpLocale(context: RequestContext, options: ResolveHttpLocaleOptions): HttpLocaleContext {
-  if (!isValidLocale(options.defaultLocale)) {
-    throw new TypeError('defaultLocale must be a syntactically valid locale string.');
-  }
+  const resolved = resolveLocaleResolverChain<HttpLocaleResolverInput>(
+    { context, defaultLocale: options.defaultLocale, supportedLocales: options.supportedLocales },
+    options,
+  );
 
-  if (!isSupportedLocale(options.defaultLocale, options.supportedLocales)) {
-    throw new TypeError('defaultLocale must be listed in supportedLocales when supportedLocales is provided.');
-  }
-
-  for (const resolver of options.resolvers ?? []) {
-    const result = normalizeLocaleResolverResult(
-      resolver({ context, defaultLocale: options.defaultLocale, supportedLocales: options.supportedLocales }),
-    );
-
-    if (result === undefined || !isValidLocale(result.locale) || !isSupportedLocale(result.locale, options.supportedLocales)) {
-      continue;
-    }
-
-    setHttpLocale(context, result.locale, { source: result.source });
-    return getHttpLocale(context) ?? { locale: result.locale, source: result.source };
-  }
-
-  setHttpLocale(context, options.defaultLocale, { source: 'default' });
-  return getHttpLocale(context) ?? { locale: options.defaultLocale, source: 'default' };
+  setHttpLocale(context, resolved.locale, { source: resolved.source });
+  return getHttpLocale(context) ?? resolved;
 }

--- a/packages/i18n/src/icu.test.ts
+++ b/packages/i18n/src/icu.test.ts
@@ -188,4 +188,22 @@ describe('@fluojs/i18n/icu MessageFormat subpath', () => {
     expect(icu.getCoreService()).toBe(core);
     expect(icu.translate('simple', { locale: 'en', values: { name: 'fluo' } })).toBe('Hello fluo');
   });
+
+  it('keeps fallback message provenance when wrapping an existing core service', () => {
+    const core = createI18n({
+      catalogs: {
+        en: {
+          ordinal: '{count, selectordinal, one {#st result} other {#th results}}',
+        },
+        ko: {},
+      },
+      defaultLocale: 'en',
+      fallbackLocales: { ko: ['en'] },
+      supportedLocales: ['en', 'ko'],
+    });
+
+    const icu = new IcuI18nService(core);
+
+    expect(icu.translate('ordinal', { locale: 'ko', values: { count: 1 } })).toBe('1st result');
+  });
 });

--- a/packages/i18n/src/icu.ts
+++ b/packages/i18n/src/icu.ts
@@ -1,9 +1,8 @@
 import { FormatError, IntlMessageFormat } from 'intl-messageformat';
 import type { Formats } from 'intl-messageformat';
 
-import { resolveCatalogMessage } from './catalog.js';
 import { I18nError } from './errors.js';
-import { I18nService, createI18n } from './service.js';
+import { I18nService, createI18n, resolveI18nMessageProvenance } from './service.js';
 import type { I18nInterpolationValues, I18nLocale, I18nModuleOptions, I18nTranslateOptions } from './types.js';
 
 /**
@@ -57,16 +56,7 @@ function toMessageFormatValues(values: I18nIcuValues | undefined): Record<string
 }
 
 function resolveMessageLocale(service: I18nService, key: string, options: I18nIcuTranslateOptions): I18nLocale {
-  const resolvedKey = options.namespace === undefined ? key : `${options.namespace}.${key}`;
-  const snapshot = service.snapshotOptions();
-
-  for (const locale of service.resolveLocales(options.locale)) {
-    if (resolveCatalogMessage(snapshot.catalogs?.[locale], resolvedKey) !== undefined) {
-      return locale;
-    }
-  }
-
-  return options.locale;
+  return resolveI18nMessageProvenance(service, key, options.locale, options.namespace)?.locale ?? options.locale;
 }
 
 function normalizeMessageFormatError(error: unknown, key: string): I18nError {

--- a/packages/i18n/src/message-provenance.ts
+++ b/packages/i18n/src/message-provenance.ts
@@ -1,0 +1,23 @@
+import { resolveCatalogMessage } from './catalog.js';
+import type { I18nLocale, I18nMessageCatalogs } from './types.js';
+
+export interface I18nMessageProvenance {
+  readonly locale: I18nLocale;
+  readonly message: string;
+}
+
+export function resolveMessageProvenance(
+  catalogs: I18nMessageCatalogs | undefined,
+  locales: readonly I18nLocale[],
+  key: string,
+): I18nMessageProvenance | undefined {
+  for (const locale of locales) {
+    const message = resolveCatalogMessage(catalogs?.[locale], key);
+
+    if (message !== undefined) {
+      return Object.freeze({ locale, message });
+    }
+  }
+
+  return undefined;
+}

--- a/packages/i18n/src/resolver-chain.ts
+++ b/packages/i18n/src/resolver-chain.ts
@@ -1,0 +1,36 @@
+import { isSupportedLocale, isValidLocale, normalizeLocaleResolverResult } from './locale-resolution.js';
+import type { I18nLocale } from './types.js';
+
+export interface LocaleResolverChainResult {
+  readonly locale: I18nLocale;
+  readonly source?: string;
+}
+
+export interface LocaleResolverChainOptions<TInput> {
+  readonly defaultLocale: I18nLocale;
+  readonly supportedLocales?: readonly I18nLocale[];
+  readonly resolvers?: readonly ((input: TInput) => unknown)[];
+}
+
+export function resolveLocaleResolverChain<TInput>(
+  input: TInput,
+  options: LocaleResolverChainOptions<TInput>,
+): LocaleResolverChainResult {
+  if (!isValidLocale(options.defaultLocale)) {
+    throw new TypeError('defaultLocale must be a syntactically valid locale string.');
+  }
+
+  if (!isSupportedLocale(options.defaultLocale, options.supportedLocales)) {
+    throw new TypeError('defaultLocale must be listed in supportedLocales when supportedLocales is provided.');
+  }
+
+  for (const resolver of options.resolvers ?? []) {
+    const result = normalizeLocaleResolverResult(resolver(input));
+
+    if (result !== undefined && isValidLocale(result.locale) && isSupportedLocale(result.locale, options.supportedLocales)) {
+      return Object.freeze({ locale: result.locale, source: result.source });
+    }
+  }
+
+  return Object.freeze({ locale: options.defaultLocale, source: 'default' });
+}

--- a/packages/i18n/src/service.ts
+++ b/packages/i18n/src/service.ts
@@ -1,4 +1,5 @@
-import { isPlainObject, resolveCatalogMessage } from './catalog.js';
+import { isPlainObject } from './catalog.js';
+import { resolveMessageProvenance } from './message-provenance.js';
 import { snapshotI18nModuleOptions } from './options.js';
 import { I18nError } from './errors.js';
 import type {
@@ -12,6 +13,8 @@ import type {
   I18nRelativeTimeFormatOptions,
   I18nTranslateOptions,
 } from './types.js';
+
+const serviceOptions = new WeakMap<I18nService, I18nModuleOptions>();
 
 function normalizeTranslationKey(key: unknown, namespace: unknown): string {
   if (typeof key !== 'string') {
@@ -135,6 +138,7 @@ export class I18nService {
    */
   constructor(options: I18nModuleOptions = {}) {
     this.options = snapshotI18nModuleOptions(options);
+    serviceOptions.set(this, this.options);
   }
 
   /**
@@ -339,12 +343,10 @@ export class I18nService {
     const resolvedKey = normalizeTranslationKey(key, options.namespace);
     const locales = this.resolveLocales(options.locale);
 
-    for (const locale of locales) {
-      const message = resolveCatalogMessage(this.options.catalogs?.[locale], resolvedKey);
+    const message = resolveMessageProvenance(this.options.catalogs, locales, resolvedKey);
 
-      if (message !== undefined) {
-        return interpolate(message, options.values);
-      }
+    if (message !== undefined) {
+      return interpolate(message.message, options.values);
     }
 
     if (options.defaultValue !== undefined) {
@@ -364,6 +366,22 @@ export class I18nService {
 
     throw new I18nError(`Missing i18n message: ${resolvedKey}`, 'I18N_MISSING_MESSAGE');
   }
+}
+
+export function resolveI18nMessageProvenance(
+  service: I18nService,
+  key: string,
+  locale: I18nLocale,
+  namespace: string | undefined,
+) {
+  const options = serviceOptions.get(service);
+
+  if (options === undefined) {
+    return undefined;
+  }
+
+  const resolvedKey = normalizeTranslationKey(key, namespace);
+  return resolveMessageProvenance(options.catalogs, service.resolveLocales(locale), resolvedKey);
 }
 
 /**


### PR DESCRIPTION
## Summary

- centralize package-private message provenance lookup
- share locale resolver-chain execution across HTTP and adapters
- preserve public APIs, fallback order, and ICU locale provenance
- add focused parity regressions and a patch Changeset

## Verification

- dependency-closure build and typecheck
- serial `@fluojs/i18n` suite: 100/100
- built-library ICU fallback-provenance driver
- Changeset release-lane gate
- exact-head contract/code/verification triad: PASS

Resolves #3292