### PR TITLE
Resolve #3196: decouple JWT runtime contracts

### DIFF
--- a/.changeset/decouple-jwt-runtime-contracts.md
+++ b/.changeset/decouple-jwt-runtime-contracts.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/jwt": patch
+---
+
+Remove the mandatory `@fluojs/runtime` dependency while preserving structural lifecycle and platform-status compatibility.

--- a/packages/jwt/package.json
+++ b/packages/jwt/package.json
@@ -47,6 +47,7 @@
     "@fluojs/di": "workspace:^"
   },
   "devDependencies": {
+    "@fluojs/runtime": "workspace:^",
     "vitest": "^3.2.4"
   }
 }

--- a/packages/jwt/package.json
+++ b/packages/jwt/package.json
@@ -44,8 +44,7 @@
   },
   "dependencies": {
     "@fluojs/core": "workspace:^",
-    "@fluojs/di": "workspace:^",
-    "@fluojs/runtime": "workspace:^"
+    "@fluojs/di": "workspace:^"
   },
   "devDependencies": {
     "vitest": "^3.2.4"

--- a/packages/jwt/src/lifecycle-contract.test.ts
+++ b/packages/jwt/src/lifecycle-contract.test.ts
@@ -2,9 +2,20 @@ import type { OnModuleDestroy } from '@fluojs/runtime';
 import { describe, expect, it } from 'vitest';
 
 import { DefaultJwtVerifier } from './signing/verifier.js';
+import type { JwtModuleDestroyLifecycle } from './signing/verifier.js';
 
 describe('DefaultJwtVerifier lifecycle contract', () => {
-  it('remains structurally assignable to the runtime destruction lifecycle', () => {
+  it('remains bidirectionally compatible with the runtime destruction lifecycle', () => {
+    const runtimeLifecycle: OnModuleDestroy = {
+      async onModuleDestroy(): Promise<void> {},
+    };
+    const jwtLifecycle: JwtModuleDestroyLifecycle = runtimeLifecycle;
+    const restoredRuntimeLifecycle: OnModuleDestroy = jwtLifecycle;
+
+    expect(restoredRuntimeLifecycle).toBe(runtimeLifecycle);
+  });
+
+  it('implements the compatible lifecycle through DefaultJwtVerifier', () => {
     const verifier = new DefaultJwtVerifier({
       algorithms: ['HS256'],
       secret: 'secret',

--- a/packages/jwt/src/lifecycle-contract.test.ts
+++ b/packages/jwt/src/lifecycle-contract.test.ts
@@ -1,0 +1,16 @@
+import type { OnModuleDestroy } from '@fluojs/runtime';
+import { describe, expect, it } from 'vitest';
+
+import { DefaultJwtVerifier } from './signing/verifier.js';
+
+describe('DefaultJwtVerifier lifecycle contract', () => {
+  it('remains structurally assignable to the runtime destruction lifecycle', () => {
+    const verifier = new DefaultJwtVerifier({
+      algorithms: ['HS256'],
+      secret: 'secret',
+    });
+    const lifecycle: OnModuleDestroy = verifier;
+
+    expect(lifecycle).toBe(verifier);
+  });
+});

--- a/packages/jwt/src/runtime-boundary.test.ts
+++ b/packages/jwt/src/runtime-boundary.test.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 const packageSourceRoot = dirname(fileURLToPath(import.meta.url));
+const packageManifestPath = resolve(packageSourceRoot, '../package.json');
 
 const rootImportSurfaceFiles = [
   'index.ts',
@@ -20,6 +21,20 @@ const rootImportSurfaceFiles = [
 ];
 
 describe('JWT runtime boundary', () => {
+  it('does not require @fluojs/runtime from its published dependency graph', async () => {
+    const packageManifest = JSON.parse(await readFile(packageManifestPath, 'utf8')) as {
+      dependencies?: Record<string, string>;
+    };
+
+    expect(packageManifest.dependencies).not.toHaveProperty('@fluojs/runtime');
+
+    for (const sourceFile of rootImportSurfaceFiles) {
+      const source = await readFile(resolve(packageSourceRoot, sourceFile), 'utf8');
+
+      expect(source, `${sourceFile} must not import @fluojs/runtime`).not.toContain('@fluojs/runtime');
+    }
+  });
+
   it('keeps node:crypto out of the root import graph until crypto operations execute', async () => {
     for (const sourceFile of rootImportSurfaceFiles) {
       const source = await readFile(resolve(packageSourceRoot, sourceFile), 'utf8');

--- a/packages/jwt/src/signing/verifier.ts
+++ b/packages/jwt/src/signing/verifier.ts
@@ -1,7 +1,6 @@
 import type { KeyObject } from 'node:crypto';
 
 import { Inject } from '@fluojs/core';
-import type { OnModuleDestroy } from '@fluojs/runtime';
 
 import { JwtConfigurationError, JwtExpiredTokenError, JwtInvalidTokenError } from '../errors.js';
 import { normalizeRefreshTokenOptions } from '../refresh/refresh-token.js';
@@ -12,6 +11,13 @@ import { JwksClient } from './jwks.js';
  * Provides the resolved JWT verifier options through dependency injection.
  */
 export const JWT_OPTIONS = Symbol.for('fluo.jwt.options');
+
+/**
+ * Describes the lifecycle hook called when a JWT module is destroyed.
+ */
+export interface JwtModuleDestroyLifecycle {
+  onModuleDestroy(): void;
+}
 
 /**
  * Maps supported HMAC JWT algorithms to their Node.js hash names.
@@ -283,7 +289,7 @@ function normalizePrincipal(claims: JwtClaims): JwtPrincipal {
  * Verifies JWT access and refresh tokens against the configured key sources.
  */
 @Inject(JWT_OPTIONS)
-export class DefaultJwtVerifier implements OnModuleDestroy {
+export class DefaultJwtVerifier implements JwtModuleDestroyLifecycle {
   private readonly jwksClient: JwksClient | undefined;
   private readonly keyResolutionState: KeyResolutionState;
   private readonly refreshKeyResolutionState: KeyResolutionState;

--- a/packages/jwt/src/signing/verifier.ts
+++ b/packages/jwt/src/signing/verifier.ts
@@ -16,7 +16,7 @@ export const JWT_OPTIONS = Symbol.for('fluo.jwt.options');
  * Describes the lifecycle hook called when a JWT module is destroyed.
  */
 export interface JwtModuleDestroyLifecycle {
-  onModuleDestroy(): void;
+  onModuleDestroy(): void | Promise<void>;
 }
 
 /**

--- a/packages/jwt/src/status.test.ts
+++ b/packages/jwt/src/status.test.ts
@@ -1,6 +1,8 @@
 import type {
   PlatformDiagnosticIssue,
   PlatformHealthReport,
+  PlatformCheckResult,
+  PersistencePlatformStatusSnapshot,
   PlatformReadinessReport,
   PlatformSnapshot,
 } from '@fluojs/runtime';
@@ -15,6 +17,7 @@ import type {
   JwtPlatformHealthReport,
   JwtPlatformOwnership,
   JwtPlatformReadinessReport,
+  JwtPlatformStatusSnapshot,
 } from './status.js';
 
 describe('createJwtPlatformStatusSnapshot', () => {
@@ -108,25 +111,46 @@ describe('createJwtPlatformDiagnosticIssues', () => {
 });
 
 describe('JWT platform status contracts', () => {
-  it('remains structurally assignable to runtime platform status contracts', () => {
-    const readiness: JwtPlatformReadinessReport = { critical: false, status: 'ready' };
-    const health: JwtPlatformHealthReport = { status: 'healthy' };
-    const ownership: JwtPlatformOwnership = { externallyManaged: true, ownsResources: false };
-    const diagnostic: JwtPlatformDiagnosticIssue = {
+  it('remains bidirectionally compatible with mutable runtime platform status contracts', () => {
+    const checks: PlatformCheckResult[] = [{ name: 'refresh-token-store', status: 'pass' }];
+    const runtimeReadiness: PlatformReadinessReport = { checks, critical: false, status: 'ready' };
+    const runtimeHealth: PlatformHealthReport = { checks, status: 'healthy' };
+    const runtimeOwnership: PlatformSnapshot['ownership'] = { externallyManaged: true, ownsResources: false };
+    const runtimeDiagnostic: PlatformDiagnosticIssue = {
       code: 'AUTH_JWT_REFRESH_TOKEN_BACKING_STORE_NOT_READY',
       componentId: 'jwt.default',
       message: 'JWT refresh token backing store is degraded.',
       severity: 'warning',
     };
+    const runtimeSnapshot: PersistencePlatformStatusSnapshot = {
+      details: {},
+      health: runtimeHealth,
+      ownership: runtimeOwnership,
+      readiness: runtimeReadiness,
+    };
 
-    const runtimeReadiness: PlatformReadinessReport = readiness;
-    const runtimeHealth: PlatformHealthReport = health;
-    const runtimeOwnership: PlatformSnapshot['ownership'] = ownership;
-    const runtimeDiagnostic: PlatformDiagnosticIssue = diagnostic;
+    const jwtReadiness: JwtPlatformReadinessReport = runtimeReadiness;
+    const jwtHealth: JwtPlatformHealthReport = runtimeHealth;
+    const jwtOwnership: JwtPlatformOwnership = runtimeOwnership;
+    const jwtDiagnostic: JwtPlatformDiagnosticIssue = runtimeDiagnostic;
+    const jwtSnapshot: JwtPlatformStatusSnapshot = runtimeSnapshot;
 
-    expect(runtimeReadiness).toEqual(readiness);
-    expect(runtimeHealth).toEqual(health);
-    expect(runtimeOwnership).toEqual(ownership);
-    expect(runtimeDiagnostic).toEqual(diagnostic);
+    jwtReadiness.checks = checks;
+    jwtHealth.checks = checks;
+    jwtOwnership.ownsResources = false;
+    jwtDiagnostic.code = 'AUTH_JWT_REFRESH_TOKEN_BACKING_STORE_NOT_READY';
+    jwtSnapshot.details = {};
+
+    const restoredReadiness: PlatformReadinessReport = jwtReadiness;
+    const restoredHealth: PlatformHealthReport = jwtHealth;
+    const restoredOwnership: PlatformSnapshot['ownership'] = jwtOwnership;
+    const restoredDiagnostic: PlatformDiagnosticIssue = jwtDiagnostic;
+    const restoredSnapshot: PersistencePlatformStatusSnapshot = jwtSnapshot;
+
+    expect(restoredReadiness).toEqual(runtimeReadiness);
+    expect(restoredHealth).toEqual(runtimeHealth);
+    expect(restoredOwnership).toEqual(runtimeOwnership);
+    expect(restoredDiagnostic).toEqual(runtimeDiagnostic);
+    expect(restoredSnapshot).toEqual(runtimeSnapshot);
   });
 });

--- a/packages/jwt/src/status.test.ts
+++ b/packages/jwt/src/status.test.ts
@@ -1,8 +1,20 @@
+import type {
+  PlatformDiagnosticIssue,
+  PlatformHealthReport,
+  PlatformReadinessReport,
+  PlatformSnapshot,
+} from '@fluojs/runtime';
 import { describe, expect, it } from 'vitest';
 
 import {
   createJwtPlatformDiagnosticIssues,
   createJwtPlatformStatusSnapshot,
+} from './status.js';
+import type {
+  JwtPlatformDiagnosticIssue,
+  JwtPlatformHealthReport,
+  JwtPlatformOwnership,
+  JwtPlatformReadinessReport,
 } from './status.js';
 
 describe('createJwtPlatformStatusSnapshot', () => {
@@ -92,5 +104,29 @@ describe('createJwtPlatformDiagnosticIssues', () => {
 
     expect(issues).toHaveLength(1);
     expect(issues[0]?.severity).toBe('error');
+  });
+});
+
+describe('JWT platform status contracts', () => {
+  it('remains structurally assignable to runtime platform status contracts', () => {
+    const readiness: JwtPlatformReadinessReport = { critical: false, status: 'ready' };
+    const health: JwtPlatformHealthReport = { status: 'healthy' };
+    const ownership: JwtPlatformOwnership = { externallyManaged: true, ownsResources: false };
+    const diagnostic: JwtPlatformDiagnosticIssue = {
+      code: 'AUTH_JWT_REFRESH_TOKEN_BACKING_STORE_NOT_READY',
+      componentId: 'jwt.default',
+      message: 'JWT refresh token backing store is degraded.',
+      severity: 'warning',
+    };
+
+    const runtimeReadiness: PlatformReadinessReport = readiness;
+    const runtimeHealth: PlatformHealthReport = health;
+    const runtimeOwnership: PlatformSnapshot['ownership'] = ownership;
+    const runtimeDiagnostic: PlatformDiagnosticIssue = diagnostic;
+
+    expect(runtimeReadiness).toEqual(readiness);
+    expect(runtimeHealth).toEqual(health);
+    expect(runtimeOwnership).toEqual(ownership);
+    expect(runtimeDiagnostic).toEqual(diagnostic);
   });
 });

--- a/packages/jwt/src/status.ts
+++ b/packages/jwt/src/status.ts
@@ -2,49 +2,60 @@
  * Describes the readiness state exposed by JWT.
  */
 export interface JwtPlatformReadinessReport {
-  readonly critical: boolean;
-  readonly reason?: string;
-  readonly status: 'ready' | 'not-ready' | 'degraded';
+  critical: boolean;
+  reason?: string;
+  status: 'ready' | 'not-ready' | 'degraded';
+  checks?: JwtPlatformCheckResult[];
 }
 
 /**
  * Describes the health state exposed by JWT.
  */
 export interface JwtPlatformHealthReport {
-  readonly reason?: string;
-  readonly status: 'healthy' | 'unhealthy' | 'degraded';
+  reason?: string;
+  status: 'healthy' | 'unhealthy' | 'degraded';
+  checks?: JwtPlatformCheckResult[];
+}
+
+/**
+ * Describes one named readiness or health probe result exposed by JWT.
+ */
+export interface JwtPlatformCheckResult {
+  name: string;
+  status: 'pass' | 'fail' | 'degraded';
+  message?: string;
 }
 
 /**
  * Describes ownership of JWT-managed resources.
  */
 export interface JwtPlatformOwnership {
-  readonly externallyManaged: boolean;
-  readonly ownsResources: boolean;
+  externallyManaged: boolean;
+  ownsResources: boolean;
 }
 
 /**
  * Describes a JWT diagnostic issue.
  */
 export interface JwtPlatformDiagnosticIssue {
-  readonly cause?: string;
-  readonly code: string;
-  readonly componentId: string;
-  readonly dependsOn?: string[];
-  readonly docsUrl?: string;
-  readonly fixHint?: string;
-  readonly message: string;
-  readonly severity: 'error' | 'warning' | 'info';
+  cause?: string;
+  code: string;
+  componentId: string;
+  dependsOn?: string[];
+  docsUrl?: string;
+  fixHint?: string;
+  message: string;
+  severity: 'error' | 'warning' | 'info';
 }
 
 /**
  * Describes the jwt platform status snapshot contract.
  */
 export interface JwtPlatformStatusSnapshot {
-  readonly details: Record<string, unknown>;
-  readonly health: JwtPlatformHealthReport;
-  readonly ownership: JwtPlatformOwnership;
-  readonly readiness: JwtPlatformReadinessReport;
+  details: Record<string, unknown>;
+  health: JwtPlatformHealthReport;
+  ownership: JwtPlatformOwnership;
+  readiness: JwtPlatformReadinessReport;
 }
 
 /**

--- a/packages/jwt/src/status.ts
+++ b/packages/jwt/src/status.ts
@@ -1,18 +1,50 @@
-import type {
-  PlatformDiagnosticIssue,
-  PlatformHealthReport,
-  PlatformReadinessReport,
-  PlatformSnapshot,
-} from '@fluojs/runtime';
+/**
+ * Describes the readiness state exposed by JWT.
+ */
+export interface JwtPlatformReadinessReport {
+  readonly critical: boolean;
+  readonly reason?: string;
+  readonly status: 'ready' | 'not-ready' | 'degraded';
+}
+
+/**
+ * Describes the health state exposed by JWT.
+ */
+export interface JwtPlatformHealthReport {
+  readonly reason?: string;
+  readonly status: 'healthy' | 'unhealthy' | 'degraded';
+}
+
+/**
+ * Describes ownership of JWT-managed resources.
+ */
+export interface JwtPlatformOwnership {
+  readonly externallyManaged: boolean;
+  readonly ownsResources: boolean;
+}
+
+/**
+ * Describes a JWT diagnostic issue.
+ */
+export interface JwtPlatformDiagnosticIssue {
+  readonly cause?: string;
+  readonly code: string;
+  readonly componentId: string;
+  readonly dependsOn?: string[];
+  readonly docsUrl?: string;
+  readonly fixHint?: string;
+  readonly message: string;
+  readonly severity: 'error' | 'warning' | 'info';
+}
 
 /**
  * Describes the jwt platform status snapshot contract.
  */
 export interface JwtPlatformStatusSnapshot {
-  readiness: PlatformReadinessReport;
-  health: PlatformHealthReport;
-  ownership: PlatformSnapshot['ownership'];
-  details: Record<string, unknown>;
+  readonly details: Record<string, unknown>;
+  readonly health: JwtPlatformHealthReport;
+  readonly ownership: JwtPlatformOwnership;
+  readonly readiness: JwtPlatformReadinessReport;
 }
 
 /**
@@ -36,7 +68,7 @@ function isRefreshTokenStoreReady(input: JwtStatusAdapterInput): boolean {
   return input.refreshTokenStoreReady ?? true;
 }
 
-function createReadiness(input: JwtStatusAdapterInput): PlatformReadinessReport {
+function createReadiness(input: JwtStatusAdapterInput): JwtPlatformReadinessReport {
   const critical = input.readinessCritical ?? false;
 
   if (isRefreshTokenStoreReady(input)) {
@@ -53,7 +85,7 @@ function createReadiness(input: JwtStatusAdapterInput): PlatformReadinessReport 
   };
 }
 
-function createHealth(input: JwtStatusAdapterInput): PlatformHealthReport {
+function createHealth(input: JwtStatusAdapterInput): JwtPlatformHealthReport {
   if (isRefreshTokenStoreReady(input)) {
     return {
       status: 'healthy',
@@ -124,7 +156,7 @@ export function createJwtPlatformStatusSnapshot(input: JwtStatusAdapterInput): J
  * @param input The input.
  * @returns The create jwt platform diagnostic issues result.
  */
-export function createJwtPlatformDiagnosticIssues(input: JwtStatusAdapterInput): PlatformDiagnosticIssue[] {
+export function createJwtPlatformDiagnosticIssues(input: JwtStatusAdapterInput): JwtPlatformDiagnosticIssue[] {
   if (isRefreshTokenStoreReady(input)) {
     return [];
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -617,9 +617,6 @@ importers:
       '@fluojs/di':
         specifier: workspace:^
         version: link:../di
-      '@fluojs/runtime':
-        specifier: workspace:^
-        version: link:../runtime
     devDependencies:
       vitest:
         specifier: ^3.2.4
@@ -4767,6 +4764,7 @@ packages:
   prom-client@15.1.3:
     resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
     engines: {node: ^16 || ^18 || >=20}
+    deprecated: prom-client has been replaced by @prometheus-io/client
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -618,6 +618,9 @@ importers:
         specifier: workspace:^
         version: link:../di
     devDependencies:
+      '@fluojs/runtime':
+        specifier: workspace:^
+        version: link:../runtime
       vitest:
         specifier: ^3.2.4
         version: 3.2.7(@types/debug@4.1.13)(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.23.1)
@@ -4764,7 +4767,6 @@ packages:
   prom-client@15.1.3:
     resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
     engines: {node: ^16 || ^18 || >=20}
-    deprecated: prom-client has been replaced by @prometheus-io/client
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}


### PR DESCRIPTION
## Summary

Remove the mandatory production dependency from `@fluojs/jwt` to `@fluojs/runtime` while preserving the existing public status and lifecycle contracts.

Linked context: Closes #3196

## Changes

- replace runtime-owned type imports with structurally compatible JWT-owned contracts
- keep `@fluojs/runtime` as a test-only devDependency
- preserve mutable status/check surfaces and lifecycle compatibility with bidirectional regression probes
- add dependency-boundary regression coverage and a patch Changeset

## Testing

- full 42-package clean-prebuild `pnpm build`
- `pnpm --filter @fluojs/jwt typecheck`
- `pnpm --filter @fluojs/jwt test` (134 tests)
- `pnpm --filter ...@fluojs/jwt test` (including 123 Passport tests)
- frozen clean-install JWT typecheck
- built JWT root import/API QA
- exact-head contract/code/verification triad: merge

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests.