### PR TITLE
docs(metrics): clarify prom-client collector installation (#3210)

### DIFF
--- a/.changeset/clarify-metrics-prom-client-installation.md
+++ b/.changeset/clarify-metrics-prom-client-installation.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/metrics": patch
+---
+
+Clarify that applications importing `prom-client` directly must install it as a direct dependency instead of relying on its transitive installation through `@fluojs/metrics`.

--- a/packages/metrics/README.ko.md
+++ b/packages/metrics/README.ko.md
@@ -139,6 +139,16 @@ class OrdersService {
 
 ### Framework metric과 app metric이 하나의 registry를 공유하기
 
+이 예제는 `Counter`와 `Registry`를 `prom-client`에서 직접 import하므로, 애플리케이션 의존성에
+`prom-client`를 추가하세요.
+
+```bash
+pnpm add prom-client
+```
+
+`@fluojs/metrics`는 내부적으로 `prom-client`를 사용하지만, 그 의존성만으로 애플리케이션에서
+`prom-client`를 지원되는 transitive import로 사용할 수 있는 것은 아닙니다.
+
 ```ts
 import { Module } from '@fluojs/core';
 import { Counter, Registry } from 'prom-client';

--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -139,6 +139,16 @@ Calling `MetricsService.counter(...)` again with the same name recreates the col
 
 ### Share one registry for framework and app metrics
 
+This example imports `Counter` and `Registry` directly from `prom-client`, so add
+`prom-client` to your application's dependencies:
+
+```bash
+pnpm add prom-client
+```
+
+`@fluojs/metrics` uses `prom-client` internally, but its dependency does not make
+`prom-client` a supported transitive import for your application.
+
 ```ts
 import { Module } from '@fluojs/core';
 import { Counter, Registry } from 'prom-client';


### PR DESCRIPTION
## Summary
- document that direct prom-client imports require a direct dependency
- keep EN/KO package README guidance aligned
- add the required patch Changeset because package-root READMEs ship in the npm tarball

## Verification
- pnpm verify:docs
- pnpm verify:changeset-release-lane -- --lane=stable --base-ref=main
- npm pack --dry-run --json .worktrees/issue-3210/packages/metrics
- exact-head contract review: merge

Closes #3210