### PR TITLE
feat(metrics): configure HTTP duration histogram buckets (#3211)

### DIFF
--- a/.changeset/configurable-http-duration-buckets.md
+++ b/.changeset/configurable-http-duration-buckets.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/metrics": minor
+---
+
+Add configurable duration histogram buckets for built-in HTTP metrics.

--- a/packages/metrics/README.ko.md
+++ b/packages/metrics/README.ko.md
@@ -94,7 +94,8 @@ MetricsModule.forRoot({
 
 `durationHistogramBuckets`는 내장 HTTP request duration histogram의
 `prom-client` 기본값을 대체합니다. 값의 단위는 초이며, alerting하려는
-latency 범위에 맞게 정해야 합니다.
+latency 범위에 맞게 정해야 합니다. 각 경계는 유한하고 엄격히 증가해야 하며,
+잘못된 구성은 setup 중 거부됩니다.
 
 ### 메트릭 엔드포인트 보호 또는 비활성화
 

--- a/packages/metrics/README.ko.md
+++ b/packages/metrics/README.ko.md
@@ -82,6 +82,20 @@ MetricsModule.forRoot({
 });
 ```
 
+### HTTP duration histogram bucket 구성
+
+```ts
+MetricsModule.forRoot({
+  http: {
+    durationHistogramBuckets: [0.01, 0.05, 0.1, 0.5, 1, 5],
+  },
+});
+```
+
+`durationHistogramBuckets`는 내장 HTTP request duration histogram의
+`prom-client` 기본값을 대체합니다. 값의 단위는 초이며, alerting하려는
+latency 범위에 맞게 정해야 합니다.
+
 ### 메트릭 엔드포인트 보호 또는 비활성화
 
 ```ts
@@ -158,7 +172,7 @@ new Counter({
 class AppModule {}
 ```
 
-여러 `MetricsModule` 인스턴스가 같은 Registry를 의도적으로 공유하는 경우, 내장 HTTP 메트릭은 framework ownership, label schema, effective path-label configuration이 모두 일치할 때만 기존 `http_requests_total`, `http_errors_total`, `http_request_duration_seconds` collector를 재사용합니다. Path-label compatibility 검사는 `pathLabelMode`, 정확히 같은 `pathLabelNormalizer` 함수 참조, `unknownPathLabel` fallback 의미론을 포함하므로 서로 다른 HTTP series policy를 하나의 collector set에 섞는 module instance는 빠르게 실패합니다. 내장 플랫폼 텔레메트리 Gauge도 같은 ownership 규칙을 따릅니다. 모듈이 만든 `fluo_component_ready`, `fluo_component_health`, `fluo_metrics_registry_mode` Gauge는 framework ownership과 label schema가 일치할 때만 재사용합니다. 플랫폼 텔레메트리 상태는 재사용된 Registry별로 추적되므로, 이후 스크레이프는 이전 module instance가 남긴 stale component readiness/health series를 제거한 뒤 메트릭을 반환합니다. Registry scrape wrapper는 최신 active module registration을 사용하며 마지막 registration이 종료되면 Registry의 원래 `metrics()` 함수를 복원합니다. 애플리케이션이 직접 등록한 중복 메트릭 이름은 Prometheus Registry 규칙대로 계속 빠르게 실패합니다.
+여러 `MetricsModule` 인스턴스가 같은 Registry를 의도적으로 공유하는 경우, 내장 HTTP 메트릭은 framework ownership, label schema, effective HTTP instrumentation configuration이 모두 일치할 때만 기존 `http_requests_total`, `http_errors_total`, `http_request_duration_seconds` collector를 재사용합니다. Compatibility 검사는 `pathLabelMode`, 정확히 같은 `pathLabelNormalizer` 함수 참조, `unknownPathLabel` fallback 의미론, 순서가 있는 `durationHistogramBuckets` 값을 포함하므로 서로 다른 HTTP series policy를 하나의 collector set에 섞는 module instance는 빠르게 실패합니다. 내장 플랫폼 텔레메트리 Gauge도 같은 ownership 규칙을 따릅니다. 모듈이 만든 `fluo_component_ready`, `fluo_component_health`, `fluo_metrics_registry_mode` Gauge는 framework ownership과 label schema가 일치할 때만 재사용합니다. 플랫폼 텔레메트리 상태는 재사용된 Registry별로 추적되므로, 이후 스크레이프는 이전 module instance가 남긴 stale component readiness/health series를 제거한 뒤 메트릭을 반환합니다. Registry scrape wrapper는 최신 active module registration을 사용하며 마지막 registration이 종료되면 Registry의 원래 `metrics()` 함수를 복원합니다. 애플리케이션이 직접 등록한 중복 메트릭 이름은 Prometheus Registry 규칙대로 계속 빠르게 실패합니다.
 
 ### 중복 메트릭 이름은 계속 빠르게 실패합니다
 
@@ -220,7 +234,8 @@ MetricsModule.forRoot({
 - `defaultMetrics`의 기본값은 `true`이며, `defaultMetrics: false`로 해당 Registry의 Prometheus 기본 프로세스/Node.js collector를 끌 수 있습니다.
 - `endpointMiddleware`는 class-based route-scoped middleware를 스크레이프 엔드포인트에만 바인딩합니다. HTTP 계측이 활성화된 경우 endpoint middleware 실패는 내장 HTTP collector에 집계됩니다.
 - HTTP 메트릭은 `http: true` 또는 `http` 옵션 객체를 전달한 경우에만 설치되며, 설치된 뒤에는 기본적으로 템플릿 기반 경로 라벨 정규화를 사용합니다.
-- 내장 HTTP collector는 같은 Registry를 공유하는 모듈 인스턴스 사이에서 framework-owned이고 예상 label schema 및 일치하는 path-label configuration을 가진 경우에만 재사용됩니다. 플랫폼 텔레메트리 Gauge는 framework-owned이고 예상 label schema를 가진 경우에만 재사용되며, 커스텀 애플리케이션 메트릭 이름 충돌은 Prometheus의 중복 이름 실패 동작을 유지합니다.
+- `http.durationHistogramBuckets`는 내장 HTTP request duration histogram bucket을 명시적인 초 단위 경계로 대체합니다.
+- 내장 HTTP collector는 같은 Registry를 공유하는 모듈 인스턴스 사이에서 framework-owned이고 예상 label schema 및 일치하는 HTTP instrumentation configuration을 가진 경우에만 재사용됩니다. 플랫폼 텔레메트리 Gauge는 framework-owned이고 예상 label schema를 가진 경우에만 재사용되며, 커스텀 애플리케이션 메트릭 이름 충돌은 Prometheus의 중복 이름 실패 동작을 유지합니다.
 - Shared Registry 텔레메트리 refresh는 소유 metrics module이 하나라도 active인 동안 유지되고 마지막 module이 종료되면 원래 `metrics()` 함수를 복원합니다.
 - raw path 라벨은 `allowUnsafeRawPathLabelMode: true`를 명시한 bounded internal route에서만 사용해야 합니다.
 - 플랫폼 텔레메트리는 `PLATFORM_SHELL`이 실제로 누락된 경우에만 생략되며, 그 외 resolve 실패는 스크레이프를 실패시킵니다.

--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -94,7 +94,8 @@ MetricsModule.forRoot({
 
 `durationHistogramBuckets` replaces the built-in HTTP request duration histogram's
 `prom-client` defaults. Values are measured in seconds and must fit the latency
-range you intend to alert on.
+range you intend to alert on. Each boundary must be finite and strictly increasing;
+invalid configuration is rejected during setup.
 
 ### Protect or disable the metrics endpoint
 

--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -82,6 +82,20 @@ MetricsModule.forRoot({
 });
 ```
 
+### Configure HTTP duration histogram buckets
+
+```ts
+MetricsModule.forRoot({
+  http: {
+    durationHistogramBuckets: [0.01, 0.05, 0.1, 0.5, 1, 5],
+  },
+});
+```
+
+`durationHistogramBuckets` replaces the built-in HTTP request duration histogram's
+`prom-client` defaults. Values are measured in seconds and must fit the latency
+range you intend to alert on.
+
 ### Protect or disable the metrics endpoint
 
 ```ts
@@ -158,7 +172,7 @@ new Counter({
 class AppModule {}
 ```
 
-When multiple metrics module instances intentionally share the same registry, built-in HTTP metrics reuse the existing `http_requests_total`, `http_errors_total`, and `http_request_duration_seconds` collectors instead of registering duplicate framework metrics only when their framework ownership, label schema, and effective path-label configuration match. The path-label compatibility check includes `pathLabelMode`, the exact `pathLabelNormalizer` function reference, and `unknownPathLabel` fallback semantics, so incompatible module instances fail fast instead of mixing different HTTP series policies into one collector set. Built-in platform telemetry gauges follow the same ownership rule: module-created `fluo_component_ready`, `fluo_component_health`, and `fluo_metrics_registry_mode` gauges are reused only when their framework ownership and label schema match. Platform telemetry state is tracked per reused registry, so a later scrape replaces stale module-owned component readiness and health series from an earlier module instance before metrics are returned. The registry scrape wrapper keeps using the latest active module registration and restores the Registry's original `metrics()` function after the last registration closes. Application-defined duplicate names still fail fast.
+When multiple metrics module instances intentionally share the same registry, built-in HTTP metrics reuse the existing `http_requests_total`, `http_errors_total`, and `http_request_duration_seconds` collectors instead of registering duplicate framework metrics only when their framework ownership, label schema, and effective HTTP instrumentation configuration match. Compatibility includes `pathLabelMode`, the exact `pathLabelNormalizer` function reference, `unknownPathLabel` fallback semantics, and ordered `durationHistogramBuckets` values, so incompatible module instances fail fast instead of mixing different HTTP series policies into one collector set. Built-in platform telemetry gauges follow the same ownership rule: module-created `fluo_component_ready`, `fluo_component_health`, and `fluo_metrics_registry_mode` gauges are reused only when their framework ownership and label schema match. Platform telemetry state is tracked per reused registry, so a later scrape replaces stale module-owned component readiness and health series from an earlier module instance before metrics are returned. The registry scrape wrapper keeps using the latest active module registration and restores the Registry's original `metrics()` function after the last registration closes. Application-defined duplicate names still fail fast.
 
 ### Duplicate metric names still fail fast
 
@@ -220,7 +234,8 @@ MetricsModule.forRoot({
 - `defaultMetrics` defaults to `true`, and `defaultMetrics: false` disables Prometheus default process and Node.js collectors for that registry.
 - `endpointMiddleware` binds class-based route-scoped middleware only to the scrape endpoint; with HTTP instrumentation enabled, endpoint middleware failures are counted by the built-in HTTP collectors.
 - HTTP metrics are installed only when `http: true` or an `http` options object is provided, and then default to template-normalized path labels.
-- Built-in HTTP collectors are reused when module instances share one registry only if they are framework-owned, have the expected label schema, and use matching path-label configuration; platform telemetry gauges are reused only if they are framework-owned and have the expected label schema; custom application metric name collisions keep Prometheus' duplicate-name failure behavior.
+- `http.durationHistogramBuckets` replaces the built-in HTTP request duration histogram buckets with explicit second-based boundaries.
+- Built-in HTTP collectors are reused when module instances share one registry only if they are framework-owned, have the expected label schema, and use matching HTTP instrumentation configuration; platform telemetry gauges are reused only if they are framework-owned and have the expected label schema; custom application metric name collisions keep Prometheus' duplicate-name failure behavior.
 - Shared Registry telemetry refresh remains installed while any owning metrics module is active and restores the original `metrics()` function after the last module closes.
 - Raw path labels require `allowUnsafeRawPathLabelMode: true` and should stay limited to bounded internal routes.
 - Platform telemetry is omitted only when `PLATFORM_SHELL` is genuinely missing; other resolution failures fail the scrape.

--- a/packages/metrics/src/http-metrics-middleware.test.ts
+++ b/packages/metrics/src/http-metrics-middleware.test.ts
@@ -99,6 +99,27 @@ describe('HttpMetricsMiddleware', () => {
     expect(metricsText).toContain('http_requests_total{method="GET",path="/users/:id",status="200"} 1');
   });
 
+  it('uses configured duration histogram buckets', async () => {
+    const registry = new Registry();
+    const middleware = new HttpMetricsMiddleware(registry, {
+      durationHistogramBuckets: [0.001, 0.002],
+    });
+    const context = createContext('/orders');
+
+    await middleware.handle(context, async () => {
+      context.response.setStatus(200);
+    });
+
+    const metricsText = await registry.metrics();
+
+    expect(metricsText).toContain(
+      'http_request_duration_seconds_bucket{le="0.001",method="GET",path="/orders",status="200"}',
+    );
+    expect(metricsText).toContain(
+      'http_request_duration_seconds_bucket{le="0.002",method="GET",path="/orders",status="200"}',
+    );
+  });
+
   it('rejects raw path labels unless explicitly allowed', () => {
     const registry = new Registry();
 

--- a/packages/metrics/src/http-metrics-middleware.test.ts
+++ b/packages/metrics/src/http-metrics-middleware.test.ts
@@ -118,6 +118,46 @@ describe('HttpMetricsMiddleware', () => {
     expect(metricsText).toContain(
       'http_request_duration_seconds_bucket{le="0.002",method="GET",path="/orders",status="200"}',
     );
+    expect(metricsText).not.toContain(
+      'http_request_duration_seconds_bucket{le="0.005",method="GET",path="/orders",status="200"}',
+    );
+  });
+
+  it('retains prom-client default duration histogram buckets when omitted', async () => {
+    const registry = new Registry();
+    const middleware = new HttpMetricsMiddleware(registry);
+    const context = createContext('/orders');
+
+    await middleware.handle(context, async () => {
+      context.response.setStatus(200);
+    });
+
+    const metricsText = await registry.metrics();
+
+    expect(metricsText).toContain(
+      'http_request_duration_seconds_bucket{le="0.005",method="GET",path="/orders",status="200"}',
+    );
+    expect(metricsText).toContain(
+      'http_request_duration_seconds_bucket{le="10",method="GET",path="/orders",status="200"}',
+    );
+  });
+
+  it.each([
+    ['non-finite', [Number.NaN]],
+    ['duplicate', [0.1, 0.1]],
+    ['non-strictly-increasing', [0.2, 0.1]],
+  ])('rejects %s duration histogram bucket boundaries before collector registration', (_description, durationHistogramBuckets) => {
+    const registry = new Registry();
+
+    expect(() => {
+      new HttpMetricsMiddleware(registry, {
+        durationHistogramBuckets,
+      });
+    }).toThrow('HttpMetricsMiddleware durationHistogramBuckets must contain finite, strictly increasing boundaries.');
+
+    expect(registry.getSingleMetric('http_requests_total')).toBeUndefined();
+    expect(registry.getSingleMetric('http_errors_total')).toBeUndefined();
+    expect(registry.getSingleMetric('http_request_duration_seconds')).toBeUndefined();
   });
 
   it('rejects raw path labels unless explicitly allowed', () => {
@@ -164,7 +204,7 @@ describe('HttpMetricsMiddleware', () => {
         pathLabelMode: 'raw',
       });
     }).toThrow(
-      'Metric name "http_requests_total" is already registered with framework HTTP path-label configuration pathLabelMode="template", pathLabelNormalizer=none, unknownPathLabel="UNKNOWN". Built-in HTTP metrics require matching path-label configuration before reuse; received pathLabelMode="raw", pathLabelNormalizer=none, unknownPathLabel="UNKNOWN".',
+      'Metric name "http_requests_total" is already registered with framework HTTP collector configuration pathLabelMode="template", pathLabelNormalizer=none, unknownPathLabel="UNKNOWN". Built-in HTTP metrics require matching HTTP collector configuration before reuse; received pathLabelMode="raw", pathLabelNormalizer=none, unknownPathLabel="UNKNOWN".',
     );
   });
 
@@ -185,7 +225,7 @@ describe('HttpMetricsMiddleware', () => {
       new HttpMetricsMiddleware(registry, {
         pathLabelNormalizer: ({ path }) => (path.startsWith('/users/') ? '/users/:id' : '/other'),
       });
-    }).toThrow('Built-in HTTP metrics require matching path-label configuration before reuse');
+    }).toThrow('Built-in HTTP metrics require matching HTTP collector configuration before reuse');
   });
 
   it('records non-throwing 4xx and 5xx responses as request errors', async () => {

--- a/packages/metrics/src/http-metrics-middleware.ts
+++ b/packages/metrics/src/http-metrics-middleware.ts
@@ -272,6 +272,20 @@ function resolveHttpMetricsCollectorConfiguration(options: HttpMetricsMiddleware
     );
   }
 
+  let previousDurationHistogramBucket: number | undefined;
+  for (const durationHistogramBucket of options.durationHistogramBuckets ?? []) {
+    if (
+      !Number.isFinite(durationHistogramBucket)
+      || (previousDurationHistogramBucket !== undefined && durationHistogramBucket <= previousDurationHistogramBucket)
+    ) {
+      throw new Error(
+        'HttpMetricsMiddleware durationHistogramBuckets must contain finite, strictly increasing boundaries.',
+      );
+    }
+
+    previousDurationHistogramBucket = durationHistogramBucket;
+  }
+
   return {
     durationHistogramBuckets: options.durationHistogramBuckets ? [...options.durationHistogramBuckets] : undefined,
     pathLabelMode: options.pathLabelMode ?? 'template',
@@ -289,7 +303,7 @@ function assertHttpMetricConfiguration(
 
   if (!registered) {
     throw new Error(
-      `Metric name "${metricName}" is already registered as a framework-owned HTTP collector without path-label configuration metadata. Built-in HTTP metrics require matching path-label configuration before reuse.`,
+      `Metric name "${metricName}" is already registered as a framework-owned HTTP collector without HTTP instrumentation configuration metadata. Built-in HTTP metrics require matching HTTP collector configuration before reuse.`,
     );
   }
 
@@ -298,7 +312,7 @@ function assertHttpMetricConfiguration(
   }
 
   throw new Error(
-    `Metric name "${metricName}" is already registered with framework HTTP path-label configuration ${describeHttpMetricConfiguration(registered)}. Built-in HTTP metrics require matching path-label configuration before reuse; received ${describeHttpMetricConfiguration(expected)}.`,
+    `Metric name "${metricName}" is already registered with framework HTTP collector configuration ${describeHttpMetricConfiguration(registered)}. Built-in HTTP metrics require matching HTTP collector configuration before reuse; received ${describeHttpMetricConfiguration(expected)}.`,
   );
 }
 

--- a/packages/metrics/src/http-metrics-middleware.ts
+++ b/packages/metrics/src/http-metrics-middleware.ts
@@ -18,6 +18,7 @@ type MetricHistogramLike = {
 };
 
 type HttpMetricsCollectorConfiguration = {
+  durationHistogramBuckets?: readonly number[];
   pathLabelMode: HttpMetricsPathLabelMode;
   pathLabelNormalizer?: HttpMetricsPathLabelNormalizer;
   unknownPathLabel: string;
@@ -43,6 +44,8 @@ export type HttpMetricsPathLabelNormalizer = (context: HttpMetricsPathLabelConte
 
 /** Options that tune HTTP request metric label generation. */
 export interface HttpMetricsMiddlewareOptions {
+  /** Duration buckets in seconds for the built-in HTTP request histogram. */
+  durationHistogramBuckets?: readonly number[];
   pathLabelMode?: HttpMetricsPathLabelMode;
   pathLabelNormalizer?: HttpMetricsPathLabelNormalizer;
   unknownPathLabel?: string;
@@ -236,6 +239,9 @@ function getOrCreateHttpHistogram(
     help: config.help,
     labelNames: [...config.labelNames],
     name: config.name,
+    ...(collectorConfiguration.durationHistogramBuckets
+      ? { buckets: [...collectorConfiguration.durationHistogramBuckets] }
+      : {}),
   });
   FRAMEWORK_HTTP_HISTOGRAMS.add(histogram);
   FRAMEWORK_HTTP_COLLECTOR_CONFIGURATION.set(histogram, collectorConfiguration);
@@ -267,6 +273,7 @@ function resolveHttpMetricsCollectorConfiguration(options: HttpMetricsMiddleware
   }
 
   return {
+    durationHistogramBuckets: options.durationHistogramBuckets ? [...options.durationHistogramBuckets] : undefined,
     pathLabelMode: options.pathLabelMode ?? 'template',
     pathLabelNormalizer: options.pathLabelNormalizer,
     unknownPathLabel: options.unknownPathLabel ?? 'UNKNOWN',
@@ -299,13 +306,29 @@ function hasSameHttpMetricConfiguration(
   left: HttpMetricsCollectorConfiguration,
   right: HttpMetricsCollectorConfiguration,
 ): boolean {
-  return left.pathLabelMode === right.pathLabelMode
+  return hasSameDurationHistogramBuckets(left.durationHistogramBuckets, right.durationHistogramBuckets)
+    && left.pathLabelMode === right.pathLabelMode
     && left.pathLabelNormalizer === right.pathLabelNormalizer
     && left.unknownPathLabel === right.unknownPathLabel;
 }
 
+function hasSameDurationHistogramBuckets(
+  left: readonly number[] | undefined,
+  right: readonly number[] | undefined,
+): boolean {
+  return left === right
+    || (left !== undefined
+      && right !== undefined
+      && left.length === right.length
+      && left.every((bucket, index) => bucket === right[index]));
+}
+
 function describeHttpMetricConfiguration(configuration: HttpMetricsCollectorConfiguration): string {
-  return `pathLabelMode="${configuration.pathLabelMode}", pathLabelNormalizer=${configuration.pathLabelNormalizer ? 'custom' : 'none'}, unknownPathLabel="${configuration.unknownPathLabel}"`;
+  const durationHistogramBuckets = configuration.durationHistogramBuckets
+    ? `, durationHistogramBuckets=[${configuration.durationHistogramBuckets.join(',')}]`
+    : '';
+
+  return `pathLabelMode="${configuration.pathLabelMode}", pathLabelNormalizer=${configuration.pathLabelNormalizer ? 'custom' : 'none'}, unknownPathLabel="${configuration.unknownPathLabel}"${durationHistogramBuckets}`;
 }
 
 function normalizePathToTemplate(path: string, params: Readonly<Record<string, string>>): string {

--- a/packages/metrics/src/metrics-module.test.ts
+++ b/packages/metrics/src/metrics-module.test.ts
@@ -591,7 +591,9 @@ describe('MetricsModule', () => {
       imports: [
         MetricsModule.forRoot({
           defaultMetrics: false,
-          http: true,
+          http: {
+            durationHistogramBuckets: [0.001, 0.002],
+          },
           path: '/metrics/:resourceId',
         }),
       ],
@@ -613,6 +615,9 @@ describe('MetricsModule', () => {
 
       expect(secondResponse.statusCode).toBe(200);
       expect(metricsText).toContain('http_requests_total{method="GET",path="/metrics/:resourceId",status="200"} 1');
+      expect(metricsText).toContain(
+        'http_request_duration_seconds_bucket{le="0.001",method="GET",path="/metrics/:resourceId",status="200"}',
+      );
     } finally {
       await app.close();
     }

--- a/packages/metrics/src/metrics-module.test.ts
+++ b/packages/metrics/src/metrics-module.test.ts
@@ -951,8 +951,18 @@ describe('MetricsModule', () => {
 
     defineModule(AppModule, {
       imports: [
-        MetricsModule.forRoot({ defaultMetrics: false, http: true, path: '/metrics-a', registry: sharedRegistry }),
-        MetricsModule.forRoot({ defaultMetrics: false, http: true, path: '/metrics-b', registry: sharedRegistry }),
+        MetricsModule.forRoot({
+          defaultMetrics: false,
+          http: { durationHistogramBuckets: [0.001, 0.002] },
+          path: '/metrics-a',
+          registry: sharedRegistry,
+        }),
+        MetricsModule.forRoot({
+          defaultMetrics: false,
+          http: { durationHistogramBuckets: [0.001, 0.002] },
+          path: '/metrics-b',
+          registry: sharedRegistry,
+        }),
       ],
     });
 
@@ -1071,7 +1081,46 @@ describe('MetricsModule', () => {
     });
 
     await expect(bootstrapApplication({ rootModule: SecondAppModule })).rejects.toThrow(
-      'Metric name "http_requests_total" is already registered with framework HTTP path-label configuration pathLabelMode="template", pathLabelNormalizer=none, unknownPathLabel="FIRST_UNKNOWN". Built-in HTTP metrics require matching path-label configuration before reuse; received pathLabelMode="template", pathLabelNormalizer=none, unknownPathLabel="SECOND_UNKNOWN".',
+      'Metric name "http_requests_total" is already registered with framework HTTP collector configuration pathLabelMode="template", pathLabelNormalizer=none, unknownPathLabel="FIRST_UNKNOWN". Built-in HTTP metrics require matching HTTP collector configuration before reuse; received pathLabelMode="template", pathLabelNormalizer=none, unknownPathLabel="SECOND_UNKNOWN".',
+    );
+  });
+
+  it('rejects shared-registry HTTP collector reuse when only duration buckets differ', async () => {
+    const sharedRegistry = new Registry();
+
+    class FirstAppModule {}
+
+    defineModule(FirstAppModule, {
+      imports: [
+        MetricsModule.forRoot({
+          defaultMetrics: false,
+          http: { durationHistogramBuckets: [0.001, 0.002] },
+          path: '/metrics-a',
+          registry: sharedRegistry,
+        }),
+      ],
+    });
+
+    const firstApp = await bootstrapApplication({
+      rootModule: FirstAppModule,
+    });
+    await firstApp.close();
+
+    class SecondAppModule {}
+
+    defineModule(SecondAppModule, {
+      imports: [
+        MetricsModule.forRoot({
+          defaultMetrics: false,
+          http: { durationHistogramBuckets: [0.002, 0.003] },
+          path: '/metrics-b',
+          registry: sharedRegistry,
+        }),
+      ],
+    });
+
+    await expect(bootstrapApplication({ rootModule: SecondAppModule })).rejects.toThrow(
+      'Metric name "http_requests_total" is already registered with framework HTTP collector configuration pathLabelMode="template", pathLabelNormalizer=none, unknownPathLabel="UNKNOWN", durationHistogramBuckets=[0.001,0.002]. Built-in HTTP metrics require matching HTTP collector configuration before reuse; received pathLabelMode="template", pathLabelNormalizer=none, unknownPathLabel="UNKNOWN", durationHistogramBuckets=[0.002,0.003].',
     );
   });
 

--- a/packages/metrics/src/metrics-module.ts
+++ b/packages/metrics/src/metrics-module.ts
@@ -23,6 +23,8 @@ import { PrometheusMeterProvider } from './providers/prometheus-meter-provider.j
 
 /** HTTP-specific metric labeling options exposed by `MetricsModule.forRoot(...)`. */
 export interface MetricsHttpOptions {
+  /** Duration buckets in seconds for the built-in HTTP request histogram. */
+  durationHistogramBuckets?: readonly number[];
   /** How request paths are converted into Prometheus label values. Defaults to route templates. */
   pathLabelMode?: HttpMetricsPathLabelMode;
   /** Custom path-label normalizer for bounded application-specific label values. */
@@ -704,6 +706,7 @@ function resolveHttpOptions(http: MetricsModuleOptions['http']): HttpMetricsMidd
 
   return {
     allowUnsafeRawPathLabelMode: http.allowUnsafeRawPathLabelMode,
+    durationHistogramBuckets: http.durationHistogramBuckets,
     pathLabelMode: http.pathLabelMode,
     pathLabelNormalizer: http.pathLabelNormalizer,
     unknownPathLabel: http.unknownPathLabel,


### PR DESCRIPTION
## Summary
- add http.durationHistogramBuckets to MetricsModule.forRoot()
- preserve prom-client defaults when omitted and replace them when configured
- validate finite strictly increasing boundaries before collector registration
- reject shared Registry reuse when bucket configuration differs
- document the public contract in EN/KO and add a minor Changeset

## Verification
- dependency-closure build
- metrics typecheck and 72 tests
- reverse-dependent tests
- public TSDoc, docs parity, and Changeset gates
- built public API QA for custom buckets and invalid-boundary rejection
- exact-head code/contract/verification reviews: merge

Closes #3211