### PR TITLE
fix(metrics): preflight default collector collisions (#3204)

### DIFF
--- a/.changeset/rollback-default-metrics-registration.md
+++ b/.changeset/rollback-default-metrics-registration.md
@@ -2,5 +2,6 @@
 "@fluojs/metrics": patch
 ---
 
-Roll back partially registered default collectors when `prom-client` registration
-fails so a later clean bootstrap can retry the registry.
+Preflight active `prom-client` default-collector collisions before registration can
+trigger side effects, and roll back collectors from unexpected registration failures
+so a later clean bootstrap can retry the registry.

--- a/.changeset/rollback-default-metrics-registration.md
+++ b/.changeset/rollback-default-metrics-registration.md
@@ -1,0 +1,6 @@
+---
+"@fluojs/metrics": patch
+---
+
+Roll back partially registered default collectors when `prom-client` registration
+fails so a later clean bootstrap can retry the registry.

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -46,7 +46,7 @@
     "@fluojs/di": "workspace:^",
     "@fluojs/http": "workspace:^",
     "@fluojs/runtime": "workspace:^",
-    "prom-client": "^15.1.3"
+    "prom-client": "15.1.3"
   },
   "devDependencies": {
     "@fluojs/testing": "workspace:^",

--- a/packages/metrics/src/metrics-module.test.ts
+++ b/packages/metrics/src/metrics-module.test.ts
@@ -469,6 +469,51 @@ describe('MetricsModule', () => {
     }
   });
 
