### PR TITLE
fix(validation): reject numeric enum reverse-map names

### DIFF
--- a/.changeset/reject-numeric-enum-reverse-names.md
+++ b/.changeset/reject-numeric-enum-reverse-names.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/validation': patch
+---
+
+Reject generated reverse-map member names when validating numeric TypeScript enums with `IsEnum`.

--- a/packages/openapi/src/schema-builder.test.ts
+++ b/packages/openapi/src/schema-builder.test.ts
@@ -100,7 +100,7 @@ describe('buildOpenApiDocument', () => {
     `);
   });
 
-  it('omits enum type when allowed values mix primitive kinds', () => {
+  it('emits only accepted numeric enum values with a numeric type', () => {
     enum NumericStatus {
       Draft,
       Published,
@@ -133,7 +133,7 @@ describe('buildOpenApiDocument', () => {
       additionalProperties: false,
       properties: {
         status: {
-          enum: ['Draft', 'Published', 0, 1],
+          enum: [0, 1], type: 'number',
         },
       },
       required: ['status'],

--- a/packages/openapi/src/schema-builder.test.ts
+++ b/packages/openapi/src/schema-builder.test.ts
@@ -102,14 +102,14 @@ describe('buildOpenApiDocument', () => {
 
   it('emits only accepted numeric enum values with a numeric type', () => {
     enum NumericStatus {
-      Draft,
+      __proto__ = 0,
       Published,
     }
 
     class UpdatePostRequest {
       @FromBody('status')
       @IsEnum(NumericStatus)
-      status = NumericStatus.Draft;
+      status = 0;
     }
 
     @Controller('/posts')

--- a/packages/validation/README.ko.md
+++ b/packages/validation/README.ko.md
@@ -179,6 +179,9 @@ Array, `Set`, `Map` member는 자동으로 검증되고 실체화되므로 neste
 `materialize()`는 의도적으로 엄격합니다. Transport가 `'42'`를 넘기고 DTO가 `number`를 기대한다면, transport나 binding layer가 먼저 변환해야 합니다.
 `@IsLatitude()`, `@IsLongitude()`를 포함한 numeric validator는 numeric string을 이미 변환된 number처럼 취급하지 않고 DTO의 numeric 값을 검증합니다.
 
+`@IsEnum(...)`은 선언된 enum 값만 허용합니다. 숫자형 TypeScript enum에서 생성된
+reverse-map 멤버 이름은 값이 아니므로 거부됩니다.
+
 ## 공개 API
 
 - **검증 엔진**: `DefaultValidator`, `DtoValidationError`, `ValidationIssue`, `Validator`

--- a/packages/validation/README.md
+++ b/packages/validation/README.md
@@ -183,6 +183,9 @@ Pass either a DTO class or a lazy constructor factory such as `() => ChildDto` o
 `materialize()` is intentionally strict. If a transport gives you `'42'` and your DTO expects `number`, the transport or binding layer must convert it first.
 Numeric validators, including `@IsLatitude()` and `@IsLongitude()`, validate numeric DTO values without treating numeric strings as already-converted numbers.
 
+`@IsEnum(...)` accepts declared enum values. For numeric TypeScript enums, generated
+reverse-map member names are not values and are rejected.
+
 ## Public API
 
 - **Validator engine**: `DefaultValidator`, `DtoValidationError`, `ValidationIssue`, `Validator`

--- a/packages/validation/src/decorators.ts
+++ b/packages/validation/src/decorators.ts
@@ -9,6 +9,7 @@ import type {
 
 import { createArrayValidationDecorator, createFlagValidationDecorator, createValidationDecorator, createValidationOptionsWithConfigDecorator, createValidatorJsDecorator } from './internal/decorator-factories.js';
 import { appendStandardClassValidationRule, type ClassDecoratorFn, type FieldDecoratorFn } from './internal/decorator-metadata.js';
+import { normalizeEnumValues } from './internal/enum-values.js';
 import { createClassValidatorFromStandardSchema, isStandardSchemaLike, type StandardSchemaV1Like } from './standard-schema.js';
 
 type ValidateClassInput = CustomClassValidator | StandardSchemaV1Like;
@@ -174,11 +175,7 @@ export const IsNegative = createFlagValidationDecorator((options) => ({ kind: 'n
  * @returns A field decorator that registers an enum-membership rule.
  */
 export function IsEnum(values: Record<string, unknown> | readonly unknown[], options?: ValidationDecoratorOptions): FieldDecoratorFn {
-  const normalized = Array.isArray(values)
-    ? values
-    : Object.entries(values)
-        .filter(([key, value]) => typeof value !== 'string' || !Object.is(Reflect.get(values, value), Number(key)))
-        .map(([, value]) => value);
+  const normalized = normalizeEnumValues(values);
   return createValidationDecorator(() => ({ kind: 'enum', values: normalized, ...options }));
 }
 

--- a/packages/validation/src/decorators.ts
+++ b/packages/validation/src/decorators.ts
@@ -174,7 +174,11 @@ export const IsNegative = createFlagValidationDecorator((options) => ({ kind: 'n
  * @returns A field decorator that registers an enum-membership rule.
  */
 export function IsEnum(values: Record<string, unknown> | readonly unknown[], options?: ValidationDecoratorOptions): FieldDecoratorFn {
-  const normalized = Array.isArray(values) ? values : Object.values(values);
+  const normalized = Array.isArray(values)
+    ? values
+    : Object.entries(values)
+        .filter(([key, value]) => typeof value !== 'string' || !Object.is(Reflect.get(values, value), Number(key)))
+        .map(([, value]) => value);
   return createValidationDecorator(() => ({ kind: 'enum', values: normalized, ...options }));
 }
 

--- a/packages/validation/src/internal/enum-values.ts
+++ b/packages/validation/src/internal/enum-values.ts
@@ -1,0 +1,24 @@
+export function normalizeEnumValues(values: Record<string, unknown> | readonly unknown[]): readonly unknown[] {
+  if (Array.isArray(values)) {
+    return values;
+  }
+
+  const entries = Object.entries(values);
+  const ownMembers = new Map(entries);
+  const normalized = new Set<unknown>();
+
+  for (const [key, value] of entries) {
+    const numericValue = Number(key);
+    const hasForwardMember = typeof value === 'string' && ownMembers.has(value);
+    const forwardValue = typeof value === 'string' ? ownMembers.get(value) : undefined;
+    const isReverseEntry =
+      typeof value === 'string' &&
+      key === String(numericValue) &&
+      ((typeof forwardValue === 'number' && key === String(forwardValue)) ||
+        (value === '__proto__' && !hasForwardMember && Number.isFinite(numericValue)));
+
+    normalized.add(isReverseEntry ? numericValue : value);
+  }
+
+  return [...normalized];
+}

--- a/packages/validation/src/is-enum.test.ts
+++ b/packages/validation/src/is-enum.test.ts
@@ -10,6 +10,33 @@ const NumericRole = {
   User: 1,
 } as const;
 
+const StringRole = {
+  Admin: 'admin',
+  User: 'user',
+} as const;
+
+enum MixedValue {
+  StringValue = 'NumericValue',
+  NumericValue = NaN,
+}
+
+enum NumericEdge {
+  NotANumber = NaN,
+  PositiveInfinity = Infinity,
+  NegativeInfinity = -Infinity,
+  NegativeFraction = -1.5,
+  Zero = -0,
+}
+
+enum PrototypeCollision {
+  __proto__ = 0,
+}
+
+enum CanonicalStringMember {
+  NaN = '__proto__',
+  Infinity = 'infinity',
+}
+
 describe('IsEnum', () => {
   it('rejects a numeric enum reverse-map name', async () => {
     // Given
@@ -40,6 +67,129 @@ describe('IsEnum', () => {
 
     // When
     const validation = validator.validate(new RoleDto(), RoleDto);
+
+    // Then
+    await expect(validation).resolves.toBeUndefined();
+  });
+
+  it('accepts an ordinary string enum-like value', async () => {
+    // Given
+    class RoleDto {
+      @IsEnum(StringRole)
+      role: unknown = StringRole.User;
+    }
+
+    const validator = new DefaultValidator();
+
+    // When
+    const validation = validator.validate(new RoleDto(), RoleDto);
+
+    // Then
+    await expect(validation).resolves.toBeUndefined();
+  });
+
+  it('accepts a declared string value that matches a numeric member name', async () => {
+    // Given
+    class MixedValueDto {
+      @IsEnum(MixedValue)
+      value: unknown = MixedValue.StringValue;
+    }
+
+    const validator = new DefaultValidator();
+
+    // When
+    const validation = validator.validate(new MixedValueDto(), MixedValueDto);
+
+    // Then
+    await expect(validation).resolves.toBeUndefined();
+  });
+
+  it('accepts the declared numeric value from a mixed enum', async () => {
+    // Given
+    class MixedValueDto {
+      @IsEnum(MixedValue)
+      value: unknown = MixedValue.NumericValue;
+    }
+
+    const validator = new DefaultValidator();
+
+    // When
+    const validation = validator.validate(new MixedValueDto(), MixedValueDto);
+
+    // Then
+    await expect(validation).resolves.toBeUndefined();
+  });
+
+  it.each([
+    ['NaN', NumericEdge.NotANumber],
+    ['positive infinity', NumericEdge.PositiveInfinity],
+    ['negative infinity', NumericEdge.NegativeInfinity],
+    ['a negative fraction', NumericEdge.NegativeFraction],
+    ['negative zero', NumericEdge.Zero],
+  ])('accepts the declared numeric enum value %s', async (_label, value) => {
+    // Given
+    class NumericEdgeDto {
+      @IsEnum(NumericEdge)
+      edge: unknown = value;
+    }
+
+    const validator = new DefaultValidator();
+
+    // When
+    const validation = validator.validate(new NumericEdgeDto(), NumericEdgeDto);
+
+    // Then
+    await expect(validation).resolves.toBeUndefined();
+  });
+
+  it.each([
+    ['NaN', CanonicalStringMember.NaN],
+    ['Infinity', CanonicalStringMember.Infinity],
+  ])('accepts the declared string enum value with canonical numeric member name %s', async (_label, value) => {
+    // Given
+    class CanonicalStringMemberDto {
+      @IsEnum(CanonicalStringMember)
+      member: unknown = value;
+    }
+
+    const validator = new DefaultValidator();
+
+    // When
+    const validation = validator.validate(new CanonicalStringMemberDto(), CanonicalStringMemberDto);
+
+    // Then
+    await expect(validation).resolves.toBeUndefined();
+  });
+
+  it('rejects a generated prototype-colliding numeric enum reverse-map name', async () => {
+    // Given
+    class PrototypeCollisionDto {
+      @IsEnum(PrototypeCollision)
+      value: unknown = PrototypeCollision.__proto__;
+    }
+
+    const validator = new DefaultValidator();
+
+    // When
+    const validation = validator.validate(Object.assign(new PrototypeCollisionDto(), { value: '__proto__' }), PrototypeCollisionDto);
+
+    // Then
+    await expect(validation).rejects.toMatchObject({
+      issues: [{ code: 'INVALID_ENUM', field: 'value' }],
+    });
+  });
+
+  it('accepts a prototype-colliding numeric enum value', async () => {
+    // Given
+    class PrototypeCollisionDto {
+      @IsEnum(PrototypeCollision)
+      value: unknown = 0;
+    }
+
+    const validator = new DefaultValidator();
+
+    // When
+    const validation = validator.validate(new PrototypeCollisionDto(), PrototypeCollisionDto);
 
     // Then
     await expect(validation).resolves.toBeUndefined();

--- a/packages/validation/src/is-enum.test.ts
+++ b/packages/validation/src/is-enum.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { IsEnum } from './decorators.js';
+import { DefaultValidator } from './validation.js';
+
+const NumericRole = {
+  0: 'Admin',
+  1: 'User',
+  Admin: 0,
+  User: 1,
+} as const;
+
+describe('IsEnum', () => {
+  it('rejects a numeric enum reverse-map name', async () => {
+    // Given
+    class RoleDto {
+      @IsEnum(NumericRole)
+      role: unknown = NumericRole.User;
+    }
+
+    const validator = new DefaultValidator();
+
+    // When
+    const validation = validator.validate(Object.assign(new RoleDto(), { role: 'Admin' }), RoleDto);
+
+    // Then
+    await expect(validation).rejects.toMatchObject({
+      issues: [{ code: 'INVALID_ENUM', field: 'role' }],
+    });
+  });
+
+  it('accepts a numeric enum value', async () => {
+    // Given
+    class RoleDto {
+      @IsEnum(NumericRole)
+      role: unknown = NumericRole.User;
+    }
+
+    const validator = new DefaultValidator();
+
+    // When
+    const validation = validator.validate(new RoleDto(), RoleDto);
+
+    // Then
+    await expect(validation).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- reject generated numeric enum reverse-map names in `IsEnum`
- preserve observable numeric, string, mixed, and edge enum values
- align OpenAPI enum output and bilingual validation docs

Closes #3277