### PR TITLE
Resolve #3195: follow JWT root export graph in boundary tests

### DIFF
--- a/packages/jwt/src/runtime-boundary.test.ts
+++ b/packages/jwt/src/runtime-boundary.test.ts
@@ -6,19 +6,30 @@ import { describe, expect, it } from 'vitest';
 
 const packageSourceRoot = dirname(fileURLToPath(import.meta.url));
 const packageManifestPath = resolve(packageSourceRoot, '../package.json');
+const fixtureSourceRoot = resolve(packageSourceRoot, '../test/runtime-boundary');
 
-const rootImportSurfaceFiles = [
-  'index.ts',
-  'errors.ts',
-  'module.ts',
-  'service.ts',
-  'status.ts',
-  'types.ts',
-  'signing/jwks.ts',
-  'signing/signer.ts',
-  'signing/verifier.ts',
-  'refresh/refresh-token.ts',
-];
+const localRuntimeModuleSpecifierPattern =
+  /^(?:import|export)\s+(?!type\b)(?:[\s\S]*?\s+from\s+)?['"](\.[^'"]+)['"];?$/gm;
+
+const collectLocalRuntimeImportGraph = async (entryPoint: string): Promise<string[]> => {
+  const sourceFiles = [entryPoint];
+  const discovered = new Set(sourceFiles);
+
+  for (const sourceFile of sourceFiles) {
+    const source = await readFile(sourceFile, 'utf8');
+
+    for (const [, moduleSpecifier] of source.matchAll(localRuntimeModuleSpecifierPattern)) {
+      const localSourceFile = resolve(dirname(sourceFile), moduleSpecifier.replace(/\.js$/u, '.ts'));
+
+      if (!discovered.has(localSourceFile)) {
+        discovered.add(localSourceFile);
+        sourceFiles.push(localSourceFile);
+      }
+    }
+  }
+
+  return sourceFiles;
+};
 
 describe('JWT runtime boundary', () => {
   it('does not require @fluojs/runtime from its published dependency graph', async () => {
@@ -28,17 +39,25 @@ describe('JWT runtime boundary', () => {
 
     expect(packageManifest.dependencies).not.toHaveProperty('@fluojs/runtime');
 
-    for (const sourceFile of rootImportSurfaceFiles) {
-      const source = await readFile(resolve(packageSourceRoot, sourceFile), 'utf8');
-
+    for (const sourceFile of await collectLocalRuntimeImportGraph(resolve(packageSourceRoot, 'index.ts'))) {
+      const source = await readFile(sourceFile, 'utf8');
       expect(source, `${sourceFile} must not import @fluojs/runtime`).not.toContain('@fluojs/runtime');
     }
   });
 
-  it('keeps node:crypto out of the root import graph until crypto operations execute', async () => {
-    for (const sourceFile of rootImportSurfaceFiles) {
-      const source = await readFile(resolve(packageSourceRoot, sourceFile), 'utf8');
+  it('follows local re-export chains from an entrypoint', async () => {
+    await expect(collectLocalRuntimeImportGraph(resolve(fixtureSourceRoot, 'root.fixture'))).resolves.toEqual([
+      resolve(fixtureSourceRoot, 'root.fixture'),
+      resolve(fixtureSourceRoot, 'child.fixture'),
+      resolve(fixtureSourceRoot, 'crypto.fixture'),
+    ]);
+  });
 
+  it('keeps node:crypto out of the root import graph until crypto operations execute', async () => {
+    const sourceFiles = await collectLocalRuntimeImportGraph(resolve(packageSourceRoot, 'index.ts'));
+
+    for (const sourceFile of sourceFiles) {
+      const source = await readFile(sourceFile, 'utf8');
       expect(source, `${sourceFile} must not statically import node:crypto values`).not.toMatch(
         /^import\s+(?!type\b)[^;]*['"]node:crypto['"]/m,
       );

--- a/packages/jwt/src/runtime-boundary.test.ts
+++ b/packages/jwt/src/runtime-boundary.test.ts
@@ -12,6 +12,13 @@ const localRuntimeModuleSpecifierPattern =
   /^(?:import|export)\s+(?!type\b)(?:[\s\S]*?\s+from\s+)?['"](\.[^'"]+)['"];?$/gm;
 const staticNodeCryptoRuntimeDeclarationPattern = /^(?:import|export)\s+(?!type\b)[^;]*['"]node:crypto['"]/m;
 
+class StaticNodeCryptoRuntimeDeclarationError extends Error {
+  constructor(sourceFile: string) {
+    super(`Static node:crypto runtime declaration found in ${sourceFile}.`);
+    this.name = 'StaticNodeCryptoRuntimeDeclarationError';
+  }
+}
+
 const collectLocalRuntimeImportGraph = async (entryPoint: string): Promise<string[]> => {
   const sourceFiles = [entryPoint];
   const discovered = new Set(sourceFiles);
@@ -37,9 +44,10 @@ const assertNoStaticNodeCryptoRuntimeDeclaration = async (entryPoint: string): P
 
   for (const sourceFile of sourceFiles) {
     const source = await readFile(sourceFile, 'utf8');
-    expect(source, `${sourceFile} must not statically import or re-export node:crypto values`).not.toMatch(
-      staticNodeCryptoRuntimeDeclarationPattern,
-    );
+
+    if (staticNodeCryptoRuntimeDeclarationPattern.test(source)) {
+      throw new StaticNodeCryptoRuntimeDeclarationError(sourceFile);
+    }
   }
 };
 
@@ -66,21 +74,27 @@ describe('JWT runtime boundary', () => {
   });
 
   it('rejects a static node:crypto import through a local re-export chain', async () => {
+    const violatingSourceFile = resolve(fixtureSourceRoot, 'crypto.fixture');
+
     await expect(
       assertNoStaticNodeCryptoRuntimeDeclaration(resolve(fixtureSourceRoot, 'root.fixture')),
-    ).rejects.toThrow();
+    ).rejects.toThrowError(new StaticNodeCryptoRuntimeDeclarationError(violatingSourceFile));
   });
 
   it('rejects named static node:crypto re-exports through a local re-export chain', async () => {
+    const violatingSourceFile = resolve(fixtureSourceRoot, 'named-crypto-export.fixture');
+
     await expect(
       assertNoStaticNodeCryptoRuntimeDeclaration(resolve(fixtureSourceRoot, 'named-crypto-export-root.fixture')),
-    ).rejects.toThrow();
+    ).rejects.toThrowError(new StaticNodeCryptoRuntimeDeclarationError(violatingSourceFile));
   });
 
   it('rejects star static node:crypto re-exports through a local re-export chain', async () => {
+    const violatingSourceFile = resolve(fixtureSourceRoot, 'star-crypto-export.fixture');
+
     await expect(
       assertNoStaticNodeCryptoRuntimeDeclaration(resolve(fixtureSourceRoot, 'star-crypto-export-root.fixture')),
-    ).rejects.toThrow();
+    ).rejects.toThrowError(new StaticNodeCryptoRuntimeDeclarationError(violatingSourceFile));
   });
 
   it('keeps node:crypto out of the root import graph until crypto operations execute', async () => {

--- a/packages/jwt/src/runtime-boundary.test.ts
+++ b/packages/jwt/src/runtime-boundary.test.ts
@@ -10,6 +10,7 @@ const fixtureSourceRoot = resolve(packageSourceRoot, '../test/runtime-boundary')
 
 const localRuntimeModuleSpecifierPattern =
   /^(?:import|export)\s+(?!type\b)(?:[\s\S]*?\s+from\s+)?['"](\.[^'"]+)['"];?$/gm;
+const staticNodeCryptoRuntimeDeclarationPattern = /^(?:import|export)\s+(?!type\b)[^;]*['"]node:crypto['"]/m;
 
 const collectLocalRuntimeImportGraph = async (entryPoint: string): Promise<string[]> => {
   const sourceFiles = [entryPoint];
@@ -29,6 +30,17 @@ const collectLocalRuntimeImportGraph = async (entryPoint: string): Promise<strin
   }
 
   return sourceFiles;
+};
+
+const assertNoStaticNodeCryptoRuntimeDeclaration = async (entryPoint: string): Promise<void> => {
+  const sourceFiles = await collectLocalRuntimeImportGraph(entryPoint);
+
+  for (const sourceFile of sourceFiles) {
+    const source = await readFile(sourceFile, 'utf8');
+    expect(source, `${sourceFile} must not statically import or re-export node:crypto values`).not.toMatch(
+      staticNodeCryptoRuntimeDeclarationPattern,
+    );
+  }
 };
 
 describe('JWT runtime boundary', () => {
@@ -53,14 +65,27 @@ describe('JWT runtime boundary', () => {
     ]);
   });
 
-  it('keeps node:crypto out of the root import graph until crypto operations execute', async () => {
-    const sourceFiles = await collectLocalRuntimeImportGraph(resolve(packageSourceRoot, 'index.ts'));
+  it('rejects a static node:crypto import through a local re-export chain', async () => {
+    await expect(
+      assertNoStaticNodeCryptoRuntimeDeclaration(resolve(fixtureSourceRoot, 'root.fixture')),
+    ).rejects.toThrow();
+  });
 
-    for (const sourceFile of sourceFiles) {
-      const source = await readFile(sourceFile, 'utf8');
-      expect(source, `${sourceFile} must not statically import node:crypto values`).not.toMatch(
-        /^import\s+(?!type\b)[^;]*['"]node:crypto['"]/m,
-      );
-    }
+  it('rejects named static node:crypto re-exports through a local re-export chain', async () => {
+    await expect(
+      assertNoStaticNodeCryptoRuntimeDeclaration(resolve(fixtureSourceRoot, 'named-crypto-export-root.fixture')),
+    ).rejects.toThrow();
+  });
+
+  it('rejects star static node:crypto re-exports through a local re-export chain', async () => {
+    await expect(
+      assertNoStaticNodeCryptoRuntimeDeclaration(resolve(fixtureSourceRoot, 'star-crypto-export-root.fixture')),
+    ).rejects.toThrow();
+  });
+
+  it('keeps node:crypto out of the root import graph until crypto operations execute', async () => {
+    await expect(
+      assertNoStaticNodeCryptoRuntimeDeclaration(resolve(packageSourceRoot, 'index.ts')),
+    ).resolves.toBeUndefined();
   });
 });

--- a/packages/jwt/test/runtime-boundary/child.fixture
+++ b/packages/jwt/test/runtime-boundary/child.fixture
@@ -1,0 +1,1 @@
+export { createDigest } from './crypto.fixture';

--- a/packages/jwt/test/runtime-boundary/crypto.fixture
+++ b/packages/jwt/test/runtime-boundary/crypto.fixture
@@ -1,0 +1,3 @@
+import { createHash } from 'node:crypto';
+
+export const createDigest = (value: string): string => createHash('sha256').update(value).digest('hex');

--- a/packages/jwt/test/runtime-boundary/named-crypto-export-root.fixture
+++ b/packages/jwt/test/runtime-boundary/named-crypto-export-root.fixture
@@ -1,0 +1,1 @@
+export * from './named-crypto-export.fixture';

--- a/packages/jwt/test/runtime-boundary/named-crypto-export.fixture
+++ b/packages/jwt/test/runtime-boundary/named-crypto-export.fixture
@@ -1,0 +1,1 @@
+export { createHash } from 'node:crypto';

--- a/packages/jwt/test/runtime-boundary/root.fixture
+++ b/packages/jwt/test/runtime-boundary/root.fixture
@@ -1,0 +1,1 @@
+export * from './child.fixture';

--- a/packages/jwt/test/runtime-boundary/star-crypto-export-root.fixture
+++ b/packages/jwt/test/runtime-boundary/star-crypto-export-root.fixture
@@ -1,0 +1,1 @@
+export * from './star-crypto-export.fixture';

--- a/packages/jwt/test/runtime-boundary/star-crypto-export.fixture
+++ b/packages/jwt/test/runtime-boundary/star-crypto-export.fixture
@@ -1,0 +1,1 @@
+export * from 'node:crypto';


### PR DESCRIPTION
## Summary

Make JWT root-import safety tests traverse the reachable local import/export graph and reject eager `node:crypto` declarations with guard-specific evidence.

Linked context: Closes #3195

## Changes

- recursively traverse local root export/import declarations
- cover direct imports plus named and star `node:crypto` re-exports
- use deterministic guard-specific errors so unrelated ENOENT failures cannot pass
- add focused transitive fixtures and self-tests

## Testing

- `pnpm --filter @fluojs/jwt... build`
- `pnpm --filter @fluojs/jwt typecheck`
- `pnpm --filter @fluojs/jwt test` (134 tests)
- `pnpm --filter ...@fluojs/jwt test`
- exact-head contract/code/verification triad: merge

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests.