### PR TITLE
Make the i18n request-locale migration handoff executable

### DIFF
--- a/docs/CONTEXT.ko.md
+++ b/docs/CONTEXT.ko.md
@@ -6,6 +6,10 @@
 
 fluo는 TC39 표준 데코레이터, 명시적 의존성 경계, 메타데이터 없는 런타임 구성을 기반으로 하는 standard-first TypeScript 백엔드 프레임워크다. legacy 데코레이터 컴파일 모드를 거부하며, behavioral contract, 플랫폼 parity, 패키지 표면의 명확성을 핵심 설계 제약으로 둔다.
 
+## Migration Reference
+
+NestJS 마이그레이션은 [NestJS migration map](./getting-started/migrate-from-nestjs.ko.md)에서 시작한다. i18n handoff는 각 custom resolver를 `HttpLocaleResolver`로 mapping하고, `FluoFactory.create(...)`에 application-owned `Middleware` 하나를 등록하며, 선택된 locale은 현재 `RequestContext`에만 저장한다. global locale fallback은 없다.
+
 ## Hard Constraints
 
 - NEVER use `experimentalDecorators`.

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -6,6 +6,10 @@ This document is the primary AI-reference entrypoint for the fluo repository. It
 
 fluo is a standard-first TypeScript backend framework built on TC39 standard decorators, explicit dependency boundaries, and metadata-free runtime wiring. It rejects legacy decorator compiler modes and treats behavioral contracts, platform parity, and package surface clarity as core design constraints.
 
+## Migration Reference
+
+For a NestJS migration, start with the [NestJS migration map](./getting-started/migrate-from-nestjs.md). Its i18n handoff maps every custom resolver to an `HttpLocaleResolver`, registers one application-owned `Middleware` through `FluoFactory.create(...)`, and stores the selected locale only on the current `RequestContext`; no global locale fallback exists.
+
 ## Hard Constraints
 
 - NEVER use `experimentalDecorators`.

--- a/docs/getting-started/migrate-from-nestjs.ko.md
+++ b/docs/getting-started/migrate-from-nestjs.ko.md
@@ -358,12 +358,25 @@ import {
   createAcceptLanguageLocaleResolver,
   getHttpLocale,
   resolveHttpLocale,
+  type HttpLocaleResolver,
 } from '@fluojs/i18n/http';
 import { localizeDtoValidationError } from '@fluojs/i18n/validation';
-import type { RequestContext } from '@fluojs/http';
+import type { Middleware, RequestContext } from '@fluojs/http';
+import { FluoFactory } from '@fluojs/runtime';
+import { createNodeHttpAdapter } from '@fluojs/runtime/node';
 import type { DtoValidationError } from '@fluojs/validation';
 
 const acceptLanguage = createAcceptLanguageLocaleResolver();
