### PR TITLE
feat(metrics): configure shared registry at bootstrap (#3201)

### DIFF
--- a/.changeset/bootstrap-metrics-registry.md
+++ b/.changeset/bootstrap-metrics-registry.md
@@ -1,6 +1,9 @@
 ---
 "@fluojs/metrics": minor
+"@fluojs/runtime": patch
 ---
 
 Configure a shared Prometheus registry through the public `METRICS_REGISTRY`
-bootstrap provider so each application bootstrap owns its metrics registry.
+bootstrap provider so each application bootstrap owns its metrics registry. Bootstrap
+registry provenance is available to runtime integrations through the narrow internal
+provider-token seam.

--- a/.changeset/bootstrap-metrics-registry.md
+++ b/.changeset/bootstrap-metrics-registry.md
@@ -1,0 +1,6 @@
+---
+"@fluojs/metrics": minor
+---
+
+Configure a shared Prometheus registry through the public `METRICS_REGISTRY`
+bootstrap provider so each application bootstrap owns its metrics registry.

--- a/packages/metrics/README.ko.md
+++ b/packages/metrics/README.ko.md
@@ -142,17 +142,10 @@ class OrdersService {
 
 ```ts
 import { Module } from '@fluojs/core';
-import { Counter, Registry } from 'prom-client';
-import { METRICS_REGISTRY, MetricsModule } from '@fluojs/metrics';
+import { METRICS_REGISTRY, MetricsModule, Registry } from '@fluojs/metrics';
 import { bootstrapApplication } from '@fluojs/runtime';
 
 const registry = new Registry();
-
-new Counter({
-  name: 'orders_total',
-  help: 'Total orders processed',
-  registers: [registry],
-});
 
 @Module({
   imports: [MetricsModule.forRoot({ http: true })],
@@ -164,6 +157,8 @@ const app = await bootstrapApplication({
   providers: [{ provide: METRICS_REGISTRY, useValue: registry }],
 });
 ```
+
+`Registry`는 `@fluojs/metrics`가 re-export하므로 이 setup에는 `prom-client` 직접 dependency가 필요하지 않습니다. application collector는 위의 `MetricsService` pattern으로 생성하세요.
 
 여러 `MetricsModule` 인스턴스가 같은 Registry를 의도적으로 공유하는 경우, 내장 HTTP 메트릭은 framework ownership, label schema, effective path-label configuration이 모두 일치할 때만 기존 `http_requests_total`, `http_errors_total`, `http_request_duration_seconds` collector를 재사용합니다. Path-label compatibility 검사는 `pathLabelMode`, 정확히 같은 `pathLabelNormalizer` 함수 참조, `unknownPathLabel` fallback 의미론을 포함하므로 서로 다른 HTTP series policy를 하나의 collector set에 섞는 module instance는 빠르게 실패합니다. 내장 플랫폼 텔레메트리 Gauge도 같은 ownership 규칙을 따릅니다. 모듈이 만든 `fluo_component_ready`, `fluo_component_health`, `fluo_metrics_registry_mode` Gauge는 framework ownership과 label schema가 일치할 때만 재사용합니다. 플랫폼 텔레메트리 상태는 재사용된 Registry별로 추적되므로, 이후 스크레이프는 이전 module instance가 남긴 stale component readiness/health series를 제거한 뒤 메트릭을 반환합니다. Registry scrape wrapper는 최신 active module registration을 사용하며 마지막 registration이 종료되면 Registry의 원래 `metrics()` 함수를 복원합니다. 애플리케이션이 직접 등록한 중복 메트릭 이름은 Prometheus Registry 규칙대로 계속 빠르게 실패합니다.
 
@@ -211,18 +206,20 @@ MetricsModule.forRoot({
 ## 공개 API
 
 - `MetricsModule.forRoot(options)`
+- 의도적으로 공유하는 `Registry`를 위한 bootstrap 전용 token `METRICS_REGISTRY`
 - `MetricsService` 및 `counter(...)`, `gauge(...)`, `histogram(...)`, `getRegistry()`
 - `METER_PROVIDER` (Token)
 - `PrometheusMeterProvider`
 - Meter abstraction type: `MeterProvider`, `MeterCounter`, `MeterGauge`, `MeterHistogram`
 - `HttpMetricsMiddleware` 및 HTTP path-label 옵션 타입
 - `provider`(현재는 `'prometheus'`만 지원), module-level `middleware`, endpoint-scoped `endpointMiddleware`를 포함한 module option
-- `prom-client`의 `Registry`
+- `prom-client`에서 re-export한 `Registry`
 
 ### 운영 기본값
 
 - `path`의 기본값은 `'/metrics'`입니다. `''`를 포함한 모든 문자열 path는 scrape endpoint를 노출하며, `path: false`로만 scrape endpoint를 완전히 비활성화할 수 있습니다.
-- `registry`를 생략하면 application bootstrap마다 fresh isolated Registry, `MetricsService`, meter provider, telemetry collector set을 소유합니다.
+- bootstrap `METRICS_REGISTRY`와 legacy `registry` option을 모두 제공하지 않으면 application bootstrap마다 fresh isolated Registry, `MetricsService`, meter provider, telemetry collector set을 소유합니다.
+- Bootstrap `METRICS_REGISTRY` provider는 legacy `registry` option보다 우선하며, 같은 token을 가진 관련 없는 module provider는 metrics ownership을 구성하지 않습니다.
 - scrape response는 active Registry의 Prometheus content type과 Registry contents를 사용합니다.
 - `defaultMetrics`의 기본값은 `true`이며, `defaultMetrics: false`로 해당 Registry의 Prometheus 기본 프로세스/Node.js collector를 끌 수 있습니다.
 - `endpointMiddleware`는 class-based route-scoped middleware를 스크레이프 엔드포인트에만 바인딩합니다. HTTP 계측이 활성화된 경우 endpoint middleware 실패는 내장 HTTP collector에 집계됩니다.

--- a/packages/metrics/README.ko.md
+++ b/packages/metrics/README.ko.md
@@ -44,14 +44,15 @@ class AppModule {}
 
 `MetricsModule.forRoot()`는 기본적으로 `GET /metrics`를 노출합니다. HTTP request instrumentation middleware를 설치하려면 `http: true` 또는 `http` option object를 전달하세요. HTTP 계측이 활성화되면 request total, error count, request duration을 기록합니다. 운영 환경에서는 scrape endpoint boundary를 명시적으로 다루세요. platform-level proxy가 준비될 때까지 `path: false`로 끄거나 dedicated endpoint middleware를 연결할 수 있습니다.
 
-Scrape endpoint는 active `prom-client` Registry output을 해당 Registry의 Prometheus content type으로 반환합니다. `MetricsModule.forRoot()`는 `registry` option을 전달하지 않는 한 application bootstrap마다 격리된 Registry를 생성합니다. 같은 dynamic module class를 다른 bootstrap에서 재사용해도 격리된 metric state는 새로 만들어집니다. framework metric과 application-defined metric이 하나의 scrape surface를 의도적으로 공유해야 할 때만 shared `Registry`를 전달하세요.
+Scrape endpoint는 active `prom-client` Registry output을 해당 Registry의 Prometheus content type으로 반환합니다. `MetricsModule.forRoot()`는 bootstrap이 `METRICS_REGISTRY`를 구성하거나 legacy `registry` option을 제공하지 않는 한 application bootstrap마다 격리된 Registry를 생성합니다. 같은 dynamic module class를 다른 bootstrap에서 재사용해도 격리된 metric state는 새로 만들어집니다. framework metric과 application-defined metric이 하나의 scrape surface를 의도적으로 공유해야 할 때만 bootstrap에서 shared `Registry`를 구성하세요.
 
 ## 공개 책임
 
 | 표면 | 책임 | 경계 |
 | --- | --- | --- |
 | `MetricsModule.forRoot(...)` | Prometheus scrape endpoint, default metrics, optional HTTP instrumentation, platform telemetry, registry ownership을 wiring합니다. | `provider`는 현재 `'prometheus'`만 받습니다. `path: false`는 scrape route와 route-scoped endpoint middleware를 비활성화합니다. |
-| `MetricsService` | Active Registry 위에서 custom `Counter`, `Gauge`, `Histogram`을 만드는 application-facing facade이며, 고급 Registry 공유를 위한 `getRegistry()`도 제공합니다. | 비즈니스/application metric은 collector helper를 사용하세요. `getRegistry()`는 active `prom-client` Registry를 `MetricsModule.forRoot({ registry })`로 직접 받을 수 없는 integration에 넘겨야 할 때만 사용하세요. |
+| `MetricsService` | Active Registry 위에서 custom `Counter`, `Gauge`, `Histogram`을 만드는 application-facing facade이며, 고급 Registry 공유를 위한 `getRegistry()`도 제공합니다. | 비즈니스/application metric은 collector helper를 사용하세요. `getRegistry()`는 active `prom-client` Registry를 bootstrap의 `METRICS_REGISTRY`로 직접 받을 수 없는 integration에 넘겨야 할 때만 사용하세요. |
+| `METRICS_REGISTRY` | Shared `prom-client` Registry를 위한 bootstrap provider token입니다. | `bootstrapApplication()` provider가 module의 legacy `registry` option보다 우선하여 ownership을 가집니다. |
 | `Registry` | Shared-registry setup을 위한 `prom-client` `Registry` constructor re-export입니다. | 같은 Prometheus Registry 구현체이므로 중복 metric name은 Prometheus semantics에 따라 계속 실패합니다. |
 | `METER_PROVIDER` / `PrometheusMeterProvider` / meter type | Provider token 또는 backend-neutral counter/gauge/histogram facade가 필요한 first-party package integration용 low-level meter bridge입니다. | Application code는 package-level integration을 직접 조합하는 경우가 아니면 보통 이 token이 필요하지 않습니다. 현재 bundled provider backend는 Prometheus뿐입니다. |
 | `middleware` | Framework HTTP metrics와 endpoint-scoped middleware 뒤의 module middleware chain에 참여하는 module-level middleware입니다. | Route-scoped가 아니므로 scrape route만 보호하려면 `endpointMiddleware`를 사용하세요. |
@@ -135,14 +136,15 @@ class OrdersService {
 
 같은 이름으로 `MetricsService.counter(...)`를 다시 호출하면 collector를 다시 만들려고 하므로 Prometheus의 duplicate-name failure behavior를 따릅니다. 요청이나 command handler마다 새로 만들지 말고 collector를 저장해 재사용하세요.
 
-`MetricsService.getRegistry()`는 module scrape endpoint, 내장 HTTP collector, platform telemetry, service를 통해 만든 custom collector가 함께 사용하는 동일한 active `prom-client` Registry를 반환합니다. Bootstrap을 직접 소유한다면 `MetricsModule.forRoot({ registry })`에 명시적 `registry`를 전달하는 방식을 우선하세요. `getRegistry()`는 DI로 `MetricsService`를 받은 advanced integration이 이미 활성화된 Registry에 third-party Prometheus collector를 등록해야 할 때 사용합니다.
+`MetricsService.getRegistry()`는 module scrape endpoint, 내장 HTTP collector, platform telemetry, service를 통해 만든 custom collector가 함께 사용하는 동일한 active `prom-client` Registry를 반환합니다. Bootstrap을 직접 소유한다면 public `METRICS_REGISTRY` token으로 명시적 shared registry를 구성하세요. `getRegistry()`는 DI로 `MetricsService`를 받은 advanced integration이 이미 활성화된 Registry에 third-party Prometheus collector를 등록해야 할 때 사용합니다.
 
 ### Framework metric과 app metric이 하나의 registry를 공유하기
 
 ```ts
 import { Module } from '@fluojs/core';
 import { Counter, Registry } from 'prom-client';
-import { MetricsModule } from '@fluojs/metrics';
+import { METRICS_REGISTRY, MetricsModule } from '@fluojs/metrics';
+import { bootstrapApplication } from '@fluojs/runtime';
 
 const registry = new Registry();
 
@@ -153,9 +155,14 @@ new Counter({
 });
 
 @Module({
-  imports: [MetricsModule.forRoot({ http: true, registry })],
+  imports: [MetricsModule.forRoot({ http: true })],
 })
 class AppModule {}
+
+const app = await bootstrapApplication({
+  rootModule: AppModule,
+  providers: [{ provide: METRICS_REGISTRY, useValue: registry }],
+});
 ```
 
 여러 `MetricsModule` 인스턴스가 같은 Registry를 의도적으로 공유하는 경우, 내장 HTTP 메트릭은 framework ownership, label schema, effective path-label configuration이 모두 일치할 때만 기존 `http_requests_total`, `http_errors_total`, `http_request_duration_seconds` collector를 재사용합니다. Path-label compatibility 검사는 `pathLabelMode`, 정확히 같은 `pathLabelNormalizer` 함수 참조, `unknownPathLabel` fallback 의미론을 포함하므로 서로 다른 HTTP series policy를 하나의 collector set에 섞는 module instance는 빠르게 실패합니다. 내장 플랫폼 텔레메트리 Gauge도 같은 ownership 규칙을 따릅니다. 모듈이 만든 `fluo_component_ready`, `fluo_component_health`, `fluo_metrics_registry_mode` Gauge는 framework ownership과 label schema가 일치할 때만 재사용합니다. 플랫폼 텔레메트리 상태는 재사용된 Registry별로 추적되므로, 이후 스크레이프는 이전 module instance가 남긴 stale component readiness/health series를 제거한 뒤 메트릭을 반환합니다. Registry scrape wrapper는 최신 active module registration을 사용하며 마지막 registration이 종료되면 Registry의 원래 `metrics()` 함수를 복원합니다. 애플리케이션이 직접 등록한 중복 메트릭 이름은 Prometheus Registry 규칙대로 계속 빠르게 실패합니다.

--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -44,14 +44,15 @@ class AppModule {}
 
 `MetricsModule.forRoot()` exposes `GET /metrics` by default. Pass `http: true` (or an `http` options object) when you want the module to install HTTP request instrumentation middleware. When HTTP instrumentation is enabled, the module records request totals, error counts, and request duration. For production deployments, make the scrape endpoint boundary explicit: either disable it with `path: false` until a platform-level proxy is in place, or attach dedicated endpoint middleware.
 
-The scrape endpoint returns the active `prom-client` registry output with that registry's Prometheus content type. `MetricsModule.forRoot()` creates an isolated registry for each application bootstrap unless you pass a `registry` option; reusing the same dynamic module class for another bootstrap receives fresh isolated metrics state. Pass a shared `Registry` only when framework metrics and application-defined metrics intentionally share one scrape surface.
+The scrape endpoint returns the active `prom-client` registry output with that registry's Prometheus content type. `MetricsModule.forRoot()` creates an isolated registry for each application bootstrap unless the bootstrap configures `METRICS_REGISTRY` or the legacy `registry` option is supplied; reusing the same dynamic module class for another bootstrap receives fresh isolated metrics state. Configure a shared `Registry` at bootstrap only when framework metrics and application-defined metrics intentionally share one scrape surface.
 
 ## Public Responsibilities
 
 | Surface | Responsibility | Boundary |
 | --- | --- | --- |
 | `MetricsModule.forRoot(...)` | Wires the Prometheus scrape endpoint, default metrics, optional HTTP instrumentation, platform telemetry, and registry ownership. | `provider` currently accepts only `'prometheus'`; `path: false` disables the scrape route and route-scoped endpoint middleware. |
-| `MetricsService` | Application-facing facade for custom `Counter`, `Gauge`, and `Histogram` metrics on the active registry, plus `getRegistry()` for deliberate advanced registry sharing. | Use collector helpers for business/application metrics. Use `getRegistry()` only when an integration must hand the active `prom-client` Registry to code that cannot receive `MetricsModule.forRoot({ registry })` directly. |
+| `MetricsService` | Application-facing facade for custom `Counter`, `Gauge`, and `Histogram` metrics on the active registry, plus `getRegistry()` for deliberate advanced registry sharing. | Use collector helpers for business/application metrics. Use `getRegistry()` only when an integration must hand the active `prom-client` Registry to code that cannot receive `METRICS_REGISTRY` at bootstrap. |
+| `METRICS_REGISTRY` | Bootstrap provider token for a shared `prom-client` Registry. | A provider supplied to `bootstrapApplication()` takes ownership over the module's legacy `registry` option. |
 | `Registry` | Re-export of `prom-client`'s `Registry` constructor for shared-registry setups. | It is the same Prometheus registry implementation; duplicate metric names still fail according to Prometheus semantics. |
 | `METER_PROVIDER` / `PrometheusMeterProvider` / meter types | Low-level meter bridge for first-party package integrations that need a provider token or backend-neutral counter/gauge/histogram facade. | Application code usually does not need this token unless it is composing package-level integrations; the only bundled provider backend today is Prometheus. |
 | `middleware` | Module-level middleware that participates in the module middleware chain after framework HTTP metrics and endpoint-scoped middleware. | It is not route-scoped; use `endpointMiddleware` when only the scrape route should be protected. |
@@ -135,14 +136,15 @@ class OrdersService {
 
 Calling `MetricsService.counter(...)` again with the same name recreates the collector and follows Prometheus' duplicate-name failure behavior. Store and reuse the collector instead of creating it inside each request or command handler.
 
-`MetricsService.getRegistry()` returns the same active `prom-client` Registry used by the module scrape endpoint, built-in HTTP collectors, platform telemetry, and custom collectors created through the service. Prefer passing an explicit `registry` to `MetricsModule.forRoot({ registry })` when you own the bootstrap. Use `getRegistry()` for advanced integrations that receive `MetricsService` through DI and need to register a third-party Prometheus collector on the already active registry.
+`MetricsService.getRegistry()` returns the same active `prom-client` Registry used by the module scrape endpoint, built-in HTTP collectors, platform telemetry, and custom collectors created through the service. When you own the bootstrap, configure an explicit shared registry with the public `METRICS_REGISTRY` token. Use `getRegistry()` for advanced integrations that receive `MetricsService` through DI and need to register a third-party Prometheus collector on the already active registry.
 
 ### Share one registry for framework and app metrics
 
 ```ts
 import { Module } from '@fluojs/core';
 import { Counter, Registry } from 'prom-client';
-import { MetricsModule } from '@fluojs/metrics';
+import { METRICS_REGISTRY, MetricsModule } from '@fluojs/metrics';
+import { bootstrapApplication } from '@fluojs/runtime';
 
 const registry = new Registry();
 
@@ -153,9 +155,14 @@ new Counter({
 });
 
 @Module({
-  imports: [MetricsModule.forRoot({ http: true, registry })],
+  imports: [MetricsModule.forRoot({ http: true })],
 })
 class AppModule {}
+
+const app = await bootstrapApplication({
+  rootModule: AppModule,
+  providers: [{ provide: METRICS_REGISTRY, useValue: registry }],
+});
 ```
 
 When multiple metrics module instances intentionally share the same registry, built-in HTTP metrics reuse the existing `http_requests_total`, `http_errors_total`, and `http_request_duration_seconds` collectors instead of registering duplicate framework metrics only when their framework ownership, label schema, and effective path-label configuration match. The path-label compatibility check includes `pathLabelMode`, the exact `pathLabelNormalizer` function reference, and `unknownPathLabel` fallback semantics, so incompatible module instances fail fast instead of mixing different HTTP series policies into one collector set. Built-in platform telemetry gauges follow the same ownership rule: module-created `fluo_component_ready`, `fluo_component_health`, and `fluo_metrics_registry_mode` gauges are reused only when their framework ownership and label schema match. Platform telemetry state is tracked per reused registry, so a later scrape replaces stale module-owned component readiness and health series from an earlier module instance before metrics are returned. The registry scrape wrapper keeps using the latest active module registration and restores the Registry's original `metrics()` function after the last registration closes. Application-defined duplicate names still fail fast.

--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -142,17 +142,10 @@ Calling `MetricsService.counter(...)` again with the same name recreates the col
 
 ```ts
 import { Module } from '@fluojs/core';
-import { Counter, Registry } from 'prom-client';
-import { METRICS_REGISTRY, MetricsModule } from '@fluojs/metrics';
+import { METRICS_REGISTRY, MetricsModule, Registry } from '@fluojs/metrics';
 import { bootstrapApplication } from '@fluojs/runtime';
 
 const registry = new Registry();
-
-new Counter({
-  name: 'orders_total',
-  help: 'Total orders processed',
-  registers: [registry],
-});
 
 @Module({
   imports: [MetricsModule.forRoot({ http: true })],
@@ -164,6 +157,8 @@ const app = await bootstrapApplication({
   providers: [{ provide: METRICS_REGISTRY, useValue: registry }],
 });
 ```
+
+`Registry` is re-exported by `@fluojs/metrics`, so this setup needs no direct `prom-client` dependency. Create application collectors through the `MetricsService` pattern above.
 
 When multiple metrics module instances intentionally share the same registry, built-in HTTP metrics reuse the existing `http_requests_total`, `http_errors_total`, and `http_request_duration_seconds` collectors instead of registering duplicate framework metrics only when their framework ownership, label schema, and effective path-label configuration match. The path-label compatibility check includes `pathLabelMode`, the exact `pathLabelNormalizer` function reference, and `unknownPathLabel` fallback semantics, so incompatible module instances fail fast instead of mixing different HTTP series policies into one collector set. Built-in platform telemetry gauges follow the same ownership rule: module-created `fluo_component_ready`, `fluo_component_health`, and `fluo_metrics_registry_mode` gauges are reused only when their framework ownership and label schema match. Platform telemetry state is tracked per reused registry, so a later scrape replaces stale module-owned component readiness and health series from an earlier module instance before metrics are returned. The registry scrape wrapper keeps using the latest active module registration and restores the Registry's original `metrics()` function after the last registration closes. Application-defined duplicate names still fail fast.
 
@@ -211,18 +206,20 @@ MetricsModule.forRoot({
 ## Public API
 
 - `MetricsModule.forRoot(options)`
+- `METRICS_REGISTRY`, the bootstrap-only token for an intentionally shared `Registry`
 - `MetricsService`, including `counter(...)`, `gauge(...)`, `histogram(...)`, and `getRegistry()`
 - `METER_PROVIDER`
 - `PrometheusMeterProvider`
 - Meter abstraction types: `MeterProvider`, `MeterCounter`, `MeterGauge`, and `MeterHistogram`
 - `HttpMetricsMiddleware` and HTTP path-label option types
 - Module options including `provider` (currently only `'prometheus'`), module-level `middleware`, and endpoint-scoped `endpointMiddleware`
-- `Registry` from `prom-client`
+- `Registry`, re-exported from `prom-client`
 
 ### Operational defaults
 
 - `path` defaults to `'/metrics'`, any string path including `''` exposes a scrape endpoint, and `path: false` disables the scrape endpoint entirely.
-- When `registry` is omitted, each application bootstrap owns a fresh isolated registry, `MetricsService`, meter provider, and telemetry collector set.
+- When neither bootstrap `METRICS_REGISTRY` nor the legacy `registry` option is supplied, each application bootstrap owns a fresh isolated registry, `MetricsService`, meter provider, and telemetry collector set.
+- A bootstrap `METRICS_REGISTRY` provider takes precedence over the legacy `registry` option; an unrelated module provider with the same token does not configure metrics ownership.
 - The scrape response uses the active registry's Prometheus content type and registry contents.
 - `defaultMetrics` defaults to `true`, and `defaultMetrics: false` disables Prometheus default process and Node.js collectors for that registry.
 - `endpointMiddleware` binds class-based route-scoped middleware only to the scrape endpoint; with HTTP instrumentation enabled, endpoint middleware failures are counted by the built-in HTTP collectors.

--- a/packages/metrics/src/metrics-module.test.ts
+++ b/packages/metrics/src/metrics-module.test.ts
@@ -1731,4 +1731,122 @@ describe('MetricsModule', () => {
       await secondApp.close();
     }
   });
+
+  it('records one HTTP observation when module instances use the bootstrap registry', async () => {
+    const sharedRegistry = new Registry();
+
+    @Controller('/orders')
+    class OrdersController {
+      @Get('/:orderId')
+      getOrder(): { id: string } {
+        return { id: '123' };
+      }
+    }
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      controllers: [OrdersController],
+      imports: [
+        MetricsModule.forRoot({ defaultMetrics: false, http: true, path: '/metrics-a' }),
+        MetricsModule.forRoot({ defaultMetrics: false, http: true, path: '/metrics-b' }),
+      ],
+    });
+
+    const app = await bootstrapApplication({
+      providers: [{ provide: METRICS_REGISTRY, useValue: sharedRegistry }],
+      rootModule: AppModule,
+    });
+
+    try {
+      // Given: two HTTP-enabled metrics modules resolve the same bootstrap registry.
+
+      // When: one application request passes through the runtime pipeline.
+      const response = createResponse();
+      await app.dispatch(createRequest('/orders/123'), response);
+
+      // Then: the shared collector receives one observation rather than one per module instance.
+      expect(response.statusCode).toBe(200);
+      expect(await sharedRegistry.metrics()).toContain(
+        'http_requests_total{method="GET",path="/orders/:orderId",status="200"} 1',
+      );
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('ignores a private module registry when bootstrap does not provide one', async () => {
+    const privateRegistry = new Registry();
+
+    class UnrelatedModule {}
+
+    defineModule(UnrelatedModule, {
+      providers: [{ provide: METRICS_REGISTRY, useValue: privateRegistry }],
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [UnrelatedModule, MetricsModule.forRoot({ defaultMetrics: false, path: false })],
+    });
+
+    const app = await bootstrapApplication({
+      rootModule: AppModule,
+    });
+
+    try {
+      // Given: an unrelated module privately provides the bootstrap token.
+
+      // When: metrics resolves its registry without a bootstrap-level provider.
+      const metricsService = (await app.container.resolve(MetricsService)) as MetricsService;
+
+      // Then: metrics retains isolated bootstrap ownership instead of reading the private provider.
+      expect(metricsService.getRegistry()).not.toBe(privateRegistry);
+      expect(await metricsService.getRegistry().metrics()).toContain('fluo_metrics_registry_mode{mode="isolated"} 1');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('prefers the bootstrap registry over the legacy registry option', async () => {
+    const bootstrapRegistry = new Registry();
+    const legacyRegistry = new Registry();
+
+    new Counter({
+      help: 'Bootstrap registry marker',
+      name: 'bootstrap_registry_marker_total',
+      registers: [bootstrapRegistry],
+    }).inc();
+    new Counter({
+      help: 'Legacy registry marker',
+      name: 'legacy_registry_marker_total',
+      registers: [legacyRegistry],
+    }).inc();
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [MetricsModule.forRoot({ defaultMetrics: false, path: false, registry: legacyRegistry })],
+    });
+
+    const app = await bootstrapApplication({
+      providers: [{ provide: METRICS_REGISTRY, useValue: bootstrapRegistry }],
+      rootModule: AppModule,
+    });
+
+    try {
+      // Given: bootstrap and legacy configuration specify distinct registries.
+
+      // When: metrics resolves its active registry.
+      const metricsService = (await app.container.resolve(MetricsService)) as MetricsService;
+      const metricsText = await metricsService.getRegistry().metrics();
+
+      // Then: the bootstrap registry has deterministic precedence.
+      expect(metricsService.getRegistry()).toBe(bootstrapRegistry);
+      expect(metricsText).toContain('bootstrap_registry_marker_total 1');
+      expect(metricsText).not.toContain('legacy_registry_marker_total 1');
+    } finally {
+      await app.close();
+    }
+  });
 });

--- a/packages/metrics/src/metrics-module.test.ts
+++ b/packages/metrics/src/metrics-module.test.ts
@@ -12,9 +12,9 @@ import {
 import { bootstrapApplication, defineModule, PLATFORM_SHELL, type PlatformComponent } from '@fluojs/runtime';
 import { Counter, Gauge, Histogram, Registry } from 'prom-client';
 import { describe, expect, it } from 'vitest';
-import { METER_PROVIDER } from './providers/meter-provider.js';
-import { MetricsModule } from './metrics-module.js';
+import { METRICS_REGISTRY, MetricsModule } from './metrics-module.js';
 import { MetricsService } from './metrics-service.js';
+import { METER_PROVIDER } from './providers/meter-provider.js';
 import { PrometheusMeterProvider } from './providers/prometheus-meter-provider.js';
 
 type TestResponse = FrameworkResponse & { body?: unknown };
@@ -782,7 +782,7 @@ describe('MetricsModule', () => {
     );
   });
 
-  it('uses shared registry when provided via options', async () => {
+  it('uses a shared registry configured by bootstrap providers', async () => {
     const sharedRegistry = new Registry();
 
     const customCounter = new Counter({
@@ -796,10 +796,11 @@ describe('MetricsModule', () => {
     class AppModule {}
 
     defineModule(AppModule, {
-      imports: [MetricsModule.forRoot({ registry: sharedRegistry, defaultMetrics: false })],
+      imports: [MetricsModule.forRoot({ defaultMetrics: false })],
     });
 
     const app = await bootstrapApplication({
+      providers: [{ provide: METRICS_REGISTRY, useValue: sharedRegistry }],
       rootModule: AppModule,
     });
 

--- a/packages/metrics/src/metrics-module.ts
+++ b/packages/metrics/src/metrics-module.ts
@@ -8,7 +8,7 @@ import {
   PLATFORM_SHELL,
   type PlatformShellSnapshot,
 } from '@fluojs/runtime';
-import { RUNTIME_CONTAINER } from '@fluojs/runtime/internal';
+import { BOOTSTRAP_PROVIDER_TOKENS, RUNTIME_CONTAINER } from '@fluojs/runtime/internal';
 import { collectDefaultMetrics, Gauge, Registry as PrometheusRegistry, type Registry } from 'prom-client';
 
 import {
@@ -66,7 +66,6 @@ export const METRICS_REGISTRY: Token<Registry> = Symbol.for('fluo.metrics.regist
 /** Module entry point that exposes `/metrics` and optional HTTP/runtime telemetry. */
 export class MetricsModule {
   private static registeredRegistries = new WeakSet<Registry>();
-  private static httpInstrumentationRegistrations = new WeakMap<Registry, HttpInstrumentationRegistration>();
 
   /**
    * Register framework metrics, optional HTTP middleware, and a scrape endpoint.
@@ -90,9 +89,9 @@ export class MetricsModule {
     const httpOptions = resolveHttpOptions(options.http);
     const metricsPath = options.path === undefined ? '/metrics' : options.path;
 
-    let registryToken: Token<Registry> = Symbol('MetricsModule.registry');
+    const registryToken: Token<Registry> = Symbol('MetricsModule.registry');
     const platformTelemetryToken: Token<RuntimePlatformTelemetry> = Symbol('MetricsModule.platformTelemetry');
-    let httpMetricsMiddleware = httpOptions
+    const httpMetricsMiddleware = httpOptions
       ? createHttpMetricsMiddleware(registryToken, httpOptions)
       : undefined;
 
@@ -106,10 +105,10 @@ export class MetricsModule {
 
     const registryProvider: Provider = {
       provide: registryToken,
-      inject: [RUNTIME_CONTAINER],
-      useFactory: async (container: unknown) => {
+      inject: [RUNTIME_CONTAINER, BOOTSTRAP_PROVIDER_TOKENS],
+      useFactory: async (container: unknown, bootstrapProviderTokens: unknown) => {
         const runtimeContainer = assertRuntimeContainer(container);
-        const configuredRegistry = hasContainerToken(runtimeContainer, METRICS_REGISTRY)
+        const configuredRegistry = assertBootstrapProviderTokens(bootstrapProviderTokens).has(METRICS_REGISTRY)
           ? assertPrometheusRegistry(await runtimeContainer.resolve(METRICS_REGISTRY))
           : undefined;
 
@@ -117,45 +116,23 @@ export class MetricsModule {
       },
     };
     const imports: ModuleType[] = [];
-    const validationProviders: Provider[] = [];
-    let includeRuntimeRegistryProvider = httpMetricsMiddleware === undefined;
+    const includeRuntimeRegistryProvider = httpMetricsMiddleware === undefined;
 
     if (httpOptions && httpMetricsMiddleware) {
-      const existingRegistration = options.registry
-        ? MetricsModule.httpInstrumentationRegistrations.get(options.registry)
-        : undefined;
+      class MetricsHttpInstrumentationModule {}
 
-      if (existingRegistration) {
-        registryToken = existingRegistration.registryToken;
-        httpMetricsMiddleware = undefined;
-        validationProviders.push(createHttpCollectorValidationProvider(registryToken, httpOptions));
-        imports.push(existingRegistration.moduleType);
-      } else {
-        includeRuntimeRegistryProvider = false;
+      defineModule(MetricsHttpInstrumentationModule, {
+        exports: [registryToken],
+        global: true,
+        middleware: [httpMetricsMiddleware],
+        providers: [registryProvider, httpMetricsMiddleware],
+      });
 
-        class MetricsHttpInstrumentationModule {}
-
-        defineModule(MetricsHttpInstrumentationModule, {
-          exports: [registryToken],
-          global: true,
-          middleware: [httpMetricsMiddleware],
-          providers: [registryProvider, httpMetricsMiddleware],
-        });
-
-        if (options.registry) {
-          MetricsModule.httpInstrumentationRegistrations.set(options.registry, {
-            moduleType: MetricsHttpInstrumentationModule,
-            registryToken,
-          });
-        }
-
-        imports.push(MetricsHttpInstrumentationModule);
-      }
+      imports.push(MetricsHttpInstrumentationModule);
     }
 
     const providers: Provider[] = [
       ...(includeRuntimeRegistryProvider ? [registryProvider] : []),
-      ...validationProviders,
       {
         provide: MetricsService,
         inject: [registryToken, platformTelemetryToken],
@@ -168,11 +145,11 @@ export class MetricsModule {
       },
       {
         provide: platformTelemetryToken,
-        inject: [registryToken, RUNTIME_CONTAINER],
-        useFactory: (registry: unknown, container: unknown) => new RuntimePlatformTelemetry(
+        inject: [registryToken, RUNTIME_CONTAINER, BOOTSTRAP_PROVIDER_TOKENS],
+        useFactory: (registry: unknown, container: unknown, bootstrapProviderTokens: unknown) => new RuntimePlatformTelemetry(
           assertPrometheusRegistry(registry),
           assertRuntimeContainer(container),
-          resolveRegistryMode(options, assertRuntimeContainer(container)),
+          resolveRegistryMode(options, assertBootstrapProviderTokens(bootstrapProviderTokens)),
           options.platformTelemetry,
         ),
       },
@@ -250,16 +227,13 @@ type RuntimePlatformTelemetryRegistryState = {
   registrations: RuntimePlatformTelemetry[];
   scrapeChain: Promise<unknown>;
 };
-type HttpInstrumentationRegistration = {
-  moduleType: ModuleType;
-  registryToken: Token<Registry>;
-};
 type ContainerPresenceProbe = RequestContext['container'] & { has?: (token: Token) => boolean };
 
 const PLATFORM_COMPONENT_LABELS = ['component_id', 'component_kind', 'operation', 'result', 'env', 'instance'] as const;
 const REGISTRY_MODE_LABELS = ['mode'] as const;
 const FRAMEWORK_PLATFORM_GAUGES = new WeakSet<Gauge<string>>();
 const PLATFORM_TELEMETRY_REGISTRY_STATES = new WeakMap<Registry, RuntimePlatformTelemetryRegistryState>();
+const HTTP_INSTRUMENTATION_OWNERS = new WeakMap<Container, WeakSet<Registry>>();
 const HEALTH_STATUSES = ['healthy', 'unhealthy', 'degraded'] as const satisfies readonly PlatformHealthStatus[];
 const READINESS_STATUSES = ['ready', 'not-ready', 'degraded'] as const satisfies readonly PlatformReadinessStatus[];
 const PLATFORM_SHELL_TOKEN_NAMES = new Set([String(PLATFORM_SHELL)]);
@@ -267,32 +241,42 @@ const PLATFORM_SHELL_TOKEN_NAMES = new Set([String(PLATFORM_SHELL)]);
 function createHttpMetricsMiddleware(
   registryToken: Token<Registry>,
   httpOptions: HttpMetricsMiddlewareOptions,
-): new (registry: Registry) => Middleware {
-  @Inject(registryToken)
+): new (registry: Registry, container: Container) => Middleware {
+  @Inject(registryToken, RUNTIME_CONTAINER)
   class MetricsHttpMiddleware implements Middleware {
-    private readonly delegate: HttpMetricsMiddleware;
+    private readonly delegate: HttpMetricsMiddleware | undefined;
 
-    constructor(registry: Registry) {
-      this.delegate = new HttpMetricsMiddleware(registry, httpOptions);
+    constructor(registry: Registry, container: unknown) {
+      const httpMetricsMiddleware = new HttpMetricsMiddleware(registry, httpOptions);
+      const runtimeContainer = assertRuntimeContainer(container);
+
+      if (claimsHttpInstrumentationOwnership(runtimeContainer, registry)) {
+        this.delegate = httpMetricsMiddleware;
+      }
     }
 
     handle(context: Parameters<Middleware['handle']>[0], next: Parameters<Middleware['handle']>[1]): ReturnType<Middleware['handle']> {
-      return this.delegate.handle(context, next);
+      return this.delegate ? this.delegate.handle(context, next) : next();
     }
   }
 
   return MetricsHttpMiddleware;
 }
 
-function createHttpCollectorValidationProvider(
-  registryToken: Token<Registry>,
-  httpOptions: HttpMetricsMiddlewareOptions,
-): Provider {
-  return {
-    provide: Symbol('MetricsModule.httpCollectorValidation'),
-    inject: [registryToken],
-    useFactory: (registry: unknown) => new HttpMetricsMiddleware(assertPrometheusRegistry(registry), httpOptions),
-  };
+function claimsHttpInstrumentationOwnership(container: Container, registry: Registry): boolean {
+  let registryOwners = HTTP_INSTRUMENTATION_OWNERS.get(container);
+
+  if (!registryOwners) {
+    registryOwners = new WeakSet();
+    HTTP_INSTRUMENTATION_OWNERS.set(container, registryOwners);
+  }
+
+  if (registryOwners.has(registry)) {
+    return false;
+  }
+
+  registryOwners.add(registry);
+  return true;
 }
 
 function assertPrometheusRegistry(value: unknown): Registry {
@@ -311,8 +295,16 @@ function assertRuntimeContainer(value: unknown): Container {
   return value;
 }
 
-function resolveRegistryMode(options: MetricsModuleOptions, container: Container): RegistryMode {
-  return options.registry || hasContainerToken(container, METRICS_REGISTRY) ? 'shared' : 'isolated';
+function assertBootstrapProviderTokens(value: unknown): ReadonlySet<Token> {
+  if (!(value instanceof Set)) {
+    throw new Error('MetricsModule bootstrap provider token metadata resolved invalidly.');
+  }
+
+  return value as ReadonlySet<Token>;
+}
+
+function resolveRegistryMode(options: MetricsModuleOptions, bootstrapProviderTokens: ReadonlySet<Token>): RegistryMode {
+  return options.registry || bootstrapProviderTokens.has(METRICS_REGISTRY) ? 'shared' : 'isolated';
 }
 
 function isRuntimeContainer(value: unknown): value is Container {

--- a/packages/metrics/src/metrics-module.ts
+++ b/packages/metrics/src/metrics-module.ts
@@ -1,6 +1,6 @@
 import { Inject, type Token } from '@fluojs/core';
-import { ContainerResolutionError, type Container, type Provider } from '@fluojs/di';
-import { Controller, Get, forRoutes, type Middleware, type MiddlewareLike, type RequestContext } from '@fluojs/http';
+import { type Container, ContainerResolutionError, type Provider } from '@fluojs/di';
+import { Controller, forRoutes, Get, type Middleware, type MiddlewareLike, type RequestContext } from '@fluojs/http';
 import {
   defineModule,
   type ModuleType,
@@ -17,8 +17,8 @@ import {
   type HttpMetricsPathLabelMode,
   type HttpMetricsPathLabelNormalizer,
 } from './http-metrics-middleware.js';
-import { METER_PROVIDER } from './providers/meter-provider.js';
 import { MetricsService } from './metrics-service.js';
+import { METER_PROVIDER } from './providers/meter-provider.js';
 import { PrometheusMeterProvider } from './providers/prometheus-meter-provider.js';
 
 /** HTTP-specific metric labeling options exposed by `MetricsModule.forRoot(...)`. */
@@ -56,9 +56,12 @@ export interface MetricsModuleOptions {
     /** Instance label value. Defaults to `local`. */
     instance?: string;
   };
-  /** External Prometheus registry to share between built-in and custom metrics. */
+  /** Legacy shared-registry fallback. Prefer the `METRICS_REGISTRY` bootstrap provider. */
   registry?: Registry;
 }
+
+/** Bootstrap provider token for a Registry shared by metrics module instances. */
+export const METRICS_REGISTRY: Token<Registry> = Symbol.for('fluo.metrics.registry');
 
 /** Module entry point that exposes `/metrics` and optional HTTP/runtime telemetry. */
 export class MetricsModule {
@@ -72,11 +75,10 @@ export class MetricsModule {
    * ```ts
    * MetricsModule.forRoot({
    *   http: { pathLabelMode: 'template' },
-   *   registry: new Registry(),
    * });
    * ```
    *
-   * @param options Metrics endpoint, registry, HTTP middleware, and runtime telemetry configuration.
+   * @param options Metrics endpoint, HTTP middleware, and runtime telemetry configuration.
    * @returns A runtime module that exposes metrics through the configured path.
    */
   static forRoot(options: MetricsModuleOptions = {}): ModuleType {
@@ -104,7 +106,15 @@ export class MetricsModule {
 
     const registryProvider: Provider = {
       provide: registryToken,
-      useFactory: () => MetricsModule.createRegistry(options),
+      inject: [RUNTIME_CONTAINER],
+      useFactory: async (container: unknown) => {
+        const runtimeContainer = assertRuntimeContainer(container);
+        const configuredRegistry = hasContainerToken(runtimeContainer, METRICS_REGISTRY)
+          ? assertPrometheusRegistry(await runtimeContainer.resolve(METRICS_REGISTRY))
+          : undefined;
+
+        return MetricsModule.createRegistry(options, configuredRegistry);
+      },
     };
     const imports: ModuleType[] = [];
     const validationProviders: Provider[] = [];
@@ -162,7 +172,7 @@ export class MetricsModule {
         useFactory: (registry: unknown, container: unknown) => new RuntimePlatformTelemetry(
           assertPrometheusRegistry(registry),
           assertRuntimeContainer(container),
-          options.registry ? 'shared' : 'isolated',
+          resolveRegistryMode(options, assertRuntimeContainer(container)),
           options.platformTelemetry,
         ),
       },
@@ -204,8 +214,8 @@ export class MetricsModule {
     return MetricsRuntimeModule;
   }
 
-  private static createRegistry(options: MetricsModuleOptions): Registry {
-    const registry = options.registry ?? new PrometheusRegistry();
+  private static createRegistry(options: MetricsModuleOptions, configuredRegistry?: Registry): Registry {
+    const registry = configuredRegistry ?? options.registry ?? new PrometheusRegistry();
 
     if (options.defaultMetrics !== false && !MetricsModule.registeredRegistries.has(registry)) {
       MetricsModule.registeredRegistries.add(registry);
@@ -299,6 +309,10 @@ function assertRuntimeContainer(value: unknown): Container {
   }
 
   return value;
+}
+
+function resolveRegistryMode(options: MetricsModuleOptions, container: Container): RegistryMode {
+  return options.registry || hasContainerToken(container, METRICS_REGISTRY) ? 'shared' : 'isolated';
 }
 
 function isRuntimeContainer(value: unknown): value is Container {

--- a/packages/metrics/src/public-surface.test.ts
+++ b/packages/metrics/src/public-surface.test.ts
@@ -3,12 +3,19 @@ import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 import * as metrics from './index.js';
-import { MetricsService, Registry } from './index.js';
-import type { MeterCounter, MeterGauge, MeterHistogram, MeterProvider } from './index.js';
+import {
+  type MeterCounter,
+  type MeterGauge,
+  type MeterHistogram,
+  type MeterProvider,
+  MetricsService,
+  Registry,
+} from './index.js';
 
 describe('@fluojs/metrics public surface', () => {
   it('keeps the documented metrics barrel public while hiding package-only wiring details', () => {
     expect(metrics).toHaveProperty('MetricsModule');
+    expect(metrics).toHaveProperty('METRICS_REGISTRY');
     expect(metrics).toHaveProperty('MetricsService');
     expect(metrics).toHaveProperty('METER_PROVIDER');
     expect(metrics).toHaveProperty('PrometheusMeterProvider');

--- a/packages/runtime/src/bootstrap.ts
+++ b/packages/runtime/src/bootstrap.ts
@@ -20,16 +20,25 @@ import { type BootstrapTimingPhase, createBootstrapTimingDiagnostics } from './h
 import { getRuntimeClassDiMetadata } from './internal/core-metadata.js';
 import { RuntimeDefaultBinder } from './internal/http-runtime.js';
 import { createDefaultApplicationLogger } from './logging/default-logger.js';
+import { defineModule } from './module-definition.js';
 import { compileModuleGraph, providerToken } from './module-graph.js';
 import { createRuntimePlatformShell, type RuntimePlatformShell } from './platform-shell.js';
-import { defineModule } from './module-definition.js';
 import {
   createLifecycleCloseError,
   createRetryableShutdownState,
   type RetryableShutdownState,
 } from './retryable-shutdown.js';
 import type { BootstrapReadySignal } from './tokens.js';
-import { APPLICATION_LOGGER, BOOTSTRAP_READY_SIGNAL, COMPILED_MODULES, HTTP_APPLICATION_ADAPTER, PLATFORM_SHELL, RUNTIME_CLEANUP_REGISTRATION, RUNTIME_CONTAINER } from './tokens.js';
+import {
+  APPLICATION_LOGGER,
+  BOOTSTRAP_PROVIDER_TOKENS,
+  BOOTSTRAP_READY_SIGNAL,
+  COMPILED_MODULES,
+  HTTP_APPLICATION_ADAPTER,
+  PLATFORM_SHELL,
+  RUNTIME_CLEANUP_REGISTRATION,
+  RUNTIME_CONTAINER,
+} from './tokens.js';
 import type {
   Application,
   ApplicationContext,
@@ -46,7 +55,6 @@ import type {
   ExceptionFilterHandler,
   MicroserviceApplication,
   MicroserviceRuntime,
-  ModuleDefinition,
   ModuleType,
   OnApplicationBootstrap,
   OnApplicationShutdown,
@@ -1325,8 +1333,14 @@ function createRuntimeProviders(
   options: { readonly providers?: Provider[] },
   logger: ApplicationLogger,
 ): Provider[] {
+  const bootstrapProviderTokens = new Set((options.providers ?? []).map(providerToken));
+
   return [
     ...(options.providers ?? []),
+    {
+      provide: BOOTSTRAP_PROVIDER_TOKENS,
+      useValue: bootstrapProviderTokens,
+    },
     {
       provide: APPLICATION_LOGGER,
       useValue: logger,

--- a/packages/runtime/src/exports.test.ts
+++ b/packages/runtime/src/exports.test.ts
@@ -41,6 +41,7 @@ describe('runtime export boundaries', () => {
   it('keeps internal root focused on wiring tokens and runtime-owned metadata seams', () => {
     expect(Object.keys(runtimeInternal).sort()).toEqual([
       'APPLICATION_LOGGER',
+      'BOOTSTRAP_PROVIDER_TOKENS',
       'BOOTSTRAP_READY_SIGNAL',
       'COMPILED_MODULES',
       'HTTP_APPLICATION_ADAPTER',

--- a/packages/runtime/src/internal.ts
+++ b/packages/runtime/src/internal.ts
@@ -1,16 +1,16 @@
 export { getRuntimeClassDiMetadata } from './internal/core-metadata.js';
-export { defineModule } from './module-definition.js';
-export { createRuntimeRouteInspection } from './route-inspection.js';
 export type { RuntimeRouteInspectionMetadata } from './internal/route-inspection-metadata.js';
 export {
   defineLegacyRuntimeRouteInspectionMetadata,
   defineStandardRuntimeRouteInspectionMetadata,
   getRuntimeRouteInspectionMetadata,
 } from './internal/route-inspection-metadata.js';
-export type { ModuleDefinition, ModuleType } from './types.js';
+export { defineModule } from './module-definition.js';
+export { createRuntimeRouteInspection } from './route-inspection.js';
 export type { BootstrapReadySignal } from './tokens.js';
 export {
   APPLICATION_LOGGER,
+  BOOTSTRAP_PROVIDER_TOKENS,
   BOOTSTRAP_READY_SIGNAL,
   COMPILED_MODULES,
   HTTP_APPLICATION_ADAPTER,
@@ -18,3 +18,4 @@ export {
   RUNTIME_CLEANUP_REGISTRATION,
   RUNTIME_CONTAINER,
 } from './tokens.js';
+export type { ModuleDefinition, ModuleType } from './types.js';

--- a/packages/runtime/src/tokens.ts
+++ b/packages/runtime/src/tokens.ts
@@ -2,10 +2,8 @@ import type { Token } from '@fluojs/core';
 import type { Container } from '@fluojs/di';
 import type { HttpApplicationAdapter } from '@fluojs/http';
 
-import type { ApplicationLogger } from './types.js';
-import type { CompiledModule } from './types.js';
-import type { RuntimeCleanupRegistration } from './types.js';
 import type { PlatformShell } from './platform-contract.js';
+import type { ApplicationLogger, CompiledModule, RuntimeCleanupRegistration } from './types.js';
 
 /** Internal signal that resolves only after application bootstrap reaches runtime readiness. */
 export interface BootstrapReadySignal {
@@ -22,6 +20,11 @@ export const APPLICATION_LOGGER: Token<ApplicationLogger> = Symbol.for('fluo.run
  * Injection token for the runtime container.
  */
 export const RUNTIME_CONTAINER: Token<Container> = Symbol('RUNTIME_CONTAINER');
+
+/**
+ * Injection token for the effective provider tokens supplied to the application bootstrap.
+ */
+export const BOOTSTRAP_PROVIDER_TOKENS: Token<ReadonlySet<Token>> = Symbol('BOOTSTRAP_PROVIDER_TOKENS');
 
 /**
  * Injection token for the compiled module list.


### PR DESCRIPTION
## Summary

Move shared Prometheus registry ownership to application bootstrap while preserving isolated-per-bootstrap defaults and the legacy `registry` option.

Linked context: Closes #3201

## Changes

- add public `METRICS_REGISTRY` bootstrap configuration with bootstrap-only provenance
- deduplicate HTTP instrumentation by runtime container and effective registry
- preserve bootstrap-over-legacy precedence and reject unrelated private module configuration
- update EN/KO metrics contracts and add runtime/metrics Changesets

## Testing

- dependency-closure build for `@fluojs/metrics`
- `@fluojs/runtime` typecheck and 342 tests
- `@fluojs/metrics` typecheck and 69 tests
- runtime reverse-dependent tests; GraphQL contention isolated by closure rebuild and two consecutive 135/135 runs
- Changeset stable release-lane gate, docs locale parity, Biome, LSP
- exact-head code, contract, and verification re-review: PASS

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated.
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. (N/A)
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests. (N/A)