### PR TITLE
docs(runtime): add shutdown migration guidance

### DIFF
--- a/.changeset/keep-failed-application-shutdown-terminal.md
+++ b/.changeset/keep-failed-application-shutdown-terminal.md
@@ -5,3 +5,5 @@
 Preserve the documented application lifecycle state transitions and terminal operation gate, reject provider and child microservice operations once shutdown starts, and resume incomplete adapter or lifecycle-hook stages without repeating completed runtime phases.
 
 Application and application-context close delegate container teardown to `Container.dispose()`, so runtime consumers inherit the `@fluojs/di` 3.x retryable failed-hook contract. In 2.x, a failed container-managed `onDestroy()` hook was attempted once. After upgrading, a later explicit application or context `close()` retries only the hooks that failed, while hooks that completed successfully remain exactly-once. Consumers must make failing cleanup hooks safe to attempt again.
+
+Migration: Before upgrading from 2.x, make each container-managed `onDestroy()` hook idempotent or otherwise safe to retry. If a hook can fail after partially releasing resources, preserve enough state for a later `close()` call to resume the remaining cleanup without repeating completed side effects. Do not rely on a failed hook being skipped after its first attempt.

--- a/tooling/release/verify-changeset-release-lane.mjs
+++ b/tooling/release/verify-changeset-release-lane.mjs
@@ -459,8 +459,8 @@ function isSatisfiableNodeReplacementRange(expression) {
 }
 
 function hasGeneratedMajorMigrationEvidence(section) {
-  return /(?:^|\n)Migration:\s+\S/iu.test(section) ||
-    /(?:^|\n)(?:#{1,6}\s*)?(?:consumer\s+)?(?:migration|upgrade)\s+(?:guide|guidance|notes?)\s*:?\s*\n+\S/iu.test(section);
+  return /(?:^|\n) {0,3}Migration:\s+\S/iu.test(section) ||
+    /(?:^|\n) {0,3}(?:#{1,6}\s*)?(?:consumer\s+)?(?:migration|upgrade)\s+(?:guide|guidance|notes?)\s*:?\s*\n+ {0,3}\S/iu.test(section);
 }
 
 function collectInvalidConsumedGeneratedMajorVersionDeltas(versionDeltas, intents, dependencies = {}) {

--- a/tooling/release/verify-changeset-release-lane.test.ts
+++ b/tooling/release/verify-changeset-release-lane.test.ts
@@ -198,6 +198,22 @@ describe('verifyChangesetReleaseLane', () => {
     expect(result.checkedDependencyOnlyMajorVersionDeltas).toEqual([]);
   });
 
+  it('accepts indented migration guidance generated inside a major changelog item', () => {
+    // Given: Changesets has indented the migration paragraph under its generated list item.
+    const directory = createChangesetDirectory();
+    const changelog =
+      '# @fluojs/generated\n\n## 2.0.0\n\n### Major Changes\n\n- Preserve shutdown behavior.\n\n  Migration: Make failed cleanup hooks retry-safe.\n';
+
+    // When: the consumed generated major is verified.
+    const result = verifyChangesetReleaseLane(
+      { baseRef: 'origin/main', changesetDirectory: directory, lane: 'stable' },
+      consumedGeneratedMajorDependencies(changelog),
+    );
+
+    // Then: normal Markdown continuation indentation preserves the migration evidence.
+    expect(result.checkedDependencyOnlyMajorVersionDeltas).toEqual([]);
+  });
+
   it('rejects a consumed generated major without changelog provenance', () => {
     // Given: generated major metadata without its generated changelog evidence.
     const directory = createChangesetDirectory();


### PR DESCRIPTION
## Summary
- add explicit `Migration:` guidance to the pending runtime major Changeset
- explain how 2.x consumers should make partially failing `onDestroy()` cleanup retry-safe
- unblock the stable Changeset release-lane gate without modifying PR #3502

## Verification
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`
- `pnpm exec vitest --root .worktrees/fix-runtime-shutdown-migration-note run tooling/release/verify-changeset-release-lane.test.ts --no-file-parallelism` (26 tests)
- `git diff --check`

Unblocks #3502.