### PR TITLE
feat(http): add response metadata helpers (#3308)

### DIFF
--- a/.changeset/lucky-seals-whisper.md
+++ b/.changeset/lucky-seals-whisper.md
@@ -1,0 +1,6 @@
+---
+"@fluojs/http": minor
+---
+
+Add portable response-header lookup helpers and safe `Content-Disposition` filename formatting
+with escaped ASCII fallback and deterministic UTF-8 `filename*` parameters.

--- a/packages/http/README.ko.md
+++ b/packages/http/README.ko.md
@@ -120,8 +120,24 @@ header 값을 납작하게 만들지 않으면서 case-insensitive lookup을 해
 comma list를 매번 수동으로 파싱하고 싶지 않거나, 기존 `Vary: *` contract를 실수로 확장하면 안
 될 때는 `appendVaryHeader(response, ...fields)`를 사용하세요.
 
+Adapter가 제공한 응답 header를 같은 방식으로 case-insensitive lookup하려면
+`getResponseHeader(response, name)`와 `hasResponseHeader(response, name)`를 사용하세요. 두 helper는
+원래의 `string | string[]` shape을 보존하고 header, body, status, commit state를 쓰지 않습니다.
+
+`attachment` 또는 `inline` Content-Disposition field value는
+`buildContentDisposition(disposition, filename)`으로 만드세요. 이 helper는 escape한 printable-ASCII
+`filename` fallback과 deterministic RFC 8187 UTF-8 `filename*` 값을 함께 만들고, carriage return 또는
+line feed가 있는 filename은 header value를 반환하기 전에 reject합니다.
+
 ```ts
-import { appendVaryHeader, getRequestHeader, type RequestContext } from '@fluojs/http';
+import {
+  appendVaryHeader,
+  buildContentDisposition,
+  getRequestHeader,
+  getResponseHeader,
+  hasResponseHeader,
+  type RequestContext,
+} from '@fluojs/http';
 
 export function readLanguage(context: RequestContext): string | undefined {
   const acceptLanguage = getRequestHeader(context.request, 'accept-language');
@@ -130,6 +146,20 @@ export function readLanguage(context: RequestContext): string | undefined {
 
 export function markLanguageVariance(context: RequestContext): void {
   appendVaryHeader(context.response, 'Accept-Language', 'Origin');
+  context.response.setHeader(
+    'Content-Disposition',
+    buildContentDisposition('attachment', 'résumé.pdf'),
+  );
+}
+
+export function readResponseEtag(
+  context: RequestContext,
+): string | string[] | undefined {
+  return getResponseHeader(context.response, 'etag');
+}
+
+export function shouldSetResponseEtag(context: RequestContext): boolean {
+  return !hasResponseHeader(context.response, 'etag');
 }
 ```
 
@@ -380,7 +410,7 @@ Multipart upload를 parse하는 어댑터는 shared HTTP contract를 adapter-spe
 - **파이프라인 계약 타입**: `Middleware`, `MiddlewareLike`, `MiddlewareContext`, `MiddlewareRouteConfig`, `Next`, `Guard`, `GuardLike`, `GuardContext`, `Interceptor`, `InterceptorLike`, `InterceptorContext`, `CallHandler`, `RequestObserver`, `RequestObserverLike`, `RequestObservationContext`, `ArgumentResolverContext`, `Binder`, `Converter`, `ConverterLike`, `ConverterTarget`, `ValidationIssue`, `Validator`
 - **Adapter API**: `HttpApplicationAdapter`, `HttpAdapterRealtimeCapability`, `ServerBackedHttpAdapterRealtimeCapability`, `FetchStyleHttpAdapterRealtimeCapability`, `HttpAdapterRealtimeBindingInstallation`, `UnsupportedHttpAdapterRealtimeCapability`, `createNoopHttpApplicationAdapter`, `createServerBackedHttpAdapterRealtimeCapability`, `createUnsupportedHttpAdapterRealtimeCapability`, `createFetchStyleHttpAdapterRealtimeCapability`
 - **예외와 오류**: `HttpExceptionDetail`, `HttpExceptionOptions`, `ErrorResponse`, `HttpException`, `BadRequestException`, `UnauthorizedException`, `ForbiddenException`, `NotFoundException`, `ConflictException`, `NotAcceptableException`, `TooManyRequestsException`, `InternalServerErrorException`, `PayloadTooLargeException`, `createErrorResponse`, `RouteConflictError`, `InvalidRoutePathError`, `InvalidHttpMethodError`, `HandlerNotFoundError`, `RequestAbortedError`, `EarlyHintsWriteError`
-- **헬퍼**: `createHandlerMapping`, `createDispatcher`, `forRoutes`, `normalizeRoutePattern`, `matchRoutePattern`, `isMiddlewareRouteConfig`, `createCorrelationMiddleware`, `createCorsMiddleware`, `createRateLimitMiddleware`, `createMemoryRateLimitStore`, `createSecurityHeadersMiddleware`, `getRequestHeader`, `appendVaryHeader`, `runWithRequestContext`, `getCurrentRequestContext`, `assertRequestContext`, `createRequestContext`, `createContextKey`, `getContextValue`, `setContextValue`, `encodeSseComment`, `encodeSseMessage`, `isSseMessage`, `formatFastPathStats`, `getDispatcherFastPathStats`, `FAST_PATH_ELIGIBILITY_SYMBOL`, `FAST_PATH_STATS_SYMBOL`
+- **헬퍼**: `createHandlerMapping`, `createDispatcher`, `forRoutes`, `normalizeRoutePattern`, `matchRoutePattern`, `isMiddlewareRouteConfig`, `createCorrelationMiddleware`, `createCorsMiddleware`, `createRateLimitMiddleware`, `createMemoryRateLimitStore`, `createSecurityHeadersMiddleware`, `getRequestHeader`, `getResponseHeader`, `hasResponseHeader`, `appendVaryHeader`, `buildContentDisposition`, `runWithRequestContext`, `getCurrentRequestContext`, `assertRequestContext`, `createRequestContext`, `createContextKey`, `getContextValue`, `setContextValue`, `encodeSseComment`, `encodeSseMessage`, `isSseMessage`, `formatFastPathStats`, `getDispatcherFastPathStats`, `FAST_PATH_ELIGIBILITY_SYMBOL`, `FAST_PATH_STATS_SYMBOL`
 - **Option 및 store type**: `CorsOptions`, `RateLimitOptions`, `RateLimitStore`, `RateLimitStoreEntry`, `SecurityHeadersOptions`, `SseSendOptions`
 
 ## Portable 서브경로 (`@fluojs/http/portable`)

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -122,8 +122,24 @@ Use `appendVaryHeader(response, ...fields)` when response negotiation or caching
 `Vary` fields without duplicating case variants, re-parsing comma lists by hand, or accidentally
 expanding an existing wildcard `Vary: *` contract.
 
+Use `getResponseHeader(response, name)` and `hasResponseHeader(response, name)` for the same
+case-insensitive lookup over adapter-provided response headers. They preserve the original
+`string | string[]` shape and do not write headers, body, status, or commit state.
+
+Use `buildContentDisposition(disposition, filename)` to create an `attachment` or `inline`
+Content-Disposition field value. It emits an escaped printable-ASCII `filename` fallback and a
+deterministic RFC 8187 UTF-8 `filename*` value. Carriage return and line feed filenames reject
+before a header value is returned.
+
 ```ts
-import { appendVaryHeader, getRequestHeader, type RequestContext } from '@fluojs/http';
+import {
+  appendVaryHeader,
+  buildContentDisposition,
+  getRequestHeader,
+  getResponseHeader,
+  hasResponseHeader,
+  type RequestContext,
+} from '@fluojs/http';
 
 export function readLanguage(context: RequestContext): string | undefined {
   const acceptLanguage = getRequestHeader(context.request, 'accept-language');
@@ -132,6 +148,20 @@ export function readLanguage(context: RequestContext): string | undefined {
 
 export function markLanguageVariance(context: RequestContext): void {
   appendVaryHeader(context.response, 'Accept-Language', 'Origin');
+  context.response.setHeader(
+    'Content-Disposition',
+    buildContentDisposition('attachment', 'résumé.pdf'),
+  );
+}
+
+export function readResponseEtag(
+  context: RequestContext,
+): string | string[] | undefined {
+  return getResponseHeader(context.response, 'etag');
+}
+
+export function shouldSetResponseEtag(context: RequestContext): boolean {
+  return !hasResponseHeader(context.response, 'etag');
 }
 ```
 
@@ -380,14 +410,14 @@ Response content negotiation formatters must return `string` or `Uint8Array` fro
 - **Routing decorators**: `Controller`, `Get`, `Sse`, `Query`, `Route`, `Post`, `Put`, `Patch`, `Delete`, `All`, `Options`, `Head`
 - **Binding decorators**: `FromBody`, `FromQuery`, `FromPath`, `FromHeader`, `FromCookie`, `RequestDto`, `Optional`, `Convert`
 - **Execution decorators**: `UseGuards`, `UseInterceptors`, `HttpCode`, `Version`, `Header`, `Redirect`, `Produces`
-- **Header helpers**: `getRequestHeader`, `appendVaryHeader`
+- **Header helpers**: `getRequestHeader`, `getResponseHeader`, `hasResponseHeader`, `appendVaryHeader`, `buildContentDisposition`
 - **Response cookie helpers**: `setCookie`, `clearCookie`, `CookieOptions`, `ClearCookieOptions`, `CookieSameSite`
 - **Request/response and context types**: `RequestContext`, `Principal`, `ContextKey`, `ControllerHandler`, `FrameworkRequest`, `FrameworkRequestFile`, `FrameworkResponse`, `EarlyHintsHeaders`, `FrameworkResponseEarlyHints`, `FrameworkResponseStream`, `FrameworkResponseCompression`, `FrameworkResponseCompressionWriteOptions`, `SseResponse`, `SseMessage`
 - **Dispatcher, routing, and negotiation types**: `Dispatcher`, `CreateDispatcherOptions`, `ErrorHandler`, `DispatcherLogger`, `HandlerMapping`, `HandlerMetadata`, `HandlerDescriptor`, `HandlerMatch`, `HandlerSource`, `RouteDefinition`, `HttpMethod`, `VersioningType`, `VersioningOptions`, `VersioningExtractor`, `VersioningExtractorResult`, `ContentNegotiationOptions`, `ResponseFormatter`, `HttpErrorRepresentationContext`, `HtmlErrorRepresentationProvider`, `HttpErrorRepresentationOptions`, `FastPathEligibility`, `FastPathStats`
 - **Pipeline contract types**: `Middleware`, `MiddlewareLike`, `MiddlewareContext`, `MiddlewareRouteConfig`, `Next`, `Guard`, `GuardLike`, `GuardContext`, `Interceptor`, `InterceptorLike`, `InterceptorContext`, `CallHandler`, `RequestObserver`, `RequestObserverLike`, `RequestObservationContext`, `ArgumentResolverContext`, `Binder`, `Converter`, `ConverterLike`, `ConverterTarget`, `ValidationIssue`, `Validator`
 - **Adapter API**: `HttpApplicationAdapter`, `HttpAdapterRealtimeCapability`, `ServerBackedHttpAdapterRealtimeCapability`, `FetchStyleHttpAdapterRealtimeCapability`, `HttpAdapterRealtimeBindingInstallation`, `UnsupportedHttpAdapterRealtimeCapability`, `createNoopHttpApplicationAdapter`, `createServerBackedHttpAdapterRealtimeCapability`, `createUnsupportedHttpAdapterRealtimeCapability`, `createFetchStyleHttpAdapterRealtimeCapability`
 - **Exceptions and errors**: `HttpExceptionDetail`, `HttpExceptionOptions`, `ErrorResponse`, `HttpException`, `BadRequestException`, `UnauthorizedException`, `ForbiddenException`, `NotFoundException`, `ConflictException`, `NotAcceptableException`, `TooManyRequestsException`, `InternalServerErrorException`, `PayloadTooLargeException`, `createErrorResponse`, `RouteConflictError`, `InvalidRoutePathError`, `InvalidHttpMethodError`, `HandlerNotFoundError`, `RequestAbortedError`, `EarlyHintsWriteError`
-- **Helpers**: `createHandlerMapping`, `createDispatcher`, `forRoutes`, `normalizeRoutePattern`, `matchRoutePattern`, `isMiddlewareRouteConfig`, `createCorrelationMiddleware`, `createCorsMiddleware`, `createRateLimitMiddleware`, `createMemoryRateLimitStore`, `createSecurityHeadersMiddleware`, `getRequestHeader`, `appendVaryHeader`, `runWithRequestContext`, `getCurrentRequestContext`, `assertRequestContext`, `createRequestContext`, `createContextKey`, `getContextValue`, `setContextValue`, `encodeSseComment`, `encodeSseMessage`, `isSseMessage`, `formatFastPathStats`, `getDispatcherFastPathStats`, `FAST_PATH_ELIGIBILITY_SYMBOL`, `FAST_PATH_STATS_SYMBOL`
+- **Helpers**: `createHandlerMapping`, `createDispatcher`, `forRoutes`, `normalizeRoutePattern`, `matchRoutePattern`, `isMiddlewareRouteConfig`, `createCorrelationMiddleware`, `createCorsMiddleware`, `createRateLimitMiddleware`, `createMemoryRateLimitStore`, `createSecurityHeadersMiddleware`, `getRequestHeader`, `getResponseHeader`, `hasResponseHeader`, `appendVaryHeader`, `buildContentDisposition`, `runWithRequestContext`, `getCurrentRequestContext`, `assertRequestContext`, `createRequestContext`, `createContextKey`, `getContextValue`, `setContextValue`, `encodeSseComment`, `encodeSseMessage`, `isSseMessage`, `formatFastPathStats`, `getDispatcherFastPathStats`, `FAST_PATH_ELIGIBILITY_SYMBOL`, `FAST_PATH_STATS_SYMBOL`
 - **Option and store types**: `CorsOptions`, `RateLimitOptions`, `RateLimitStore`, `RateLimitStoreEntry`, `SecurityHeadersOptions`, `SseSendOptions`
 
 ## Portable Subpath (`@fluojs/http/portable`)

--- a/packages/http/src/header-helpers.test.ts
+++ b/packages/http/src/header-helpers.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
+import {
+  appendVaryHeader,
+  buildContentDisposition,
+  getRequestHeader,
+  getResponseHeader,
+  hasResponseHeader,
+} from './index.js';
 import type { FrameworkRequest, FrameworkResponse } from './types.js';
-import { appendVaryHeader, getRequestHeader } from './index.js';
 
 function createRequest(
   headers: FrameworkRequest['headers'],
@@ -70,6 +76,57 @@ describe('getRequestHeader', () => {
     });
 
     expect(getRequestHeader(request, 'accept')).toBe('   ');
+  });
+});
+
+describe('response metadata helpers', () => {
+  it('reads response headers case-insensitively without flattening arrays or mutating response state', () => {
+    const upstreamValues = ['trace-a', 'trace-b'];
+    const response = createResponse();
+    response.headers['X-Trace-Id'] = upstreamValues;
+    response.statusCode = 202;
+    response.statusSet = true;
+
+    expect(getResponseHeader(response, 'x-trace-id')).toBe(upstreamValues);
+    expect(getResponseHeader(response, 'X-TRACE-ID')).toBe(upstreamValues);
+    expect(hasResponseHeader(response, 'x-trace-id')).toBe(true);
+    expect(hasResponseHeader(response, 'x-missing')).toBe(false);
+    expect(response).toMatchObject({
+      committed: false,
+      headers: { 'X-Trace-Id': upstreamValues },
+      statusCode: 202,
+      statusSet: true,
+    });
+  });
+
+  it('returns undefined and false for blank or missing response header names', () => {
+    const response = createResponse();
+    response.headers.ETag = '"response-v1"';
+
+    expect(getResponseHeader(response, '   ')).toBeUndefined();
+    expect(hasResponseHeader(response, '   ')).toBe(false);
+    expect(getResponseHeader(response, 'x-missing')).toBeUndefined();
+    expect(hasResponseHeader(response, 'x-missing')).toBe(false);
+  });
+});
+
+describe('buildContentDisposition', () => {
+  it('creates deterministic quoted ASCII and UTF-8 filename parameters for attachment and inline responses', () => {
+    expect(buildContentDisposition('attachment', 'résumé "2026"\\draft.txt')).toBe(
+      `attachment; filename="r?sum? \\"2026\\"\\\\draft.txt"; filename*=UTF-8''r%C3%A9sum%C3%A9%20%222026%22%5Cdraft.txt`,
+    );
+    expect(buildContentDisposition('inline', 'resume.txt')).toBe(
+      `inline; filename="resume.txt"; filename*=UTF-8''resume.txt`,
+    );
+  });
+
+  it('rejects carriage-return and line-feed filename injection before creating a header value', () => {
+    expect(() => buildContentDisposition('attachment', 'report\r\nX-Injected: true')).toThrow(
+      'Content-Disposition filenames cannot contain CR or LF characters.',
+    );
+    expect(() => buildContentDisposition('inline', 'report\nX-Injected: true')).toThrow(
+      'Content-Disposition filenames cannot contain CR or LF characters.',
+    );
   });
 });
 

