### PR TITLE
docs(metrics): correct registry mode gauge documentation (#3208)

### DIFF
--- a/.changeset/correct-metrics-registry-mode-gauge-documentation.md
+++ b/.changeset/correct-metrics-registry-mode-gauge-documentation.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/metrics": patch
+---
+
+Correct the registry-mode gauge documentation to distinguish module configuration from scrape-time registry sharing.

--- a/packages/metrics/README.ko.md
+++ b/packages/metrics/README.ko.md
@@ -170,7 +170,7 @@ Prometheus 메트릭 이름은 하나의 Registry 안에서 고유해야 합니�
 
 - `fluo_component_ready`: 준비 완료 시 1, 아닐 시 0.
 - `fluo_component_health`: 정상 상태 시 1, 아닐 시 0.
-- `fluo_metrics_registry_mode`: active registry mode를 `mode="isolated"` 또는 `mode="shared"` label과 gauge value `1`로 나타냅니다.
+- `fluo_metrics_registry_mode`: `MetricsModule.forRoot()`가 Registry를 생성하면 `mode="isolated"`, `registry` option을 전달하면 `mode="shared"` label과 gauge value `1`을 노출합니다. 이 label은 module registration configuration을 나타내며 scrape 시점에 Registry 공유 여부를 추론하지 않습니다.
 
 이 데이터는 built-in `/metrics` controller와 `MetricsService.getRegistry().metrics()`를 사용하는 advanced custom scraper를 포함해 active Registry가 스크레이프될 때마다 `PLATFORM_SHELL`을 쿼리하여 갱신됩니다. 초기화 시 환경 라벨을 제공할 수 있습니다.
 

--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -170,7 +170,7 @@ The module emits fluo-specific gauges that mirror the platform shell and registe
 
 - `fluo_component_ready`: `1` when a component is ready, otherwise `0`.
 - `fluo_component_health`: `1` when a component is healthy, otherwise `0`.
-- `fluo_metrics_registry_mode`: gauge value `1` with a `mode="isolated"` or `mode="shared"` label for the active registry mode.
+- `fluo_metrics_registry_mode`: gauge value `1` with `mode="isolated"` when `MetricsModule.forRoot()` creates its registry, or `mode="shared"` when you pass a `registry` option. The label reports that module registration configuration; it does not infer registry sharing at scrape time.
 
 The platform snapshot is refreshed during each registry scrape, including advanced `MetricsService.getRegistry().metrics()` scrape paths, and you can attach environment labels up front.
 


### PR DESCRIPTION
## Summary
- clarify that fluo_metrics_registry_mode reports the MetricsModule.forRoot() registry configuration
- document isolated/shared mapping consistently in EN and KO
- add a patch Changeset for the shipped package README correction

## Verification
- pnpm docs:sync-check
- pnpm verify:changeset-release-lane -- --lane=stable --base-ref=main
- npm pack --dry-run --json .worktrees/issue-3208/packages/metrics
- exact-head contract review: merge

Closes #3208