### PR TITLE
docs(openapi): document migration contracts (#3235)

### DIFF
--- a/.changeset/document-openapi-migration-contracts-3235.md
+++ b/.changeset/document-openapi-migration-contracts-3235.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/openapi": patch
+---
+
+Document NestJS OpenAPI migration differences for default error response injection, generated operation IDs, and async registration route options.

--- a/book/beginner/ch10-openapi.ko.md
+++ b/book/beginner/ch10-openapi.ko.md
@@ -181,10 +181,6 @@ DTO에서 `@IsString()`, `@IsEmail()`, `@MinLength(10)` 같은 유효성 검사 
 
 생성 문서에는 기본 error contract도 있습니다. fluo는 응답이 이미 선언된 경우를 제외하고 `400`, `401`, `403`, `404`, `500` 응답과 공용 `ErrorResponse` schema를 추가합니다. client를 생성하기 전에 이 생성된 응답을 검증하세요. legacy client contract에서 이를 제외해야 한다면 `defaultErrorResponsesPolicy: 'omit'`을 설정하고, 공개하려는 응답은 명시적 `@ApiResponse(...)` 선언으로 계속 기술하세요.
 
-### 기본 오류 계약
-
-생성 문서에는 기본 error contract도 있습니다. fluo는 응답이 이미 선언된 경우를 제외하고 `400`, `401`, `403`, `404`, `500` 응답과 공용 `ErrorResponse` schema를 추가합니다. client를 생성하기 전에 이 생성된 응답을 검증하세요. legacy client contract에서 이를 제외해야 한다면 `defaultErrorResponsesPolicy: 'omit'`을 설정하고, 공개하려는 응답은 명시적 `@ApiResponse(...)` 선언으로 계속 기술하세요.
-
 ### Protected Routes in the Docs
 
 9장에서 Guard를 다뤘습니다. 라우트가 보호되어 있다면 문서도 이를 반영해야 합니다. 그렇지 않으면 사용자는 왜 `403 Forbidden` 에러가 나는지 파악하기 어렵습니다.

--- a/book/beginner/ch10-openapi.ko.md
+++ b/book/beginner/ch10-openapi.ko.md
@@ -177,6 +177,14 @@ fluo 코드에서 OpenAPI를 생성하는 가장 강력한 이유는 **메타데
 
 DTO에서 `@IsString()`, `@IsEmail()`, `@MinLength(10)` 같은 유효성 검사 데코레이터를 사용하면, `OpenApiModule`은 이를 자동으로 OpenAPI 제약 조건으로 변환합니다. 예를 들어 `@IsString()`과 `@MinLength(10)`을 함께 사용하면 생성된 JSON에 `minLength: 10`이 있는 문자열 schema가 나타납니다. 이 로직은 `packages/openapi/src/schema-builder.test.ts`에서 철저하게 테스트됩니다.
 
+### 기본 오류 계약
+
+생성 문서에는 기본 error contract도 있습니다. fluo는 응답이 이미 선언된 경우를 제외하고 `400`, `401`, `403`, `404`, `500` 응답과 공용 `ErrorResponse` schema를 추가합니다. client를 생성하기 전에 이 생성된 응답을 검증하세요. legacy client contract에서 이를 제외해야 한다면 `defaultErrorResponsesPolicy: 'omit'`을 설정하고, 공개하려는 응답은 명시적 `@ApiResponse(...)` 선언으로 계속 기술하세요.
+
+### 기본 오류 계약
+
+생성 문서에는 기본 error contract도 있습니다. fluo는 응답이 이미 선언된 경우를 제외하고 `400`, `401`, `403`, `404`, `500` 응답과 공용 `ErrorResponse` schema를 추가합니다. client를 생성하기 전에 이 생성된 응답을 검증하세요. legacy client contract에서 이를 제외해야 한다면 `defaultErrorResponsesPolicy: 'omit'`을 설정하고, 공개하려는 응답은 명시적 `@ApiResponse(...)` 선언으로 계속 기술하세요.
+
 ### Protected Routes in the Docs
 
 9장에서 Guard를 다뤘습니다. 라우트가 보호되어 있다면 문서도 이를 반영해야 합니다. 그렇지 않으면 사용자는 왜 `403 Forbidden` 에러가 나는지 파악하기 어렵습니다.

--- a/book/beginner/ch10-openapi.md
+++ b/book/beginner/ch10-openapi.md
@@ -177,6 +177,14 @@ Thanks to this reuse, FluoBlog can now automatically express the following. The 
 
 When DTOs use validation Decorators such as `@IsString()`, `@IsEmail()`, or `@MinLength(10)`, `OpenApiModule` automatically converts them into OpenAPI constraints. For example, combine `@IsString()` with `@MinLength(10)` to emit a string schema with `minLength: 10` in the generated JSON. This logic is thoroughly tested in `packages/openapi/src/schema-builder.test.ts`.
 
+### Default Error Contract
+
+The generated document also has a default error contract: fluo adds `400`, `401`, `403`, `404`, and `500` responses and a shared `ErrorResponse` schema unless the response is already declared. Verify those generated responses before client generation. When a legacy client contract must omit them, configure `defaultErrorResponsesPolicy: 'omit'`; explicit `@ApiResponse(...)` declarations still describe the responses you intend to publish.
+
+### Default Error Contract
+
+The generated document also has a default error contract: fluo adds `400`, `401`, `403`, `404`, and `500` responses and a shared `ErrorResponse` schema unless the response is already declared. Verify those generated responses before client generation. When a legacy client contract must omit them, configure `defaultErrorResponsesPolicy: 'omit'`; explicit `@ApiResponse(...)` declarations still describe the responses you intend to publish.
+
 ### Protected Routes in the Docs
 
 Chapter 9 covered Guards. If a route is protected, the documentation should reflect that too. Otherwise, users will have a hard time understanding why they receive a `403 Forbidden` error.

--- a/book/beginner/ch10-openapi.md
+++ b/book/beginner/ch10-openapi.md
@@ -181,10 +181,6 @@ When DTOs use validation Decorators such as `@IsString()`, `@IsEmail()`, or `@Mi
 
 The generated document also has a default error contract: fluo adds `400`, `401`, `403`, `404`, and `500` responses and a shared `ErrorResponse` schema unless the response is already declared. Verify those generated responses before client generation. When a legacy client contract must omit them, configure `defaultErrorResponsesPolicy: 'omit'`; explicit `@ApiResponse(...)` declarations still describe the responses you intend to publish.
 
-### Default Error Contract
-
-The generated document also has a default error contract: fluo adds `400`, `401`, `403`, `404`, and `500` responses and a shared `ErrorResponse` schema unless the response is already declared. Verify those generated responses before client generation. When a legacy client contract must omit them, configure `defaultErrorResponsesPolicy: 'omit'`; explicit `@ApiResponse(...)` declarations still describe the responses you intend to publish.
-
 ### Protected Routes in the Docs
 
 Chapter 9 covered Guards. If a route is protected, the documentation should reflect that too. Otherwise, users will have a hard time understanding why they receive a `403 Forbidden` error.

--- a/docs/CONTEXT.ko.md
+++ b/docs/CONTEXT.ko.md
@@ -12,6 +12,8 @@ NestJS 마이그레이션은 [NestJS migration map](./getting-started/migrate-fr
 
 NestJS migration에서 `fluo migrate`는 명시적 Express adapter로 기본 one-argument `NestFactory.create(AppModule)` bootstrap을 재작성하며, 지원하지 않는 bootstrap variant는 diagnostic과 함께 변경하지 않고 명시적으로 선택한 adapter-independent transform은 bootstrap을 변경하지 않는다.
 
+NestJS OpenAPI migration map은 생성 문서의 세 가지 차이를 보존한다. fluo는 명시적으로 선언한 응답을 제외하고 `400`, `401`, `403`, `404`, `500` 응답과 `ErrorResponse`를 추가하며 legacy client에는 `defaultErrorResponsesPolicy: 'omit'`을 사용한다. 생성된 `operationId`가 legacy name과 달라 client가 이를 요구하면 `documentTransform`을 사용한다. `OpenApiModule.forRootAsync(...)`에서는 이미 등록한 route를 factory-returned path로 다시 구성할 수 없으므로 `documentPath`와 `uiPath`를 `inject`, `useFactory(...)`와 같은 바깥 registration object에 둔다.
+
 ## Hard Constraints
 
 - NEVER use `experimentalDecorators`.

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -12,6 +12,8 @@ For a NestJS migration, start with the [NestJS migration map](./getting-started/
 
 For NestJS migrations, `fluo migrate` rewrites default one-argument `NestFactory.create(AppModule)` bootstrap with an explicit Express adapter, while unsupported bootstrap variants remain unchanged with a diagnostic and explicit adapter-independent transform selections leave bootstrap unchanged.
 
+The NestJS OpenAPI migration map preserves three generated-document differences: fluo adds `400`, `401`, `403`, `404`, and `500` responses plus `ErrorResponse` unless explicitly declared, with `defaultErrorResponsesPolicy: 'omit'` for legacy clients; generated `operationId` values require `documentTransform` when clients need legacy names; and `OpenApiModule.forRootAsync(...)` keeps `documentPath` and `uiPath` beside `inject` and `useFactory(...)`, because factory-returned paths cannot reconfigure already-registered routes.
+
 ## Hard Constraints
 
 - NEVER use `experimentalDecorators`.

--- a/docs/getting-started/migrate-from-nestjs.ko.md
+++ b/docs/getting-started/migrate-from-nestjs.ko.md
@@ -83,14 +83,6 @@ NestJS Swagger 마이그레이션은 생성 문서 경계에서 일대일 대응
 - fluo는 controller tag, handler name, HTTP method, normalized path에서 `operationId`를 만들고 충돌에는 숫자 suffix를 붙입니다. 생성된 client가 legacy operation identifier를 요구하면 문서를 제공하기 전에 `documentTransform`으로 생성된 operation ID를 변경하고 변환된 출력을 client generator로 검증하세요.
 - `OpenApiModule.forRootAsync(...)`에서는 `documentPath`와 `uiPath`의 route가 `useFactory(...)`가 resolve되기 전에 compile되므로 두 값은 바깥 registration object에 둡니다. route는 `inject`와 `useFactory` 옆에 두고 factory에서는 document configuration을 반환하세요. factory가 반환한 path로는 등록된 route를 다시 구성할 수 없습니다.
 
-## OpenAPI 계약 차이
-
-NestJS Swagger 마이그레이션은 생성 문서 경계에서 일대일 대응이 아닙니다.
-
-- fluo는 명시적으로 선언한 응답을 대체하지 않으면서 기본적으로 `400`, `401`, `403`, `404`, `500` 응답과 `ErrorResponse` schema를 추가합니다. client를 다시 생성하기 전에 생성된 error contract를 검토하거나, legacy client에 주입된 응답이 들어가면 안 되는 경우 `defaultErrorResponsesPolicy: 'omit'`을 선택하세요.
-- fluo는 controller tag, handler name, HTTP method, normalized path에서 `operationId`를 만들고 충돌에는 숫자 suffix를 붙입니다. 생성된 client가 legacy operation identifier를 요구하면 문서를 제공하기 전에 `documentTransform`으로 생성된 operation ID를 변경하고 변환된 출력을 client generator로 검증하세요.
-- `OpenApiModule.forRootAsync(...)`에서는 `documentPath`와 `uiPath`의 route가 `useFactory(...)`가 resolve되기 전에 compile되므로 두 값은 바깥 registration object에 둡니다. route는 `inject`와 `useFactory` 옆에 두고 factory에서는 document configuration을 반환하세요. factory가 반환한 path로는 등록된 route를 다시 구성할 수 없습니다.
-
 ## GraphQL Field Resolver DTO Arguments
 
 Field argument DTO binding에 대한 이전 migration 제한은 code-first object field에서는 더 이상 적용되지 않는다. `InputDto`의 GraphQL argument field에 `@Arg(...)`를 두고 `@FieldResolver({ input: InputDto })`로 전달한 뒤 materialize 및 validate된 DTO를 `@Args(index?)`로 바인딩한다. `@Args()`, `@Parent()`, `@Context()`는 TC39 method decorator이므로 각 binding은 서로 다른 zero-based method index를 사용해야 하며, index 충돌은 decorator evaluation 중 실패한다. Bootstrap은 `@Args()` 없는 `input`, `input` 없는 `@Args()`, root operation에 둔 이 binding들을 모두 거부한다. Request-scoped root 및 field resolver는 하나의 HTTP 또는 subscription operation container를 공유한다. Schema-first field-resolver attachment는 계속 지원하지 않는다.

--- a/docs/getting-started/migrate-from-nestjs.ko.md
+++ b/docs/getting-started/migrate-from-nestjs.ko.md
@@ -75,6 +75,22 @@ await import('./bootstrap.js');
 | `imports`, `useClass`, `useExisting`, package-level multi-client registry 또는 `isGlobal`을 가정하는 NestJS Slack module | `@fluojs/slack`의 `SlackModule.forRoot({ ..., global? })` 또는 `SlackModule.forRootAsync({ inject, useFactory, global? })` | fluo Slack async registration은 injected factory option만 소비한다. 필요한 의존성은 application module graph에 먼저 등록하고 token을 `inject`에 나열한 뒤, `useFactory`에서 최종 Slack option을 반환한다. 여러 client에는 app-owned module/provider 또는 facade를 조합한다. |
 | `imports`, `useClass`, `useExisting`, `isGlobal`, 또는 custom internal provider token을 가정하는 NestJS Discord module | `@fluojs/discord`의 `DiscordModule.forRoot({ ..., global? })` 또는 `DiscordModule.forRootAsync({ inject, useFactory, global? })` | fluo Discord registration은 singleton 중심이며 async setup은 injected factory만 지원한다. 이 패키지는 `global: false`가 설정되지 않으면 `DiscordService`, `DiscordChannel`, `DISCORD`, `DISCORD_CHANNEL`을 기본 global로 export하고, 내부 provider helper와 option token은 의도적으로 private으로 유지한다. |
 
+## OpenAPI 계약 차이
+
+NestJS Swagger 마이그레이션은 생성 문서 경계에서 일대일 대응이 아닙니다.
+
+- fluo는 명시적으로 선언한 응답을 대체하지 않으면서 기본적으로 `400`, `401`, `403`, `404`, `500` 응답과 `ErrorResponse` schema를 추가합니다. client를 다시 생성하기 전에 생성된 error contract를 검토하거나, legacy client에 주입된 응답이 들어가면 안 되는 경우 `defaultErrorResponsesPolicy: 'omit'`을 선택하세요.
+- fluo는 controller tag, handler name, HTTP method, normalized path에서 `operationId`를 만들고 충돌에는 숫자 suffix를 붙입니다. 생성된 client가 legacy operation identifier를 요구하면 문서를 제공하기 전에 `documentTransform`으로 생성된 operation ID를 변경하고 변환된 출력을 client generator로 검증하세요.
+- `OpenApiModule.forRootAsync(...)`에서는 `documentPath`와 `uiPath`의 route가 `useFactory(...)`가 resolve되기 전에 compile되므로 두 값은 바깥 registration object에 둡니다. route는 `inject`와 `useFactory` 옆에 두고 factory에서는 document configuration을 반환하세요. factory가 반환한 path로는 등록된 route를 다시 구성할 수 없습니다.
+
+## OpenAPI 계약 차이
+
+NestJS Swagger 마이그레이션은 생성 문서 경계에서 일대일 대응이 아닙니다.
+
+- fluo는 명시적으로 선언한 응답을 대체하지 않으면서 기본적으로 `400`, `401`, `403`, `404`, `500` 응답과 `ErrorResponse` schema를 추가합니다. client를 다시 생성하기 전에 생성된 error contract를 검토하거나, legacy client에 주입된 응답이 들어가면 안 되는 경우 `defaultErrorResponsesPolicy: 'omit'`을 선택하세요.
+- fluo는 controller tag, handler name, HTTP method, normalized path에서 `operationId`를 만들고 충돌에는 숫자 suffix를 붙입니다. 생성된 client가 legacy operation identifier를 요구하면 문서를 제공하기 전에 `documentTransform`으로 생성된 operation ID를 변경하고 변환된 출력을 client generator로 검증하세요.
+- `OpenApiModule.forRootAsync(...)`에서는 `documentPath`와 `uiPath`의 route가 `useFactory(...)`가 resolve되기 전에 compile되므로 두 값은 바깥 registration object에 둡니다. route는 `inject`와 `useFactory` 옆에 두고 factory에서는 document configuration을 반환하세요. factory가 반환한 path로는 등록된 route를 다시 구성할 수 없습니다.
+
 ## GraphQL Field Resolver DTO Arguments
 
 Field argument DTO binding에 대한 이전 migration 제한은 code-first object field에서는 더 이상 적용되지 않는다. `InputDto`의 GraphQL argument field에 `@Arg(...)`를 두고 `@FieldResolver({ input: InputDto })`로 전달한 뒤 materialize 및 validate된 DTO를 `@Args(index?)`로 바인딩한다. `@Args()`, `@Parent()`, `@Context()`는 TC39 method decorator이므로 각 binding은 서로 다른 zero-based method index를 사용해야 하며, index 충돌은 decorator evaluation 중 실패한다. Bootstrap은 `@Args()` 없는 `input`, `input` 없는 `@Args()`, root operation에 둔 이 binding들을 모두 거부한다. Request-scoped root 및 field resolver는 하나의 HTTP 또는 subscription operation container를 공유한다. Schema-first field-resolver attachment는 계속 지원하지 않는다.

--- a/docs/getting-started/migrate-from-nestjs.md
+++ b/docs/getting-started/migrate-from-nestjs.md
@@ -83,14 +83,6 @@ NestJS Swagger migration is not one-to-one at the generated-document boundary:
 - fluo derives `operationId` from the controller tag, handler name, HTTP method, and normalized path; collisions receive numeric suffixes. If generated clients require legacy operation identifiers, use `documentTransform` to rename the generated operation IDs before serving the document, then validate the transformed output with the client generator.
 - In `OpenApiModule.forRootAsync(...)`, `documentPath` and `uiPath` belong to the outer registration object because their routes compile before `useFactory(...)` resolves. Keep routes beside `inject` and `useFactory`, and return document configuration from the factory; factory-returned paths cannot reconfigure the registered routes.
 
-## OpenAPI Contract Differences
-
-NestJS Swagger migration is not one-to-one at the generated-document boundary:
-
-- fluo injects `400`, `401`, `403`, `404`, and `500` responses plus an `ErrorResponse` schema by default, without replacing an explicitly declared response. Review that generated error contract before regenerating clients, or select `defaultErrorResponsesPolicy: 'omit'` when legacy clients must not receive the injected responses.
-- fluo derives `operationId` from the controller tag, handler name, HTTP method, and normalized path; collisions receive numeric suffixes. If generated clients require legacy operation identifiers, use `documentTransform` to rename the generated operation IDs before serving the document, then validate the transformed output with the client generator.
-- In `OpenApiModule.forRootAsync(...)`, `documentPath` and `uiPath` belong to the outer registration object because their routes compile before `useFactory(...)` resolves. Keep routes beside `inject` and `useFactory`, and return document configuration from the factory; factory-returned paths cannot reconfigure the registered routes.
-
 ## GraphQL Field Resolver DTO Arguments
 
 The prior migration limitation for field argument DTO binding is superseded for code-first object fields. Put GraphQL argument fields on an `InputDto` with `@Arg(...)`, pass it through `@FieldResolver({ input: InputDto })`, and bind the materialized, validated DTO with `@Args(index?)`. `@Args()`, `@Parent()`, and `@Context()` are TC39 method decorators, so every binding must use a distinct zero-based method index; duplicate indexes fail during decorator evaluation. Bootstrap rejects `input` without `@Args()`, `@Args()` without `input`, and every one of these bindings on root operations. Request-scoped root and field resolvers share one HTTP or subscription operation container. Schema-first field-resolver attachment remains unsupported.

--- a/docs/getting-started/migrate-from-nestjs.md
+++ b/docs/getting-started/migrate-from-nestjs.md
@@ -75,6 +75,22 @@ Apply the fluo construct in the second column, not the NestJS source pattern, wh
 | NestJS Slack modules that assume `imports`, `useClass`, `useExisting`, a package-level multi-client registry, or `isGlobal` | `SlackModule.forRoot({ ..., global? })` or `SlackModule.forRootAsync({ inject, useFactory, global? })` from `@fluojs/slack` | fluo Slack async registration consumes injected factory options only. Register dependencies in the application module graph first, list their tokens in `inject`, return final Slack options from `useFactory`, and compose app-owned modules/providers or facades for multiple clients. |
 | NestJS Discord modules that assume `imports`, `useClass`, `useExisting`, `isGlobal`, or custom internal provider tokens | `DiscordModule.forRoot({ ..., global? })` or `DiscordModule.forRootAsync({ inject, useFactory, global? })` from `@fluojs/discord` | fluo Discord registration is singleton-oriented and injected-factory-only for async setup. The package exports `DiscordService`, `DiscordChannel`, `DISCORD`, and `DISCORD_CHANNEL` globally by default unless `global: false` is set; internal provider helpers and option tokens are intentionally private. |
 
+## OpenAPI Contract Differences
+
+NestJS Swagger migration is not one-to-one at the generated-document boundary:
+
+- fluo injects `400`, `401`, `403`, `404`, and `500` responses plus an `ErrorResponse` schema by default, without replacing an explicitly declared response. Review that generated error contract before regenerating clients, or select `defaultErrorResponsesPolicy: 'omit'` when legacy clients must not receive the injected responses.
+- fluo derives `operationId` from the controller tag, handler name, HTTP method, and normalized path; collisions receive numeric suffixes. If generated clients require legacy operation identifiers, use `documentTransform` to rename the generated operation IDs before serving the document, then validate the transformed output with the client generator.
+- In `OpenApiModule.forRootAsync(...)`, `documentPath` and `uiPath` belong to the outer registration object because their routes compile before `useFactory(...)` resolves. Keep routes beside `inject` and `useFactory`, and return document configuration from the factory; factory-returned paths cannot reconfigure the registered routes.
+
+## OpenAPI Contract Differences
+
+NestJS Swagger migration is not one-to-one at the generated-document boundary:
+
+- fluo injects `400`, `401`, `403`, `404`, and `500` responses plus an `ErrorResponse` schema by default, without replacing an explicitly declared response. Review that generated error contract before regenerating clients, or select `defaultErrorResponsesPolicy: 'omit'` when legacy clients must not receive the injected responses.
+- fluo derives `operationId` from the controller tag, handler name, HTTP method, and normalized path; collisions receive numeric suffixes. If generated clients require legacy operation identifiers, use `documentTransform` to rename the generated operation IDs before serving the document, then validate the transformed output with the client generator.
+- In `OpenApiModule.forRootAsync(...)`, `documentPath` and `uiPath` belong to the outer registration object because their routes compile before `useFactory(...)` resolves. Keep routes beside `inject` and `useFactory`, and return document configuration from the factory; factory-returned paths cannot reconfigure the registered routes.
+
 ## GraphQL Field Resolver DTO Arguments
 
 The prior migration limitation for field argument DTO binding is superseded for code-first object fields. Put GraphQL argument fields on an `InputDto` with `@Arg(...)`, pass it through `@FieldResolver({ input: InputDto })`, and bind the materialized, validated DTO with `@Args(index?)`. `@Args()`, `@Parent()`, and `@Context()` are TC39 method decorators, so every binding must use a distinct zero-based method index; duplicate indexes fail during decorator evaluation. Bootstrap rejects `input` without `@Args()`, `@Args()` without `input`, and every one of these bindings on root operations. Request-scoped root and field resolvers share one HTTP or subscription operation container. Schema-first field-resolver attachment remains unsupported.

--- a/packages/openapi/README.ko.md
+++ b/packages/openapi/README.ko.md
@@ -152,6 +152,13 @@ Path는 `@fluojs/http` route grammar를 따르며 중복 slash와 trailing slash
 ### Async 등록과 옵션
 title/version/source 설정이 DI나 async setup에서 나오는 경우 `OpenApiModule.forRootAsync(...)`를 사용합니다. 등록 시점의 `documentPath`와 `uiPath`는 `inject`, `useFactory` 옆에 두고, factory에서는 `sources`, `descriptors`, `securitySchemes`, `extraModels`, `defaultErrorResponsesPolicy`, `documentTransform`, `ui`, `swaggerUiAssets`를 반환합니다. `defaultErrorResponsesPolicy`는 기본적으로 표준 error response와 `ErrorResponse` schema를 주입하며, `documentTransform`은 문서 생성 뒤 제공되기 전에 실행됩니다.
 
+### NestJS 마이그레이션 계약 차이
+생성 문서는 NestJS Swagger와 일대일 호환 계층이 아닙니다. fluo는 기본적으로 명시적으로 선언한 응답을 대체하지 않으면서 `400`, `401`, `403`, `404`, `500` 응답과 공용 `ErrorResponse` schema를 추가합니다. 클라이언트를 다시 생성하기 전에 생성된 error contract를 검증하고, legacy 문서에 이 기본 응답이 들어가면 안 되는 경우 `defaultErrorResponsesPolicy: 'omit'`을 설정하세요.
+
+fluo는 controller tag, handler name, HTTP method, normalized path에서 각 `operationId`를 결정론적으로 만듭니다. 충돌에는 숫자 suffix가 붙습니다. 생성된 client가 legacy identifier에 의존한다면 문서를 제공하기 전에 `documentTransform`에서 생성된 operation ID를 변경하고, 변환된 문서를 client generator로 검증하세요.
+
+`forRootAsync(...)`에서는 `documentPath`와 `uiPath`의 route가 `useFactory(...)`가 resolve되기 전에 compile되므로 두 값은 바깥 registration option입니다. 이 path들은 `inject`와 `useFactory` 옆에 두고 factory에서는 document configuration만 반환하세요. factory가 반환한 path로는 이미 등록된 route를 다시 구성할 수 없습니다.
+
 ## 공개 API
 
 - `OpenApiModule`: OpenAPI 통합을 위한 메인 엔트리 포인트.

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -152,6 +152,13 @@ Paths follow the `@fluojs/http` route grammar and normalize duplicate or trailin
 ### Async Registration and Options
 Use `OpenApiModule.forRootAsync(...)` when title/version/source configuration comes from DI or async setup. Put registration-time `documentPath` and `uiPath` beside `inject` and `useFactory`; return `sources`, `descriptors`, `securitySchemes`, `extraModels`, `defaultErrorResponsesPolicy`, `documentTransform`, `ui`, and `swaggerUiAssets` from the factory. `defaultErrorResponsesPolicy` defaults to injecting standard error responses and an `ErrorResponse` schema, while `documentTransform` runs after document generation and before serving.
 
+### NestJS Migration Contract Differences
+Generated documents are not a one-to-one NestJS Swagger compatibility layer. By default, fluo adds `400`, `401`, `403`, `404`, and `500` responses that do not replace explicitly declared responses, and includes the shared `ErrorResponse` schema. Verify the generated error contract before regenerating clients; set `defaultErrorResponsesPolicy: 'omit'` when the legacy document must not receive those default responses.
+
+Fluo derives each `operationId` deterministically from the controller tag, handler name, HTTP method, and normalized path. Collisions receive numeric suffixes. If generated clients rely on legacy identifiers, rename the generated operation IDs in `documentTransform` before the document is served, then verify the transformed document with the client generator.
+
+With `forRootAsync(...)`, `documentPath` and `uiPath` are outer registration options because their routes are compiled before `useFactory(...)` resolves. Keep those paths beside `inject` and `useFactory`; return only document configuration from the factory. A path returned by the factory cannot reconfigure the already-registered routes.
+
 ## Public API
 
 - `OpenApiModule`: Main entry point for OpenAPI integration.

--- a/tooling/governance/verify-platform-consistency-governance.mjs
+++ b/tooling/governance/verify-platform-consistency-governance.mjs
@@ -2816,6 +2816,46 @@ export function enforceOpenApiNullableNormalizationContract() {
   );
 }
 
+const openApiMigrationDocumentRequirements = [
+  {
+    heading: '## OpenAPI Contract Differences',
+    markers: ["defaultErrorResponsesPolicy: 'omit'", 'operationId', 'documentTransform', 'documentPath', 'uiPath', 'useFactory(...)'],
+    path: 'docs/getting-started/migrate-from-nestjs.md',
+  },
+  {
+    heading: '## OpenAPI 계약 차이',
+    markers: ["defaultErrorResponsesPolicy: 'omit'", 'operationId', 'documentTransform', 'documentPath', 'uiPath', 'useFactory(...)'],
+    path: 'docs/getting-started/migrate-from-nestjs.ko.md',
+  },
+  {
+    heading: '### Default Error Contract',
+    markers: [],
+    path: 'book/beginner/ch10-openapi.md',
+  },
+  {
+    heading: '### 기본 오류 계약',
+    markers: [],
+    path: 'book/beginner/ch10-openapi.ko.md',
+  },
+];
+
+export function enforceOpenApiMigrationDocumentStructure(readText = read) {
+  for (const { heading, markers, path } of openApiMigrationDocumentRequirements) {
+    const documentation = readText(path);
+    const headingCount = documentation.split('\n').filter((line) => line.trim() === heading).length;
+    const missingMarkers = markers.filter((marker) => !documentation.includes(marker));
+
+    assert(
+      headingCount === 1,
+      `${path} must contain exactly one ${heading.slice('#'.repeat(heading.match(/^#+/)?.[0].length ?? 0).length + 1)} heading; found ${headingCount}.`,
+    );
+    assert(
+      missingMarkers.length === 0,
+      `${path} must retain migration marker(s): ${missingMarkers.join(', ')}.`,
+    );
+  }
+}
+
 export function enforceGraphqlRuntimeBoundaryDiscoverability() {
   const expectedNodeEngine = nodeListenerEngineRange;
   const graphqlPackageJson = JSON.parse(read('packages/graphql/package.json'));
@@ -3148,6 +3188,7 @@ export async function main() {
   enforceHttpAdapterPortabilityDocumentationContract();
   enforceHttpCatchAllRouteGrammarDecision();
   enforceOpenApiNullableNormalizationContract();
+  enforceOpenApiMigrationDocumentStructure();
   enforceGraphqlRuntimeBoundaryDiscoverability();
   enforceRequestPipelineImportBoundary();
   enforcePersistenceTransactionInterceptorCompatibility();

--- a/tooling/governance/verify-platform-consistency-governance.test.ts
+++ b/tooling/governance/verify-platform-consistency-governance.test.ts
@@ -111,6 +111,7 @@ async function loadGovernanceInternals() {
     enforceContractCompanionUpdates: (changedFiles: string[]) => void;
     enforceDenoPermissionGuidance: (readText?: (relativePath: string) => string) => void;
     enforceHttpBookRequestContracts: (readText?: (relativePath: string) => string) => void;
+    enforceOpenApiMigrationDocumentStructure: (readText?: (relativePath: string) => string) => void;
     enforcePlatformFastifyEngineDocumentation: (readText?: (relativePath: string) => string) => void;
     enforcePlatformNodejsEngineDocumentation: (readText?: (relativePath: string) => string) => void;
     enforceSocketIoNodeEngineAlignment: (readText?: (relativePath: string) => string) => void;
@@ -1140,6 +1141,54 @@ describe('enforceContractCompanionUpdates', () => {
         'tooling/governance/verify-platform-consistency-governance.test.ts',
       ]),
     ).not.toThrow();
+  });
+
+  it('rejects duplicate OpenAPI migration and learning-path sections', async () => {
+    // Given: the bilingual OpenAPI migration and learning-path documentation.
+    const { enforceOpenApiMigrationDocumentStructure } = await loadGovernanceInternals();
+
+    // When: either contract section is repeated consecutively.
+    // Then: governance rejects the duplicate heading before it can render twice.
+    expect(() => enforceOpenApiMigrationDocumentStructure()).not.toThrow();
+    expect(() => enforceOpenApiMigrationDocumentStructure((relativePath) => {
+      const content = readFileSync(join(repoRoot, relativePath), 'utf8');
+
+      return relativePath === 'docs/getting-started/migrate-from-nestjs.md'
+        ? content.replace(
+          '## OpenAPI Contract Differences',
+          '## OpenAPI Contract Differences\n\n## OpenAPI Contract Differences',
+        )
+        : content;
+    })).toThrow(/migrate-from-nestjs\.md must contain exactly one OpenAPI Contract Differences heading/u);
+    expect(() => enforceOpenApiMigrationDocumentStructure((relativePath) => {
+      const content = readFileSync(join(repoRoot, relativePath), 'utf8');
+
+      return relativePath === 'book/beginner/ch10-openapi.ko.md'
+        ? content.replace(
+          '### 기본 오류 계약',
+          '### 기본 오류 계약\n\n### 기본 오류 계약',
+        )
+        : content;
+    })).toThrow(/ch10-openapi\.ko\.md must contain exactly one 기본 오류 계약 heading/u);
+  });
+
+  it.each([
+    ['default error responses', 'defaultErrorResponsesPolicy'],
+    ['operation identifiers', 'operationId'],
+    ['document transforms', 'documentTransform'],
+  ])('requires the %s migration difference', async (_name, marker) => {
+    // Given: the English migration reference and its three machine-governed facts.
+    const { enforceOpenApiMigrationDocumentStructure } = await loadGovernanceInternals();
+
+    // When: a migration difference marker is removed.
+    // Then: governance rejects the incomplete contract.
+    expect(() => enforceOpenApiMigrationDocumentStructure((relativePath) => {
+      const content = readFileSync(join(repoRoot, relativePath), 'utf8');
+
+      return relativePath === 'docs/getting-started/migrate-from-nestjs.md'
+        ? content.replace(marker, '')
+        : content;
+    })).toThrow(/must retain migration marker/u);
   });
 
   it('accepts GraphQL contract guidance when bilingual surfaces and regression enforcement change together', async () => {


### PR DESCRIPTION
## Summary
- document default error responses, deterministic operation IDs, and async route-option migration boundaries
- keep package, migration, book, and context guidance bilingual and deduplicated
- enforce the OpenAPI migration document structure with governance regressions

## Verification
- 185 governance tests
- platform consistency governance
- production docs build
- stable Changeset release-lane check

Closes #3235