--- a/packages/http/src/header-helpers.ts
+++ b/packages/http/src/header-helpers.ts
@@ -80,6 +80,85 @@ export function getRequestHeader(
 }
 
 /**
+ * Reads one response header without flattening multi-value arrays.
+ *
+ * @param response Adapter-normalized response carrying the outbound headers map.
+ * @param name Header name to resolve case-insensitively.
+ * @returns The original scalar, array, or `undefined` stored on the response.
+ */
+export function getResponseHeader(
+  response: FrameworkResponse,
+  name: string,
+): string | string[] | undefined {
+  return findCaseInsensitiveHeaderEntry(response.headers, name)?.[1];
+}
+
+/**
+ * Checks whether one response header is present without mutating the response.
+ *
+ * @param response Adapter-normalized response carrying the outbound headers map.
+ * @param name Header name to resolve case-insensitively.
+ * @returns `true` when a matching response header has a value.
+ */
+export function hasResponseHeader(
+  response: FrameworkResponse,
+  name: string,
+): boolean {
+  return getResponseHeader(response, name) !== undefined;
+}
+
+/**
+ * Creates a portable Content-Disposition value with ASCII and UTF-8 filename parameters.
+ *
+ * @param disposition Whether the response is an `attachment` or rendered `inline`.
+ * @param filename Original filename to encode for a response header.
+ * @returns A Content-Disposition field value with escaped ASCII and RFC 8187 UTF-8 parameters.
+ * @throws {TypeError} When the disposition is unsupported or the filename contains CR or LF.
+ */
+export function buildContentDisposition(
+  disposition: 'attachment' | 'inline',
+  filename: string,
+): string {
+  if (disposition !== 'attachment' && disposition !== 'inline') {
+    throw new TypeError('Content-Disposition disposition must be attachment or inline.');
+  }
+
+  if (filename.includes('\r') || filename.includes('\n')) {
+    throw new TypeError('Content-Disposition filenames cannot contain CR or LF characters.');
+  }
+
+  const asciiFilename = filename
+    .replace(/[^\x20-\x7E]/gu, '?')
+    .replaceAll('\\', '\\\\')
+    .replaceAll('"', '\\"');
+  const utf8Filename = Array.from(new TextEncoder().encode(filename), (byte) => {
+    const isAlphaNumeric =
+      (byte >= 0x30 && byte <= 0x39) ||
+      (byte >= 0x41 && byte <= 0x5a) ||
+      (byte >= 0x61 && byte <= 0x7a);
+    const isRfc8187Punctuation =
+      byte === 0x21 ||
+      byte === 0x23 ||
+      byte === 0x24 ||
+      byte === 0x26 ||
+      byte === 0x2b ||
+      byte === 0x2d ||
+      byte === 0x2e ||
+      byte === 0x5e ||
+      byte === 0x5f ||
+      byte === 0x60 ||
+      byte === 0x7c ||
+      byte === 0x7e;
+
+    return isAlphaNumeric || isRfc8187Punctuation
+      ? String.fromCharCode(byte)
+      : `%${byte.toString(16).toUpperCase().padStart(2, '0')}`;
+  }).join('');
+
+  return `${disposition}; filename="${asciiFilename}"; filename*=UTF-8''${utf8Filename}`;
+}
+
+/**
  * Reads the first non-empty request header value across duplicate case variants.
  *
  * @param request Adapter-normalized request carrying the inbound headers map.

--- a/packages/http/src/index.portable.ts
+++ b/packages/http/src/index.portable.ts
@@ -41,7 +41,13 @@ export {
 export type { FastPathEligibility, FastPathStats } from './dispatch/fast-path/index.js';
 export * from './errors.js';
 export * from './exceptions.js';
-export { appendVaryHeader, getRequestHeader } from './header-helpers.js';
+export {
+  appendVaryHeader,
+  buildContentDisposition,
+  getRequestHeader,
+  getResponseHeader,
+  hasResponseHeader,
+} from './header-helpers.js';
 export * from './mapping.js';
 export * from './middleware/correlation.js';
 export * from './middleware/cors.js';

--- a/packages/http/src/public-api.test.ts
+++ b/packages/http/src/public-api.test.ts
@@ -173,7 +173,10 @@ describe('@fluojs/http public API surface', () => {
     expect(httpPublicApi).toHaveProperty('createRateLimitMiddleware');
     expect(httpPublicApi).toHaveProperty('createSecurityHeadersMiddleware');
     expect(httpPublicApi).toHaveProperty('appendVaryHeader');
+    expect(httpPublicApi).toHaveProperty('buildContentDisposition');
     expect(httpPublicApi).toHaveProperty('getRequestHeader');
+    expect(httpPublicApi).toHaveProperty('getResponseHeader');
+    expect(httpPublicApi).toHaveProperty('hasResponseHeader');
     expect(httpPublicApi).not.toHaveProperty('readFirstNonEmptyRequestHeaderValue');
     expect(httpPublicApi).toHaveProperty('SseResponse');
     expect(httpPublicApi).toHaveProperty('encodeSseComment');


### PR DESCRIPTION
Closes #3308

Adds portable response header lookup and safe Content-Disposition helpers with EN/KO documentation and a minor Changeset.

Verification: HTTP closure build/typecheck/tests, runtime tests, testing portability suite, public-export TSDoc governance, and exact-head full triad review.