### PR TITLE
fix(cli): preserve Nest constructor injection semantics

### DIFF
--- a/.changeset/preserve-nest-constructor-injection.md
+++ b/.changeset/preserve-nest-constructor-injection.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/cli": patch
+---
+
+Preserve every NestJS constructor dependency when `fluo migrate` converts safe parameter-level `@Inject(...)` usage, and report unsupported constructor shapes without dropping dependencies.

--- a/packages/cli/src/commands/migrate.test.ts
+++ b/packages/cli/src/commands/migrate.test.ts
@@ -185,14 +185,9 @@ export class AppController {
     expect(report.dryRun).toBe(false);
     expect(report.mode).toBe('apply');
     expect(report.changedFiles).toBe(1);
-    expect(report.warningCount).toBe(1);
-    expect(report.files[0]?.warningCount).toBe(1);
-    expect(report.files[0]?.warnings[0]).toMatchObject({
-      category: 'inject-token',
-      categoryLabel: 'DI token migration (@Inject)',
-      line: 5,
-      message: 'Constructor @Inject(TOKEN) parameter decorators need manual migration to class-level @Inject(TOKEN, ...) syntax.',
-    });
+    expect(report.warningCount).toBe(0);
+    expect(report.files[0]?.warningCount).toBe(0);
+    expect(report.files[0]?.warnings).toEqual([]);
   });
 
   it('outputs "Automated rewrites:" section header for changed files', async () => {
@@ -237,7 +232,11 @@ void bootstrap();
 
 @Controller('users')
 export class UsersController {
-  constructor(@Inject('TOKEN') private readonly token: string) {}
+  constructor(
+    @Inject('TOKEN') private readonly token: string,
+    private readonly secondary: SecondaryDependency,
+    ...remaining: readonly RemainingDependency[]
+  ) {}
 
   @Post()
   @UsePipes(new ValidationPipe({ transform: true }))
@@ -258,7 +257,7 @@ export class UsersController {
     const output = stdoutBuffer.join('');
     expect(exitCode).toBe(0);
     expect(output).toContain('Manual follow-up required:');
-    expect(output).toMatch(/\[DI token migration \(@Inject\)\]/);
+    expect(output).toMatch(/\[Unsupported constructor injection\]/);
     expect(output).toContain('Docs: https://github.com/fluojs/fluo');
     expect(output).toContain('post-codemod checklist');
   });
@@ -305,7 +304,11 @@ export class UsersController {
 
 @Controller('app')
 export class AppController {
-  constructor(@Inject('SVC') private readonly svc: unknown) {}
+  constructor(
+    @Inject('SVC') private readonly svc: unknown,
+    private readonly secondary: SecondaryDependency,
+    ...remaining: readonly RemainingDependency[]
+  ) {}
 }
 `,
     );

--- a/packages/cli/src/transforms/nestjs-migrate.test.ts
+++ b/packages/cli/src/transforms/nestjs-migrate.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'nod
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import ts from 'typescript';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import {
@@ -377,6 +378,7 @@ describe('users', () => {
       join(workspaceDirectory, 'src', 'three-dependencies.service.ts'),
       `import { Inject, Injectable } from '@nestjs/common';
 
+class SecondaryDependency {}
 const PRIMARY_TOKEN = Symbol('primary');
 const TERTIARY_TOKEN = Symbol('tertiary');
 
@@ -440,6 +442,273 @@ export class UnsafeDependenciesService {
     expect(serviceContent).toContain('@Inject(PRIMARY_TOKEN)');
     expect(serviceContent).toContain('...remaining: readonly RemainingDependency[]');
     expect(report.fileResults.flatMap((result) => result.warnings).some((warning) => warning.category === 'inject-token-unsupported')).toBe(true);
+  });
+
+  it('retains constructors that infer a token from an unresolved value import', () => {
+    // Given
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-migrate-'));
+    temporaryDirectories.push(workspaceDirectory);
+
+    mkdirSync(join(workspaceDirectory, 'src'), { recursive: true });
+    writeFileSync(
+      join(workspaceDirectory, 'src', 'unresolved-import.service.ts'),
+      `import { Inject, Injectable } from '@nestjs/common';
+import { ImportedDependency } from './dependencies';
+
+const TOKEN = Symbol('token');
+
+@Injectable()
+export class UnresolvedImportService {
+  constructor(
+    @Inject(TOKEN) private readonly token: string,
+    private readonly dependency: ImportedDependency,
+  ) {}
+}
+`,
+    );
+
+    // When
+    const report = runNestJsMigration({
+      apply: true,
+      enabledTransforms: new Set(MIGRATION_TRANSFORMS),
+      targetPath: workspaceDirectory,
+    });
+    const serviceContent = readFileSync(join(workspaceDirectory, 'src', 'unresolved-import.service.ts'), 'utf8');
+
+    // Then
+    expect(serviceContent).toContain("import { Inject } from '@nestjs/common';");
+    expect(serviceContent).toContain('@Inject(TOKEN)');
+    expect(report.fileResults.flatMap((result) => result.warnings).some((warning) => warning.category === 'inject-token-unsupported')).toBe(true);
+  });
+
+  it('retains constructors that infer a token from an import type', () => {
+    // Given
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-migrate-'));
+    temporaryDirectories.push(workspaceDirectory);
+
+    mkdirSync(join(workspaceDirectory, 'src'), { recursive: true });
+    writeFileSync(
+      join(workspaceDirectory, 'src', 'import-type.service.ts'),
+      `import { Inject, Injectable } from '@nestjs/common';
+import type { ImportedDependency } from './dependencies';
+
+const TOKEN = Symbol('token');
+
+@Injectable()
+export class ImportTypeService {
+  constructor(
+    @Inject(TOKEN) private readonly token: string,
+    private readonly dependency: ImportedDependency,
+  ) {}
+}
+`,
+    );
+
+    // When
+    const report = runNestJsMigration({
+      apply: true,
+      enabledTransforms: new Set(MIGRATION_TRANSFORMS),
+      targetPath: workspaceDirectory,
+    });
+    const serviceContent = readFileSync(join(workspaceDirectory, 'src', 'import-type.service.ts'), 'utf8');
+
+    // Then
+    expect(serviceContent).toContain("import { Inject } from '@nestjs/common';");
+    expect(serviceContent).toContain('@Inject(TOKEN)');
+    expect(report.fileResults.flatMap((result) => result.warnings).some((warning) => warning.category === 'inject-token-unsupported')).toBe(true);
+  });
+
+  it('retains constructors that infer a token from an interface', () => {
+    // Given
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-migrate-'));
+    temporaryDirectories.push(workspaceDirectory);
+
+    mkdirSync(join(workspaceDirectory, 'src'), { recursive: true });
+    writeFileSync(
+      join(workspaceDirectory, 'src', 'interface.service.ts'),
+      `import { Inject, Injectable } from '@nestjs/common';
+
+interface InterfaceDependency {}
+const TOKEN = Symbol('token');
+
+@Injectable()
+export class InterfaceService {
+  constructor(
+    @Inject(TOKEN) private readonly token: string,
+    private readonly dependency: InterfaceDependency,
+  ) {}
+}
+`,
+    );
+
+    // When
+    const report = runNestJsMigration({
+      apply: true,
+      enabledTransforms: new Set(MIGRATION_TRANSFORMS),
+      targetPath: workspaceDirectory,
+    });
+    const serviceContent = readFileSync(join(workspaceDirectory, 'src', 'interface.service.ts'), 'utf8');
+
+    // Then
+    expect(serviceContent).toContain('@Inject(TOKEN)');
+    expect(serviceContent).toContain('dependency: InterfaceDependency');
+    expect(report.fileResults.flatMap((result) => result.warnings).some((warning) => warning.category === 'inject-token-unsupported')).toBe(true);
+  });
+
+  it('retains constructors that infer a token from a type alias', () => {
+    // Given
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-migrate-'));
+    temporaryDirectories.push(workspaceDirectory);
+
+    mkdirSync(join(workspaceDirectory, 'src'), { recursive: true });
+    writeFileSync(
+      join(workspaceDirectory, 'src', 'type-alias.service.ts'),
+      `import { Inject, Injectable } from '@nestjs/common';
+
+type AliasDependency = { readonly id: string };
+const TOKEN = Symbol('token');
+
+@Injectable()
+export class TypeAliasService {
+  constructor(
+    @Inject(TOKEN) private readonly token: string,
+    private readonly dependency: AliasDependency,
+  ) {}
+}
+`,
+    );
+
+    // When
+    const report = runNestJsMigration({
+      apply: true,
+      enabledTransforms: new Set(MIGRATION_TRANSFORMS),
+      targetPath: workspaceDirectory,
+    });
+    const serviceContent = readFileSync(join(workspaceDirectory, 'src', 'type-alias.service.ts'), 'utf8');
+
+    // Then
+    expect(serviceContent).toContain('@Inject(TOKEN)');
+    expect(serviceContent).toContain('dependency: AliasDependency');
+    expect(report.fileResults.flatMap((result) => result.warnings).some((warning) => warning.category === 'inject-token-unsupported')).toBe(true);
+  });
+
+  it('converts a safe aliased Nest Inject decorator', () => {
+    // Given
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-migrate-'));
+    temporaryDirectories.push(workspaceDirectory);
+
+    mkdirSync(join(workspaceDirectory, 'src'), { recursive: true });
+    writeFileSync(
+      join(workspaceDirectory, 'src', 'aliased-inject.service.ts'),
+      `import { Inject as NestInject, Injectable } from '@nestjs/common';
+
+const TOKEN = Symbol('token');
+class RuntimeDependency {}
+
+@Injectable()
+export class AliasedInjectService {
+  constructor(
+    @NestInject(TOKEN) private readonly token: string,
+    private readonly dependency: RuntimeDependency,
+  ) {}
+}
+`,
+    );
+
+    // When
+    runNestJsMigration({
+      apply: true,
+      enabledTransforms: new Set(MIGRATION_TRANSFORMS),
+      targetPath: workspaceDirectory,
+    });
+    const serviceContent = readFileSync(join(workspaceDirectory, 'src', 'aliased-inject.service.ts'), 'utf8');
+
+    // Then
+    expect(serviceContent).toContain('import { Inject as NestInject } from "@fluojs/core";');
+    expect(serviceContent).toContain('@NestInject(TOKEN, RuntimeDependency)');
+  });
+
+  it('retains unsafe aliased Nest Inject decorators with a diagnostic', () => {
+    // Given
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-migrate-'));
+    temporaryDirectories.push(workspaceDirectory);
+
+    mkdirSync(join(workspaceDirectory, 'src'), { recursive: true });
+    writeFileSync(
+      join(workspaceDirectory, 'src', 'unsafe-aliased-inject.service.ts'),
+      `import { Inject as NestInject, Injectable } from '@nestjs/common';
+
+const TOKEN = Symbol('token');
+
+@Injectable()
+export class UnsafeAliasedInjectService {
+  constructor(
+    @NestInject(TOKEN) private readonly token: string,
+    private readonly dependency: Dependency,
+    ...remaining: readonly RemainingDependency[]
+  ) {}
+}
+`,
+    );
+
+    // When
+    const report = runNestJsMigration({
+      apply: true,
+      enabledTransforms: new Set(MIGRATION_TRANSFORMS),
+      targetPath: workspaceDirectory,
+    });
+    const serviceContent = readFileSync(join(workspaceDirectory, 'src', 'unsafe-aliased-inject.service.ts'), 'utf8');
+
+    // Then
+    expect(serviceContent).toContain("import { Inject as NestInject } from '@nestjs/common';");
+    expect(serviceContent).toContain('@NestInject(TOKEN)');
+    expect(report.fileResults.flatMap((result) => result.warnings).some((warning) => warning.category === 'inject-token-unsupported')).toBe(true);
+  });
+
+  it('emits a runtime Inject binding separately from type-only core imports', () => {
+    // Given
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-migrate-'));
+    temporaryDirectories.push(workspaceDirectory);
+
+    mkdirSync(join(workspaceDirectory, 'src'), { recursive: true });
+    writeFileSync(
+      join(workspaceDirectory, 'src', 'type-only-core-import.service.ts'),
+      `import type { InjectionToken } from '@fluojs/core';
+import { Inject as NestInject, Injectable } from '@nestjs/common';
+
+const TOKEN = Symbol('token');
+class RuntimeDependency {}
+type RuntimeMarker = InjectionToken;
+
+@Injectable()
+export class TypeOnlyCoreImportService {
+  constructor(
+    @NestInject(TOKEN) private readonly token: string,
+    private readonly dependency: RuntimeDependency,
+  ) {}
+}
+`,
+    );
+
+    // When
+    runNestJsMigration({
+      apply: true,
+      enabledTransforms: new Set(MIGRATION_TRANSFORMS),
+      targetPath: workspaceDirectory,
+    });
+    const serviceContent = readFileSync(join(workspaceDirectory, 'src', 'type-only-core-import.service.ts'), 'utf8');
+    const emitted = ts.transpileModule(serviceContent, {
+      compilerOptions: {
+        module: ts.ModuleKind.ESNext,
+        target: ts.ScriptTarget.ES2022,
+      },
+    });
+
+    // Then
+    expect(serviceContent).toContain("import type { InjectionToken } from '@fluojs/core';");
+    expect(serviceContent).toContain('import { Inject as NestInject } from "@fluojs/core";');
+    expect(emitted.diagnostics).toEqual([]);
+    expect(emitted.outputText).toContain('NestInject(TOKEN, RuntimeDependency)');
   });
 
   it('attaches correct warning categories to each warning type', () => {

--- a/packages/cli/src/transforms/nestjs-migrate.test.ts
+++ b/packages/cli/src/transforms/nestjs-migrate.test.ts
@@ -477,6 +477,71 @@ export class PartiallyMigratedService {
     expect(report.fileResults.flatMap((result) => result.warnings).some((warning) => warning.category === 'inject-token')).toBe(false);
   });
 
+  it('merges Nest Inject tokens into an existing namespace Fluo Inject decorator', () => {
+    // Given
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-migrate-'));
+    temporaryDirectories.push(workspaceDirectory);
+
+    mkdirSync(join(workspaceDirectory, 'src'), { recursive: true });
+    writeFileSync(
+      join(workspaceDirectory, 'src', 'namespace-decorator.service.ts'),
+      `import * as Core from '@fluojs/core';
+import { Inject as NestInject } from '@nestjs/common';
+
+const A_TOKEN = Symbol('a');
+const B_TOKEN = Symbol('b');
+
+@Core.Inject(A_TOKEN)
+export class NamespaceDecoratorService {
+  constructor(@NestInject(B_TOKEN) private readonly dependency: string) {}
+}
+`,
+    );
+
+    // When
+    const report = runNestJsMigration({
+      apply: true,
+      enabledTransforms: new Set(MIGRATION_TRANSFORMS),
+      targetPath: workspaceDirectory,
+    });
+    const serviceContent = readFileSync(join(workspaceDirectory, 'src', 'namespace-decorator.service.ts'), 'utf8');
+
+    // Then
+    expect(serviceContent).toContain('@Core.Inject(A_TOKEN, B_TOKEN)');
+    expect(serviceContent.match(/@Core\.Inject\(/g)).toHaveLength(1);
+    expect(serviceContent).not.toContain('@NestInject(');
+    expect(report.warningCount).toBe(0);
+  });
+
+  it('reports injectable when constructor token rewriting is the only change', () => {
+    // Given
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-migrate-'));
+    temporaryDirectories.push(workspaceDirectory);
+
+    mkdirSync(join(workspaceDirectory, 'src'), { recursive: true });
+    writeFileSync(
+      join(workspaceDirectory, 'src', 'constructor-only.service.ts'),
+      `import { Inject } from '@nestjs/common';
+
+const TOKEN = Symbol('token');
+
+export class ConstructorOnlyService {
+  constructor(@Inject(TOKEN) private readonly dependency: string) {}
+}
+`,
+    );
+
+    // When
+    const report = runNestJsMigration({
+      apply: true,
+      enabledTransforms: new Set(['injectable']),
+      targetPath: workspaceDirectory,
+    });
+
+    // Then
+    expect(report.fileResults[0]?.appliedTransforms).toEqual(['injectable']);
+  });
+
   it('retains constructor injection when a type name collides with a runtime value', () => {
     // Given
     const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-migrate-'));
@@ -620,6 +685,8 @@ export class UnsafeConstructorService {
     const serviceContent = readFileSync(join(workspaceDirectory, 'src', 'mixed-constructor-safety.service.ts'), 'utf8');
 
     // Then
+    expect(serviceContent).toContain('import { Inject as FluoInject } from "@fluojs/core";');
+    expect(serviceContent).toContain("import { Inject } from '@nestjs/common';");
     expect(serviceContent).toContain('@FluoInject(SAFE_TOKEN)');
     expect(serviceContent).toContain('@Inject(UNSAFE_TOKEN)');
     expect(serviceContent).toContain('...remaining: readonly unknown[]');

--- a/packages/cli/src/transforms/nestjs-migrate.test.ts
+++ b/packages/cli/src/transforms/nestjs-migrate.test.ts
@@ -664,6 +664,42 @@ export class ImportedTypeCollisionService {
     expect(report.fileResults.flatMap((result) => result.warnings).some((warning) => warning.category === 'inject-token-unsupported')).toBe(true);
   });
 
+  it('retains constructor injection when a class type parameter collides with a runtime value', () => {
+    // Given
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-migrate-'));
+    temporaryDirectories.push(workspaceDirectory);
+
+    mkdirSync(join(workspaceDirectory, 'src'), { recursive: true });
+    writeFileSync(
+      join(workspaceDirectory, 'src', 'generic-type-parameter-collision.service.ts'),
+      `import { Inject } from '@nestjs/common';
+
+const TOKEN = Symbol('token');
+const Dependency = Symbol('wrong-token');
+
+class Consumer<Dependency> {
+  constructor(
+    @Inject(TOKEN) private readonly token: string,
+    private readonly dependency: Dependency,
+  ) {}
+}
+`,
+    );
+
+    // When
+    const report = runNestJsMigration({
+      apply: true,
+      enabledTransforms: new Set(MIGRATION_TRANSFORMS),
+      targetPath: workspaceDirectory,
+    });
+    const serviceContent = readFileSync(join(workspaceDirectory, 'src', 'generic-type-parameter-collision.service.ts'), 'utf8');
+
+    // Then
+    expect(serviceContent).toContain('@Inject(TOKEN)');
+    expect(serviceContent).not.toContain('@Inject(TOKEN, Dependency)');
+    expect(report.fileResults.flatMap((result) => result.warnings).some((warning) => warning.category === 'inject-token-unsupported')).toBe(true);
+  });
+
   it('rewrites generated Inject imports when only injectable is enabled', () => {
     // Given
     const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-migrate-'));

--- a/packages/cli/src/transforms/nestjs-migrate.test.ts
+++ b/packages/cli/src/transforms/nestjs-migrate.test.ts
@@ -367,6 +367,81 @@ describe('users', () => {
     expect(secondReport.changedFiles).toBe(0);
   });
 
+  it('converts every constructor dependency to an ordered class-level Inject tuple', () => {
+    // Given
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-migrate-'));
+    temporaryDirectories.push(workspaceDirectory);
+
+    mkdirSync(join(workspaceDirectory, 'src'), { recursive: true });
+    writeFileSync(
+      join(workspaceDirectory, 'src', 'three-dependencies.service.ts'),
+      `import { Inject, Injectable } from '@nestjs/common';
+
+const PRIMARY_TOKEN = Symbol('primary');
+const TERTIARY_TOKEN = Symbol('tertiary');
+
+@Injectable()
+export class ThreeDependenciesService {
+  constructor(
+    @Inject(PRIMARY_TOKEN) private readonly primary: string,
+    private readonly secondary: SecondaryDependency,
+    @Inject(TERTIARY_TOKEN) private readonly tertiary: string,
+  ) {}
+}
+`,
+    );
+
+    // When
+    const report = runNestJsMigration({
+      apply: true,
+      enabledTransforms: new Set(MIGRATION_TRANSFORMS),
+      targetPath: workspaceDirectory,
+    });
+    const serviceContent = readFileSync(join(workspaceDirectory, 'src', 'three-dependencies.service.ts'), 'utf8');
+
+    // Then
+    expect(serviceContent).toContain('@Inject(PRIMARY_TOKEN, SecondaryDependency, TERTIARY_TOKEN)');
+    expect(serviceContent).not.toContain('constructor(@Inject');
+    expect(report.fileResults.flatMap((result) => result.warnings).some((warning) => warning.category === 'inject-token')).toBe(false);
+  });
+
+  it('retains unsafe constructor dependencies and reports an unsupported inject-token diagnostic', () => {
+    // Given
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-migrate-'));
+    temporaryDirectories.push(workspaceDirectory);
+
+    mkdirSync(join(workspaceDirectory, 'src'), { recursive: true });
+    writeFileSync(
+      join(workspaceDirectory, 'src', 'unsafe-dependencies.service.ts'),
+      `import { Inject, Injectable } from '@nestjs/common';
+
+const PRIMARY_TOKEN = Symbol('primary');
+
+@Injectable()
+export class UnsafeDependenciesService {
+  constructor(
+    @Inject(PRIMARY_TOKEN) private readonly primary: string,
+    private readonly secondary: SecondaryDependency,
+    ...remaining: readonly RemainingDependency[]
+  ) {}
+}
+`,
+    );
+
+    // When
+    const report = runNestJsMigration({
+      apply: true,
+      enabledTransforms: new Set(MIGRATION_TRANSFORMS),
+      targetPath: workspaceDirectory,
+    });
+    const serviceContent = readFileSync(join(workspaceDirectory, 'src', 'unsafe-dependencies.service.ts'), 'utf8');
+
+    // Then
+    expect(serviceContent).toContain('@Inject(PRIMARY_TOKEN)');
+    expect(serviceContent).toContain('...remaining: readonly RemainingDependency[]');
+    expect(report.fileResults.flatMap((result) => result.warnings).some((warning) => warning.category === 'inject-token-unsupported')).toBe(true);
+  });
+
   it('attaches correct warning categories to each warning type', () => {
     const workspaceDirectory = createMigrationFixture();
 
@@ -386,7 +461,7 @@ describe('users', () => {
     }
 
     const categories = new Set(allWarnings.map((w) => w.category));
-    expect(categories.has('inject-token')).toBe(true);
+    expect(categories.has('inject-token-unsupported')).toBe(false);
     expect(categories.has('request-dto')).toBe(true);
     expect(categories.has('pipe-converter')).toBe(true);
   });

--- a/packages/cli/src/transforms/nestjs-migrate.test.ts
+++ b/packages/cli/src/transforms/nestjs-migrate.test.ts
@@ -457,7 +457,10 @@ const B_TOKEN = Symbol('b');
 
 @FluoInject(A_TOKEN)
 export class PartiallyMigratedService {
-  constructor(@NestInject(B_TOKEN) private readonly dependency: string) {}
+  constructor(
+    private readonly existing: object,
+    @NestInject(B_TOKEN) private readonly dependency: string,
+  ) {}
 }
 `,
     );
@@ -493,7 +496,10 @@ const B_TOKEN = Symbol('b');
 
 @Core.Inject(A_TOKEN)
 export class NamespaceDecoratorService {
-  constructor(@NestInject(B_TOKEN) private readonly dependency: string) {}
+  constructor(
+    private readonly existing: object,
+    @NestInject(B_TOKEN) private readonly dependency: string,
+  ) {}
 }
 `,
     );
@@ -510,6 +516,45 @@ export class NamespaceDecoratorService {
     expect(serviceContent).toContain('@Core.Inject(A_TOKEN, B_TOKEN)');
     expect(serviceContent.match(/@Core\.Inject\(/g)).toHaveLength(1);
     expect(serviceContent).not.toContain('@NestInject(');
+    expect(report.warningCount).toBe(0);
+  });
+
+  it('normalizes legacy Fluo Inject arrays while replacing converted token positions', () => {
+    // Given
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-migrate-'));
+    temporaryDirectories.push(workspaceDirectory);
+
+    mkdirSync(join(workspaceDirectory, 'src'), { recursive: true });
+    writeFileSync(
+      join(workspaceDirectory, 'src', 'legacy-array-decorator.service.ts'),
+      `import { Inject as FluoInject } from '@fluojs/core';
+import { Inject as NestInject } from '@nestjs/common';
+
+const A_TOKEN = Symbol('a');
+const B_TOKEN = Symbol('b');
+
+@FluoInject([A_TOKEN])
+export class LegacyArrayDecoratorService {
+  constructor(
+    private readonly existing: object,
+    @NestInject(B_TOKEN) private readonly dependency: string,
+  ) {}
+}
+`,
+    );
+
+    // When
+    const report = runNestJsMigration({
+      apply: true,
+      enabledTransforms: new Set(MIGRATION_TRANSFORMS),
+      targetPath: workspaceDirectory,
+    });
+    const serviceContent = readFileSync(join(workspaceDirectory, 'src', 'legacy-array-decorator.service.ts'), 'utf8');
+
+    // Then
+    expect(serviceContent).toContain('@FluoInject(A_TOKEN, B_TOKEN)');
+    expect(serviceContent).not.toContain('@FluoInject([');
+    expect(serviceContent.match(/@FluoInject\(/g)).toHaveLength(1);
     expect(report.warningCount).toBe(0);
   });
 
@@ -575,6 +620,43 @@ export class CollidingDependencyService {
       targetPath: workspaceDirectory,
     });
     const serviceContent = readFileSync(join(workspaceDirectory, 'src', 'colliding-dependency.service.ts'), 'utf8');
+
+    // Then
+    expect(serviceContent).toContain('@Inject(TOKEN)');
+    expect(serviceContent).not.toContain('@Inject(TOKEN, Dependency)');
+    expect(report.fileResults.flatMap((result) => result.warnings).some((warning) => warning.category === 'inject-token-unsupported')).toBe(true);
+  });
+
+  it('retains constructor injection when an imported type collides with a runtime value', () => {
+    // Given
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-migrate-'));
+    temporaryDirectories.push(workspaceDirectory);
+
+    mkdirSync(join(workspaceDirectory, 'src'), { recursive: true });
+    writeFileSync(
+      join(workspaceDirectory, 'src', 'imported-type-collision.service.ts'),
+      `import type { Dependency } from './types';
+import { Inject } from '@nestjs/common';
+
+const TOKEN = Symbol('token');
+const Dependency = Symbol('wrong-token');
+
+export class ImportedTypeCollisionService {
+  constructor(
+    @Inject(TOKEN) private readonly token: string,
+    private readonly dependency: Dependency,
+  ) {}
+}
+`,
+    );
+
+    // When
+    const report = runNestJsMigration({
+      apply: true,
+      enabledTransforms: new Set(MIGRATION_TRANSFORMS),
+      targetPath: workspaceDirectory,
+    });
+    const serviceContent = readFileSync(join(workspaceDirectory, 'src', 'imported-type-collision.service.ts'), 'utf8');
 
     // Then
     expect(serviceContent).toContain('@Inject(TOKEN)');

--- a/packages/cli/src/transforms/nestjs-migrate.test.ts
+++ b/packages/cli/src/transforms/nestjs-migrate.test.ts
@@ -5,12 +5,12 @@ import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import {
-  MIGRATION_TRANSFORMS,
-  WARNING_CATEGORIES,
   getWarningCategoryLabel,
   groupWarningsByCategory,
-  runNestJsMigration,
+  MIGRATION_TRANSFORMS,
   type MigrationWarning,
+  runNestJsMigration,
+  WARNING_CATEGORIES,
 } from './nestjs-migrate.js';
 
 const temporaryDirectories: string[] = [];

--- a/packages/cli/src/transforms/nestjs-migrate.test.ts
+++ b/packages/cli/src/transforms/nestjs-migrate.test.ts
@@ -407,6 +407,225 @@ export class ThreeDependenciesService {
     expect(report.fileResults.flatMap((result) => result.warnings).some((warning) => warning.category === 'inject-token')).toBe(false);
   });
 
+  it('migrates Nest Inject from an overloaded constructor implementation', () => {
+    // Given
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-migrate-'));
+    temporaryDirectories.push(workspaceDirectory);
+
+    mkdirSync(join(workspaceDirectory, 'src'), { recursive: true });
+    writeFileSync(
+      join(workspaceDirectory, 'src', 'overloaded-constructor.service.ts'),
+      `import { Inject as NestInject } from '@nestjs/common';
+
+const TOKEN = Symbol('token');
+
+export class OverloadedConstructorService {
+  constructor(token: string);
+  constructor(@NestInject(TOKEN) private readonly token: string) {}
+}
+`,
+    );
+
+    // When
+    const report = runNestJsMigration({
+      apply: true,
+      enabledTransforms: new Set(MIGRATION_TRANSFORMS),
+      targetPath: workspaceDirectory,
+    });
+    const serviceContent = readFileSync(join(workspaceDirectory, 'src', 'overloaded-constructor.service.ts'), 'utf8');
+
+    // Then
+    expect(serviceContent).toContain('import { Inject as NestInject } from "@fluojs/core";');
+    expect(serviceContent).toContain('@NestInject(TOKEN)');
+    expect(serviceContent).not.toContain('constructor(@NestInject');
+    expect(report.fileResults.flatMap((result) => result.warnings).some((warning) => warning.category === 'inject-token')).toBe(false);
+  });
+
+  it('merges existing Fluo Inject tokens with migrated Nest Inject tokens', () => {
+    // Given
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-migrate-'));
+    temporaryDirectories.push(workspaceDirectory);
+
+    mkdirSync(join(workspaceDirectory, 'src'), { recursive: true });
+    writeFileSync(
+      join(workspaceDirectory, 'src', 'partially-migrated.service.ts'),
+      `import { Inject as FluoInject } from '@fluojs/core';
+import { Inject as NestInject } from '@nestjs/common';
+
+const A_TOKEN = Symbol('a');
+const B_TOKEN = Symbol('b');
+
+@FluoInject(A_TOKEN)
+export class PartiallyMigratedService {
+  constructor(@NestInject(B_TOKEN) private readonly dependency: string) {}
+}
+`,
+    );
+
+    // When
+    const report = runNestJsMigration({
+      apply: true,
+      enabledTransforms: new Set(MIGRATION_TRANSFORMS),
+      targetPath: workspaceDirectory,
+    });
+    const serviceContent = readFileSync(join(workspaceDirectory, 'src', 'partially-migrated.service.ts'), 'utf8');
+
+    // Then
+    expect(serviceContent).toContain('@FluoInject(A_TOKEN, B_TOKEN)');
+    expect(serviceContent.match(/@FluoInject\(/g)).toHaveLength(1);
+    expect(serviceContent).not.toContain('@NestInject(');
+    expect(report.fileResults.flatMap((result) => result.warnings).some((warning) => warning.category === 'inject-token')).toBe(false);
+  });
+
+  it('retains constructor injection when a type name collides with a runtime value', () => {
+    // Given
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-migrate-'));
+    temporaryDirectories.push(workspaceDirectory);
+
+    mkdirSync(join(workspaceDirectory, 'src'), { recursive: true });
+    writeFileSync(
+      join(workspaceDirectory, 'src', 'colliding-dependency.service.ts'),
+      `import { Inject, Injectable } from '@nestjs/common';
+
+const TOKEN = Symbol('token');
+const Dependency = Symbol('wrong-token');
+interface Dependency {
+  readonly id: string;
+}
+
+@Injectable()
+export class CollidingDependencyService {
+  constructor(
+    @Inject(TOKEN) private readonly token: string,
+    private readonly dependency: Dependency,
+  ) {}
+}
+`,
+    );
+
+    // When
+    const report = runNestJsMigration({
+      apply: true,
+      enabledTransforms: new Set(MIGRATION_TRANSFORMS),
+      targetPath: workspaceDirectory,
+    });
+    const serviceContent = readFileSync(join(workspaceDirectory, 'src', 'colliding-dependency.service.ts'), 'utf8');
+
+    // Then
+    expect(serviceContent).toContain('@Inject(TOKEN)');
+    expect(serviceContent).not.toContain('@Inject(TOKEN, Dependency)');
+    expect(report.fileResults.flatMap((result) => result.warnings).some((warning) => warning.category === 'inject-token-unsupported')).toBe(true);
+  });
+
+  it('rewrites generated Inject imports when only injectable is enabled', () => {
+    // Given
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-migrate-'));
+    temporaryDirectories.push(workspaceDirectory);
+
+    mkdirSync(join(workspaceDirectory, 'src'), { recursive: true });
+    writeFileSync(
+      join(workspaceDirectory, 'src', 'injectable-only.service.ts'),
+      `import { Inject } from '@nestjs/common';
+
+const TOKEN = Symbol('token');
+
+export class InjectableOnlyService {
+  constructor(@Inject(TOKEN) private readonly dependency: string) {}
+}
+`,
+    );
+
+    // When
+    const report = runNestJsMigration({
+      apply: true,
+      enabledTransforms: new Set(['injectable']),
+      targetPath: workspaceDirectory,
+    });
+    const serviceContent = readFileSync(join(workspaceDirectory, 'src', 'injectable-only.service.ts'), 'utf8');
+
+    // Then
+    expect(serviceContent).toContain('import { Inject } from "@fluojs/core";');
+    expect(serviceContent).toContain('@Inject(TOKEN)');
+    expect(serviceContent).not.toContain('@nestjs/common');
+    expect(report.fileResults.flatMap((result) => result.warnings).some((warning) => warning.category === 'inject-token')).toBe(false);
+  });
+
+  it('adds a named Fluo Inject import alongside a namespace core import', () => {
+    // Given
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-migrate-'));
+    temporaryDirectories.push(workspaceDirectory);
+
+    mkdirSync(join(workspaceDirectory, 'src'), { recursive: true });
+    writeFileSync(
+      join(workspaceDirectory, 'src', 'namespace-core-import.service.ts'),
+      `import * as Core from '@fluojs/core';
+import { Inject } from '@nestjs/common';
+
+const TOKEN = Symbol('token');
+
+export class NamespaceCoreImportService {
+  constructor(@Inject(TOKEN) private readonly dependency: string) {}
+}
+
+void Core;
+`,
+    );
+
+    // When
+    runNestJsMigration({
+      apply: true,
+      enabledTransforms: new Set(MIGRATION_TRANSFORMS),
+      targetPath: workspaceDirectory,
+    });
+    const serviceContent = readFileSync(join(workspaceDirectory, 'src', 'namespace-core-import.service.ts'), 'utf8');
+
+    // Then
+    expect(serviceContent).toContain('import * as Core from \'@fluojs/core\';');
+    expect(serviceContent).toContain('import { Inject } from "@fluojs/core";');
+    expect(serviceContent).toContain('@Inject(TOKEN)');
+  });
+
+  it('converts safe constructors while retaining unsafe constructors with diagnostics', () => {
+    // Given
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-migrate-'));
+    temporaryDirectories.push(workspaceDirectory);
+
+    mkdirSync(join(workspaceDirectory, 'src'), { recursive: true });
+    writeFileSync(
+      join(workspaceDirectory, 'src', 'mixed-constructor-safety.service.ts'),
+      `import { Inject } from '@nestjs/common';
+
+const SAFE_TOKEN = Symbol('safe');
+const UNSAFE_TOKEN = Symbol('unsafe');
+
+export class SafeConstructorService {
+  constructor(@Inject(SAFE_TOKEN) private readonly dependency: string) {}
+}
+
+export class UnsafeConstructorService {
+  constructor(
+    @Inject(UNSAFE_TOKEN) private readonly dependency: string,
+    ...remaining: readonly unknown[]
+  ) {}
+}
+`,
+    );
+
+    // When
+    const report = runNestJsMigration({
+      apply: true,
+      enabledTransforms: new Set(MIGRATION_TRANSFORMS),
+      targetPath: workspaceDirectory,
+    });
+    const serviceContent = readFileSync(join(workspaceDirectory, 'src', 'mixed-constructor-safety.service.ts'), 'utf8');
+
+    // Then
+    expect(serviceContent).toContain('@FluoInject(SAFE_TOKEN)');
+    expect(serviceContent).toContain('@Inject(UNSAFE_TOKEN)');
+    expect(serviceContent).toContain('...remaining: readonly unknown[]');
+    expect(report.fileResults.flatMap((result) => result.warnings).some((warning) => warning.category === 'inject-token-unsupported')).toBe(true);
+  });
+
   it('retains unsafe constructor dependencies and reports an unsupported inject-token diagnostic', () => {
     // Given
     const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-migrate-'));

--- a/packages/cli/src/transforms/nestjs-migrate.ts
+++ b/packages/cli/src/transforms/nestjs-migrate.ts
@@ -652,11 +652,28 @@ function getTypeOnlyImportNames(sourceFile: ts.SourceFile): ReadonlySet<string> 
   return names;
 }
 
+function getInScopeTypeParameterNames(node: ts.Node): ReadonlySet<string> {
+  const names = new Set<string>();
+
+  for (let current: ts.Node | undefined = node; current; current = current.parent) {
+    if (!ts.isClassDeclaration(current) && !ts.isFunctionLike(current)) {
+      continue;
+    }
+
+    for (const typeParameter of current.typeParameters ?? []) {
+      names.add(typeParameter.name.text);
+    }
+  }
+
+  return names;
+}
+
 function createInjectionTokenFromType(
   type: ts.TypeNode | undefined,
   runtimeValueNames: ReadonlySet<string>,
   collidingTypeValueNames: ReadonlySet<string>,
   typeOnlyImportNames: ReadonlySet<string>,
+  inScopeTypeParameterNames: ReadonlySet<string>,
 ): ts.Expression | undefined {
   if (
     !type
@@ -665,6 +682,7 @@ function createInjectionTokenFromType(
     || !runtimeValueNames.has(type.typeName.text)
     || collidingTypeValueNames.has(type.typeName.text)
     || typeOnlyImportNames.has(type.typeName.text)
+    || inScopeTypeParameterNames.has(type.typeName.text)
   ) {
     return undefined;
   }
@@ -715,6 +733,7 @@ function getConstructorInjectionTokens(
   }
 
   const tokens: ts.Expression[] = [];
+  const inScopeTypeParameterNames = getInScopeTypeParameterNames(classDeclaration);
   let decoratorLocalName: string | undefined;
   for (const [index, parameter] of parameters.entries()) {
     if (parameter.dotDotDotToken || parameter.questionToken || parameter.initializer || !ts.isIdentifier(parameter.name)) {
@@ -757,6 +776,7 @@ function getConstructorInjectionTokens(
       runtimeValueNames,
       collidingTypeValueNames,
       typeOnlyImportNames,
+      inScopeTypeParameterNames,
     );
     if (!token) {
       return { kind: 'unsafe', node: parameter };

--- a/packages/cli/src/transforms/nestjs-migrate.ts
+++ b/packages/cli/src/transforms/nestjs-migrate.ts
@@ -15,6 +15,7 @@ export type MigrationTransformKind = typeof MIGRATION_TRANSFORMS[number];
 
 type ImportBinding = {
   imported: string;
+  isTypeOnly: boolean;
   local: string;
 };
 
@@ -176,17 +177,18 @@ function getImportBindings(importDeclaration: ts.ImportDeclaration): ImportBindi
 
   return importClause.namedBindings.elements.map((element) => ({
     imported: (element.propertyName ?? element.name).text,
+    isTypeOnly: importClause.isTypeOnly || element.isTypeOnly,
     local: element.name.text,
   }));
 }
 
 function createImportSpecifier(binding: ImportBinding): ts.ImportSpecifier {
   if (binding.imported === binding.local) {
-    return ts.factory.createImportSpecifier(false, undefined, ts.factory.createIdentifier(binding.local));
+    return ts.factory.createImportSpecifier(binding.isTypeOnly, undefined, ts.factory.createIdentifier(binding.local));
   }
 
   return ts.factory.createImportSpecifier(
-    false,
+    binding.isTypeOnly,
     ts.factory.createIdentifier(binding.imported),
     ts.factory.createIdentifier(binding.local),
   );
@@ -227,24 +229,32 @@ function mergeNamedImport(statements: ts.Statement[], moduleSpecifier: string, n
     return statements;
   }
 
-  const deduped = new Map<string, ImportBinding>();
-  for (const binding of newBindings) {
-    deduped.set(toBindingKey(binding), binding);
-  }
-
   let merged = false;
   const updated = statements.map((statement) => {
-    if (!ts.isImportDeclaration(statement) || !ts.isStringLiteral(statement.moduleSpecifier) || statement.moduleSpecifier.text !== moduleSpecifier) {
+    if (
+      merged
+      || !ts.isImportDeclaration(statement)
+      || !ts.isStringLiteral(statement.moduleSpecifier)
+      || statement.moduleSpecifier.text !== moduleSpecifier
+      || statement.importClause?.isTypeOnly
+    ) {
       return statement;
     }
 
-    const existingBindings = getImportBindings(statement);
-    for (const binding of existingBindings) {
-      deduped.set(toBindingKey(binding), binding);
+    const bindings = new Map<string, ImportBinding>();
+    for (const binding of getImportBindings(statement)) {
+      bindings.set(toBindingKey(binding), binding);
+    }
+
+    for (const binding of newBindings) {
+      const existing = bindings.get(toBindingKey(binding));
+      if (!existing || !binding.isTypeOnly) {
+        bindings.set(toBindingKey(binding), binding);
+      }
     }
 
     merged = true;
-    const mergedBindings = [...deduped.values()].sort((left, right) => left.local.localeCompare(right.local));
+    const mergedBindings = [...bindings.values()].sort((left, right) => left.local.localeCompare(right.local));
     return updateNamedImports(statement, mergedBindings) ?? statement;
   });
 
@@ -257,7 +267,7 @@ function mergeNamedImport(statements: ts.Statement[], moduleSpecifier: string, n
     ts.factory.createImportClause(
       false,
       undefined,
-      ts.factory.createNamedImports([...deduped.values()].sort((left, right) => left.local.localeCompare(right.local)).map(createImportSpecifier)),
+      ts.factory.createNamedImports([...newBindings].sort((left, right) => left.local.localeCompare(right.local)).map(createImportSpecifier)),
     ),
     ts.factory.createStringLiteral(moduleSpecifier),
   );
@@ -328,7 +338,7 @@ function rewriteImports(source: string, filePath: string): { changed: boolean; s
   const warnings: MigrationWarning[] = [];
   const additions = new Map<string, ImportBinding[]>();
   const statements: ts.Statement[] = [];
-  const hasNestInjectParameter = hasInjectParameterDecorator(sourceFile);
+  const hasNestInjectParameter = hasNestInjectParameterDecorator(sourceFile, getNestInjectLocalNames(sourceFile));
   let touched = false;
 
   for (const statement of sourceFile.statements) {
@@ -352,6 +362,11 @@ function rewriteImports(source: string, filePath: string): { changed: boolean; s
     const remaining: ImportBinding[] = [];
 
     for (const binding of getImportBindings(statement)) {
+      if (binding.isTypeOnly) {
+        remaining.push(binding);
+        continue;
+      }
+
       if (binding.imported === 'Inject' && hasNestInjectParameter) {
         remaining.push(binding);
         continue;
@@ -365,7 +380,7 @@ function rewriteImports(source: string, filePath: string): { changed: boolean; s
 
       touched = true;
       const moduleBindings = additions.get(targetModule) ?? [];
-      moduleBindings.push({ imported: binding.imported, local: binding.local });
+      moduleBindings.push(binding);
       additions.set(targetModule, moduleBindings);
     }
 
@@ -420,7 +435,49 @@ function hasDecoratorNamed(modifiers: readonly ts.ModifierLike[] | undefined, na
   return modifiers.some((modifier) => ts.isDecorator(modifier) && isDecoratorNamed(modifier, name));
 }
 
-function hasInjectParameterDecorator(sourceFile: ts.SourceFile): boolean {
+function getNestInjectLocalNames(sourceFile: ts.SourceFile): ReadonlySet<string> {
+  const localNames = new Set<string>();
+
+  for (const statement of sourceFile.statements) {
+    if (
+      !ts.isImportDeclaration(statement)
+      || !ts.isStringLiteral(statement.moduleSpecifier)
+      || statement.moduleSpecifier.text !== '@nestjs/common'
+      || statement.importClause?.isTypeOnly
+      || !statement.importClause?.namedBindings
+      || !ts.isNamedImports(statement.importClause.namedBindings)
+    ) {
+      continue;
+    }
+
+    for (const element of statement.importClause.namedBindings.elements) {
+      if (!element.isTypeOnly && (element.propertyName ?? element.name).text === 'Inject') {
+        localNames.add(element.name.text);
+      }
+    }
+  }
+
+  return localNames;
+}
+
+function getNestInjectDecoratorLocalName(decorator: ts.Decorator, localNames: ReadonlySet<string>): string | undefined {
+  if (!ts.isCallExpression(decorator.expression) || !ts.isIdentifier(decorator.expression.expression)) {
+    return undefined;
+  }
+
+  const localName = decorator.expression.expression.text;
+  return localNames.has(localName) ? localName : undefined;
+}
+
+function hasNestInjectDecorator(modifiers: readonly ts.ModifierLike[] | undefined, localNames: ReadonlySet<string>): boolean {
+  if (!modifiers) {
+    return false;
+  }
+
+  return modifiers.some((modifier) => ts.isDecorator(modifier) && !!getNestInjectDecoratorLocalName(modifier, localNames));
+}
+
+function hasNestInjectParameterDecorator(sourceFile: ts.SourceFile, localNames: ReadonlySet<string>): boolean {
   let found = false;
 
   const visit = (node: ts.Node): void => {
@@ -428,7 +485,7 @@ function hasInjectParameterDecorator(sourceFile: ts.SourceFile): boolean {
       return;
     }
 
-    if (ts.isParameter(node) && hasDecoratorNamed(node.modifiers, 'Inject')) {
+    if (ts.isParameter(node) && hasNestInjectDecorator(node.modifiers, localNames)) {
       found = true;
       return;
     }
@@ -440,55 +497,76 @@ function hasInjectParameterDecorator(sourceFile: ts.SourceFile): boolean {
   return found;
 }
 
-function createInjectionTokenFromType(type: ts.TypeNode | undefined): ts.Expression | undefined {
-  if (!type || !ts.isTypeReferenceNode(type)) {
+function getRuntimeValueNames(sourceFile: ts.SourceFile): ReadonlySet<string> {
+  const names = new Set<string>();
+
+  for (const statement of sourceFile.statements) {
+    if (
+      (ts.isClassDeclaration(statement) || ts.isEnumDeclaration(statement) || ts.isFunctionDeclaration(statement))
+      && statement.name
+    ) {
+      names.add(statement.name.text);
+      continue;
+    }
+
+    if (ts.isVariableStatement(statement)) {
+      for (const declaration of statement.declarationList.declarations) {
+        if (ts.isIdentifier(declaration.name)) {
+          names.add(declaration.name.text);
+        }
+      }
+    }
+  }
+
+  return names;
+}
+
+function createInjectionTokenFromType(type: ts.TypeNode | undefined, runtimeValueNames: ReadonlySet<string>): ts.Expression | undefined {
+  if (!type || !ts.isTypeReferenceNode(type) || !ts.isIdentifier(type.typeName) || !runtimeValueNames.has(type.typeName.text)) {
     return undefined;
   }
 
-  const createEntityExpression = (name: ts.EntityName): ts.Expression => {
-    if (ts.isIdentifier(name)) {
-      return ts.factory.createIdentifier(name.text);
-    }
-
-    return ts.factory.createPropertyAccessExpression(createEntityExpression(name.left), name.right);
-  };
-
-  return createEntityExpression(type.typeName);
+  return ts.factory.createIdentifier(type.typeName.text);
 }
 
 function getConstructorInjectionTokens(
   classDeclaration: ts.ClassDeclaration,
-): { kind: 'none' } | { kind: 'safe'; tokens: readonly ts.Expression[] } | { kind: 'unsafe'; node: ts.Node } {
+  nestInjectLocalNames: ReadonlySet<string>,
+  runtimeValueNames: ReadonlySet<string>,
+): { kind: 'none' } | { decoratorLocalName: string; kind: 'safe'; tokens: readonly ts.Expression[] } | { kind: 'unsafe'; node: ts.Node } {
   const constructorDeclaration = classDeclaration.members.find(ts.isConstructorDeclaration);
   if (!constructorDeclaration) {
     return { kind: 'none' };
   }
 
   const parameters = constructorDeclaration.parameters;
-  const hasInjectParameter = parameters.some((parameter) => hasDecoratorNamed(parameter.modifiers, 'Inject'));
+  const hasInjectParameter = parameters.some((parameter) => hasNestInjectDecorator(parameter.modifiers, nestInjectLocalNames));
   if (!hasInjectParameter) {
     return { kind: 'none' };
   }
 
-  if (hasDecoratorNamed(classDeclaration.modifiers, 'Inject')) {
+  if (hasNestInjectDecorator(classDeclaration.modifiers, nestInjectLocalNames)) {
     return { kind: 'unsafe', node: classDeclaration };
   }
 
   const tokens: ts.Expression[] = [];
+  let decoratorLocalName: string | undefined;
   for (const parameter of parameters) {
     if (parameter.dotDotDotToken || parameter.questionToken || parameter.initializer || !ts.isIdentifier(parameter.name)) {
       return { kind: 'unsafe', node: parameter };
     }
 
     const decorators = parameter.modifiers?.filter(ts.isDecorator) ?? [];
-    const injectDecorators = decorators.filter((decorator) => isDecoratorNamed(decorator, 'Inject'));
+    const injectDecorators = decorators
+      .map((decorator) => ({ decorator, localName: getNestInjectDecoratorLocalName(decorator, nestInjectLocalNames) }))
+      .filter((entry): entry is { decorator: ts.Decorator; localName: string } => !!entry.localName);
     if (decorators.length !== injectDecorators.length || injectDecorators.length > 1) {
       return { kind: 'unsafe', node: parameter };
     }
 
     const [injectDecorator] = injectDecorators;
     if (injectDecorator) {
-      const expression = injectDecorator.expression;
+      const expression = injectDecorator.decorator.expression;
       if (!ts.isCallExpression(expression) || expression.arguments.length !== 1) {
         return { kind: 'unsafe', node: parameter };
       }
@@ -499,10 +577,11 @@ function getConstructorInjectionTokens(
       }
 
       tokens.push(token);
+      decoratorLocalName ??= injectDecorator.localName;
       continue;
     }
 
-    const token = createInjectionTokenFromType(parameter.type);
+    const token = createInjectionTokenFromType(parameter.type, runtimeValueNames);
     if (!token) {
       return { kind: 'unsafe', node: parameter };
     }
@@ -510,20 +589,26 @@ function getConstructorInjectionTokens(
     tokens.push(token);
   }
 
-  return { kind: 'safe', tokens };
+  if (!decoratorLocalName) {
+    return { kind: 'unsafe', node: constructorDeclaration };
+  }
+
+  return { decoratorLocalName, kind: 'safe', tokens };
 }
 
 function rewriteConstructorInjectTokens(source: string, filePath: string): { changed: boolean; source: string; warnings: MigrationWarning[] } {
   const sourceFile = parseSource(source, filePath);
   const warnings: MigrationWarning[] = [];
-  const safeClasses = new Map<ts.ClassDeclaration, readonly ts.Expression[]>();
+  const nestInjectLocalNames = getNestInjectLocalNames(sourceFile);
+  const runtimeValueNames = getRuntimeValueNames(sourceFile);
+  const safeClasses = new Map<ts.ClassDeclaration, { decoratorLocalName: string; tokens: readonly ts.Expression[] }>();
   let hasUnsafeConstructor = false;
 
   const inspect = (node: ts.Node): void => {
     if (ts.isClassDeclaration(node)) {
-      const result = getConstructorInjectionTokens(node);
+      const result = getConstructorInjectionTokens(node, nestInjectLocalNames, runtimeValueNames);
       if (result.kind === 'safe') {
-        safeClasses.set(node, result.tokens);
+        safeClasses.set(node, result);
       }
 
       if (result.kind === 'unsafe') {
@@ -551,15 +636,15 @@ function rewriteConstructorInjectTokens(source: string, filePath: string): { cha
   const transformer = <T extends ts.Node>(context: ts.TransformationContext) => {
     const visit = (node: ts.Node): ts.Node => {
       if (ts.isClassDeclaration(node)) {
-        const tokens = safeClasses.get(node);
-        if (tokens) {
+        const injection = safeClasses.get(node);
+        if (injection) {
           const members = node.members.map((member) => {
             if (!ts.isConstructorDeclaration(member)) {
               return member;
             }
 
             const parameters = member.parameters.map((parameter) => {
-              const modifiers = parameter.modifiers?.filter((modifier) => !ts.isDecorator(modifier) || !isDecoratorNamed(modifier, 'Inject'));
+              const modifiers = parameter.modifiers?.filter((modifier) => !ts.isDecorator(modifier) || !getNestInjectDecoratorLocalName(modifier, nestInjectLocalNames));
               return ts.factory.updateParameterDeclaration(
                 parameter,
                 modifiers,
@@ -573,7 +658,13 @@ function rewriteConstructorInjectTokens(source: string, filePath: string): { cha
             return ts.factory.updateConstructorDeclaration(member, member.modifiers, parameters, member.body);
           });
           const modifiers = [
-            ts.factory.createDecorator(ts.factory.createCallExpression(ts.factory.createIdentifier('Inject'), undefined, tokens)),
+            ts.factory.createDecorator(
+              ts.factory.createCallExpression(
+                ts.factory.createIdentifier(injection.decoratorLocalName),
+                undefined,
+                injection.tokens,
+              ),
+            ),
             ...(node.modifiers ?? []),
           ];
 
@@ -770,7 +861,7 @@ function rewriteInjectableAndScope(
     const nextSourceFile = parseSource(nextSource, filePath);
     nextSource = printSourceFile(
       nextSourceFile,
-      mergeNamedImport([...nextSourceFile.statements], '@fluojs/core', [{ imported: 'Scope', local: scopeDecoratorName }]),
+      mergeNamedImport([...nextSourceFile.statements], '@fluojs/core', [{ imported: 'Scope', isTypeOnly: false, local: scopeDecoratorName }]),
     );
   }
 
@@ -951,7 +1042,10 @@ function rewriteBootstrap(source: string, filePath: string): { changed: boolean;
   nextSource = removed.source;
 
   const nextSourceFile = parseSource(nextSource, filePath);
-  const withRuntimeImport = printSourceFile(nextSourceFile, mergeNamedImport([...nextSourceFile.statements], '@fluojs/runtime', [{ imported: 'FluoFactory', local: 'FluoFactory' }]));
+  const withRuntimeImport = printSourceFile(
+    nextSourceFile,
+    mergeNamedImport([...nextSourceFile.statements], '@fluojs/runtime', [{ imported: 'FluoFactory', isTypeOnly: false, local: 'FluoFactory' }]),
+  );
 
   return {
     changed: withRuntimeImport !== source,
@@ -1137,7 +1231,9 @@ function rewriteTesting(source: string, filePath: string): { changed: boolean; s
   const nextSourceFile = parseSource(nextSource, filePath);
   nextSource = printSourceFile(
     nextSourceFile,
-    mergeNamedImport([...nextSourceFile.statements], '@fluojs/testing', [{ imported: 'createTestingModule', local: 'createTestingModule' }]),
+    mergeNamedImport([...nextSourceFile.statements], '@fluojs/testing', [
+      { imported: 'createTestingModule', isTypeOnly: false, local: 'createTestingModule' },
+    ]),
   );
 
   const withFluoImportSourceFile = parseSource(nextSource, filePath);
@@ -1238,6 +1334,7 @@ function rewriteBaseUrlPaths(paths: unknown, baseUrl: string | undefined): Recor
 
 function detectManualFollowUps(source: string, filePath: string, includeInjectTokenWarning: boolean): MigrationWarning[] {
   const sourceFile = parseSource(source, filePath);
+  const nestInjectLocalNames = getNestInjectLocalNames(sourceFile);
   const warnings: MigrationWarning[] = [];
   let hasRequestDecoratorWarning = false;
   let hasInjectParameterWarning = false;
@@ -1251,7 +1348,7 @@ function detectManualFollowUps(source: string, filePath: string, includeInjectTo
         }
 
         const decoratorName = modifier.expression.expression.text;
-        if (includeInjectTokenWarning && !hasInjectParameterWarning && decoratorName === 'Inject') {
+        if (includeInjectTokenWarning && !hasInjectParameterWarning && nestInjectLocalNames.has(decoratorName)) {
           hasInjectParameterWarning = true;
           warnings.push(
             buildWarning(filePath, sourceFile, modifier, 'inject-token', 'Constructor @Inject(TOKEN) parameter decorators need manual migration to class-level @Inject(TOKEN, ...) syntax.'),

--- a/packages/cli/src/transforms/nestjs-migrate.ts
+++ b/packages/cli/src/transforms/nestjs-migrate.ts
@@ -498,6 +498,27 @@ function getFluoInjectLocalNames(sourceFile: ts.SourceFile): ReadonlySet<string>
   return localNames;
 }
 
+function getFluoInjectNamespaceLocalNames(sourceFile: ts.SourceFile): ReadonlySet<string> {
+  const localNames = new Set<string>();
+
+  for (const statement of sourceFile.statements) {
+    if (
+      !ts.isImportDeclaration(statement)
+      || !ts.isStringLiteral(statement.moduleSpecifier)
+      || statement.moduleSpecifier.text !== '@fluojs/core'
+      || statement.importClause?.isTypeOnly
+      || !statement.importClause?.namedBindings
+      || !ts.isNamespaceImport(statement.importClause.namedBindings)
+    ) {
+      continue;
+    }
+
+    localNames.add(statement.importClause.namedBindings.name.text);
+  }
+
+  return localNames;
+}
+
 function getNestInjectDecoratorLocalName(decorator: ts.Decorator, localNames: ReadonlySet<string>): string | undefined {
   if (!ts.isCallExpression(decorator.expression) || !ts.isIdentifier(decorator.expression.expression)) {
     return undefined;
@@ -518,17 +539,27 @@ function hasNestInjectDecorator(modifiers: readonly ts.ModifierLike[] | undefine
 function getFluoInjectClassDecorator(
   modifiers: readonly ts.ModifierLike[] | undefined,
   localNames: ReadonlySet<string>,
+  namespaceLocalNames: ReadonlySet<string>,
 ): { decorator: ts.Decorator; expression: ts.CallExpression } | undefined {
   if (!modifiers) {
     return undefined;
   }
 
   for (const modifier of modifiers) {
-    if (!ts.isDecorator(modifier) || !ts.isCallExpression(modifier.expression) || !ts.isIdentifier(modifier.expression.expression)) {
+    if (!ts.isDecorator(modifier) || !ts.isCallExpression(modifier.expression)) {
       continue;
     }
 
-    if (localNames.has(modifier.expression.expression.text)) {
+    const decoratorTarget = modifier.expression.expression;
+    if (
+      (ts.isIdentifier(decoratorTarget) && localNames.has(decoratorTarget.text))
+      || (
+        ts.isPropertyAccessExpression(decoratorTarget)
+        && ts.isIdentifier(decoratorTarget.expression)
+        && namespaceLocalNames.has(decoratorTarget.expression.text)
+        && decoratorTarget.name.text === 'Inject'
+      )
+    ) {
       return { decorator: modifier, expression: modifier.expression };
     }
   }
@@ -688,6 +719,7 @@ function rewriteConstructorInjectTokens(source: string, filePath: string): { cha
   const warnings: MigrationWarning[] = [];
   const nestInjectLocalNames = getNestInjectLocalNames(sourceFile);
   const fluoInjectLocalNames = getFluoInjectLocalNames(sourceFile);
+  const fluoInjectNamespaceLocalNames = getFluoInjectNamespaceLocalNames(sourceFile);
   const runtimeValueNames = getRuntimeValueNames(sourceFile);
   const collidingTypeValueNames = getCollidingTypeValueNames(sourceFile, runtimeValueNames);
   const safeClasses = new Map<ts.ClassDeclaration, { decoratorLocalName: string; tokens: readonly ts.Expression[] }>();
@@ -747,7 +779,11 @@ function rewriteConstructorInjectTokens(source: string, filePath: string): { cha
             });
             return ts.factory.updateConstructorDeclaration(member, member.modifiers, parameters, member.body);
           });
-          const existingInjectDecorator = getFluoInjectClassDecorator(node.modifiers, fluoInjectLocalNames);
+          const existingInjectDecorator = getFluoInjectClassDecorator(
+            node.modifiers,
+            fluoInjectLocalNames,
+            fluoInjectNamespaceLocalNames,
+          );
           const modifiers = existingInjectDecorator
             ? node.modifiers?.map((modifier) =>
                 modifier === existingInjectDecorator.decorator
@@ -1567,6 +1603,7 @@ function runTypeScriptTransforms(
     warnings.push(...rewritten.warnings);
 
     if (rewritten.changed) {
+      appliedTransforms.push('injectable');
       const rewrittenImports = rewriteImports(nextSource, filePath, new Set(['Inject']));
       nextSource = rewrittenImports.source;
       warnings.push(...rewrittenImports.warnings);

--- a/packages/cli/src/transforms/nestjs-migrate.ts
+++ b/packages/cli/src/transforms/nestjs-migrate.ts
@@ -626,10 +626,37 @@ function getCollidingTypeValueNames(sourceFile: ts.SourceFile, runtimeValueNames
   return names;
 }
 
+function getTypeOnlyImportNames(sourceFile: ts.SourceFile): ReadonlySet<string> {
+  const names = new Set<string>();
+
+  for (const statement of sourceFile.statements) {
+    if (!ts.isImportDeclaration(statement) || !statement.importClause) {
+      continue;
+    }
+
+    if (statement.importClause.name && statement.importClause.isTypeOnly) {
+      names.add(statement.importClause.name.text);
+    }
+
+    if (!statement.importClause.namedBindings || !ts.isNamedImports(statement.importClause.namedBindings)) {
+      continue;
+    }
+
+    for (const element of statement.importClause.namedBindings.elements) {
+      if (statement.importClause.isTypeOnly || element.isTypeOnly) {
+        names.add(element.name.text);
+      }
+    }
+  }
+
+  return names;
+}
+
 function createInjectionTokenFromType(
   type: ts.TypeNode | undefined,
   runtimeValueNames: ReadonlySet<string>,
   collidingTypeValueNames: ReadonlySet<string>,
+  typeOnlyImportNames: ReadonlySet<string>,
 ): ts.Expression | undefined {
   if (
     !type
@@ -637,6 +664,7 @@ function createInjectionTokenFromType(
     || !ts.isIdentifier(type.typeName)
     || !runtimeValueNames.has(type.typeName.text)
     || collidingTypeValueNames.has(type.typeName.text)
+    || typeOnlyImportNames.has(type.typeName.text)
   ) {
     return undefined;
   }
@@ -644,11 +672,26 @@ function createInjectionTokenFromType(
   return ts.factory.createIdentifier(type.typeName.text);
 }
 
+function getExistingInjectTokens(expression: ts.CallExpression): readonly ts.Expression[] | undefined {
+  if (expression.arguments.length !== 1 || !ts.isArrayLiteralExpression(expression.arguments[0])) {
+    return expression.arguments;
+  }
+
+  if (expression.arguments[0].elements.some((element) => !ts.isExpression(element))) {
+    return undefined;
+  }
+
+  return expression.arguments[0].elements.filter(ts.isExpression);
+}
+
 function getConstructorInjectionTokens(
   classDeclaration: ts.ClassDeclaration,
   nestInjectLocalNames: ReadonlySet<string>,
   runtimeValueNames: ReadonlySet<string>,
   collidingTypeValueNames: ReadonlySet<string>,
+  typeOnlyImportNames: ReadonlySet<string>,
+  existingInjectTokens: readonly ts.Expression[] | undefined,
+  hasExistingInjectDecorator: boolean,
 ): { kind: 'none' } | { decoratorLocalName: string; kind: 'safe'; tokens: readonly ts.Expression[] } | { kind: 'unsafe'; node: ts.Node } {
   const constructorDeclaration = classDeclaration.members.find(
     (member): member is ts.ConstructorDeclaration => ts.isConstructorDeclaration(member) && member.body !== undefined,
@@ -667,9 +710,13 @@ function getConstructorInjectionTokens(
     return { kind: 'unsafe', node: classDeclaration };
   }
 
+  if (hasExistingInjectDecorator && !existingInjectTokens) {
+    return { kind: 'unsafe', node: classDeclaration };
+  }
+
   const tokens: ts.Expression[] = [];
   let decoratorLocalName: string | undefined;
-  for (const parameter of parameters) {
+  for (const [index, parameter] of parameters.entries()) {
     if (parameter.dotDotDotToken || parameter.questionToken || parameter.initializer || !ts.isIdentifier(parameter.name)) {
       return { kind: 'unsafe', node: parameter };
     }
@@ -699,7 +746,18 @@ function getConstructorInjectionTokens(
       continue;
     }
 
-    const token = createInjectionTokenFromType(parameter.type, runtimeValueNames, collidingTypeValueNames);
+    const existingToken = existingInjectTokens?.[index];
+    if (existingToken) {
+      tokens.push(existingToken);
+      continue;
+    }
+
+    const token = createInjectionTokenFromType(
+      parameter.type,
+      runtimeValueNames,
+      collidingTypeValueNames,
+      typeOnlyImportNames,
+    );
     if (!token) {
       return { kind: 'unsafe', node: parameter };
     }
@@ -722,12 +780,29 @@ function rewriteConstructorInjectTokens(source: string, filePath: string): { cha
   const fluoInjectNamespaceLocalNames = getFluoInjectNamespaceLocalNames(sourceFile);
   const runtimeValueNames = getRuntimeValueNames(sourceFile);
   const collidingTypeValueNames = getCollidingTypeValueNames(sourceFile, runtimeValueNames);
+  const typeOnlyImportNames = getTypeOnlyImportNames(sourceFile);
   const safeClasses = new Map<ts.ClassDeclaration, { decoratorLocalName: string; tokens: readonly ts.Expression[] }>();
   let hasUnsafeConstructor = false;
 
   const inspect = (node: ts.Node): void => {
     if (ts.isClassDeclaration(node)) {
-      const result = getConstructorInjectionTokens(node, nestInjectLocalNames, runtimeValueNames, collidingTypeValueNames);
+      const existingInjectDecorator = getFluoInjectClassDecorator(
+        node.modifiers,
+        fluoInjectLocalNames,
+        fluoInjectNamespaceLocalNames,
+      );
+      const existingInjectTokens = existingInjectDecorator
+        ? getExistingInjectTokens(existingInjectDecorator.expression)
+        : undefined;
+      const result = getConstructorInjectionTokens(
+        node,
+        nestInjectLocalNames,
+        runtimeValueNames,
+        collidingTypeValueNames,
+        typeOnlyImportNames,
+        existingInjectTokens,
+        !!existingInjectDecorator,
+      );
       if (result.kind === 'safe') {
         safeClasses.set(node, result);
       }
@@ -793,7 +868,7 @@ function rewriteConstructorInjectTokens(source: string, filePath: string): { cha
                         existingInjectDecorator.expression,
                         existingInjectDecorator.expression.expression,
                         existingInjectDecorator.expression.typeArguments,
-                        [...existingInjectDecorator.expression.arguments, ...injection.tokens],
+                        injection.tokens,
                       ),
                     )
                   : modifier,

--- a/packages/cli/src/transforms/nestjs-migrate.ts
+++ b/packages/cli/src/transforms/nestjs-migrate.ts
@@ -23,6 +23,7 @@ type ImportBinding = {
  */
 export const WARNING_CATEGORIES = [
   'inject-token',
+  'inject-token-unsupported',
   'request-dto',
   'pipe-converter',
   'bootstrap-unsupported',
@@ -50,6 +51,7 @@ export type MigrationWarning = {
 
 const WARNING_CATEGORY_LABEL: Record<WarningCategory, string> = {
   'inject-token': 'DI token migration (@Inject)',
+  'inject-token-unsupported': 'Unsupported constructor injection',
   'request-dto': 'Request DTO migration (handler parameter decorators)',
   'pipe-converter': 'Pipe/converter migration',
   'bootstrap-unsupported': 'Unsupported bootstrap variant',
@@ -326,6 +328,7 @@ function rewriteImports(source: string, filePath: string): { changed: boolean; s
   const warnings: MigrationWarning[] = [];
   const additions = new Map<string, ImportBinding[]>();
   const statements: ts.Statement[] = [];
+  const hasNestInjectParameter = hasInjectParameterDecorator(sourceFile);
   let touched = false;
 
   for (const statement of sourceFile.statements) {
@@ -349,6 +352,11 @@ function rewriteImports(source: string, filePath: string): { changed: boolean; s
     const remaining: ImportBinding[] = [];
 
     for (const binding of getImportBindings(statement)) {
+      if (binding.imported === 'Inject' && hasNestInjectParameter) {
+        remaining.push(binding);
+        continue;
+      }
+
       const targetModule = NEST_COMMON_TO_FLUO[binding.imported];
       if (!targetModule) {
         remaining.push(binding);
@@ -410,6 +418,188 @@ function hasDecoratorNamed(modifiers: readonly ts.ModifierLike[] | undefined, na
   }
 
   return modifiers.some((modifier) => ts.isDecorator(modifier) && isDecoratorNamed(modifier, name));
+}
+
+function hasInjectParameterDecorator(sourceFile: ts.SourceFile): boolean {
+  let found = false;
+
+  const visit = (node: ts.Node): void => {
+    if (found) {
+      return;
+    }
+
+    if (ts.isParameter(node) && hasDecoratorNamed(node.modifiers, 'Inject')) {
+      found = true;
+      return;
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return found;
+}
+
+function createInjectionTokenFromType(type: ts.TypeNode | undefined): ts.Expression | undefined {
+  if (!type || !ts.isTypeReferenceNode(type)) {
+    return undefined;
+  }
+
+  const createEntityExpression = (name: ts.EntityName): ts.Expression => {
+    if (ts.isIdentifier(name)) {
+      return ts.factory.createIdentifier(name.text);
+    }
+
+    return ts.factory.createPropertyAccessExpression(createEntityExpression(name.left), name.right);
+  };
+
+  return createEntityExpression(type.typeName);
+}
+
+function getConstructorInjectionTokens(
+  classDeclaration: ts.ClassDeclaration,
+): { kind: 'none' } | { kind: 'safe'; tokens: readonly ts.Expression[] } | { kind: 'unsafe'; node: ts.Node } {
+  const constructorDeclaration = classDeclaration.members.find(ts.isConstructorDeclaration);
+  if (!constructorDeclaration) {
+    return { kind: 'none' };
+  }
+
+  const parameters = constructorDeclaration.parameters;
+  const hasInjectParameter = parameters.some((parameter) => hasDecoratorNamed(parameter.modifiers, 'Inject'));
+  if (!hasInjectParameter) {
+    return { kind: 'none' };
+  }
+
+  if (hasDecoratorNamed(classDeclaration.modifiers, 'Inject')) {
+    return { kind: 'unsafe', node: classDeclaration };
+  }
+
+  const tokens: ts.Expression[] = [];
+  for (const parameter of parameters) {
+    if (parameter.dotDotDotToken || parameter.questionToken || parameter.initializer || !ts.isIdentifier(parameter.name)) {
+      return { kind: 'unsafe', node: parameter };
+    }
+
+    const decorators = parameter.modifiers?.filter(ts.isDecorator) ?? [];
+    const injectDecorators = decorators.filter((decorator) => isDecoratorNamed(decorator, 'Inject'));
+    if (decorators.length !== injectDecorators.length || injectDecorators.length > 1) {
+      return { kind: 'unsafe', node: parameter };
+    }
+
+    const [injectDecorator] = injectDecorators;
+    if (injectDecorator) {
+      const expression = injectDecorator.expression;
+      if (!ts.isCallExpression(expression) || expression.arguments.length !== 1) {
+        return { kind: 'unsafe', node: parameter };
+      }
+
+      const [token] = expression.arguments;
+      if (!token) {
+        return { kind: 'unsafe', node: parameter };
+      }
+
+      tokens.push(token);
+      continue;
+    }
+
+    const token = createInjectionTokenFromType(parameter.type);
+    if (!token) {
+      return { kind: 'unsafe', node: parameter };
+    }
+
+    tokens.push(token);
+  }
+
+  return { kind: 'safe', tokens };
+}
+
+function rewriteConstructorInjectTokens(source: string, filePath: string): { changed: boolean; source: string; warnings: MigrationWarning[] } {
+  const sourceFile = parseSource(source, filePath);
+  const warnings: MigrationWarning[] = [];
+  const safeClasses = new Map<ts.ClassDeclaration, readonly ts.Expression[]>();
+  let hasUnsafeConstructor = false;
+
+  const inspect = (node: ts.Node): void => {
+    if (ts.isClassDeclaration(node)) {
+      const result = getConstructorInjectionTokens(node);
+      if (result.kind === 'safe') {
+        safeClasses.set(node, result.tokens);
+      }
+
+      if (result.kind === 'unsafe') {
+        hasUnsafeConstructor = true;
+        warnings.push(
+          buildWarning(
+            filePath,
+            sourceFile,
+            result.node,
+            'inject-token-unsupported',
+            'Unable to safely convert constructor injection. Keep the NestJS constructor unchanged and manually add class-level @Inject(...) tokens in constructor parameter order.',
+          ),
+        );
+      }
+    }
+
+    ts.forEachChild(node, inspect);
+  };
+
+  inspect(sourceFile);
+  if (safeClasses.size === 0 || hasUnsafeConstructor) {
+    return { changed: false, source, warnings };
+  }
+
+  const transformer = <T extends ts.Node>(context: ts.TransformationContext) => {
+    const visit = (node: ts.Node): ts.Node => {
+      if (ts.isClassDeclaration(node)) {
+        const tokens = safeClasses.get(node);
+        if (tokens) {
+          const members = node.members.map((member) => {
+            if (!ts.isConstructorDeclaration(member)) {
+              return member;
+            }
+
+            const parameters = member.parameters.map((parameter) => {
+              const modifiers = parameter.modifiers?.filter((modifier) => !ts.isDecorator(modifier) || !isDecoratorNamed(modifier, 'Inject'));
+              return ts.factory.updateParameterDeclaration(
+                parameter,
+                modifiers,
+                parameter.dotDotDotToken,
+                parameter.name,
+                parameter.questionToken,
+                parameter.type,
+                parameter.initializer,
+              );
+            });
+            return ts.factory.updateConstructorDeclaration(member, member.modifiers, parameters, member.body);
+          });
+          const modifiers = [
+            ts.factory.createDecorator(ts.factory.createCallExpression(ts.factory.createIdentifier('Inject'), undefined, tokens)),
+            ...(node.modifiers ?? []),
+          ];
+
+          return ts.factory.updateClassDeclaration(
+            node,
+            modifiers,
+            node.name,
+            node.typeParameters,
+            node.heritageClauses,
+            members,
+          );
+        }
+      }
+
+      return ts.visitEachChild(node, visit, context);
+    };
+
+    return (node: T) => ts.visitNode(node, visit);
+  };
+
+  const transformed = ts.transform(sourceFile, [transformer]).transformed[0] as ts.SourceFile;
+  return {
+    changed: true,
+    source: printer.printFile(transformed),
+    warnings,
+  };
 }
 
 function hasConflictingScopeImport(sourceFile: ts.SourceFile): boolean {
@@ -1046,7 +1236,7 @@ function rewriteBaseUrlPaths(paths: unknown, baseUrl: string | undefined): Recor
   return Object.fromEntries(rewrittenEntries);
 }
 
-function detectManualFollowUps(source: string, filePath: string): MigrationWarning[] {
+function detectManualFollowUps(source: string, filePath: string, includeInjectTokenWarning: boolean): MigrationWarning[] {
   const sourceFile = parseSource(source, filePath);
   const warnings: MigrationWarning[] = [];
   let hasRequestDecoratorWarning = false;
@@ -1061,7 +1251,7 @@ function detectManualFollowUps(source: string, filePath: string): MigrationWarni
         }
 
         const decoratorName = modifier.expression.expression.text;
-        if (!hasInjectParameterWarning && decoratorName === 'Inject') {
+        if (includeInjectTokenWarning && !hasInjectParameterWarning && decoratorName === 'Inject') {
           hasInjectParameterWarning = true;
           warnings.push(
             buildWarning(filePath, sourceFile, modifier, 'inject-token', 'Constructor @Inject(TOKEN) parameter decorators need manual migration to class-level @Inject(TOKEN, ...) syntax.'),
@@ -1158,6 +1348,12 @@ function runTypeScriptTransforms(
   const appliedTransforms: MigrationTransformKind[] = [];
   const warnings: MigrationWarning[] = [];
 
+  if (enabledTransforms.has('injectable')) {
+    const rewritten = rewriteConstructorInjectTokens(nextSource, filePath);
+    nextSource = rewritten.source;
+    warnings.push(...rewritten.warnings);
+  }
+
   if (enabledTransforms.has('imports')) {
     const rewritten = rewriteImports(nextSource, filePath);
     nextSource = rewritten.source;
@@ -1207,7 +1403,7 @@ function runTypeScriptTransforms(
     }
   }
 
-  warnings.push(...detectManualFollowUps(source, filePath));
+  warnings.push(...detectManualFollowUps(source, filePath, !enabledTransforms.has('injectable')));
 
   return {
     appliedTransforms: [...new Set(appliedTransforms)],

--- a/packages/cli/src/transforms/nestjs-migrate.ts
+++ b/packages/cli/src/transforms/nestjs-migrate.ts
@@ -241,6 +241,10 @@ function mergeNamedImport(statements: ts.Statement[], moduleSpecifier: string, n
       return statement;
     }
 
+    if (!statement.importClause?.namedBindings || !ts.isNamedImports(statement.importClause.namedBindings)) {
+      return statement;
+    }
+
     const bindings = new Map<string, ImportBinding>();
     for (const binding of getImportBindings(statement)) {
       bindings.set(toBindingKey(binding), binding);
@@ -333,7 +337,11 @@ function removeImportBinding(
   };
 }
 
-function rewriteImports(source: string, filePath: string): { changed: boolean; source: string; warnings: MigrationWarning[] } {
+function rewriteImports(
+  source: string,
+  filePath: string,
+  allowedNestImports?: ReadonlySet<string>,
+): { changed: boolean; source: string; warnings: MigrationWarning[] } {
   const sourceFile = parseSource(source, filePath);
   const warnings: MigrationWarning[] = [];
   const additions = new Map<string, ImportBinding[]>();
@@ -363,6 +371,11 @@ function rewriteImports(source: string, filePath: string): { changed: boolean; s
 
     for (const binding of getImportBindings(statement)) {
       if (binding.isTypeOnly) {
+        remaining.push(binding);
+        continue;
+      }
+
+      if (allowedNestImports && !allowedNestImports.has(binding.imported)) {
         remaining.push(binding);
         continue;
       }
@@ -460,6 +473,31 @@ function getNestInjectLocalNames(sourceFile: ts.SourceFile): ReadonlySet<string>
   return localNames;
 }
 
+function getFluoInjectLocalNames(sourceFile: ts.SourceFile): ReadonlySet<string> {
+  const localNames = new Set<string>();
+
+  for (const statement of sourceFile.statements) {
+    if (
+      !ts.isImportDeclaration(statement)
+      || !ts.isStringLiteral(statement.moduleSpecifier)
+      || statement.moduleSpecifier.text !== '@fluojs/core'
+      || statement.importClause?.isTypeOnly
+      || !statement.importClause?.namedBindings
+      || !ts.isNamedImports(statement.importClause.namedBindings)
+    ) {
+      continue;
+    }
+
+    for (const element of statement.importClause.namedBindings.elements) {
+      if (!element.isTypeOnly && (element.propertyName ?? element.name).text === 'Inject') {
+        localNames.add(element.name.text);
+      }
+    }
+  }
+
+  return localNames;
+}
+
 function getNestInjectDecoratorLocalName(decorator: ts.Decorator, localNames: ReadonlySet<string>): string | undefined {
   if (!ts.isCallExpression(decorator.expression) || !ts.isIdentifier(decorator.expression.expression)) {
     return undefined;
@@ -475,6 +513,27 @@ function hasNestInjectDecorator(modifiers: readonly ts.ModifierLike[] | undefine
   }
 
   return modifiers.some((modifier) => ts.isDecorator(modifier) && !!getNestInjectDecoratorLocalName(modifier, localNames));
+}
+
+function getFluoInjectClassDecorator(
+  modifiers: readonly ts.ModifierLike[] | undefined,
+  localNames: ReadonlySet<string>,
+): { decorator: ts.Decorator; expression: ts.CallExpression } | undefined {
+  if (!modifiers) {
+    return undefined;
+  }
+
+  for (const modifier of modifiers) {
+    if (!ts.isDecorator(modifier) || !ts.isCallExpression(modifier.expression) || !ts.isIdentifier(modifier.expression.expression)) {
+      continue;
+    }
+
+    if (localNames.has(modifier.expression.expression.text)) {
+      return { decorator: modifier, expression: modifier.expression };
+    }
+  }
+
+  return undefined;
 }
 
 function hasNestInjectParameterDecorator(sourceFile: ts.SourceFile, localNames: ReadonlySet<string>): boolean {
@@ -521,8 +580,33 @@ function getRuntimeValueNames(sourceFile: ts.SourceFile): ReadonlySet<string> {
   return names;
 }
 
-function createInjectionTokenFromType(type: ts.TypeNode | undefined, runtimeValueNames: ReadonlySet<string>): ts.Expression | undefined {
-  if (!type || !ts.isTypeReferenceNode(type) || !ts.isIdentifier(type.typeName) || !runtimeValueNames.has(type.typeName.text)) {
+function getCollidingTypeValueNames(sourceFile: ts.SourceFile, runtimeValueNames: ReadonlySet<string>): ReadonlySet<string> {
+  const names = new Set<string>();
+
+  for (const statement of sourceFile.statements) {
+    if (
+      (ts.isInterfaceDeclaration(statement) || ts.isTypeAliasDeclaration(statement))
+      && runtimeValueNames.has(statement.name.text)
+    ) {
+      names.add(statement.name.text);
+    }
+  }
+
+  return names;
+}
+
+function createInjectionTokenFromType(
+  type: ts.TypeNode | undefined,
+  runtimeValueNames: ReadonlySet<string>,
+  collidingTypeValueNames: ReadonlySet<string>,
+): ts.Expression | undefined {
+  if (
+    !type
+    || !ts.isTypeReferenceNode(type)
+    || !ts.isIdentifier(type.typeName)
+    || !runtimeValueNames.has(type.typeName.text)
+    || collidingTypeValueNames.has(type.typeName.text)
+  ) {
     return undefined;
   }
 
@@ -533,8 +617,11 @@ function getConstructorInjectionTokens(
   classDeclaration: ts.ClassDeclaration,
   nestInjectLocalNames: ReadonlySet<string>,
   runtimeValueNames: ReadonlySet<string>,
+  collidingTypeValueNames: ReadonlySet<string>,
 ): { kind: 'none' } | { decoratorLocalName: string; kind: 'safe'; tokens: readonly ts.Expression[] } | { kind: 'unsafe'; node: ts.Node } {
-  const constructorDeclaration = classDeclaration.members.find(ts.isConstructorDeclaration);
+  const constructorDeclaration = classDeclaration.members.find(
+    (member): member is ts.ConstructorDeclaration => ts.isConstructorDeclaration(member) && member.body !== undefined,
+  );
   if (!constructorDeclaration) {
     return { kind: 'none' };
   }
@@ -581,7 +668,7 @@ function getConstructorInjectionTokens(
       continue;
     }
 
-    const token = createInjectionTokenFromType(parameter.type, runtimeValueNames);
+    const token = createInjectionTokenFromType(parameter.type, runtimeValueNames, collidingTypeValueNames);
     if (!token) {
       return { kind: 'unsafe', node: parameter };
     }
@@ -600,13 +687,15 @@ function rewriteConstructorInjectTokens(source: string, filePath: string): { cha
   const sourceFile = parseSource(source, filePath);
   const warnings: MigrationWarning[] = [];
   const nestInjectLocalNames = getNestInjectLocalNames(sourceFile);
+  const fluoInjectLocalNames = getFluoInjectLocalNames(sourceFile);
   const runtimeValueNames = getRuntimeValueNames(sourceFile);
+  const collidingTypeValueNames = getCollidingTypeValueNames(sourceFile, runtimeValueNames);
   const safeClasses = new Map<ts.ClassDeclaration, { decoratorLocalName: string; tokens: readonly ts.Expression[] }>();
   let hasUnsafeConstructor = false;
 
   const inspect = (node: ts.Node): void => {
     if (ts.isClassDeclaration(node)) {
-      const result = getConstructorInjectionTokens(node, nestInjectLocalNames, runtimeValueNames);
+      const result = getConstructorInjectionTokens(node, nestInjectLocalNames, runtimeValueNames, collidingTypeValueNames);
       if (result.kind === 'safe') {
         safeClasses.set(node, result);
       }
@@ -629,10 +718,11 @@ function rewriteConstructorInjectTokens(source: string, filePath: string): { cha
   };
 
   inspect(sourceFile);
-  if (safeClasses.size === 0 || hasUnsafeConstructor) {
+  if (safeClasses.size === 0) {
     return { changed: false, source, warnings };
   }
 
+  const generatedFluoInjectLocalName = hasUnsafeConstructor ? [...fluoInjectLocalNames][0] ?? 'FluoInject' : undefined;
   const transformer = <T extends ts.Node>(context: ts.TransformationContext) => {
     const visit = (node: ts.Node): ts.Node => {
       if (ts.isClassDeclaration(node)) {
@@ -657,16 +747,31 @@ function rewriteConstructorInjectTokens(source: string, filePath: string): { cha
             });
             return ts.factory.updateConstructorDeclaration(member, member.modifiers, parameters, member.body);
           });
-          const modifiers = [
-            ts.factory.createDecorator(
-              ts.factory.createCallExpression(
-                ts.factory.createIdentifier(injection.decoratorLocalName),
-                undefined,
-                injection.tokens,
-              ),
-            ),
-            ...(node.modifiers ?? []),
-          ];
+          const existingInjectDecorator = getFluoInjectClassDecorator(node.modifiers, fluoInjectLocalNames);
+          const modifiers = existingInjectDecorator
+            ? node.modifiers?.map((modifier) =>
+                modifier === existingInjectDecorator.decorator
+                  ? ts.factory.updateDecorator(
+                      existingInjectDecorator.decorator,
+                      ts.factory.updateCallExpression(
+                        existingInjectDecorator.expression,
+                        existingInjectDecorator.expression.expression,
+                        existingInjectDecorator.expression.typeArguments,
+                        [...existingInjectDecorator.expression.arguments, ...injection.tokens],
+                      ),
+                    )
+                  : modifier,
+              )
+            : [
+                ts.factory.createDecorator(
+                  ts.factory.createCallExpression(
+                    ts.factory.createIdentifier(generatedFluoInjectLocalName ?? injection.decoratorLocalName),
+                    undefined,
+                    injection.tokens,
+                  ),
+                ),
+                ...(node.modifiers ?? []),
+              ];
 
           return ts.factory.updateClassDeclaration(
             node,
@@ -686,9 +791,20 @@ function rewriteConstructorInjectTokens(source: string, filePath: string): { cha
   };
 
   const transformed = ts.transform(sourceFile, [transformer]).transformed[0] as ts.SourceFile;
+  let nextSource = printer.printFile(transformed);
+  if (generatedFluoInjectLocalName && fluoInjectLocalNames.size === 0) {
+    const nextSourceFile = parseSource(nextSource, filePath);
+    nextSource = printSourceFile(
+      nextSourceFile,
+      mergeNamedImport([...nextSourceFile.statements], '@fluojs/core', [
+        { imported: 'Inject', isTypeOnly: false, local: generatedFluoInjectLocalName },
+      ]),
+    );
+  }
+
   return {
     changed: true,
-    source: printer.printFile(transformed),
+    source: nextSource,
     warnings,
   };
 }
@@ -1449,6 +1565,12 @@ function runTypeScriptTransforms(
     const rewritten = rewriteConstructorInjectTokens(nextSource, filePath);
     nextSource = rewritten.source;
     warnings.push(...rewritten.warnings);
+
+    if (rewritten.changed) {
+      const rewrittenImports = rewriteImports(nextSource, filePath, new Set(['Inject']));
+      nextSource = rewrittenImports.source;
+      warnings.push(...rewrittenImports.warnings);
+    }
   }
 
   if (enabledTransforms.has('imports')) {


### PR DESCRIPTION
Closes #3139

## Summary
- migrate proven constructor injection tokens while diagnosing ambiguous type-only/generic collisions
- preserve positional tokens across named, namespace, and legacy array Inject decorators
- keep overload, mixed safe/unsafe, and appliedTransforms behavior explicit

## Verification
- CLI closure build + typecheck
- CLI full 464/464 and reverse dependents
- migration targeted 38/38
- Biome, changeset governance, diff-check