+  it('rolls back partial default collector registration so a cleaned registry can retry', async () => {
+    const sharedRegistry = new Registry();
+
+    new Counter({
+      help: 'Application-owned collector that forces a prom-client collision.',
+      name: 'process_cpu_seconds_total',
+      registers: [sharedRegistry],
+    });
+
+    class FailedAppModule {}
+
+    defineModule(FailedAppModule, {
+      imports: [MetricsModule.forRoot({ path: false, registry: sharedRegistry })],
+    });
+
+    // Given: prom-client registers the CPU user and system collectors before its total collector collides.
+    await expect(bootstrapApplication({ rootModule: FailedAppModule })).rejects.toThrow(
+      'A metric with the name process_cpu_seconds_total has already been registered.',
+    );
+
+    // Then: failed framework registration preserves only the application-owned conflict.
+    expect(sharedRegistry.getSingleMetric('process_cpu_user_seconds_total')).toBeUndefined();
+    expect(sharedRegistry.getSingleMetric('process_cpu_system_seconds_total')).toBeUndefined();
+
+    sharedRegistry.removeSingleMetric('process_cpu_seconds_total');
+
+    class CleanAppModule {}
+
+    defineModule(CleanAppModule, {
+      imports: [MetricsModule.forRoot({ path: false, registry: sharedRegistry })],
+    });
+
+    // When: a clean bootstrap retries the same registry.
+    const app = await bootstrapApplication({ rootModule: CleanAppModule });
+
+    try {
+      // Then: all default CPU collectors register without stale framework ownership.
+      expect(sharedRegistry.getSingleMetric('process_cpu_user_seconds_total')).toBeDefined();
+      expect(sharedRegistry.getSingleMetric('process_cpu_system_seconds_total')).toBeDefined();
+      expect(sharedRegistry.getSingleMetric('process_cpu_seconds_total')).toBeDefined();
+    } finally {
+      await app.close();
+    }
+  });
+
   it('uses explicit platform telemetry labels when provided', async () => {
     class AppModule {}
 

--- a/packages/metrics/src/metrics-module.test.ts
+++ b/packages/metrics/src/metrics-module.test.ts
@@ -582,6 +582,98 @@ describe('MetricsModule', () => {
     }
   });
 
+  it('does not reject an inactive process handles collector name', async () => {
+    const activeHandlesDescriptor = Object.getOwnPropertyDescriptor(process, '_getActiveHandles');
+    Reflect.deleteProperty(process, '_getActiveHandles');
+
+    const sharedRegistry = new Registry();
+    const applicationCollector = new Gauge({
+      help: 'Application metric with an inactive default collector name.',
+      name: 'nodejs_active_handles',
+      registers: [sharedRegistry],
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [MetricsModule.forRoot({ path: false, registry: sharedRegistry })],
+    });
+
+    try {
+      const app = await bootstrapApplication({ rootModule: AppModule });
+
+      try {
+        expect(sharedRegistry.getSingleMetric('nodejs_active_handles')).toBe(applicationCollector);
+      } finally {
+        await app.close();
+      }
+    } finally {
+      if (activeHandlesDescriptor) {
+        Object.defineProperty(process, '_getActiveHandles', activeHandlesDescriptor);
+      }
+    }
+  });
+
+  it('does not reject an inactive process requests collector name', async () => {
+    const activeRequestsDescriptor = Object.getOwnPropertyDescriptor(process, '_getActiveRequests');
+    Reflect.deleteProperty(process, '_getActiveRequests');
+
+    const sharedRegistry = new Registry();
+    const applicationCollector = new Gauge({
+      help: 'Application metric with an inactive default collector name.',
+      name: 'nodejs_active_requests',
+      registers: [sharedRegistry],
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [MetricsModule.forRoot({ path: false, registry: sharedRegistry })],
+    });
+
+    try {
+      const app = await bootstrapApplication({ rootModule: AppModule });
+
+      try {
+        expect(sharedRegistry.getSingleMetric('nodejs_active_requests')).toBe(applicationCollector);
+      } finally {
+        await app.close();
+      }
+    } finally {
+      if (activeRequestsDescriptor) {
+        Object.defineProperty(process, '_getActiveRequests', activeRequestsDescriptor);
+      }
+    }
+  });
+
+  it('rejects a Linux-active default collector name', async () => {
+    const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+
+    const sharedRegistry = new Registry();
+    new Gauge({
+      help: 'Application metric with a Linux-active default collector name.',
+      name: 'process_open_fds',
+      registers: [sharedRegistry],
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [MetricsModule.forRoot({ path: false, registry: sharedRegistry })],
+    });
+
+    try {
+      await expect(bootstrapApplication({ rootModule: AppModule })).rejects.toThrow(
+        'A metric with the name process_open_fds has already been registered.',
+      );
+    } finally {
+      if (platformDescriptor) {
+        Object.defineProperty(process, 'platform', platformDescriptor);
+      }
+    }
+  });
+
   it('uses explicit platform telemetry labels when provided', async () => {
     class AppModule {}
 

--- a/packages/metrics/src/metrics-module.test.ts
+++ b/packages/metrics/src/metrics-module.test.ts
@@ -1,3 +1,5 @@
+import { createRequire } from 'node:module';
+
 import { getModuleMetadata, Inject } from '@fluojs/core';
 import { ContainerResolutionError } from '@fluojs/di';
 import {
@@ -11,7 +13,7 @@ import {
 } from '@fluojs/http';
 import { bootstrapApplication, defineModule, PLATFORM_SHELL, type PlatformComponent } from '@fluojs/runtime';
 import { Counter, Gauge, Histogram, Registry } from 'prom-client';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { METRICS_REGISTRY, MetricsModule } from './metrics-module.js';
 import { MetricsService } from './metrics-service.js';
 import { METER_PROVIDER } from './providers/meter-provider.js';
@@ -20,6 +22,8 @@ import { PrometheusMeterProvider } from './providers/prometheus-meter-provider.j
 type TestResponse = FrameworkResponse & { body?: unknown };
 type TestPlatformHealthStatus = 'healthy' | 'unhealthy' | 'degraded';
 type TestPlatformReadinessStatus = 'ready' | 'not-ready' | 'degraded';
+
+const perfHooks = createRequire(import.meta.url)('node:perf_hooks');
 
 function createRequest(path: string, headers: FrameworkRequest['headers'] = {}): FrameworkRequest {
   return {
@@ -469,12 +473,17 @@ describe('MetricsModule', () => {
     }
   });
 
-  it('rolls back partial default collector registration so a cleaned registry can retry', async () => {
+  it('preserves application-owned collectors on a default collector collision so a cleaned registry can retry', async () => {
     const sharedRegistry = new Registry();
 
-    new Counter({
+    const conflictingCollector = new Counter({
       help: 'Application-owned collector that forces a prom-client collision.',
       name: 'process_cpu_seconds_total',
+      registers: [sharedRegistry],
+    });
+    const unrelatedCollector = new Gauge({
+      help: 'Application-owned collector unrelated to the default metric collision.',
+      name: 'app_unrelated_metric',
       registers: [sharedRegistry],
     });
 
@@ -484,12 +493,12 @@ describe('MetricsModule', () => {
       imports: [MetricsModule.forRoot({ path: false, registry: sharedRegistry })],
     });
 
-    // Given: prom-client registers the CPU user and system collectors before its total collector collides.
     await expect(bootstrapApplication({ rootModule: FailedAppModule })).rejects.toThrow(
       'A metric with the name process_cpu_seconds_total has already been registered.',
     );
 
-    // Then: failed framework registration preserves only the application-owned conflict.
+    expect(sharedRegistry.getSingleMetric('process_cpu_seconds_total')).toBe(conflictingCollector);
+    expect(sharedRegistry.getSingleMetric('app_unrelated_metric')).toBe(unrelatedCollector);
     expect(sharedRegistry.getSingleMetric('process_cpu_user_seconds_total')).toBeUndefined();
     expect(sharedRegistry.getSingleMetric('process_cpu_system_seconds_total')).toBeUndefined();
 
@@ -501,16 +510,75 @@ describe('MetricsModule', () => {
       imports: [MetricsModule.forRoot({ path: false, registry: sharedRegistry })],
     });
 
-    // When: a clean bootstrap retries the same registry.
     const app = await bootstrapApplication({ rootModule: CleanAppModule });
 
     try {
-      // Then: all default CPU collectors register without stale framework ownership.
       expect(sharedRegistry.getSingleMetric('process_cpu_user_seconds_total')).toBeDefined();
       expect(sharedRegistry.getSingleMetric('process_cpu_system_seconds_total')).toBeDefined();
       expect(sharedRegistry.getSingleMetric('process_cpu_seconds_total')).toBeDefined();
     } finally {
       await app.close();
+    }
+  });
+
+  it('preflights a late default collector collision before enabling its event-loop monitor', async () => {
+    const sharedRegistry = new Registry();
+    const eventLoopMonitor = { enable: vi.fn() };
+    const monitorEventLoopDelay = vi.spyOn(perfHooks, 'monitorEventLoopDelay').mockReturnValue(eventLoopMonitor);
+
+    new Gauge({
+      help: 'Application-owned collector that collides after prom-client enables the event-loop monitor.',
+      name: 'nodejs_eventloop_lag_seconds',
+      registers: [sharedRegistry],
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [MetricsModule.forRoot({ path: false, registry: sharedRegistry })],
+    });
+
+    try {
+      await expect(bootstrapApplication({ rootModule: AppModule })).rejects.toThrow(
+        'A metric with the name nodejs_eventloop_lag_seconds has already been registered.',
+      );
+
+      expect(monitorEventLoopDelay).not.toHaveBeenCalled();
+      expect(eventLoopMonitor.enable).not.toHaveBeenCalled();
+    } finally {
+      monitorEventLoopDelay.mockRestore();
+    }
+  });
+
+  it('does not reject an inactive Darwin-only default collector name', async () => {
+    const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+
+    const sharedRegistry = new Registry();
+    const applicationCollector = new Gauge({
+      help: 'Application metric with an inactive default collector name.',
+      name: 'process_open_fds',
+      registers: [sharedRegistry],
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [MetricsModule.forRoot({ path: false, registry: sharedRegistry })],
+    });
+
+    try {
+      const app = await bootstrapApplication({ rootModule: AppModule });
+
+      try {
+        expect(sharedRegistry.getSingleMetric('process_open_fds')).toBe(applicationCollector);
+      } finally {
+        await app.close();
+      }
+    } finally {
+      if (platformDescriptor) {
+        Object.defineProperty(process, 'platform', platformDescriptor);
+      }
     }
   });
 

--- a/packages/metrics/src/metrics-module.ts
+++ b/packages/metrics/src/metrics-module.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+
 import { Inject, type Token } from '@fluojs/core';
 import { type Container, ContainerResolutionError, type Provider } from '@fluojs/di';
 import { Controller, forRoutes, Get, type Middleware, type MiddlewareLike, type RequestContext } from '@fluojs/http';
@@ -195,6 +198,8 @@ export class MetricsModule {
     const registry = configuredRegistry ?? options.registry ?? new PrometheusRegistry();
 
     if (options.defaultMetrics !== false && !MetricsModule.registeredRegistries.has(registry)) {
+      assertNoDefaultMetricCollisions(registry);
+
       const existingMetricNames = new Set(registry.getMetricsAsArray().map((metric) => metric.name));
 
       try {
@@ -244,6 +249,16 @@ type ContainerPresenceProbe = RequestContext['container'] & { has?: (token: Toke
 
 const PLATFORM_COMPONENT_LABELS = ['component_id', 'component_kind', 'operation', 'result', 'env', 'instance'] as const;
 const REGISTRY_MODE_LABELS = ['mode'] as const;
+const require = createRequire(import.meta.url);
+const DEFAULT_METRIC_COLLECTORS = collectDefaultMetrics.metricsList.map((collectorName) => {
+  const collector: unknown = require(`prom-client/lib/metrics/${collectorName}`);
+
+  if (!hasDefaultMetricNames(collector)) {
+    throw new Error(`prom-client default collector "${collectorName}" does not expose metricNames.`);
+  }
+
+  return { collectorName, metricNames: collector.metricNames };
+});
 const FRAMEWORK_PLATFORM_GAUGES = new WeakSet<Gauge<string>>();
 const PLATFORM_TELEMETRY_REGISTRY_STATES = new WeakMap<Registry, RuntimePlatformTelemetryRegistryState>();
 const HTTP_INSTRUMENTATION_OWNERS = new WeakMap<Container, WeakSet<Registry>>();
@@ -298,6 +313,45 @@ function assertPrometheusRegistry(value: unknown): Registry {
   }
 
   return value;
+}
+
+function hasDefaultMetricNames(value: unknown): value is { metricNames: readonly string[] } {
+  return typeof value === 'function'
+    && 'metricNames' in value
+    && Array.isArray(value.metricNames)
+    && value.metricNames.every((metricName) => typeof metricName === 'string');
+}
+
+function assertNoDefaultMetricCollisions(registry: Registry): void {
+  for (const { collectorName, metricNames } of DEFAULT_METRIC_COLLECTORS) {
+    if (!isDefaultCollectorActive(collectorName)) {
+      continue;
+    }
+
+    for (const metricName of metricNames) {
+      if (registry.getSingleMetric(metricName)) {
+        throw new Error(`A metric with the name ${metricName} has already been registered.`);
+      }
+    }
+  }
+}
+
+function isDefaultCollectorActive(collectorName: string): boolean {
+  if (collectorName === 'processOpenFileDescriptors') {
+    return process.platform === 'linux';
+  }
+
+  if (collectorName === 'processMaxFileDescriptors') {
+    try {
+      return readFileSync('/proc/self/limits', 'utf8')
+        .split('\n')
+        .some((line) => line.startsWith('Max open files'));
+    } catch {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 function assertRuntimeContainer(value: unknown): Container {

--- a/packages/metrics/src/metrics-module.ts
+++ b/packages/metrics/src/metrics-module.ts
@@ -250,6 +250,9 @@ type ContainerPresenceProbe = RequestContext['container'] & { has?: (token: Toke
 const PLATFORM_COMPONENT_LABELS = ['component_id', 'component_kind', 'operation', 'result', 'env', 'instance'] as const;
 const REGISTRY_MODE_LABELS = ['mode'] as const;
 const require = createRequire(import.meta.url);
+// prom-client exposes collector IDs publicly but not their metric names. This v15.1.3-only
+// private metadata seam keeps collision preflight side-effect-free; the exact package pin and
+// runtime-support regression must be updated together before changing prom-client.
 const DEFAULT_METRIC_COLLECTORS = collectDefaultMetrics.metricsList.map((collectorName) => {
   const collector: unknown = require(`prom-client/lib/metrics/${collectorName}`);
 
@@ -337,6 +340,14 @@ function assertNoDefaultMetricCollisions(registry: Registry): void {
 }
 
 function isDefaultCollectorActive(collectorName: string): boolean {
+  if (collectorName === 'processHandles') {
+    return typeof Reflect.get(process, '_getActiveHandles') === 'function';
+  }
+
+  if (collectorName === 'processRequests') {
+    return typeof Reflect.get(process, '_getActiveRequests') === 'function';
+  }
+
   if (collectorName === 'processOpenFileDescriptors') {
     return process.platform === 'linux';
   }

--- a/packages/metrics/src/metrics-module.ts
+++ b/packages/metrics/src/metrics-module.ts
@@ -195,8 +195,21 @@ export class MetricsModule {
     const registry = configuredRegistry ?? options.registry ?? new PrometheusRegistry();
 
     if (options.defaultMetrics !== false && !MetricsModule.registeredRegistries.has(registry)) {
+      const existingMetricNames = new Set(registry.getMetricsAsArray().map((metric) => metric.name));
+
+      try {
+        collectDefaultMetrics({ register: registry });
+      } catch (error) {
+        for (const metric of registry.getMetricsAsArray()) {
+          if (!existingMetricNames.has(metric.name)) {
+            registry.removeSingleMetric(metric.name);
+          }
+        }
+
+        throw error;
+      }
+
       MetricsModule.registeredRegistries.add(registry);
-      collectDefaultMetrics({ register: registry });
     }
 
     return registry;

--- a/packages/metrics/src/runtime-support.test.ts
+++ b/packages/metrics/src/runtime-support.test.ts
@@ -1,6 +1,10 @@
 import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 
 import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const PROM_CLIENT_PRIVATE_SEAM_VERSION = '15.1.3';
 
 describe('@fluojs/metrics runtime support metadata', () => {
   it('matches the Node.js range required by its mandatory runtime dependency', () => {
@@ -14,5 +18,28 @@ describe('@fluojs/metrics runtime support metadata', () => {
 
     // Then: metrics does not advertise support outside the runtime requirement.
     expect(metricsNodeEngine).toBe(runtimeNodeEngine);
+  });
+
+  it('pins the prom-client private collector metadata seam to the installed contract', () => {
+    // Given: the published metrics manifest and the installed prom-client package.
+    const metricsManifest = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
+    const promClientManifest: { version: string } = require('prom-client/package.json');
+    const promClient: { collectDefaultMetrics: { metricsList: readonly string[] } } = require('prom-client');
+
+    // When: each default collector's private metadata is loaded without invoking registration.
+    const collectorMetricNames = promClient.collectDefaultMetrics.metricsList.map((collectorName) => {
+      const collector: { metricNames?: unknown } = require(`prom-client/lib/metrics/${collectorName}`);
+      return collector.metricNames;
+    });
+
+    // Then: the private paths and metadata are bounded to the exact dependency release.
+    expect(metricsManifest.dependencies['prom-client']).toBe(PROM_CLIENT_PRIVATE_SEAM_VERSION);
+    expect(promClientManifest.version).toBe(PROM_CLIENT_PRIVATE_SEAM_VERSION);
+    for (const metricNames of collectorMetricNames) {
+      expect(Array.isArray(metricNames)).toBe(true);
+      if (Array.isArray(metricNames)) {
+        expect(metricNames.every((metricName) => typeof metricName === 'string')).toBe(true);
+      }
+    }
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -640,7 +640,7 @@ importers:
         specifier: workspace:^
         version: link:../runtime
       prom-client:
-        specifier: ^15.1.3
+        specifier: 15.1.3
         version: 15.1.3
     devDependencies:
       '@fluojs/testing':
@@ -1077,15 +1077,15 @@ importers:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
     devDependencies:
-      '@playwright/test':
-        specifier: ^1.61.1
-        version: 1.61.1
       '@fluojs-internal/tooling-vite':
         specifier: workspace:^
         version: link:../../tooling/vite
       '@fluojs/runtime':
         specifier: workspace:^
         version: link:../runtime
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.61.1
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -4770,6 +4770,7 @@ packages:
   prom-client@15.1.3:
     resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
     engines: {node: ^16 || ^18 || >=20}
+    deprecated: prom-client has been replaced by @prometheus-io/client
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}


### PR DESCRIPTION
## Summary

Prevent failed Prometheus default collector registration from leaving partial collectors or runtime resources behind.

Linked context: Closes #3204

## Changes

- preflight active default collector collisions before side-effectful registration
- preserve application collectors and roll back unexpected partial registrations
- mirror platform/runtime collector activation conditions
- exact-pin and regression-guard the validated `prom-client` private metadata seam
- add patch Changeset and deterministic rollback/retry coverage

## Testing

- frozen lockfile installation
- explicit all-package clean-dist and full `pnpm build`
- `@fluojs/metrics` typecheck and 77 tests
- direct reverse-dependent tests/typecheck
- Changeset stable release-lane gate
- Biome and LSP diagnostics
- built collision/preflight/retry manual driver
- exact-head code, contract, and verification review after two fix-back rounds: PASS

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary. (N/A: no exports changed)
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. (N/A)
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. (N/A: restores existing failure contract)
- [x] Intentional limitations are explicitly stated.
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (N/A)
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. (N/A)
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests. (N/A)