### PR TITLE
fix(jwt): isolate algorithm policy from public lookups

### DIFF
--- a/.changeset/fix-jwt-public-hash-policy.md
+++ b/.changeset/fix-jwt-public-hash-policy.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/jwt': patch
+---
+
+Keep JWT signer and verifier algorithm policies independent from mutable public hash lookup exports.

--- a/packages/jwt/README.ko.md
+++ b/packages/jwt/README.ko.md
@@ -214,7 +214,7 @@ Lazy loading은 import-time 안전성 속성일 뿐입니다. 서명이나 검�
 ### 에러와 diagnostics
 - `JwtVerificationError`, `JwtInvalidTokenError`, `JwtExpiredTokenError`, `JwtConfigurationError`: 타입이 지정된 JWT 실패입니다.
 - `createJwtPlatformStatusSnapshot(...)`, `createJwtPlatformDiagnosticIssues(...)`: status 및 diagnostic helper입니다.
-- `JWT_OPTIONS`, `HMAC_HASH`, `ASYMMETRIC_HASH`: 모듈과 검증 레이어에서 사용하는 export token/constant입니다.
+- `JWT_OPTIONS`, `HMAC_HASH`, `ASYMMETRIC_HASH`: 모듈과 검증 레이어에서 사용하는 export token/constant입니다. `HMAC_HASH`와 `ASYMMETRIC_HASH`는 readonly lookup 값이므로 변경하지 마세요.
 
 ### Deprecated compatibility helper
 - `normalizeRefreshTokenOptions(...)`: 기존 caller의 root import 호환성만을 위해 유지됩니다. package normalization 내부 helper를 직접 호출하기보다 `JwtModule.forRoot(...)` / `JwtModule.forRootAsync(...)`와 `RefreshTokenService`를 사용하세요.

--- a/packages/jwt/README.md
+++ b/packages/jwt/README.md
@@ -214,7 +214,7 @@ Lazy loading is an import-time safety property only. It does **not** make signin
 ### Errors and diagnostics
 - `JwtVerificationError`, `JwtInvalidTokenError`, `JwtExpiredTokenError`, `JwtConfigurationError`: Typed JWT failures.
 - `createJwtPlatformStatusSnapshot(...)` and `createJwtPlatformDiagnosticIssues(...)`: Status and diagnostic helpers.
-- `JWT_OPTIONS`, `HMAC_HASH`, `ASYMMETRIC_HASH`: Exported tokens/constants used by the module and verification layer.
+- `JWT_OPTIONS`, `HMAC_HASH`, `ASYMMETRIC_HASH`: Exported tokens/constants used by the module and verification layer. `HMAC_HASH` and `ASYMMETRIC_HASH` are readonly lookup values; do not mutate them.
 
 ### Deprecated compatibility helpers
 - `normalizeRefreshTokenOptions(...)`: Retained only for root-import compatibility with existing callers. Prefer `JwtModule.forRoot(...)` / `JwtModule.forRootAsync(...)` plus `RefreshTokenService` instead of calling package normalization internals.

--- a/packages/jwt/src/signing/algorithm-policy.ts
+++ b/packages/jwt/src/signing/algorithm-policy.ts
@@ -1,0 +1,16 @@
+import type { JwtAlgorithm } from '../types.js';
+
+export const SUPPORTED_HMAC_HASH: Readonly<Partial<Record<JwtAlgorithm, string>>> = Object.freeze({
+  HS256: 'sha256',
+  HS384: 'sha384',
+  HS512: 'sha512',
+});
+
+export const SUPPORTED_ASYMMETRIC_HASH: Readonly<Partial<Record<JwtAlgorithm, string>>> = Object.freeze({
+  RS256: 'sha256',
+  RS384: 'sha384',
+  RS512: 'sha512',
+  ES256: 'sha256',
+  ES384: 'sha384',
+  ES512: 'sha512',
+});

--- a/packages/jwt/src/signing/signer.test.ts
+++ b/packages/jwt/src/signing/signer.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { JwtConfigurationError } from '../errors.js';
 import type { JwtVerifierOptions } from '../types.js';
 import { DefaultJwtSigner } from './signer.js';
