### PR TITLE
fix(http): freeze HandlerMapping descriptor snapshots (#3184)

### DIFF
--- a/.changeset/freeze-handler-mapping-snapshot.md
+++ b/.changeset/freeze-handler-mapping-snapshot.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/http": patch
+---
+
+Freeze HandlerMapping descriptors so route inspection remains synchronized with matching.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
 
       - name: Test (scoped PR package scripts)
         if: matrix.project == 'other' && github.event_name == 'pull_request' && needs.resolve-pr-verification-scope.outputs.mode == 'scoped' && needs.resolve-pr-verification-scope.outputs.test_package_names != ''
-        run: pnpm -r --if-present ${{ needs.resolve-pr-verification-scope.outputs.test_filter_args }} run test
+        run: pnpm --workspace-concurrency=1 -r --if-present ${{ needs.resolve-pr-verification-scope.outputs.test_filter_args }} run test
 
       - name: Test (scoped PR fallback paths)
         if: matrix.project == 'other' && github.event_name == 'pull_request' && needs.resolve-pr-verification-scope.outputs.mode == 'scoped' && needs.resolve-pr-verification-scope.outputs.test_paths != ''

--- a/packages/http/src/dispatch/dispatcher.ts
+++ b/packages/http/src/dispatch/dispatcher.ts
@@ -26,6 +26,7 @@ import type {
   InterceptorLike,
   MiddlewareContext,
   MiddlewareLike,
+  MiddlewareSnapshotLike,
   RequestContext,
   RequestObservationContext,
   RequestObserver,
@@ -104,7 +105,7 @@ type FrameworkRequestWithPrincipal = FrameworkRequest & {
 
 interface CompiledMiddlewareScopePlan {
   alwaysRequiresRequestScope: boolean;
-  conditionalDefinitions: MiddlewareLike[];
+  conditionalDefinitions: MiddlewareSnapshotLike[];
 }
 
 interface CompiledDispatchStartPlan {
@@ -300,7 +301,7 @@ function createRequestDispatchScope(rootContainer: Container): DispatchScope {
 }
 
 function activeMiddlewareMayRequireRequestScope(
-  definitions: readonly MiddlewareLike[],
+  definitions: readonly MiddlewareSnapshotLike[],
   request: FrameworkRequest,
 ): boolean {
   return definitions.some((definition) => {
@@ -312,8 +313,8 @@ function activeMiddlewareMayRequireRequestScope(
   });
 }
 
-function compileMiddlewareScopePlan(definitions: readonly MiddlewareLike[]): CompiledMiddlewareScopePlan {
-  const conditionalDefinitions: MiddlewareLike[] = [];
+function compileMiddlewareScopePlan(definitions: readonly MiddlewareSnapshotLike[]): CompiledMiddlewareScopePlan {
+  const conditionalDefinitions: MiddlewareSnapshotLike[] = [];
 
   for (const definition of definitions) {
     if (!isMiddlewareRouteConfig(definition) || definition.routes.length === 0) {

--- a/packages/http/src/mapping.test.ts
+++ b/packages/http/src/mapping.test.ts
@@ -1,6 +1,6 @@
 import { defineControllerMetadata, defineRouteMetadata } from '@fluojs/core/internal';
 import { Container } from '@fluojs/di';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { All, Controller, Get, Query, Route, Version } from './decorators.js';
 import { InvalidRoutePathError, RouteConflictError } from './errors.js';
@@ -138,7 +138,7 @@ describe('handler mapping', () => {
     expect(match?.descriptor).toBe(descriptor);
   });
 
-  it('keeps matching bound to the exposed descriptor snapshot', () => {
+  it('keeps matching bound to an immutable exposed descriptor snapshot', () => {
     @Controller('/users')
     class UsersController {
       @Get('/:id')
@@ -149,12 +149,18 @@ describe('handler mapping', () => {
 
     const mapping = createHandlerMapping([{ controllerToken: UsersController }]);
     const descriptor = mapping.descriptors[0];
+    const descriptorsProperty = Object.getOwnPropertyDescriptor(mapping, 'descriptors');
 
     expect(Reflect.set(mapping, 'descriptors', [])).toBe(false);
     expect(mapping.descriptors).toContain(descriptor);
-    expect(Object.isFrozen(mapping)).toBe(true);
+    expect(descriptorsProperty).toMatchObject({
+      configurable: false,
+      writable: false,
+    });
+    expect(Object.isFrozen(mapping)).toBe(false);
+    const match = vi.spyOn(mapping, 'match');
 
-    const match = mapping.match({
+    const result = mapping.match({
       body: undefined,
       cookies: {},
       headers: {},
@@ -166,7 +172,8 @@ describe('handler mapping', () => {
       url: '/users/42',
     });
 
-    expect(match?.descriptor).toBe(descriptor);
+    expect(result?.descriptor).toBe(descriptor);
+    expect(match).toHaveBeenCalledOnce();
   });
 
   it('isolates route middleware matching from source input mutation', async () => {

--- a/packages/http/src/mapping.test.ts
+++ b/packages/http/src/mapping.test.ts
@@ -49,17 +49,26 @@ describe('handler mapping', () => {
     });
   });
 
-  it('keeps route inspection synchronized with matching after descriptor mutation attempts', () => {
-    @Controller('/users')
+  it('freezes mapping snapshots without freezing caller metadata', () => {
     class UsersController {
-      @Get('/:id')
       getUser() {
         return { ok: true };
       }
     }
 
+    const route = {
+      headers: [{ name: 'x-source', value: 'original' }],
+      method: 'GET',
+      path: '/:id',
+    };
+    defineControllerMetadata(UsersController, { basePath: '/users' });
+    defineRouteMetadata(UsersController.prototype, 'getUser', route);
+
     const mapping = createHandlerMapping([{ controllerToken: UsersController }]);
     const descriptor = mapping.descriptors[0];
+
+    route.path = '/:slug';
+    route.headers[0]!.value = 'mutated';
 
     expect(() => {
       mapping.descriptors.push(descriptor);
@@ -70,6 +79,9 @@ describe('handler mapping', () => {
     expect(() => {
       descriptor.metadata.pathParams.push('slug');
     }).toThrow(TypeError);
+    expect(Object.isFrozen(route)).toBe(false);
+    expect(Object.isFrozen(route.headers)).toBe(false);
+    expect(descriptor.route.headers).toEqual([{ name: 'x-source', value: 'original' }]);
 
     const match = mapping.match({
       body: undefined,
@@ -85,7 +97,10 @@ describe('handler mapping', () => {
 
     expect(match).toMatchObject({
       descriptor: {
-        route: { path: '/users/:id' },
+        route: {
+          headers: [{ name: 'x-source', value: 'original' }],
+          path: '/users/:id',
+        },
       },
       params: { id: '42' },
     });

--- a/packages/http/src/mapping.test.ts
+++ b/packages/http/src/mapping.test.ts
@@ -1,10 +1,41 @@
 import { defineControllerMetadata, defineRouteMetadata } from '@fluojs/core/internal';
+import { Container } from '@fluojs/di';
 import { describe, expect, it } from 'vitest';
 
 import { All, Controller, Get, Query, Route, Version } from './decorators.js';
 import { InvalidRoutePathError, RouteConflictError } from './errors.js';
 import { createHandlerMapping } from './mapping.js';
+import { isMiddlewareRouteConfig, runMiddlewareChain } from './middleware/middleware.js';
+import type { FrameworkRequest, FrameworkResponse, Middleware, MiddlewareContext, Next } from './types.js';
 import { VersioningType } from './types.js';
+
+function createMiddlewareContext(path: string, container: Container): MiddlewareContext {
+  const request: FrameworkRequest = {
+    body: undefined,
+    cookies: {},
+    headers: {},
+    method: 'GET',
+    params: {},
+    path,
+    query: {},
+    raw: {},
+    url: path,
+  };
+  const response: FrameworkResponse = {
+    committed: false,
+    headers: {},
+    redirect() {},
+    send() {},
+    setHeader() {},
+    setStatus() {},
+  };
+
+  return {
+    request,
+    requestContext: { container, metadata: {}, request, response },
+    response,
+  };
+}
 
 describe('handler mapping', () => {
   it('normalizes paths and extracts path params', () => {
@@ -105,6 +136,165 @@ describe('handler mapping', () => {
       params: { id: '42' },
     });
     expect(match?.descriptor).toBe(descriptor);
+  });
+
+  it('keeps matching bound to the exposed descriptor snapshot', () => {
+    @Controller('/users')
+    class UsersController {
+      @Get('/:id')
+      getUser() {
+        return { ok: true };
+      }
+    }
+
+    const mapping = createHandlerMapping([{ controllerToken: UsersController }]);
+    const descriptor = mapping.descriptors[0];
+
+    expect(Reflect.set(mapping, 'descriptors', [])).toBe(false);
+    expect(mapping.descriptors).toContain(descriptor);
+    expect(Object.isFrozen(mapping)).toBe(true);
+
+    const match = mapping.match({
+      body: undefined,
+      cookies: {},
+      headers: {},
+      method: 'GET',
+      params: {},
+      path: '/users/42',
+      query: {},
+      raw: {},
+      url: '/users/42',
+    });
+
+    expect(match?.descriptor).toBe(descriptor);
+  });
+
+  it('isolates route middleware matching from source input mutation', async () => {
+    const events: string[] = [];
+
+    class RouteMiddleware implements Middleware {
+      async handle(_context: MiddlewareContext, next: Next) {
+        events.push('middleware');
+        await next();
+      }
+    }
+
+    @Controller('/users')
+    class UsersController {
+      @Get('/:id')
+      getUser() {
+        return { ok: true };
+      }
+    }
+
+    const sourceConfig = { middleware: RouteMiddleware, routes: ['/users/*'] };
+    const mapping = createHandlerMapping([{
+      controllerToken: UsersController,
+      moduleMiddleware: [sourceConfig],
+    }]);
+    const descriptor = mapping.match({
+      body: undefined,
+      cookies: {},
+      headers: {},
+      method: 'GET',
+      params: {},
+      path: '/users/42',
+      query: {},
+      raw: {},
+      url: '/users/42',
+    })?.descriptor;
+
+    expect(descriptor).toBeDefined();
+    if (!descriptor) {
+      throw new Error('Expected a matching descriptor.');
+    }
+
+    sourceConfig.routes[0] = '/admin/*';
+
+    const mappedConfig = descriptor.metadata.moduleMiddleware[0];
+    expect(isMiddlewareRouteConfig(mappedConfig)).toBe(true);
+    if (!isMiddlewareRouteConfig(mappedConfig)) {
+      throw new Error('Expected a mapped middleware route config.');
+    }
+
+    expect(mappedConfig).not.toBe(sourceConfig);
+    expect(mappedConfig).toMatchObject({ routes: ['/users/*'] });
+    expect(Object.isFrozen(mappedConfig)).toBe(true);
+    expect(Object.isFrozen(mappedConfig.routes)).toBe(true);
+
+    const container = new Container().register(RouteMiddleware);
+    await runMiddlewareChain(
+      descriptor.metadata.moduleMiddleware,
+      createMiddlewareContext('/users/42', container),
+      async () => {
+        events.push('terminal');
+      },
+    );
+
+    expect(events).toEqual(['middleware', 'terminal']);
+  });
+
+  it('prevents public middleware snapshot mutation from changing matching', async () => {
+    const events: string[] = [];
+
+    class RouteMiddleware implements Middleware {
+      async handle(_context: MiddlewareContext, next: Next) {
+        events.push('middleware');
+        await next();
+      }
+    }
+
+    @Controller('/users')
+    class UsersController {
+      @Get('/:id')
+      getUser() {
+        return { ok: true };
+      }
+    }
+
+    const sourceConfig = { middleware: RouteMiddleware, routes: ['/users/*'] };
+    const mapping = createHandlerMapping([{
+      controllerToken: UsersController,
+      moduleMiddleware: [sourceConfig],
+    }]);
+    const descriptor = mapping.match({
+      body: undefined,
+      cookies: {},
+      headers: {},
+      method: 'GET',
+      params: {},
+      path: '/users/42',
+      query: {},
+      raw: {},
+      url: '/users/42',
+    })?.descriptor;
+
+    expect(descriptor).toBeDefined();
+    if (!descriptor) {
+      throw new Error('Expected a matching descriptor.');
+    }
+
+    const mappedConfig = descriptor.metadata.moduleMiddleware[0];
+
+    expect(isMiddlewareRouteConfig(mappedConfig)).toBe(true);
+    if (!isMiddlewareRouteConfig(mappedConfig)) {
+      throw new Error('Expected a mapped middleware route config.');
+    }
+
+    expect(Reflect.set(mappedConfig.routes, 0, '/admin/*')).toBe(false);
+    expect(mappedConfig.middleware).toBe(RouteMiddleware);
+    expect(mappedConfig.routes).toEqual(['/users/*']);
+
+    const container = new Container().register(RouteMiddleware);
+    await runMiddlewareChain(
+      descriptor.metadata.moduleMiddleware,
+      createMiddlewareContext('/users/42', container),
+      async () => {
+        events.push('terminal');
+      },
+    );
+
+    expect(events).toEqual(['middleware', 'terminal']);
   });
 
   it('fails fast on duplicate normalized route registrations', () => {

--- a/packages/http/src/mapping.test.ts
+++ b/packages/http/src/mapping.test.ts
@@ -49,6 +49,49 @@ describe('handler mapping', () => {
     });
   });
 
+  it('keeps route inspection synchronized with matching after descriptor mutation attempts', () => {
+    @Controller('/users')
+    class UsersController {
+      @Get('/:id')
+      getUser() {
+        return { ok: true };
+      }
+    }
+
+    const mapping = createHandlerMapping([{ controllerToken: UsersController }]);
+    const descriptor = mapping.descriptors[0];
+
+    expect(() => {
+      mapping.descriptors.push(descriptor);
+    }).toThrow(TypeError);
+    expect(() => {
+      descriptor.route.path = '/users/:slug';
+    }).toThrow(TypeError);
+    expect(() => {
+      descriptor.metadata.pathParams.push('slug');
+    }).toThrow(TypeError);
+
+    const match = mapping.match({
+      body: undefined,
+      cookies: {},
+      headers: {},
+      method: 'GET',
+      params: {},
+      path: '/users/42',
+      query: {},
+      raw: {},
+      url: '/users/42',
+    });
+
+    expect(match).toMatchObject({
+      descriptor: {
+        route: { path: '/users/:id' },
+      },
+      params: { id: '42' },
+    });
+    expect(match?.descriptor).toBe(descriptor);
+  });
+
   it('fails fast on duplicate normalized route registrations', () => {
     @Controller('/health')
     class HealthController {

--- a/packages/http/src/mapping.ts
+++ b/packages/http/src/mapping.ts
@@ -421,13 +421,32 @@ function buildDescriptorList(sources: HandlerSource[], versioning: ResolvedVersi
   return descriptors;
 }
 
-function freezeDescriptorSnapshot(descriptors: HandlerDescriptor[]): HandlerDescriptor[] {
-  for (const descriptor of descriptors) {
+function freezeDescriptorSnapshot(descriptors: readonly HandlerDescriptor[]): HandlerDescriptor[] {
+  const snapshot = descriptors.map((descriptor) => {
+    const { metadata, route } = descriptor;
+
+    return {
+      ...descriptor,
+      metadata: {
+        ...metadata,
+        moduleMiddleware: [...metadata.moduleMiddleware],
+        pathParams: [...metadata.pathParams],
+      },
+      route: {
+        ...route,
+        ...(route.guards ? { guards: [...route.guards] } : {}),
+        ...(route.headers ? { headers: route.headers.map((header) => ({ ...header })) } : {}),
+        ...(route.interceptors ? { interceptors: [...route.interceptors] } : {}),
+        ...(route.produces ? { produces: [...route.produces] } : {}),
+        ...(route.redirect ? { redirect: { ...route.redirect } } : {}),
+      },
+    };
+  });
+
+  for (const descriptor of snapshot) {
     const { metadata, route } = descriptor;
 
     if (route.headers) {
-      route.headers = route.headers.map((header) => ({ ...header }));
-
       for (const header of route.headers) {
         Object.freeze(header);
       }
@@ -436,7 +455,6 @@ function freezeDescriptorSnapshot(descriptors: HandlerDescriptor[]): HandlerDesc
     }
 
     if (route.redirect) {
-      route.redirect = { ...route.redirect };
       Object.freeze(route.redirect);
     }
 
@@ -460,8 +478,8 @@ function freezeDescriptorSnapshot(descriptors: HandlerDescriptor[]): HandlerDesc
     Object.freeze(descriptor);
   }
 
-  Object.freeze(descriptors);
-  return descriptors;
+  Object.freeze(snapshot);
+  return snapshot;
 }
 
 /**

--- a/packages/http/src/mapping.ts
+++ b/packages/http/src/mapping.ts
@@ -16,6 +16,7 @@ import type {
   HttpMethod,
   InterceptorLike,
   MiddlewareLike,
+  MiddlewareSnapshotLike,
   VersioningExtractor,
   VersioningOptions,
 } from './types.js';
@@ -484,7 +485,9 @@ function freezeDescriptorSnapshot(descriptors: readonly HandlerDescriptor[]): Ha
   return snapshot;
 }
 
-function freezeModuleMiddlewareSnapshot(definitions: readonly MiddlewareLike[]): readonly MiddlewareLike[] {
+function freezeModuleMiddlewareSnapshot(
+  definitions: readonly (MiddlewareLike | MiddlewareSnapshotLike)[],
+): readonly MiddlewareSnapshotLike[] {
   const snapshot = definitions.map((definition) => {
     if (!isMiddlewareRouteConfig(definition)) {
       return definition;
@@ -511,7 +514,7 @@ export function createHandlerMapping(sources: HandlerSource[], options?: CreateH
   const descriptors = freezeDescriptorSnapshot(buildDescriptorList(sources, versioning));
   const descriptorIndex = buildDescriptorIndex(descriptors);
 
-  return Object.freeze({
+  const mapping = {
     descriptors,
     match(request: FrameworkRequest): HandlerMatch | undefined {
       const method = request.method.toUpperCase();
@@ -576,5 +579,12 @@ export function createHandlerMapping(sources: HandlerSource[], options?: CreateH
 
       return undefined;
     },
+  };
+
+  Object.defineProperty(mapping, 'descriptors', {
+    configurable: false,
+    writable: false,
   });
+
+  return mapping;
 }

--- a/packages/http/src/mapping.ts
+++ b/packages/http/src/mapping.ts
@@ -421,6 +421,49 @@ function buildDescriptorList(sources: HandlerSource[], versioning: ResolvedVersi
   return descriptors;
 }
 
+function freezeDescriptorSnapshot(descriptors: HandlerDescriptor[]): HandlerDescriptor[] {
+  for (const descriptor of descriptors) {
+    const { metadata, route } = descriptor;
+
+    if (route.headers) {
+      route.headers = route.headers.map((header) => ({ ...header }));
+
+      for (const header of route.headers) {
+        Object.freeze(header);
+      }
+
+      Object.freeze(route.headers);
+    }
+
+    if (route.redirect) {
+      route.redirect = { ...route.redirect };
+      Object.freeze(route.redirect);
+    }
+
+    if (route.guards) {
+      Object.freeze(route.guards);
+    }
+
+    if (route.interceptors) {
+      Object.freeze(route.interceptors);
+    }
+
+    if (route.produces) {
+      route.produces = [...route.produces];
+      Object.freeze(route.produces);
+    }
+
+    Object.freeze(route);
+    Object.freeze(metadata.moduleMiddleware);
+    Object.freeze(metadata.pathParams);
+    Object.freeze(metadata);
+    Object.freeze(descriptor);
+  }
+
+  Object.freeze(descriptors);
+  return descriptors;
+}
+
 /**
  * Create handler mapping.
  *
@@ -430,7 +473,7 @@ function buildDescriptorList(sources: HandlerSource[], versioning: ResolvedVersi
  */
 export function createHandlerMapping(sources: HandlerSource[], options?: CreateHandlerMappingOptions): HandlerMapping {
   const versioning = resolveVersioning(options);
-  const descriptors = buildDescriptorList(sources, versioning);
+  const descriptors = freezeDescriptorSnapshot(buildDescriptorList(sources, versioning));
   const descriptorIndex = buildDescriptorIndex(descriptors);
 
   return {

--- a/packages/http/src/mapping.ts
+++ b/packages/http/src/mapping.ts
@@ -4,6 +4,7 @@ import { getControllerMetadata, getRouteMetadata } from '@fluojs/core/internal';
 import { attachCompiledRouteIdentity } from './compiled-route-identity.js';
 import { getRouteProducesMetadata } from './decorators.js';
 import { RouteConflictError } from './errors.js';
+import { isMiddlewareRouteConfig } from './middleware/middleware.js';
 import { extractRoutePathParams, normalizeRoutePath, parseRoutePath, type RoutePathSegment } from './route-path.js';
 import type {
   FrameworkRequest,
@@ -14,6 +15,7 @@ import type {
   HandlerSource,
   HttpMethod,
   InterceptorLike,
+  MiddlewareLike,
   VersioningExtractor,
   VersioningOptions,
 } from './types.js';
@@ -429,7 +431,7 @@ function freezeDescriptorSnapshot(descriptors: readonly HandlerDescriptor[]): Ha
       ...descriptor,
       metadata: {
         ...metadata,
-        moduleMiddleware: [...metadata.moduleMiddleware],
+        moduleMiddleware: freezeModuleMiddlewareSnapshot(metadata.moduleMiddleware),
         pathParams: [...metadata.pathParams],
       },
       route: {
@@ -482,6 +484,21 @@ function freezeDescriptorSnapshot(descriptors: readonly HandlerDescriptor[]): Ha
   return snapshot;
 }
 
+function freezeModuleMiddlewareSnapshot(definitions: readonly MiddlewareLike[]): readonly MiddlewareLike[] {
+  const snapshot = definitions.map((definition) => {
+    if (!isMiddlewareRouteConfig(definition)) {
+      return definition;
+    }
+
+    return Object.freeze({
+      middleware: definition.middleware,
+      routes: Object.freeze([...definition.routes]),
+    });
+  });
+
+  return Object.freeze(snapshot);
+}
+
 /**
  * Create handler mapping.
  *
@@ -494,7 +511,7 @@ export function createHandlerMapping(sources: HandlerSource[], options?: CreateH
   const descriptors = freezeDescriptorSnapshot(buildDescriptorList(sources, versioning));
   const descriptorIndex = buildDescriptorIndex(descriptors);
 
-  return {
+  return Object.freeze({
     descriptors,
     match(request: FrameworkRequest): HandlerMatch | undefined {
       const method = request.method.toUpperCase();
@@ -559,5 +576,5 @@ export function createHandlerMapping(sources: HandlerSource[], options?: CreateH
 
       return undefined;
     },
-  };
+  });
 }

--- a/packages/http/src/middleware/middleware.ts
+++ b/packages/http/src/middleware/middleware.ts
@@ -73,7 +73,7 @@ async function resolveMiddleware(definition: MiddlewareLike, requestContext: Req
 }
 
 async function resolveActiveMiddlewareDefinitions(
-  definitions: MiddlewareLike[],
+  definitions: readonly MiddlewareLike[],
   context: MiddlewareContext,
 ): Promise<Middleware[]> {
   const requestPath = context.request.path;
@@ -114,7 +114,7 @@ function deferNext(next: Next): Next {
  * @returns The run middleware chain result.
  */
 export async function runMiddlewareChain(
-  definitions: MiddlewareLike[],
+  definitions: readonly MiddlewareLike[],
   context: MiddlewareContext,
   terminal: Next,
 ): Promise<void> {

--- a/packages/http/src/middleware/middleware.ts
+++ b/packages/http/src/middleware/middleware.ts
@@ -1,9 +1,18 @@
 import type { Constructor, Token } from '@fluojs/core';
 
 import { normalizeRoutePath } from '../route-path.js';
-import type { Middleware, MiddlewareContext, MiddlewareLike, MiddlewareRouteConfig, Next, RequestContext } from '../types.js';
+import type {
+  Middleware,
+  MiddlewareContext,
+  MiddlewareLike,
+  MiddlewareRouteConfig,
+  MiddlewareRouteSnapshot,
+  MiddlewareSnapshotLike,
+  Next,
+  RequestContext,
+} from '../types.js';
 
-function isMiddleware(value: MiddlewareLike): value is Middleware {
+function isMiddleware(value: MiddlewareLike | MiddlewareSnapshotLike): value is Middleware {
   return typeof value === 'object' && value !== null && 'handle' in value;
 }
 
@@ -13,7 +22,9 @@ function isMiddleware(value: MiddlewareLike): value is Middleware {
  * @param value The value.
  * @returns The is middleware route config result.
  */
-export function isMiddlewareRouteConfig(value: MiddlewareLike): value is MiddlewareRouteConfig {
+export function isMiddlewareRouteConfig(
+  value: MiddlewareLike | MiddlewareSnapshotLike,
+): value is MiddlewareRouteConfig | MiddlewareRouteSnapshot {
   return typeof value === 'object' && value !== null && 'middleware' in value && 'routes' in value;
 }
 
@@ -64,7 +75,10 @@ export function forRoutes<T extends Constructor<Middleware>>(
   return { middleware: middlewareClass, routes };
 }
 
-async function resolveMiddleware(definition: MiddlewareLike, requestContext: RequestContext): Promise<Middleware> {
+async function resolveMiddleware(
+  definition: MiddlewareLike | MiddlewareSnapshotLike,
+  requestContext: RequestContext,
+): Promise<Middleware> {
   if (isMiddleware(definition)) {
     return definition;
   }
@@ -73,7 +87,7 @@ async function resolveMiddleware(definition: MiddlewareLike, requestContext: Req
 }
 
 async function resolveActiveMiddlewareDefinitions(
-  definitions: readonly MiddlewareLike[],
+  definitions: readonly (MiddlewareLike | MiddlewareSnapshotLike)[],
   context: MiddlewareContext,
 ): Promise<Middleware[]> {
   const requestPath = context.request.path;
@@ -114,7 +128,7 @@ function deferNext(next: Next): Next {
  * @returns The run middleware chain result.
  */
 export async function runMiddlewareChain(
-  definitions: readonly MiddlewareLike[],
+  definitions: readonly (MiddlewareLike | MiddlewareSnapshotLike)[],
   context: MiddlewareContext,
   terminal: Next,
 ): Promise<void> {

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -252,7 +252,7 @@ export interface HandlerMetadata {
   controllerPath: string;
   effectivePath: string;
   effectiveVersion?: string;
-  moduleMiddleware: MiddlewareLike[];
+  moduleMiddleware: readonly MiddlewareLike[];
   moduleType?: Constructor;
   pathParams: string[];
 }
@@ -357,7 +357,7 @@ export interface Middleware {
 /** Declarative middleware binding for selected route patterns. */
 export interface MiddlewareRouteConfig {
   middleware: Constructor<Middleware>;
-  routes: string[];
+  routes: readonly string[];
 }
 
 /** Guard execution context for one matched handler invocation. */

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -252,7 +252,7 @@ export interface HandlerMetadata {
   controllerPath: string;
   effectivePath: string;
   effectiveVersion?: string;
-  moduleMiddleware: readonly MiddlewareLike[];
+  moduleMiddleware: readonly MiddlewareSnapshotLike[];
   moduleType?: Constructor;
   pathParams: string[];
 }
@@ -357,7 +357,13 @@ export interface Middleware {
 /** Declarative middleware binding for selected route patterns. */
 export interface MiddlewareRouteConfig {
   middleware: Constructor<Middleware>;
-  routes: readonly string[];
+  routes: string[];
+}
+
+/** @internal Immutable route-binding view retained by handler mapping snapshots. */
+export interface MiddlewareRouteSnapshot {
+  readonly middleware: Constructor<Middleware>;
+  readonly routes: readonly string[];
 }
 
 /** Guard execution context for one matched handler invocation. */
@@ -427,6 +433,8 @@ export interface Converter {
 
 /** Middleware reference accepted by module/runtime configuration. */
 export type MiddlewareLike = Middleware | Token<Middleware> | MiddlewareRouteConfig;
+/** @internal Middleware reference retained by handler mapping snapshots. */
+export type MiddlewareSnapshotLike = Middleware | Token<Middleware> | MiddlewareRouteSnapshot;
 /** Guard reference accepted by route metadata and runtime configuration. */
 export type GuardLike = Guard | Token<Guard>;
 /** Interceptor reference accepted by route metadata and runtime configuration. */

--- a/packages/openapi/src/openapi-module.test.ts
+++ b/packages/openapi/src/openapi-module.test.ts
@@ -28,6 +28,7 @@ import {
 } from './decorators.js';
 import * as openApiPublicApi from './index.js';
 import { OpenApiModule } from './openapi-module.js';
+import { cloneSnapshotValue } from './snapshot.js';
 import type { OpenApiDocument } from './schema-builder.js';
 
 type TestFrameworkResponse = FrameworkResponse & { body?: unknown };
@@ -2332,7 +2333,9 @@ describe('OpenApiModule', () => {
       }
     }
 
-    const descriptors = createHandlerMapping([{ controllerToken: DescriptorStableController }]).descriptors;
+    const descriptors = cloneSnapshotValue(
+      createHandlerMapping([{ controllerToken: DescriptorStableController }]).descriptors,
+    );
     const extraModels = [StableExtraModel];
     const sources: HandlerSource[] = [{ controllerToken: StableController }];
     const securitySchemes = {

--- a/packages/openapi/src/path-item.test.ts
+++ b/packages/openapi/src/path-item.test.ts
@@ -67,14 +67,9 @@ describe('OpenAPI Path Item validation', () => {
     // Given
     @Controller('/unsupported')
     class UnsupportedController {
-      @Get('/') handle() { return undefined; }
+      @Route(method, '/') handle() { return undefined; }
     }
     const descriptors = createHandlerMapping([{ controllerToken: UnsupportedController }]).descriptors;
-    const descriptor = descriptors[0];
-    if (descriptor === undefined) {
-      throw new TypeError('Expected the unsupported-method fixture to create one descriptor.');
-    }
-    Reflect.set(descriptor.route, 'method', method);
 
     // When
     const buildDocument = () => buildOpenApiDocument({ ...DOCUMENT_OPTIONS, descriptors });

--- a/packages/react/src/page-catalog.test.ts
+++ b/packages/react/src/page-catalog.test.ts
@@ -46,7 +46,9 @@ describe('React page catalog', () => {
     // When
     const catalog = createReactPageCatalog(mapping.descriptors);
     const runtimeRoutes = createRuntimeRouteCatalog(mapping.descriptors);
-    mapping.descriptors[0]?.metadata.pathParams.push('mutated-after-projection');
+    expect(() => {
+      mapping.descriptors[0]?.metadata.pathParams.push('mutated-after-projection');
+    }).toThrow(TypeError);
     const matchAfterProjection = mapping.match(createGetRequest('/v2/products/sku-42'));
 
     // Then

--- a/tooling/governance/native-response-cookie-ci.test.ts
+++ b/tooling/governance/native-response-cookie-ci.test.ts
@@ -16,3 +16,19 @@ it('builds the portable cookie helper dependency closure in native CI', () => {
   // Then
   expect(nativeJob).toContain('run: pnpm --filter @fluojs/http... build');
 });
+
+it('runs scoped PR package scripts serially to prevent shared artifact build races', () => {
+  // Given
+  const workflow = readFileSync(resolve(import.meta.dirname, '../../.github/workflows/ci.yml'), 'utf8');
+
+  // When
+  const scopedPackageTestStep = workflow.slice(
+    workflow.indexOf('      - name: Test (scoped PR package scripts)'),
+    workflow.indexOf('      - name: Test (scoped PR fallback paths)'),
+  );
+
+  // Then
+  expect(scopedPackageTestStep).toMatch(
+    /run: pnpm --workspace-concurrency=1 -r --if-present \$\{\{ needs\.resolve-pr-verification-scope\.outputs\.test_filter_args \}\} run test/u,
+  );
+});


### PR DESCRIPTION
Closes #3184

Freezes mapping-owned descriptor and middleware snapshots so inspection and matching cannot diverge, with OpenAPI regression coverage and a patch Changeset.

Verification: HTTP 333/333, OpenAPI 90/90, dependency build/typechecks, and unanimous exact-head full triad review.