### PR TITLE
fix(jwt): normalize non-object token parts

### DIFF
--- a/.changeset/fix-jwt-json-object-validation.md
+++ b/.changeset/fix-jwt-json-object-validation.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/jwt': patch
+---
+
+Normalize non-object JSON JWT headers and payloads to `JwtInvalidTokenError` instead of leaking raw runtime errors.

--- a/packages/jwt/src/signing/verifier.test.ts
+++ b/packages/jwt/src/signing/verifier.test.ts
@@ -634,6 +634,32 @@ describe('DefaultJwtVerifier', () => {
     await expect(verifier.verifyAccessToken(token)).rejects.toBeInstanceOf(JwtInvalidTokenError);
   });
 
+  it('rejects valid-JSON non-object JWT headers and payloads with a typed invalid-token error', async () => {
+    const verifier = new DefaultJwtVerifier({
+      algorithms: ['HS256'],
+      secret: 'secret',
+    });
+    const invalidJsonValues = ['null', '[]', '"payload"', '42'];
+
+    for (const payloadJson of invalidJsonValues) {
+      const token = signRawPayload(payloadJson, 'secret');
+
+      await expect(verifier.verifyAccessToken(token)).rejects.toBeInstanceOf(JwtInvalidTokenError);
+      await expect(verifier.verifyAccessToken(token)).rejects.toMatchObject({ code: 'JWT_INVALID_TOKEN' });
+    }
+
+    for (const headerJson of invalidJsonValues) {
+      const token = signRawPayload(
+        JSON.stringify({ exp: Math.floor(Date.now() / 1000) + 60, sub: 'invalid-header' }),
+        'secret',
+        JSON.parse(headerJson) as Record<string, unknown>,
+      );
+
+      await expect(verifier.verifyAccessToken(token)).rejects.toBeInstanceOf(JwtInvalidTokenError);
+      await expect(verifier.verifyAccessToken(token)).rejects.toMatchObject({ code: 'JWT_INVALID_TOKEN' });
+    }
+  });
+
   it('verifies signature before payload parsing on malformed payload tokens', async () => {
     const headerSegment = encodeBase64Url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
     const payloadSegment = encodeBase64Url('not-json-payload');

--- a/packages/jwt/src/signing/verifier.ts
+++ b/packages/jwt/src/signing/verifier.ts
@@ -242,8 +242,18 @@ function decodeBase64Url(value: string): Buffer {
 
 function parseJwtPart<T>(value: string): T {
   try {
-    return JSON.parse(decodeBase64Url(value).toString('utf8')) as T;
-  } catch {
+    const parsed: unknown = JSON.parse(decodeBase64Url(value).toString('utf8'));
+
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      throw new JwtInvalidTokenError('JWT header and payload must be JSON objects.');
+    }
+
+    return parsed as T;
+  } catch (error) {
+    if (error instanceof JwtInvalidTokenError) {
+      throw error;
+    }
+
     throw new JwtInvalidTokenError();
   }
 }


### PR DESCRIPTION
## Summary

Normalize valid-JSON JWT header and payload values that are not objects to the public `JwtInvalidTokenError` boundary instead of leaking raw runtime `TypeError`.

Linked context: Closes #3193

## Changes

- reject `null`, array, string, and number JWT header/payload JSON shapes
- add regression coverage for header and payload shapes and stable `JWT_INVALID_TOKEN` code
- add a patch Changeset for `@fluojs/jwt`

## Testing

- `pnpm --filter '@fluojs/jwt...' build`
- `pnpm --filter '@fluojs/jwt' typecheck`
- `pnpm --filter '@fluojs/jwt' test` (133 passed)
- `pnpm --filter '...@fluojs/jwt' test` (`@fluojs/passport`: 123 passed)
- manual built-package verification observed `JwtInvalidTokenError` with `JWT_INVALID_TOKEN`

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] No public exports changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] No platform contract docs changed.