### PR TITLE
fix(validation): preserve colliding nested rules

### DIFF
--- a/.changeset/preserve-intersection-nested-rules.md
+++ b/.changeset/preserve-intersection-nested-rules.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/validation': patch
+---
+
+Preserve and validate colliding nested rules copied by `IntersectionType`.

--- a/packages/validation/README.ko.md
+++ b/packages/validation/README.ko.md
@@ -143,6 +143,11 @@ validation 및 binding metadata를 보존합니다. `PickType`, `OmitType`,
 `PartialType`은 생략되었거나 optional이 된 필드에 의존할 수 있는 base
 class-level validator를 derived DTO로 전달하지 않습니다.
 
+`IntersectionType(...)` source가 같은 property에 서로 다른
+`@ValidateNested(...)` target을 선언하면 모든 nested rule이 보존되고 검증됩니다.
+공유 property의 plain value는 초기 실체화 중 plain 상태로 유지되므로 각 nested
+target이 해당 value를 독립적으로 실체화하고 검증할 수 있습니다.
+
 ### Standard Schema 지원
 
 Standard Schema adapter는 유효하지 않은 입력을 명시적인 issue로 보고해야 합니다. issue가 없는 검증 결과는 성공으로 처리합니다.

--- a/packages/validation/README.md
+++ b/packages/validation/README.md
@@ -147,6 +147,11 @@ the documented subclassing pattern shown above. `PickType`, `OmitType`, and
 `PartialType` do not carry base class-level validators onto derived DTOs because
 those validators can depend on fields that were omitted or made optional.
 
+When `IntersectionType(...)` sources declare different `@ValidateNested(...)`
+targets for the same property, every nested rule is preserved and validated.
+Plain values for that shared property remain plain during the initial hydration
+so each nested target can materialize and validate the value independently.
+
 ### Standard Schema support
 
 Standard Schema adapters are expected to report invalid input through explicit issues. Validation results without issues are treated as successful.

--- a/packages/validation/src/internal/dto-materialization.ts
+++ b/packages/validation/src/internal/dto-materialization.ts
@@ -138,6 +138,13 @@ export function createNestedDtoInstance<T>(
     }
 
     for (const nestedEntry of metadata.nestedDtoTransforms) {
+      const hasConflictingTarget = metadata.nestedDtoTransforms.some(
+        (candidate) => candidate.propertyKey === nestedEntry.propertyKey && candidate.target !== nestedEntry.target,
+      );
+      if (hasConflictingTarget) {
+        continue;
+      }
+
       const currentValue = instance[nestedEntry.propertyKey];
       if (currentValue === undefined || currentValue === null) {
         continue;

--- a/packages/validation/src/internal/dto-metadata-cache.ts
+++ b/packages/validation/src/internal/dto-metadata-cache.ts
@@ -1,7 +1,6 @@
 import type { Constructor, MetadataPropertyKey } from '@fluojs/core';
 import {
   type DtoFieldBindingMetadata,
-  type DtoFieldValidationRule,
   getClassValidationRules,
   getDtoBindingSchema,
   getDtoValidationSchema,
@@ -44,18 +43,16 @@ function collectNestedDtoTransforms(dtoValidationSchema: DtoValidationSchema): C
   const nestedEntries: CachedDtoMetadata['nestedDtoTransforms'][number][] = [];
 
   for (const entry of dtoValidationSchema) {
-    const nestedRule = entry.rules.find(
-      (rule: DtoFieldValidationRule): rule is Extract<DtoFieldValidationRule, { kind: 'nested' }> => rule.kind === 'nested',
-    );
+    for (const rule of entry.rules) {
+      if (rule.kind !== 'nested') {
+        continue;
+      }
 
-    if (!nestedRule) {
-      continue;
+      nestedEntries.push({
+        propertyKey: entry.propertyKey,
+        target: resolveNestedDto(rule.dto),
+      });
     }
-
-    nestedEntries.push({
-      propertyKey: entry.propertyKey,
-      target: resolveNestedDto(nestedRule.dto),
-    });
   }
 
   return nestedEntries;

--- a/packages/validation/src/intersection-nested-rules.test.ts
+++ b/packages/validation/src/intersection-nested-rules.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { IsNumber, IsString, ValidateNested } from './decorators.js';
+import { IntersectionType } from './mapped-types.js';
+import { DefaultValidator } from './validation.js';
+
+describe('IntersectionType nested rules', () => {
+  it('materializes when source DTOs share a property with different nested rules', async () => {
+    // Given
+    class NamedChildDto {
+      @IsString()
+      name = '';
+    }
+
+    class RankedChildDto {
+      @IsNumber()
+      rank = 0;
+    }
+
+    class NamedParentDto {
+      @ValidateNested(() => NamedChildDto)
+      child = new NamedChildDto();
+    }
+
+    class RankedParentDto {
+      @ValidateNested(() => RankedChildDto)
+      child = new RankedChildDto();
+    }
+
+    class CombinedParentDto extends IntersectionType(NamedParentDto, RankedParentDto) {}
+    const validator = new DefaultValidator();
+
+    // When
+    const result = validator.materialize({ child: { name: 'fluo', rank: 1 } }, CombinedParentDto);
+
+    // Then
+    await expect(result).resolves.toMatchObject({ child: { name: 'fluo', rank: 1 } });
+  });
+});


### PR DESCRIPTION
## Summary

Preserve every nested validation rule contributed through IntersectionType when source DTOs share one property.

Linked context: Closes #3275

## Changes

- retain every nested DTO transform in metadata cache
- defer conflicting target hydration so each validation rule materializes independently
- add regression coverage and align EN/KO README contracts
- add a patch Changeset for @fluojs/validation

## Testing

- validation dependency closure build and typecheck
- validation: 87 tests passed
- direct dependents: HTTP 323, i18n 98, OpenAPI 83, Prisma 64 passed
- GraphQL timeout baseline reproduced more broadly on clean main; branch functional assertions and build-output passed
- exact-head code, contract, and verification review triad: merge

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] No public export signatures changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] The preserved nested-rule contract is documented in affected README files.
- [x] Runtime invariant is covered by regression tests.

## Platform consistency governance (SSOT)

- [x] No platform contract surfaces changed.