### PR TITLE
fix(openapi): remove stale validation runtime dependency (#3236)

### DIFF
--- a/.changeset/remove-openapi-validation-dependency.md
+++ b/.changeset/remove-openapi-validation-dependency.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/openapi": patch
+---
+
+Remove the stale `@fluojs/validation` runtime dependency. OpenAPI consumes DTO metadata through `@fluojs/core/request-pipeline`.

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -48,6 +48,7 @@
     "@fluojs/runtime": "workspace:^"
   },
   "devDependencies": {
+    "@fluojs/validation": "workspace:^",
     "vitest": "^3.2.4"
   }
 }

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -44,7 +44,6 @@
   },
   "dependencies": {
     "@fluojs/core": "workspace:^",
-    "@fluojs/validation": "workspace:^",
     "@fluojs/http": "workspace:^",
     "@fluojs/runtime": "workspace:^"
   },

--- a/packages/openapi/src/package-dependencies.test.ts
+++ b/packages/openapi/src/package-dependencies.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const packageJsonPath = fileURLToPath(new URL('../package.json', import.meta.url));
+
+describe('@fluojs/openapi package dependency contract', () => {
+  it('does not declare validation as a runtime dependency', () => {
+    // Given
+    const manifest = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+
+    // When
+    const runtimeDependencies = manifest.dependencies;
+
+    // Then
+    expect(runtimeDependencies).not.toHaveProperty('@fluojs/validation');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -734,6 +734,9 @@ importers:
         specifier: workspace:^
         version: link:../runtime
     devDependencies:
+      '@fluojs/validation':
+        specifier: workspace:^
+        version: link:../validation
       vitest:
         specifier: ^3.2.4
         version: 3.2.7(@types/debug@4.1.13)(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.23.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -733,9 +733,6 @@ importers:
       '@fluojs/runtime':
         specifier: workspace:^
         version: link:../runtime
-      '@fluojs/validation':
-        specifier: workspace:^
-        version: link:../validation
     devDependencies:
       vitest:
         specifier: ^3.2.4


### PR DESCRIPTION
## Summary
- remove the stale @fluojs/validation runtime dependency from @fluojs/openapi
- retain validation as a test-only devDependency
- lock the package boundary with a manifest regression test and patch Changeset

## Verification
- frozen clean install and clean-dist full build
- @fluojs/openapi typecheck and 87 tests
- direct reverse-dependent verification
- packed-consumer runtime import

Closes #3236