-import { DefaultJwtVerifier } from './verifier.js';
+import { ASYMMETRIC_HASH, DefaultJwtVerifier, HMAC_HASH } from './verifier.js';
 
 function encodeBase64Url(value: string): string {
   return Buffer.from(value, 'utf8').toString('base64url');
@@ -31,6 +31,21 @@ describe('DefaultJwtSigner', () => {
     expect(() => new DefaultJwtSigner({ algorithms: ['toString' as never], secret: 'secret' })).toThrow(
       'JWT signer received unsupported JWT algorithm "toString".',
     );
+  });
+
+  it('keeps public hash lookups immutable and independent from signing policy', async () => {
+    expect(Object.isFrozen(HMAC_HASH)).toBe(true);
+    expect(Object.isFrozen(ASYMMETRIC_HASH)).toBe(true);
+    expect(Reflect.set(HMAC_HASH, 'HS999', 'sha256')).toBe(false);
+    expect(Reflect.deleteProperty(HMAC_HASH, 'HS256')).toBe(false);
+    expect(Reflect.set(ASYMMETRIC_HASH, 'RS999', 'sha256')).toBe(false);
+    expect(Reflect.deleteProperty(ASYMMETRIC_HASH, 'RS256')).toBe(false);
+
+    const signer = new DefaultJwtSigner({ algorithms: ['HS256'], secret: 'secret' });
+    const verifier = new DefaultJwtVerifier({ algorithms: ['HS256'], secret: 'secret' });
+    const token = await signer.signAccessToken({ sub: 'immutable-policy-user' });
+
+    await expect(verifier.verifyAccessToken(token)).resolves.toMatchObject({ subject: 'immutable-policy-user' });
   });
 
   it('rejects empty and duplicate key IDs during construction', () => {

--- a/packages/jwt/src/signing/signer.ts
+++ b/packages/jwt/src/signing/signer.ts
@@ -3,8 +3,9 @@ import { Inject } from '@fluojs/core';
 import { JwtConfigurationError } from '../errors.js';
 import { normalizeRefreshTokenOptions } from '../refresh/refresh-token.js';
 import type { JwtAlgorithm, JwtClaims, JwtKeyEntry, JwtVerifierOptions } from '../types.js';
+import { SUPPORTED_ASYMMETRIC_HASH, SUPPORTED_HMAC_HASH } from './algorithm-policy.js';
 import { assertJwtKeyEntries } from './key-entries.js';
-import { ASYMMETRIC_HASH, HMAC_HASH, JWT_OPTIONS } from './verifier.js';
+import { JWT_OPTIONS } from './verifier.js';
 
 function encodeBase64Url(value: Buffer | string): string {
   return Buffer.from(value)
@@ -21,7 +22,7 @@ function resolveSigningKeyEntry(options: JwtVerifierOptions, algorithm: JwtAlgor
     return undefined;
   }
 
-  if (hasOwnAlgorithmMapping(HMAC_HASH, algorithm)) {
+  if (hasOwnAlgorithmMapping(SUPPORTED_HMAC_HASH, algorithm)) {
     return keys.find((entry) => typeof entry.secret === 'string' && entry.secret.length > 0);
   }
 
@@ -36,7 +37,7 @@ function hasOwnAlgorithmMapping(
 }
 
 function isSupportedSigningAlgorithm(algorithm: string | undefined): algorithm is JwtAlgorithm {
-  return hasOwnAlgorithmMapping(HMAC_HASH, algorithm) || hasOwnAlgorithmMapping(ASYMMETRIC_HASH, algorithm);
+  return hasOwnAlgorithmMapping(SUPPORTED_HMAC_HASH, algorithm) || hasOwnAlgorithmMapping(SUPPORTED_ASYMMETRIC_HASH, algorithm);
 }
 
 function assertSigningAlgorithms(algorithms: JwtAlgorithm[]): void {
@@ -72,7 +73,7 @@ export class DefaultJwtSigner {
     assertSigningAlgorithms(options.algorithms);
     assertJwtKeyEntries(options.keys);
     this.refreshAlgorithms = this.options.algorithms.filter(
-      (algorithm): algorithm is JwtAlgorithm => hasOwnAlgorithmMapping(HMAC_HASH, algorithm),
+      (algorithm): algorithm is JwtAlgorithm => hasOwnAlgorithmMapping(SUPPORTED_HMAC_HASH, algorithm),
     );
   }
 
@@ -100,7 +101,7 @@ export class DefaultJwtSigner {
   private async signToken(claims: JwtClaims, options: JwtVerifierOptions, hmacOnly: boolean): Promise<string> {
     const algorithm: JwtAlgorithm | undefined = options.algorithms.find((alg) => {
       if (hmacOnly) {
-        return hasOwnAlgorithmMapping(HMAC_HASH, alg);
+        return hasOwnAlgorithmMapping(SUPPORTED_HMAC_HASH, alg);
       }
 
       return isSupportedSigningAlgorithm(alg);
@@ -118,7 +119,7 @@ export class DefaultJwtSigner {
       );
     }
 
-    const isAsymmetric = hasOwnAlgorithmMapping(ASYMMETRIC_HASH, algorithm);
+    const isAsymmetric = hasOwnAlgorithmMapping(SUPPORTED_ASYMMETRIC_HASH, algorithm);
 
     const now = Math.floor(Date.now() / 1000);
     const ttl = resolveAccessTokenTtlSeconds(options);
@@ -149,7 +150,7 @@ export class DefaultJwtSigner {
         throw new JwtConfigurationError('JWT private key is not configured.');
       }
 
-      const hash = ASYMMETRIC_HASH[algorithm];
+      const hash = SUPPORTED_ASYMMETRIC_HASH[algorithm];
 
       if (!hash) {
         throw new JwtConfigurationError(`No hash mapping for asymmetric algorithm "${algorithm}".`);
@@ -169,7 +170,7 @@ export class DefaultJwtSigner {
         throw new JwtConfigurationError('JWT secret is not configured.');
       }
 
-      const hash = HMAC_HASH[algorithm];
+      const hash = SUPPORTED_HMAC_HASH[algorithm];
 
       if (!hash) {
         throw new JwtConfigurationError(`No hash mapping for HMAC algorithm "${algorithm}".`);

--- a/packages/jwt/src/signing/verifier.ts
+++ b/packages/jwt/src/signing/verifier.ts
@@ -6,6 +6,7 @@ import type { OnModuleDestroy } from '@fluojs/runtime';
 import { JwtConfigurationError, JwtExpiredTokenError, JwtInvalidTokenError } from '../errors.js';
 import { normalizeRefreshTokenOptions } from '../refresh/refresh-token.js';
 import type { JwtAlgorithm, JwtClaims, JwtKeyEntry, JwtPrincipal, JwtVerifierOptions } from '../types.js';
+import { SUPPORTED_ASYMMETRIC_HASH, SUPPORTED_HMAC_HASH } from './algorithm-policy.js';
 import { JwksClient } from './jwks.js';
 import { assertJwtKeyEntries } from './key-entries.js';
 
@@ -17,23 +18,12 @@ export const JWT_OPTIONS = Symbol.for('fluo.jwt.options');
 /**
  * Maps supported HMAC JWT algorithms to their Node.js hash names.
  */
-export const HMAC_HASH: Partial<Record<JwtAlgorithm, string>> = {
-  HS256: 'sha256',
-  HS384: 'sha384',
-  HS512: 'sha512',
-};
+export const HMAC_HASH: Readonly<Partial<Record<JwtAlgorithm, string>>> = Object.freeze({ ...SUPPORTED_HMAC_HASH });
 
 /**
  * Maps supported asymmetric JWT algorithms to their Node.js hash names.
  */
-export const ASYMMETRIC_HASH: Partial<Record<JwtAlgorithm, string>> = {
-  RS256: 'sha256',
-  RS384: 'sha384',
-  RS512: 'sha512',
-  ES256: 'sha256',
-  ES384: 'sha384',
-  ES512: 'sha512',
-};
+export const ASYMMETRIC_HASH: Readonly<Partial<Record<JwtAlgorithm, string>>> = Object.freeze({ ...SUPPORTED_ASYMMETRIC_HASH });
 
 function hasOwnAlgorithmMapping(
   mappings: Partial<Record<JwtAlgorithm, string>>,
@@ -43,7 +33,7 @@ function hasOwnAlgorithmMapping(
 }
 
 function isSupportedAlgorithm(alg: string | undefined): alg is JwtAlgorithm {
-  return hasOwnAlgorithmMapping(HMAC_HASH, alg) || hasOwnAlgorithmMapping(ASYMMETRIC_HASH, alg);
+  return hasOwnAlgorithmMapping(SUPPORTED_HMAC_HASH, alg) || hasOwnAlgorithmMapping(SUPPORTED_ASYMMETRIC_HASH, alg);
 }
 
 function assertJwtAlgorithms(algorithms: JwtAlgorithm[], context: string): void {
@@ -189,7 +179,7 @@ async function verifyHmacSignature(
   signingInput: string,
   signatureSegment: string,
 ): Promise<void> {
-  const hash = HMAC_HASH[algorithm];
+  const hash = SUPPORTED_HMAC_HASH[algorithm];
 
   if (!hash) {
     throw new JwtInvalidTokenError();
@@ -211,7 +201,7 @@ async function verifyAsymmetricSignature(
   signingInput: string,
   signatureSegment: string,
 ): Promise<void> {
-  const hash = ASYMMETRIC_HASH[algorithm];
+  const hash = SUPPORTED_ASYMMETRIC_HASH[algorithm];
 
   if (!hash) {
     throw new JwtInvalidTokenError();
@@ -382,7 +372,7 @@ export class DefaultJwtVerifier implements OnModuleDestroy {
   private createRefreshVerificationOptions(
     refreshToken: ReturnType<typeof normalizeRefreshTokenOptions>,
   ): JwtVerifierOptions {
-    const algorithms = this.options.algorithms.filter((algorithm): algorithm is JwtAlgorithm => hasOwnAlgorithmMapping(HMAC_HASH, algorithm));
+    const algorithms = this.options.algorithms.filter((algorithm): algorithm is JwtAlgorithm => hasOwnAlgorithmMapping(SUPPORTED_HMAC_HASH, algorithm));
 
     if (algorithms.length === 0) {
       throw new JwtConfigurationError(
@@ -450,7 +440,7 @@ export class DefaultJwtVerifier implements OnModuleDestroy {
     keyResolutionState: KeyResolutionState,
     jwksClient: JwksClient | undefined,
   ): Promise<void> {
-    if (hasOwnAlgorithmMapping(HMAC_HASH, header.alg)) {
+    if (hasOwnAlgorithmMapping(SUPPORTED_HMAC_HASH, header.alg)) {
       await this.verifyHmacTokenSignature(header, signingInput, signatureSegment, options, keyResolutionState);
       return;
     }


### PR DESCRIPTION
## Summary

Keep JWT signer and verifier algorithm policy independent from exported lookup objects, and freeze the public lookups as documented readonly values.

Linked context: Closes #3194

## Changes

- move signer/verifier policy to private immutable lookup tables
- freeze compatible public `HMAC_HASH` and `ASYMMETRIC_HASH` values
- add mutation regression coverage and EN/KO README guidance
- add a patch Changeset for `@fluojs/jwt`

## Testing

- `pnpm --filter '@fluojs/jwt...' build`
- `pnpm --filter '@fluojs/jwt' typecheck`
- `pnpm --filter '@fluojs/jwt' test` (134 passed)
- `pnpm --filter '...@fluojs/jwt' test` (`@fluojs/passport`: 123 passed)
- manual built-package mutation attempts remained false and HS256 sign/verify succeeded

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Existing public lookup exports retain their names and now document readonly behavior.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] No platform contract docs changed.