### PR TITLE
feat(http): bind portable DTO file arrays (#3190)

### DIFF
--- a/.changeset/from-files-portable-dto-binding.md
+++ b/.changeset/from-files-portable-dto-binding.md
@@ -1,0 +1,6 @@
+---
+"@fluojs/core": minor
+"@fluojs/http": minor
+---
+
+Add `@FromFiles(fieldname?)` for binding portable multipart file arrays into request DTOs.

--- a/book/beginner/ch05-routing-controllers.ko.md
+++ b/book/beginner/ch05-routing-controllers.ko.md
@@ -224,6 +224,27 @@ export class PostsController {
 
 각 라우트는 자신이 받을 입력 DTO를 직접 선언합니다. `@RequestDto(...)`는 핸들러가 사용할 DTO를 고르고, `@FromPath(...)`, `@FromQuery(...)`, `@FromBody(...)` 같은 필드 단위 바인딩 데코레이터는 각 DTO 필드를 어떤 요청 출처에서 채울지 말해 줍니다. `FindPostParamsDto`는 `/:id` 경로에서 바인딩된 입력 형태를 보여 주고, `SearchPostsQueryDto`는 쿼리 문자열에서 읽을 값을 하나의 입력 객체로 모읍니다. `CreatePostDto`는 요청 본문이 서비스 경계로 들어가기 전에 어떤 형태여야 하는지 드러냅니다.
 
+### Multipart 파일 입력
+
+Multipart endpoint도 같은 DTO 계약 안에 portable file input을 둘 수 있습니다. `@FromFiles(...)`는 항상 readonly 배열을 바인딩하고 multipart field name으로 필터링한 upload 순서를 보존하며 `FrameworkRequestFile` 데이터만 DTO에 전달합니다.
+
+```typescript
+import { FromFiles, RequestDto, type FrameworkRequestFile } from '@fluojs/http';
+
+class UploadPostAssetsDto {
+  @FromFiles('attachments')
+  attachments: readonly FrameworkRequestFile[] = [];
+}
+
+@Post('/:id/assets')
+@RequestDto(UploadPostAssetsDto)
+uploadAssets(input: UploadPostAssetsDto) {
+  return { uploaded: input.attachments.length };
+}
+```
+
+Adapter가 file collection을 제공하지 않았을 때 필수 `@FromFiles(...)` 필드는 일반 missing-field 오류를 사용합니다. 부재가 유효하다면 `@Optional()`을 붙이세요. Collection이 제공됐지만 일치하는 field name이 없으면 빈 배열이 됩니다. Handler가 필터링되지 않은 전체 요청 collection을 필요로 하면 `RequestContext.request.files`도 계속 사용할 수 있습니다.
+
 ### Why Explicit Binding Matters
 
 명시적인 바인딩은 처음 요청 흐름을 읽을 때 특히 큰 도움이 됩니다. 핸들러 시그니처를 보면 라우트가 어떤 DTO를 받는지 바로 확인할 수 있고, 입력 계약이 메서드마다 한 객체로 고정되어 있어 요청 흐름을 추적하기도 쉽습니다.

--- a/book/beginner/ch05-routing-controllers.md
+++ b/book/beginner/ch05-routing-controllers.md
@@ -224,6 +224,27 @@ export class PostsController {
 
 Each route directly declares the input DTO it receives. `@RequestDto(...)` selects the DTO for the handler, and field-level binding decorators such as `@FromPath(...)`, `@FromQuery(...)`, and `@FromBody(...)` say which request source fills each DTO field. `FindPostParamsDto` shows the input shape bound from the `/:id` path, `SearchPostsQueryDto` gathers values read from the query string into one input object, and `CreatePostDto` shows what shape the request body should have before it crosses the service boundary.
 
+### Multipart File Inputs
+
+Multipart endpoints can keep portable file inputs in the same DTO contract. `@FromFiles(...)` always binds a readonly array, filters by multipart field name in upload order, and passes only `FrameworkRequestFile` data into the DTO:
+
+```typescript
+import { FromFiles, RequestDto, type FrameworkRequestFile } from '@fluojs/http';
+
+class UploadPostAssetsDto {
+  @FromFiles('attachments')
+  attachments: readonly FrameworkRequestFile[] = [];
+}
+
+@Post('/:id/assets')
+@RequestDto(UploadPostAssetsDto)
+uploadAssets(input: UploadPostAssetsDto) {
+  return { uploaded: input.attachments.length };
+}
+```
+
+If the adapter did not provide a file collection, a required `@FromFiles(...)` field uses the normal missing-field error; add `@Optional()` when absence is valid. A provided collection with no matching field name becomes an empty array. `RequestContext.request.files` remains available when a handler needs the unfiltered request collection.
+
 ### Why Explicit Binding Matters
 
 Explicit binding is especially helpful when you first read a request flow. The handler signature immediately shows which DTO the route receives, and because the input contract is fixed as one object per method, it is easier to trace the request flow.

--- a/examples/minimal/README.ko.md
+++ b/examples/minimal/README.ko.md
@@ -10,6 +10,7 @@
 - `@Module`, `@Inject`, `@Controller`, `@Get`을 사용한 표준 데코레이터 DI
 - `HealthModule.forRoot(...)`의 내장 `/health` 및 `/ready` 엔드포인트
 - `/hello` 경로의 단일 스타터 컨트롤러
+- `@FromFiles('attachments')`를 사용한 `/uploads`의 portable multipart DTO 바인딩
 - `@fluojs/testing`을 사용한 단위 및 e2e 스타일 테스트
 
 ## 실행 방법
@@ -35,6 +36,7 @@ examples/minimal/
 │   ├── main.ts             # 진입점: adapter-first Fastify startup
 │   ├── hello.controller.ts # GET /hello
 │   ├── hello.service.ts    # 비즈니스 로직
+│   ├── upload.controller.ts # POST /uploads portable multipart DTO
 │   └── app.test.ts         # unit + createTestApp request helper 테스트
 └── README.md
 ```

--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -10,6 +10,7 @@ The smallest runnable fluo application. This example follows the same adapter-fi
 - Standard decorator DI with `@Module`, `@Inject`, `@Controller`, `@Get`
 - Built-in `/health` and `/ready` endpoints from `HealthModule.forRoot(...)`
 - A single starter controller at `/hello`
+- Portable multipart DTO binding at `/uploads` with `@FromFiles('attachments')`
 - Unit and e2e-style testing with `@fluojs/testing`
 
 ## how to run
@@ -35,6 +36,7 @@ examples/minimal/
 │   ├── main.ts             # Entry point: adapter-first Fastify startup
 │   ├── hello.controller.ts # GET /hello
 │   ├── hello.service.ts    # Business logic
+│   ├── upload.controller.ts # POST /uploads portable multipart DTO
 │   └── app.test.ts         # Unit + createTestApp request-helper tests
 └── README.md
 ```

--- a/examples/minimal/src/app.ts
+++ b/examples/minimal/src/app.ts
@@ -3,10 +3,11 @@ import { HealthModule as RuntimeHealthModule } from '@fluojs/runtime';
 
 import { HelloController } from './hello.controller';
 import { HelloService } from './hello.service';
+import { UploadController } from './upload.controller';
 
 @Module({
   imports: [RuntimeHealthModule.forRoot()],
-  controllers: [HelloController],
+  controllers: [HelloController, UploadController],
   providers: [HelloService],
 })
 export class AppModule {}

--- a/examples/minimal/src/upload.controller.ts
+++ b/examples/minimal/src/upload.controller.ts
@@ -1,0 +1,24 @@
+import {
+  Controller,
+  FromFiles,
+  Post,
+  RequestDto,
+  type FrameworkRequestFile,
+} from '@fluojs/http';
+
+export class UploadAssetsDto {
+  @FromFiles('attachments')
+  attachments: readonly FrameworkRequestFile[] = [];
+}
+
+@Controller('/uploads')
+export class UploadController {
+  @Post('/')
+  @RequestDto(UploadAssetsDto)
+  upload(input: UploadAssetsDto): { filenames: readonly string[]; uploaded: number } {
+    return {
+      filenames: input.attachments.map((file) => file.originalname),
+      uploaded: input.attachments.length,
+    };
+  }
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -74,4 +74,4 @@ export type MetadataPropertyKey = string | symbol;
 /**
  * Canonical request-data origins used by packages that describe how metadata values are bound.
  */
-export type MetadataSource = 'path' | 'query' | 'header' | 'cookie' | 'body';
+export type MetadataSource = 'path' | 'query' | 'header' | 'cookie' | 'body' | 'files';

--- a/packages/http/README.ko.md
+++ b/packages/http/README.ko.md
@@ -367,12 +367,42 @@ Fluo의 HTTP 데코레이터는 TC39 표준 데코레이터이며, runtime 또�
 
 Multipart upload를 parse하는 어댑터는 shared HTTP contract를 adapter-specific file type으로 augment하지 말고 runtime-neutral `FrameworkRequestFile` 값을 `FrameworkRequest.files`에 붙여야 합니다. 이 seam은 모든 HTTP adapter가 제공할 수 있는 portable field(`fieldname`, `originalname`, `mimetype`, `buffer`, `size`)만 의도적으로 모델링합니다. Platform package는 더 풍부한 native file object를 raw request surface에 유지할 수 있지만, guard, binder, middleware, interceptor, controller가 cross-runtime 동작을 필요로 하면 `RequestContext.request.files`를 통해 파일을 읽어야 합니다.
 
+### Multipart DTO 필드
+
+Multipart 파일이 handler 입력 계약에 포함되면 `@RequestDto(...)`와 함께 `@FromFiles(fieldname?)`를 사용하세요.
+
+```ts
+import {
+  FromFiles,
+  Optional,
+  RequestDto,
+  type FrameworkRequestFile,
+} from '@fluojs/http';
+
+class UploadAssetsDto {
+  @FromFiles('attachments')
+  attachments: readonly FrameworkRequestFile[] = [];
+
+  @FromFiles('cover')
+  @Optional()
+  cover?: readonly FrameworkRequestFile[];
+}
+
+@Post('/')
+@RequestDto(UploadAssetsDto)
+upload(input: UploadAssetsDto) {
+  return input.attachments.map((file) => file.originalname);
+}
+```
+
+`@FromFiles(...)`는 array-only입니다. `FrameworkRequest.files`가 있으면 `fieldname`으로 필터링된 readonly 배열을 어댑터 도착 순서대로 반환하며, collection이 있지만 일치 항목이 없으면 `[]`가 됩니다. Collection이 없으면 필수 필드는 표준 missing-field 오류를 내고 `@Optional()` 필드는 `undefined`로 남습니다. Converter와 validation은 같은 portable 배열을 받습니다. DTO binder는 다섯 `FrameworkRequestFile` 필드만 projection하므로 adapter-native file property가 DTO 경계를 넘어오지 않습니다. 전체 요청 collection이 필요한 controller와 pipeline stage에서는 기존처럼 `RequestContext.request.files`에 직접 접근할 수 있습니다.
+
 응답 content negotiation formatter는 `ResponseFormatter.format(...)`에서 `string` 또는 `Uint8Array`를 반환해야 합니다. Node.js `Buffer` 값은 `Buffer`가 `Uint8Array`를 구현하므로 계속 할당 가능하지만, formatter contract는 runtime-neutral byte 동작에만 의존해야 합니다.
 
 ## 공개 API
 
 - **라우팅 데코레이터**: `Controller`, `Get`, `Sse`, `Query`, `Route`, `Post`, `Put`, `Patch`, `Delete`, `All`, `Options`, `Head`
-- **바인딩 데코레이터**: `FromBody`, `FromQuery`, `FromPath`, `FromHeader`, `FromCookie`, `RequestDto`, `Optional`, `Convert`
+- **바인딩 데코레이터**: `FromBody`, `FromQuery`, `FromPath`, `FromHeader`, `FromCookie`, `FromFiles`, `RequestDto`, `Optional`, `Convert`
 - **실행 데코레이터**: `UseGuards`, `UseInterceptors`, `HttpCode`, `Version`, `Header`, `Redirect`, `Produces`
 - **응답 쿠키 helper**: `setCookie`, `clearCookie`, `CookieOptions`, `ClearCookieOptions`, `CookieSameSite`
 - **요청/응답 및 컨텍스트 타입**: `RequestContext`, `Principal`, `ContextKey`, `ControllerHandler`, `FrameworkRequest`, `FrameworkRequestFile`, `FrameworkResponse`, `EarlyHintsHeaders`, `FrameworkResponseEarlyHints`, `FrameworkResponseStream`, `FrameworkResponseCompression`, `FrameworkResponseCompressionWriteOptions`, `SseResponse`, `SseMessage`

--- a/packages/http/README.ko.md
+++ b/packages/http/README.ko.md
@@ -373,8 +373,10 @@ Multipart 파일이 handler 입력 계약에 포함되면 `@RequestDto(...)`와 
 
 ```ts
 import {
+  Controller,
   FromFiles,
   Optional,
+  Post,
   RequestDto,
   type FrameworkRequestFile,
 } from '@fluojs/http';
@@ -388,10 +390,13 @@ class UploadAssetsDto {
   cover?: readonly FrameworkRequestFile[];
 }
 
-@Post('/')
-@RequestDto(UploadAssetsDto)
-upload(input: UploadAssetsDto) {
-  return input.attachments.map((file) => file.originalname);
+@Controller('/uploads')
+export class UploadController {
+  @Post('/')
+  @RequestDto(UploadAssetsDto)
+  upload(input: UploadAssetsDto) {
+    return input.attachments.map((file) => file.originalname);
+  }
 }
 ```
 

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -379,8 +379,10 @@ Use `@FromFiles(fieldname?)` with `@RequestDto(...)` when multipart files are pa
 
 ```ts
 import {
+  Controller,
   FromFiles,
   Optional,
+  Post,
   RequestDto,
   type FrameworkRequestFile,
 } from '@fluojs/http';
@@ -394,10 +396,13 @@ class UploadAssetsDto {
   cover?: readonly FrameworkRequestFile[];
 }
 
-@Post('/')
-@RequestDto(UploadAssetsDto)
-upload(input: UploadAssetsDto) {
-  return input.attachments.map((file) => file.originalname);
+@Controller('/uploads')
+export class UploadController {
+  @Post('/')
+  @RequestDto(UploadAssetsDto)
+  upload(input: UploadAssetsDto) {
+    return input.attachments.map((file) => file.originalname);
+  }
 }
 ```
 

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -373,12 +373,42 @@ Adapters should pass an `AbortSignal` on `FrameworkRequest.signal` when the plat
 
 Adapters that parse multipart uploads should attach runtime-neutral `FrameworkRequestFile` values to `FrameworkRequest.files` rather than augmenting the shared HTTP contract with adapter-specific file types. The seam intentionally models the portable fields every HTTP adapter can provide (`fieldname`, `originalname`, `mimetype`, `buffer`, and `size`); platform packages may keep richer native file objects on their raw request surfaces, but guards, binders, middleware, interceptors, and controllers should read files through `RequestContext.request.files` when they need cross-runtime behavior.
 
+### Multipart DTO fields
+
+Use `@FromFiles(fieldname?)` with `@RequestDto(...)` when multipart files are part of a handler's input contract:
+
+```ts
+import {
+  FromFiles,
+  Optional,
+  RequestDto,
+  type FrameworkRequestFile,
+} from '@fluojs/http';
+
+class UploadAssetsDto {
+  @FromFiles('attachments')
+  attachments: readonly FrameworkRequestFile[] = [];
+
+  @FromFiles('cover')
+  @Optional()
+  cover?: readonly FrameworkRequestFile[];
+}
+
+@Post('/')
+@RequestDto(UploadAssetsDto)
+upload(input: UploadAssetsDto) {
+  return input.attachments.map((file) => file.originalname);
+}
+```
+
+`@FromFiles(...)` is array-only: when `FrameworkRequest.files` exists, it returns a readonly array filtered by `fieldname` in adapter arrival order; a present collection without matches becomes `[]`. When the collection is absent, required fields produce the standard missing-field error and `@Optional()` leaves the field `undefined`. Converters and validation receive that same portable array. The DTO binder projects only the five `FrameworkRequestFile` fields, so adapter-native file properties cannot leak through the DTO boundary. Direct `RequestContext.request.files` access remains supported for controllers and pipeline stages that need the entire request collection.
+
 Response content negotiation formatters must return `string` or `Uint8Array` from `ResponseFormatter.format(...)`. Node.js `Buffer` values remain assignable because `Buffer` implements `Uint8Array`, but formatter contracts should rely only on runtime-neutral byte behavior.
 
 ## Public API
 
 - **Routing decorators**: `Controller`, `Get`, `Sse`, `Query`, `Route`, `Post`, `Put`, `Patch`, `Delete`, `All`, `Options`, `Head`
-- **Binding decorators**: `FromBody`, `FromQuery`, `FromPath`, `FromHeader`, `FromCookie`, `RequestDto`, `Optional`, `Convert`
+- **Binding decorators**: `FromBody`, `FromQuery`, `FromPath`, `FromHeader`, `FromCookie`, `FromFiles`, `RequestDto`, `Optional`, `Convert`
 - **Execution decorators**: `UseGuards`, `UseInterceptors`, `HttpCode`, `Version`, `Header`, `Redirect`, `Produces`
 - **Header helpers**: `getRequestHeader`, `appendVaryHeader`
 - **Response cookie helpers**: `setCookie`, `clearCookie`, `CookieOptions`, `ClearCookieOptions`, `CookieSameSite`

--- a/packages/http/src/adapters/binding.test.ts
+++ b/packages/http/src/adapters/binding.test.ts
@@ -5,6 +5,7 @@ import {
   Convert,
   FromBody,
   FromCookie,
+  FromFiles,
   FromHeader,
   FromPath,
   FromQuery,
@@ -23,7 +24,12 @@ import {
 import { DefaultBinder } from './binding.js';
 import { getCompiledDtoBindingPlan } from './dto-binding-plan.js';
 import { HttpDtoValidationAdapter } from './dto-validation-adapter.js';
-import type { ArgumentResolverContext, FrameworkRequest, FrameworkResponse } from '../types.js';
+import type {
+  ArgumentResolverContext,
+  FrameworkRequest,
+  FrameworkRequestFile,
+  FrameworkResponse,
+} from '../types.js';
 
 function createRequest(overrides: Partial<FrameworkRequest> = {}): FrameworkRequest {
   return {
@@ -246,6 +252,143 @@ describe('DefaultBinder', () => {
     expect(bound.tags).toEqual(['admin']);
   });
 
+  it('binds filtered portable file arrays in adapter order without native leakage', async () => {
+    const attachments = [
+      {
+        buffer: new Uint8Array([1]),
+        fieldname: 'attachments',
+        mimetype: 'text/plain',
+        nativeUpload: { stream: 'native-only' },
+        originalname: 'first.txt',
+        size: 1,
+      },
+      {
+        buffer: new Uint8Array([2]),
+        fieldname: 'cover',
+        mimetype: 'text/plain',
+        nativeUpload: { stream: 'native-only' },
+        originalname: 'cover.txt',
+        size: 1,
+      },
+      {
+        buffer: new Uint8Array([3]),
+        fieldname: 'attachments',
+        mimetype: 'text/plain',
+        nativeUpload: { stream: 'native-only' },
+        originalname: 'second.txt',
+        size: 1,
+      },
+    ] satisfies readonly (FrameworkRequestFile & { nativeUpload: { stream: string } })[];
+
+    class UploadRequest {
+      @FromFiles('attachments')
+      attachments: readonly FrameworkRequestFile[] = [];
+    }
+
+    const request = createRequest({ files: attachments });
+    const binder = new DefaultBinder();
+    const bound = (await binder.bind(UploadRequest, createContext(request))) as UploadRequest;
+
+    expect(bound.attachments.map((file) => file.originalname)).toEqual(['first.txt', 'second.txt']);
+    expect(bound.attachments[0]).not.toBe(attachments[0]);
+    expect(bound.attachments[0]).toEqual({
+      buffer: new Uint8Array([1]),
+      fieldname: 'attachments',
+      mimetype: 'text/plain',
+      originalname: 'first.txt',
+      size: 1,
+    });
+    expect(bound.attachments[0]).not.toHaveProperty('nativeUpload');
+    expect(request.files?.[0]).toBe(attachments[0]);
+  });
+
+  it('distinguishes absent files from present unmatched fields and supports Optional', async () => {
+    class RequiredUploadRequest {
+      @FromFiles('attachments')
+      attachments: readonly FrameworkRequestFile[] = [];
+    }
+
+    class OptionalUploadRequest {
+      @FromFiles('attachments')
+      @Optional()
+      attachments?: readonly FrameworkRequestFile[];
+    }
+
+    const binder = new DefaultBinder();
+
+    await expect(
+      binder.bind(RequiredUploadRequest, createContext(createRequest())),
+    ).rejects.toMatchObject({
+      details: [
+        {
+          code: 'MISSING_FIELD',
+          field: 'attachments',
+          source: 'files',
+        },
+      ],
+      status: 400,
+    });
+
+    const absent = (await binder.bind(
+      OptionalUploadRequest,
+      createContext(createRequest()),
+    )) as OptionalUploadRequest;
+    const unmatched = (await binder.bind(
+      OptionalUploadRequest,
+      createContext(
+        createRequest({
+          files: [
+            {
+              buffer: new Uint8Array([1]),
+              fieldname: 'cover',
+              mimetype: 'text/plain',
+              originalname: 'cover.txt',
+              size: 1,
+            },
+          ],
+        }),
+      ),
+    )) as OptionalUploadRequest;
+
+    expect(absent.attachments).toBeUndefined();
+    expect(unmatched.attachments).toEqual([]);
+  });
+
+  it('applies converters to portable file arrays', async () => {
+    class FileNameConverter {
+      convert(value: unknown, target: { source: string }) {
+        expect(target.source).toBe('files');
+        return (value as readonly FrameworkRequestFile[]).map((file) => file.originalname);
+      }
+    }
+
+    class UploadRequest {
+      @FromFiles('attachments')
+      @Convert(FileNameConverter)
+      filenames: string[] = [];
+    }
+
+    const binder = new DefaultBinder();
+    const bound = (await binder.bind(
+      UploadRequest,
+      createContext(
+        createRequest({
+          files: [
+            {
+              buffer: new Uint8Array([1]),
+              fieldname: 'attachments',
+              mimetype: 'text/plain',
+              originalname: 'first.txt',
+              size: 1,
+            },
+          ],
+        }),
+      ),
+    )) as UploadRequest;
+
+    expect(bound.filenames).toEqual(['first.txt']);
+  });
+
   it('applies global converters before assigning DTO fields', async () => {
     class QueryNumberConverter {
       convert(value: unknown, target: { source: string }) {
@@ -356,6 +499,43 @@ describe('DefaultBinder', () => {
 });
 
 describe('HttpDtoValidationAdapter', () => {
+  it('validates matched file arrays after binding', async () => {
+    class UploadRequest {
+      @FromFiles('attachments')
+      @ArrayMinSize(1)
+      attachments: readonly FrameworkRequestFile[] = [];
+    }
+
+    const binder = new DefaultBinder();
+    const validator = new HttpDtoValidationAdapter();
+    const bound = (await binder.bind(
+      UploadRequest,
+      createContext(
+        createRequest({
+          files: [
+            {
+              buffer: new Uint8Array([1]),
+              fieldname: 'cover',
+              mimetype: 'text/plain',
+              originalname: 'cover.txt',
+              size: 1,
+            },
+          ],
+        }),
+      ),
+    )) as UploadRequest;
+
+    await expect(validator.validate(bound, UploadRequest)).rejects.toMatchObject({
+      details: [
+        {
+          field: 'attachments',
+          source: 'files',
+        },
+      ],
+      status: 400,
+    });
+  });
+
   it('uses DTO decorator validation rules and raises bad request details', async () => {
     class CreateUserRequest {
       @FromBody('name')

--- a/packages/http/src/adapters/dto-binding-plan.ts
+++ b/packages/http/src/adapters/dto-binding-plan.ts
@@ -9,7 +9,7 @@ import {
 } from '@fluojs/core/request-pipeline';
 
 import { getRequestHeader } from '../header-helpers.js';
-import type { FrameworkRequest } from '../types.js';
+import type { FrameworkRequest, FrameworkRequestFile } from '../types.js';
 
 function toFieldName(propertyKey: MetadataPropertyKey): string {
   return typeof propertyKey === 'string' ? propertyKey : String(propertyKey);
@@ -17,6 +17,16 @@ function toFieldName(propertyKey: MetadataPropertyKey): string {
 
 function resolveSourceKey(propertyKey: MetadataPropertyKey, key?: string): string {
   return key ?? toFieldName(propertyKey);
+}
+
+function toPortableRequestFile(file: FrameworkRequestFile): FrameworkRequestFile {
+  return {
+    buffer: file.buffer,
+    fieldname: file.fieldname,
+    mimetype: file.mimetype,
+    originalname: file.originalname,
+    size: file.size,
+  };
 }
 
 export interface CompiledDtoBindingPlanEntry {
@@ -52,6 +62,9 @@ function createSourceReader(source: MetadataSource, sourceKey: string): (request
       return (request) => request.cookies[sourceKey];
     case 'body':
       return (request) => (request.body as Record<string, unknown> | undefined)?.[sourceKey];
+    case 'files':
+      return (request) =>
+        request.files?.filter((file) => file.fieldname === sourceKey).map(toPortableRequestFile);
     default:
       return () => undefined;
   }

--- a/packages/http/src/decorators.ts
+++ b/packages/http/src/decorators.ts
@@ -600,6 +600,18 @@ export const FromCookie = createDtoFieldDecorator('cookie');
  * @returns A field decorator that marks the binding source as `body`.
  */
 export const FromBody = createDtoFieldDecorator('body');
+/**
+ * Binds a DTO field from portable multipart files.
+ *
+ * The binding always yields a readonly array when the request exposes a file
+ * collection, preserving adapter order and filtering by the optional field name.
+ * An absent file collection remains absent so `@Optional()` can opt out of the
+ * normal required-field error.
+ *
+ * @param key Optional multipart field-name filter. Defaults to the DTO field name.
+ * @returns A field decorator that marks the binding source as `files`.
+ */
+export const FromFiles = createDtoFieldDecorator('files');
 
 /**
  * Marks a DTO field binding as optional.

--- a/packages/http/src/index.portable.ts
+++ b/packages/http/src/index.portable.ts
@@ -9,6 +9,7 @@ export {
   Delete,
   FromBody,
   FromCookie,
+  FromFiles,
   FromHeader,
   FromPath,
   FromQuery,


### PR DESCRIPTION
Closes #3190

Adds portable `@FromFiles(fieldname?)` DTO binding, exports, EN/KO docs, book guidance, a minimal multipart example, and a minor Changeset.

Verification: dependency builds, core/http typechecks, example consumer typecheck, HTTP 333/333, controlled reverse-dependent runs, and unanimous exact-head full triad review.