+
+class TenantLocaleResolver {
+  resolve(context: RequestContext) {
+    const locale = context.request.headers['x-tenant-locale'];
+    return typeof locale === 'string' ? { locale, source: 'tenant-header' } : undefined;
+  }
+}
+
+const tenantLocaleResolver = new TenantLocaleResolver();
+const mapTenantLocaleResolver: HttpLocaleResolver = ({ context }) => tenantLocaleResolver.resolve(context);
 
 @Module({
   imports: [
@@ -379,13 +392,22 @@ const acceptLanguage = createAcceptLanguageLocaleResolver();
 })
 class AppModule {}
 
-function bindRequestLocale(context: RequestContext) {
-  return resolveHttpLocale(context, {
-    defaultLocale: 'en',
-    supportedLocales: ['en', 'ko'],
-    resolvers: [acceptLanguage],
-  });
-}
+const requestLocaleHook: Middleware = {
+  async handle({ requestContext }, next) {
+    resolveHttpLocale(requestContext, {
+      defaultLocale: 'en',
+      supportedLocales: ['en', 'ko'],
+      resolvers: [mapTenantLocaleResolver, acceptLanguage],
+    });
+    await next();
+  },
+};
+
+const app = await FluoFactory.create(AppModule, {
+  adapter: createNodeHttpAdapter({ port: 3000 }),
+  middleware: [requestLocaleHook],
+});
+await app.listen();
 
 function localizeValidationFailure(
   i18n: I18nService,
@@ -397,7 +419,7 @@ function localizeValidationFailure(
 }
 ```
 
-Downstream translation 또는 validation-error handling 전에 application-owned middleware나 다른 request hook에서 `bindRequestLocale(...)`을 호출한다. `resolveHttpLocale(...)`은 resolver를 배열 순서대로 실행하고 invalid 또는 unsupported result를 무시하며, 아무 것도 match하지 않으면 configured default를 source `default`로 저장한다. `getHttpLocale(...)`은 해당 `RequestContext`만 읽고 global state는 조회하지 않는다.
+각 custom NestJS resolver class를 `HttpLocaleResolver`로 mapping하고 `FluoFactory.create(...)`에 application-owned `Middleware` 하나를 등록한다. 이 hook은 `Accept-Language`보다 tenant 값을 먼저 resolve하며, downstream translation 또는 validation-error handling은 같은 `RequestContext`에서 결과를 읽는다. `resolveHttpLocale(...)`은 resolver를 배열 순서대로 실행하고 invalid 또는 unsupported result를 무시하며, 아무 것도 match하지 않으면 configured default를 source `default`로 저장한다. `getHttpLocale(...)`은 해당 `RequestContext`만 읽고 global state 또는 다른 request의 locale은 조회하지 않는다.
 
 `localizeDtoValidationError(...)`은 명시적 locale을 사용한 issue message를 포함하는 새 error를 반환한다. 기본 namespace는 `validation`이고 candidate key는 `source.field.code`에서 `code` 순서로 해석되며, `fallbackToIssueMessage: false`를 선택하지 않으면 missing translation은 원래 issue message를 보존한다. 이 helper는 transport-agnostic 상태를 유지한다. 여기서는 HTTP가 locale을 선택하지만 validation localization 자체는 HTTP state를 읽지 않는다.
 

--- a/docs/getting-started/migrate-from-nestjs.md
+++ b/docs/getting-started/migrate-from-nestjs.md
@@ -358,12 +358,25 @@ import {
   createAcceptLanguageLocaleResolver,
   getHttpLocale,
   resolveHttpLocale,
+  type HttpLocaleResolver,
 } from '@fluojs/i18n/http';
 import { localizeDtoValidationError } from '@fluojs/i18n/validation';
-import type { RequestContext } from '@fluojs/http';
+import type { Middleware, RequestContext } from '@fluojs/http';
+import { FluoFactory } from '@fluojs/runtime';
+import { createNodeHttpAdapter } from '@fluojs/runtime/node';
 import type { DtoValidationError } from '@fluojs/validation';
 
 const acceptLanguage = createAcceptLanguageLocaleResolver();
+
+class TenantLocaleResolver {
+  resolve(context: RequestContext) {
+    const locale = context.request.headers['x-tenant-locale'];
+    return typeof locale === 'string' ? { locale, source: 'tenant-header' } : undefined;
+  }
+}
+
+const tenantLocaleResolver = new TenantLocaleResolver();
+const mapTenantLocaleResolver: HttpLocaleResolver = ({ context }) => tenantLocaleResolver.resolve(context);
 
 @Module({
   imports: [
@@ -379,13 +392,22 @@ const acceptLanguage = createAcceptLanguageLocaleResolver();
 })
 class AppModule {}
 
-function bindRequestLocale(context: RequestContext) {
-  return resolveHttpLocale(context, {
-    defaultLocale: 'en',
-    supportedLocales: ['en', 'ko'],
-    resolvers: [acceptLanguage],
-  });
-}
+const requestLocaleHook: Middleware = {
+  async handle({ requestContext }, next) {
+    resolveHttpLocale(requestContext, {
+      defaultLocale: 'en',
+      supportedLocales: ['en', 'ko'],
+      resolvers: [mapTenantLocaleResolver, acceptLanguage],
+    });
+    await next();
+  },
+};
+
+const app = await FluoFactory.create(AppModule, {
+  adapter: createNodeHttpAdapter({ port: 3000 }),
+  middleware: [requestLocaleHook],
+});
+await app.listen();
 
 function localizeValidationFailure(
   i18n: I18nService,
@@ -397,7 +419,7 @@ function localizeValidationFailure(
 }
 ```
 
-Invoke `bindRequestLocale(...)` from application-owned middleware or another request hook before downstream translation or validation-error handling. `resolveHttpLocale(...)` runs resolvers in array order, ignores invalid or unsupported results, and stores the configured default with source `default` when none match. `getHttpLocale(...)` reads only that `RequestContext`; it does not consult global state.
+Map each custom NestJS resolver class to an `HttpLocaleResolver` and register one application-owned `Middleware` in `FluoFactory.create(...)`. The hook resolves the tenant value before `Accept-Language`, then downstream translation or validation-error handling reads the result from the same `RequestContext`. `resolveHttpLocale(...)` runs resolvers in array order, ignores invalid or unsupported results, and stores the configured default with source `default` when none match. `getHttpLocale(...)` reads only that `RequestContext`; it does not consult global state or another request's locale.
 
 `localizeDtoValidationError(...)` returns a new error whose issue messages use the explicit locale. Its default namespace is `validation`, candidate keys run from `source.field.code` through `code`, and missing translations preserve the original issue message unless `fallbackToIssueMessage: false` is selected. The helper remains transport-agnostic: HTTP chooses the locale here, but validation localization never reads HTTP state itself.
 

--- a/packages/i18n/src/http.request.test.ts
+++ b/packages/i18n/src/http.request.test.ts
@@ -1,0 +1,90 @@
+import { Module } from '@fluojs/core';
+import { Controller, Get, type Middleware, type RequestContext } from '@fluojs/http';
+import { createTestApp } from '@fluojs/testing';
+import { describe, expect, it } from 'vitest';
+
+import {
+  getHttpLocale,
+  resolveHttpLocale,
+  type HttpLocaleResolver,
+} from './http.js';
+
+function createDeferred<T>() {
+  let resolvePromise: ((value: T | PromiseLike<T>) => void) | undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+
+  if (!resolvePromise) {
+    throw new TypeError('Promise executor did not initialize its resolver synchronously.');
+  }
+
+  return { promise, resolve: resolvePromise };
+}
+
+describe('@fluojs/i18n HTTP request-locale composition', () => {
+  it('isolates custom resolver locales across overlapping request hooks', async () => {
+    // Given
+    const firstRequestEntered = createDeferred<void>();
+    const releaseFirstRequest = createDeferred<void>();
+    const customLocaleResolver: HttpLocaleResolver = ({ context }) => {
+      const locale = context.request.headers['x-locale'];
+
+      return typeof locale === 'string' ? { locale, source: 'custom-header' } : undefined;
+    };
+    const localeHook: Middleware = {
+      async handle({ requestContext }, next) {
+        const locale = resolveHttpLocale(requestContext, {
+          defaultLocale: 'en',
+          resolvers: [customLocaleResolver],
+          supportedLocales: ['en', 'ko'],
+        });
+
+        if (locale.locale === 'en') {
+          firstRequestEntered.resolve();
+          await releaseFirstRequest.promise;
+        }
+
+        await next();
+      },
+    };
+
+    @Controller('/locale')
+    class LocaleController {
+      @Get('/')
+      readLocale(_input: undefined, context: RequestContext) {
+        return getHttpLocale(context);
+      }
+    }
+
+    @Module({ controllers: [LocaleController] })
+    class AppModule {}
+
+    const app = await createTestApp({
+      middleware: [localeHook],
+      rootModule: AppModule,
+    });
+
+    try {
+      // When
+      const firstRequest = app.request('GET', '/locale').header('x-locale', 'en').send();
+      await firstRequestEntered.promise;
+      const secondResponse = await app.request('GET', '/locale').header('x-locale', 'ko').send();
+      releaseFirstRequest.resolve();
+      const firstResponse = await firstRequest;
+
+      // Then
+      expect(secondResponse).toMatchObject({
+        body: { locale: 'ko', source: 'custom-header' },
+        status: 200,
+      });
+      expect(firstResponse).toMatchObject({
+        body: { locale: 'en', source: 'custom-header' },
+        status: 200,
+      });
+    } finally {
+      releaseFirstRequest.resolve();
+      await app.close();
+    }
+  });
+});

--- a/tooling/governance/verify-platform-consistency-governance.mjs
+++ b/tooling/governance/verify-platform-consistency-governance.mjs
@@ -186,6 +186,7 @@ const ssotPairs = [
   ['docs/contracts/react-rsc-graduation.md', 'docs/contracts/react-rsc-graduation.ko.md'],
   ['docs/contracts/release-governance.md', 'docs/contracts/release-governance.ko.md'],
   ['docs/contracts/platform-conformance-authoring-checklist.md', 'docs/contracts/platform-conformance-authoring-checklist.ko.md'],
+  ['docs/getting-started/migrate-from-nestjs.md', 'docs/getting-started/migrate-from-nestjs.ko.md'],
   ['docs/reference/package-folder-structure.md', 'docs/reference/package-folder-structure.ko.md'],
   ['docs/reference/package-surface.md', 'docs/reference/package-surface.ko.md'],
 ];


### PR DESCRIPTION
## Summary

- document a production `FluoFactory.create(...)` middleware registration for request locale resolution
- map a custom resolver class to `HttpLocaleResolver` ahead of Accept-Language
- add a deterministic overlapping-request integration test proving RequestContext isolation
- synchronize EN/KO migration and CONTEXT discoverability guidance

## Verification

- dependency-closure build and `@fluojs/i18n` typecheck
- focused real request-flow test
- serial i18n suite: 11 files / 109 tests
- full docs verification: 88 static pages
- platform governance, docs parity, migration governance, release-lane, and diff gates
- exact-head contract/code/verification triad: PASS

Resolves #3293