### PR TITLE
fix(metrics): align Node support with runtime (#3205)

### DIFF
--- a/.changeset/align-metrics-node-engines.md
+++ b/.changeset/align-metrics-node-engines.md
@@ -1,0 +1,7 @@
+---
+'@fluojs/metrics': major
+---
+
+Align the declared Node.js support range with the mandatory `@fluojs/runtime` dependency.
+
+Migration: Node.js >=20.0.0 <20.19.3 support is removed, and Node.js 21 is no longer supported. Upgrade to Node.js >=20.19.3 <21 or Node.js >=22.2.0 <27 before installing this release.

--- a/packages/metrics/README.ko.md
+++ b/packages/metrics/README.ko.md
@@ -22,7 +22,7 @@ pnpm add @fluojs/metrics
 
 ## 요구 사항
 
-`@fluojs/metrics`는 Node.js 20 이상에서 실행됩니다. package manifest는 `engines.node >=20.0.0`을 선언합니다.
+`@fluojs/metrics`는 필수 `@fluojs/runtime` 의존성과 동일한 Node.js `>=20.19.3 <21 || >=22.2.0 <27`을 요구합니다.
 
 ## 사용 시점
 

--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -22,7 +22,7 @@ pnpm add @fluojs/metrics
 
 ## Requirements
 
-`@fluojs/metrics` runs on Node.js 20 or newer; the package manifest declares `engines.node >=20.0.0`.
+`@fluojs/metrics` requires Node.js `>=20.19.3 <21 || >=22.2.0 <27`, matching its mandatory `@fluojs/runtime` dependency.
 
 ## When to Use
 

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -17,7 +17,7 @@
     "directory": "packages/metrics"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.19.3 <21 || >=22.2.0 <27"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/metrics/src/runtime-support.test.ts
+++ b/packages/metrics/src/runtime-support.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+describe('@fluojs/metrics runtime support metadata', () => {
+  it('matches the Node.js range required by its mandatory runtime dependency', () => {
+    // Given: the published metrics manifest and its mandatory runtime dependency manifest.
+    const metricsManifest = readFileSync(new URL('../package.json', import.meta.url), 'utf8');
+    const runtimeManifest = readFileSync(new URL('../../runtime/package.json', import.meta.url), 'utf8');
+
+    // When: their declared Node.js engine ranges are read.
+    const metricsNodeEngine = JSON.parse(metricsManifest).engines.node;
+    const runtimeNodeEngine = JSON.parse(runtimeManifest).engines.node;
+
+    // Then: metrics does not advertise support outside the runtime requirement.
+    expect(metricsNodeEngine).toBe(runtimeNodeEngine);
+  });
+});


### PR DESCRIPTION
## Summary

Align `@fluojs/metrics` Node.js support metadata with its mandatory `@fluojs/runtime` dependency.

Linked context: Closes #3205

## Changes

- match the metrics `engines.node` range to runtime
- update English and Korean installation requirements
- add a manifest regression test and major Changeset with migration guidance

## Testing

- `pnpm --filter "@fluojs/metrics..." build`
- `pnpm --filter "@fluojs/metrics" typecheck`
- `pnpm --filter "@fluojs/metrics" test` (67 passed)
- `pnpm --filter "...@fluojs/metrics" test`
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`
- exact-head code, contract, and verification review: PASS

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary. (N/A: no exports changed)
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. (N/A)
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated.
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. (N/A)
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests. (N/A)