### PR TITLE
test(omo): align worker mode governance

### DIFF
--- a/tooling/governance/omo-native-assets.test.ts
+++ b/tooling/governance/omo-native-assets.test.ts
@@ -98,21 +98,21 @@ describe('OMO native asset manifest', () => {
   it('keeps execute-lane workers single-depth and non-orchestrating', () => {
     const config = JSON.parse(read('.omo/omo.jsonc')) as OmoProjectConfig;
     const agents = config.agents ?? {};
-    const workerNames = [
-      'fluo-issue-preflight',
-      'fluo-issue-implementer',
-      'fluo-contract-reviewer',
-      'fluo-code-reviewer',
-      'fluo-verification-reviewer',
-      'fluo-issue-operator',
-    ] as const;
+    const workerModes = {
+      'fluo-issue-preflight': 'in-process',
+      'fluo-issue-implementer': 'process',
+      'fluo-contract-reviewer': 'in-process',
+      'fluo-code-reviewer': 'in-process',
+      'fluo-verification-reviewer': 'in-process',
+      'fluo-issue-operator': 'process',
+    } as const;
 
     expect(config.task?.max_depth).toBe(1);
     expect(agents['fluo-issue-supervisor']).toBeUndefined();
-    for (const workerName of workerNames) {
+    for (const [workerName, executionMode] of Object.entries(workerModes)) {
       const worker = agents[workerName];
       expect(worker, `${workerName} must be registered`).toBeDefined();
-      expect(worker?.execution_mode).toBe('process');
+      expect(worker?.execution_mode).toBe(executionMode);
       expect(worker?.tools?.['task']).toBe(false);
       expect(worker?.tools?.['dag']).toBe(false);
       expect(worker?.tools?.['team_create']).toBe(false);


### PR DESCRIPTION
## Summary

Align the OMO native-asset governance assertion with the intentional worker execution modes introduced by `1025e848`. The stale blanket `process` expectation currently fails `CI/Test (other)` on clean `main` and blocks unrelated PRs including #3510 and #3511.

Linked context: clean-main CI baseline repair for the active execute-lane run

## Changes

- Assert `in-process` for preflight and read-only reviewer workers.
- Preserve `process` assertions for the issue implementer and issue operator.
- Keep the existing single-depth and non-orchestration tool restrictions unchanged.

## Testing

- Red control on clean `main`: `pnpm vitest run --project tooling --maxWorkers=1` -> 1 failed, 1297 passed, 1 skipped
- Focused regression: 6/6 passed
- Full tooling project from the fix worktree: 73 files, 1299/1299 tests passed
- `git diff --check`
- TypeScript LSP diagnostics: no errors or warnings

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

## Public export documentation

- [x] No public exports changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed.
- [x] Governance now distinguishes intentional in-process reviewers from process-isolated mutating workers.
- [x] The worker-mode contract is covered by the corrected regression.

## Platform consistency governance (SSOT)

- [x] No platform contract changed.
- [x] No EN/KO documentation surface changed.