### PR TITLE
docs(validation): align validator contracts

### DIFF
--- a/.changeset/align-validation-doc-contracts.md
+++ b/.changeset/align-validation-doc-contracts.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/validation": patch
+---
+
+Correct the documented `Validate` callback signature and clarify that `IsObject` accepts plain objects only.

--- a/packages/validation/README.ko.md
+++ b/packages/validation/README.ko.md
@@ -166,6 +166,14 @@ class RestrictedUserDto {
 
 `ValidateClass(...)`는 custom class-level validator도 받을 수 있습니다. `Validate(...)`는 built-in decorator만으로 부족할 때 custom field-level validator를 붙이고, `ValidateIf(...)`는 predicate가 false를 반환하면 dependent validator를 short-circuit합니다.
 
+### Custom field 검증
+
+`Validate(callback)`는 callback을 `(value, context)`로 호출합니다. `context.dto`는
+포함하는 DTO이고, `context.propertyKey`는 decorator가 적용된 field key입니다.
+
+`@IsObject()`는 null-prototype record를 포함한 plain object만 허용합니다. Class
+instance, `Date`, `Map`, `Set` 값은 거부합니다.
+
 ### 네트워크 검증기
 
 `@IsIP()`는 기본적으로 IPv4와 IPv6 문자열을 모두 검증합니다. 한 IP 버전으로

--- a/packages/validation/README.md
+++ b/packages/validation/README.md
@@ -170,6 +170,14 @@ class RestrictedUserDto {
 
 `ValidateClass(...)` also accepts custom class-level validators. `Validate(...)` attaches custom field-level validators when built-in decorators are not enough, and `ValidateIf(...)` short-circuits dependent validators when its predicate returns false.
 
+### Custom field validation
+
+`Validate(callback)` invokes `callback(value, context)`. `context.dto` is the
+containing DTO, and `context.propertyKey` is the decorated field key.
+
+`@IsObject()` accepts only plain objects, including null-prototype records. It
+rejects class instances, `Date`, `Map`, and `Set` values.
+
 ### Network validators
 
 `@IsIP()` validates IPv4 and IPv6 strings by default. Pass `@IsIP('4')` or

--- a/packages/validation/src/decorators.ts
+++ b/packages/validation/src/decorators.ts
@@ -139,7 +139,8 @@ export const IsDate = createFlagValidationDecorator((options) => ({ kind: 'date'
  */
 export const IsArray = createFlagValidationDecorator((options) => ({ kind: 'array', ...options }));
 /**
- * Validates that the decorated field is an object value.
+ * Validates that the decorated field is a plain object value, including a null-prototype record.
+ * Class instances, `Date`, `Map`, and `Set` values are rejected.
  *
  * @param options Optional validation behavior (`message`, `code`, `each`).
  * @returns A field decorator that registers an object validation rule.
@@ -670,7 +671,8 @@ export function ArrayUnique(
 /**
  * Registers a custom field-level validation function.
  *
- * @param validate Custom validator callback invoked with `(dto, value)`.
+ * @param validate Custom validator callback invoked with `(value, context)`, where `context.dto`
+ * is the containing DTO and `context.propertyKey` is the decorated field key.
  * @param options Optional custom-validator metadata (`message`, `code`, `source`, `each`).
  * @returns A field decorator that registers a custom validation rule.
  */


### PR DESCRIPTION
Closes #3278

## Summary
- correct `Validate(...)` TSDoc to document `(value, context)` and its context fields
- clarify that `IsObject()` accepts plain objects, including null-prototype records, and rejects class instances, `Date`, `Map`, and `Set`
- align validation README EN/KO and document the patch release intent
- leave the beginner validation book unchanged because it does not teach these advanced contracts

## Verification
- public export TSDoc changed-mode and targeted full-file checks
- docs sync, typecheck, and build
- validation typecheck and 103 tests
- stable changeset lane and diff check
- exact-head code, contract, and verification reviews: merge