### PR TITLE
fix(openapi): generate route template parameters (#3232)

### DIFF
--- a/.changeset/issue-3232-openapi-path-parameters.md
+++ b/.changeset/issue-3232-openapi-path-parameters.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/openapi': patch
+---
+
+Generate required string path parameters from route templates when request DTO bindings and explicit parameter metadata are absent.

--- a/packages/openapi/src/schema-builder.test.ts
+++ b/packages/openapi/src/schema-builder.test.ts
@@ -6,6 +6,39 @@ import { ApiBearerAuth, ApiBody, ApiExcludeEndpoint, ApiOperation, ApiResponse, 
 import { buildOpenApiDocument } from './schema-builder.js';
 
 describe('buildOpenApiDocument', () => {
+  it('generates required path parameters from route templates without DTO bindings', () => {
+    @Controller('/accounts/:accountId/resources')
+    class ResourcesController {
+      @Get('/:resourceId')
+      get() {
+        return { ok: true };
+      }
+    }
+
+    const descriptors = createHandlerMapping([{ controllerToken: ResourcesController }]).descriptors;
+    const document = buildOpenApiDocument({
+      defaultErrorResponsesPolicy: 'omit',
+      descriptors,
+      title: 'Route Parameters API',
+      version: '1.0.0',
+    });
+
+    expect(document.paths['/accounts/{accountId}/resources/{resourceId}']?.get?.parameters).toEqual([
+      {
+        in: 'path',
+        name: 'accountId',
+        required: true,
+        schema: { type: 'string' },
+      },
+      {
+        in: 'path',
+        name: 'resourceId',
+        required: true,
+        schema: { type: 'string' },
+      },
+    ]);
+  });
+
   it('keeps nested request-body schemas stable', () => {
     class AuthorDto {
       @IsString()

--- a/packages/openapi/src/schema-builder.ts
+++ b/packages/openapi/src/schema-builder.ts
@@ -791,21 +791,20 @@ function ensureComponentSchema(
 
 function createParameters(
   dto: Constructor | undefined,
+  routePath: string,
   context: BuildSchemaContext,
 ): OpenApiParameterObject[] {
-  if (!dto) {
-    return [];
-  }
-
-  const entries = collectDtoEntries(dto, context).filter(
-    (entry): entry is typeof entry & { binding: DtoBindingEntry } =>
-      entry.binding?.metadata.source === 'path'
-      || entry.binding?.metadata.source === 'query'
-      || entry.binding?.metadata.source === 'header'
-      || entry.binding?.metadata.source === 'cookie',
-  );
-
-  return entries.map((entry) => {
+  const entries = dto
+    ? collectDtoEntries(dto, context)
+      .filter(
+        (entry): entry is typeof entry & { binding: DtoBindingEntry } =>
+          entry.binding?.metadata.source === 'path'
+          || entry.binding?.metadata.source === 'query'
+          || entry.binding?.metadata.source === 'header'
+          || entry.binding?.metadata.source === 'cookie',
+      )
+    : [];
+  const parameters = entries.map((entry) => {
     const source = entry.binding.metadata.source as 'cookie' | 'header' | 'path' | 'query';
     const rules = entry.validation?.rules ?? [];
     const inferred = inferPrimitiveTypeFromRules(rules, context) ?? {};
@@ -819,6 +818,25 @@ function createParameters(
       schema,
     };
   });
+  const documentedPathParameters = new Set(
+    parameters.filter((parameter) => parameter.in === 'path').map((parameter) => parameter.name),
+  );
+
+  for (const match of routePath.matchAll(/:([a-zA-Z_][a-zA-Z0-9_]*)/g)) {
+    const name = match[1];
+
+    if (!documentedPathParameters.has(name)) {
+      documentedPathParameters.add(name);
+      parameters.push({
+        in: 'path',
+        name,
+        required: true,
+        schema: { type: 'string' },
+      });
+    }
+  }
+
+  return parameters;
 }
 
 function ensureErrorResponseSchema(componentSchemas: Record<string, OpenApiSchemaObject>): OpenApiSchemaObject {
@@ -1158,7 +1176,10 @@ function createOperationObject(
   context: BuildSchemaContext,
   usedOperationIds: Set<string>,
 ): OpenApiOperationObject {
-  const parameters = mergeOperationParameters(createParameters(descriptor.route.request, context), methodMeta?.parameters);
+  const parameters = mergeOperationParameters(
+    createParameters(descriptor.route.request, descriptor.route.path, context),
+    methodMeta?.parameters,
+  );
   const requestBody = mergeOperationRequestBody(
     createRequestBody(descriptor.route.request, componentSchemas, context),
     methodMeta,


### PR DESCRIPTION
## Summary
- generate required OpenAPI path parameters directly from route templates
- preserve DTO and explicit metadata precedence
- add regression coverage and a patch Changeset

## Verification
- @fluojs/openapi build, typecheck, and 88 tests
- direct reverse-dependent typecheck
- built-package manual QA

Closes #3232