### PR TITLE
docs(http): correct website guide examples (#3188)

### DIFF
--- a/apps/docs/content/docs/guides/first-feature.ko.mdx
+++ b/apps/docs/content/docs/guides/first-feature.ko.mdx
@@ -52,6 +52,7 @@ Provider는 business behavior를 소유해야 합니다. Controller는 transport
 ## 3. HTTP boundary 정의
 
 ```ts
+import { Inject } from '@fluojs/core';
 import { Controller, FromBody, FromPath, Get, Post, RequestDto } from '@fluojs/http';
 
 import { UsersService } from './users.service';
@@ -67,6 +68,7 @@ class FindUserParamsDto {
 }
 
 @Controller('/users')
+@Inject(UsersService)
 export class UsersController {
   constructor(private readonly users: UsersService) {}
 

--- a/apps/docs/content/docs/guides/first-feature.ko.mdx
+++ b/apps/docs/content/docs/guides/first-feature.ko.mdx
@@ -52,26 +52,34 @@ Provider는 business behavior를 소유해야 합니다. Controller는 transport
 ## 3. HTTP boundary 정의
 
 ```ts
-import { Body, Controller, Get, Param, Post } from '@fluojs/http';
+import { Controller, FromBody, FromPath, Get, Post, RequestDto } from '@fluojs/http';
 
 import { UsersService } from './users.service';
 
-interface CreateUserBody {
-  name: string;
+class CreateUserDto {
+  @FromBody()
+  name!: string;
+}
+
+class FindUserParamsDto {
+  @FromPath('id')
+  id!: string;
 }
 
 @Controller('/users')
 export class UsersController {
   constructor(private readonly users: UsersService) {}
 
-  @Post()
-  create(@Body() body: CreateUserBody) {
-    return this.users.create(body.name);
+  @Post('/')
+  @RequestDto(CreateUserDto)
+  create(input: CreateUserDto) {
+    return this.users.create(input.name);
   }
 
   @Get('/:id')
-  findOne(@Param('id') id: string) {
-    return this.users.findById(id);
+  @RequestDto(FindUserParamsDto)
+  findOne(input: FindUserParamsDto) {
+    return this.users.findById(input.id);
   }
 }
 ```
@@ -83,7 +91,10 @@ Controller는 route shape와 request binding을 소유합니다. Package나 pers
 Route가 실제 외부 입력을 받기 시작하면 `@fluojs/validation`을 사용하세요. DTO validation은 edge에 두고, 검증된 값을 내부로 전달합니다.
 
 ```ts
+import { FromBody } from '@fluojs/http';
+
 export class CreateUserDto {
+  @FromBody()
   name!: string;
 }
 ```

--- a/apps/docs/content/docs/guides/first-feature.mdx
+++ b/apps/docs/content/docs/guides/first-feature.mdx
@@ -52,26 +52,34 @@ Providers should own business behavior. Controllers should only translate transp
 ## 3. Define the HTTP boundary
 
 ```ts
-import { Body, Controller, Get, Param, Post } from '@fluojs/http';
+import { Controller, FromBody, FromPath, Get, Post, RequestDto } from '@fluojs/http';
 
 import { UsersService } from './users.service';
 
-interface CreateUserBody {
-  name: string;
+class CreateUserDto {
+  @FromBody()
+  name!: string;
+}
+
+class FindUserParamsDto {
+  @FromPath('id')
+  id!: string;
 }
 
 @Controller('/users')
 export class UsersController {
   constructor(private readonly users: UsersService) {}
 
-  @Post()
-  create(@Body() body: CreateUserBody) {
-    return this.users.create(body.name);
+  @Post('/')
+  @RequestDto(CreateUserDto)
+  create(input: CreateUserDto) {
+    return this.users.create(input.name);
   }
 
   @Get('/:id')
-  findOne(@Param('id') id: string) {
-    return this.users.findById(id);
+  @RequestDto(FindUserParamsDto)
+  findOne(input: FindUserParamsDto) {
+    return this.users.findById(input.id);
   }
 }
 ```
@@ -83,7 +91,10 @@ The controller owns route shape and request binding. It should not hide package 
 Use `@fluojs/validation` once the route accepts real external input. Keep DTO validation at the edge and pass validated values inward.
 
 ```ts
+import { FromBody } from '@fluojs/http';
+
 export class CreateUserDto {
+  @FromBody()
   name!: string;
 }
 ```

--- a/apps/docs/content/docs/guides/first-feature.mdx
+++ b/apps/docs/content/docs/guides/first-feature.mdx
@@ -52,6 +52,7 @@ Providers should own business behavior. Controllers should only translate transp
 ## 3. Define the HTTP boundary
 
 ```ts
+import { Inject } from '@fluojs/core';
 import { Controller, FromBody, FromPath, Get, Post, RequestDto } from '@fluojs/http';
 
 import { UsersService } from './users.service';
@@ -67,6 +68,7 @@ class FindUserParamsDto {
 }
 
 @Controller('/users')
+@Inject(UsersService)
 export class UsersController {
   constructor(private readonly users: UsersService) {}
 

--- a/apps/docs/content/docs/guides/http-api.ko.mdx
+++ b/apps/docs/content/docs/guides/http-api.ko.mdx
@@ -13,17 +13,26 @@ fluo의 HTTP 모델은 두 책임으로 나뉩니다.
 ## 1. Controller에서 시작
 
 ```ts
-import { Body, Controller, Get, Param, Post } from '@fluojs/http';
+import { Controller, FromBody, FromPath, Get, Post, RequestDto } from '@fluojs/http';
 
-interface CreateArticleBody {
-  title: string;
-  body: string;
+class CreateArticleDto {
+  @FromBody()
+  title!: string;
+
+  @FromBody()
+  body!: string;
+}
+
+class FindArticleParamsDto {
+  @FromPath('slug')
+  slug!: string;
 }
 
 @Controller('/articles')
 export class ArticlesController {
-  @Post()
-  create(@Body() input: CreateArticleBody) {
+  @Post('/')
+  @RequestDto(CreateArticleDto)
+  create(input: CreateArticleDto) {
     return {
       slug: input.title.toLowerCase().replaceAll(' ', '-'),
       title: input.title,
@@ -32,8 +41,9 @@ export class ArticlesController {
   }
 
   @Get('/:slug')
-  findOne(@Param('slug') slug: string) {
-    return { slug };
+  @RequestDto(FindArticleParamsDto)
+  findOne(input: FindArticleParamsDto) {
+    return { slug: input.slug };
   }
 }
 ```

--- a/apps/docs/content/docs/guides/http-api.mdx
+++ b/apps/docs/content/docs/guides/http-api.mdx
@@ -13,17 +13,26 @@ Keep this split in mind: application code should depend on HTTP contracts, not o
 ## 1. Start with a controller
 
 ```ts
-import { Body, Controller, Get, Param, Post } from '@fluojs/http';
+import { Controller, FromBody, FromPath, Get, Post, RequestDto } from '@fluojs/http';
 
-interface CreateArticleBody {
-  title: string;
-  body: string;
+class CreateArticleDto {
+  @FromBody()
+  title!: string;
+
+  @FromBody()
+  body!: string;
+}
+
+class FindArticleParamsDto {
+  @FromPath('slug')
+  slug!: string;
 }
 
 @Controller('/articles')
 export class ArticlesController {
-  @Post()
-  create(@Body() input: CreateArticleBody) {
+  @Post('/')
+  @RequestDto(CreateArticleDto)
+  create(input: CreateArticleDto) {
     return {
       slug: input.title.toLowerCase().replaceAll(' ', '-'),
       title: input.title,
@@ -32,8 +41,9 @@ export class ArticlesController {
   }
 
   @Get('/:slug')
-  findOne(@Param('slug') slug: string) {
-    return { slug };
+  @RequestDto(FindArticleParamsDto)
+  findOne(input: FindArticleParamsDto) {
+    return { slug: input.slug };
   }
 }
 ```

--- a/tooling/governance/http-website-guide-snippets.d.mts
+++ b/tooling/governance/http-website-guide-snippets.d.mts
@@ -1,0 +1,21 @@
+export interface DtoBinding {
+  readonly key: string | undefined;
+  readonly member: string;
+  readonly source: 'FromBody' | 'FromPath';
+}
+
+export interface GuideRouteBinding {
+  readonly bindings: readonly DtoBinding[];
+  readonly method: 'Get' | 'Post';
+  readonly name: string;
+  readonly parameterDto: string | undefined;
+  readonly pathPlaceholders: readonly string[];
+  readonly requestDto: string | undefined;
+  readonly routePath: string;
+}
+
+export function intendedHttpSnippets(markdown: string): readonly string[];
+export function semanticDiagnostics(relativePath: string, sourceText: string): string[];
+export function exportedHttpNames(): Set<string>;
+export function routeBindings(sourceText: string): GuideRouteBinding[];
+export function classDecoratorArguments(sourceText: string, className: string, decoratorName: string): string[];

--- a/tooling/governance/http-website-guide-snippets.mjs
+++ b/tooling/governance/http-website-guide-snippets.mjs
@@ -1,0 +1,216 @@
+import { dirname, join, resolve } from 'node:path';
+import {
+  canHaveDecorators,
+  createCompilerHost,
+  createProgram,
+  createSourceFile,
+  DiagnosticCategory,
+  flattenDiagnosticMessageText,
+  getDecorators,
+  getPreEmitDiagnostics,
+  isCallExpression,
+  isClassDeclaration,
+  isIdentifier,
+  isMethodDeclaration,
+  isPropertyDeclaration,
+  isTypeReferenceNode,
+  ModuleKind,
+  ModuleResolutionKind,
+  ScriptKind,
+  ScriptTarget,
+} from 'typescript';
+
+const repoRoot = resolve(import.meta.dirname, '..', '..');
+const httpEntrypointPath = join(repoRoot, 'packages/http/src/index.ts');
+
+function compilerOptions() {
+  return {
+    baseUrl: repoRoot,
+    exactOptionalPropertyTypes: true,
+    module: ModuleKind.ESNext,
+    moduleResolution: ModuleResolutionKind.Bundler,
+    noEmit: true,
+    noUncheckedIndexedAccess: true,
+    paths: {
+      '@fluojs/core/internal': ['packages/core/src/internal.ts'],
+      '@fluojs/core/request-pipeline': ['packages/core/src/request-pipeline.ts'],
+      '@fluojs/*': ['packages/*/src/index.ts'],
+    },
+    skipLibCheck: true,
+    strict: true,
+    target: ScriptTarget.ES2022,
+    types: ['node'],
+  };
+}
+
+function virtualSnippetPath(relativePath) {
+  return join(repoRoot, '.virtual-http-docs', relativePath.replace(/\.(?:md|mdx)$/u, '.ts'));
+}
+
+function virtualFixtures(relativePath) {
+  if (!relativePath.includes('first-feature')) {
+    return new Map();
+  }
+
+  return new Map([
+    [
+      join(dirname(virtualSnippetPath(relativePath)), 'users.service.ts'),
+      `export class UsersService {
+  create(name: string): { readonly id: string; readonly name: string } {
+    return { id: '1', name };
+  }
+
+  findById(id: string): { readonly id: string; readonly name: string } | undefined {
+    return { id, name: 'Ada' };
+  }
+}
+`,
+    ],
+  ]);
+}
+
+export function semanticDiagnostics(relativePath, sourceText) {
+  const sourcePath = virtualSnippetPath(relativePath);
+  const sourceFiles = new Map([[sourcePath, sourceText], ...virtualFixtures(relativePath)]);
+  const options = compilerOptions();
+  const host = createCompilerHost(options, true);
+  const defaultFileExists = host.fileExists.bind(host);
+  const defaultDirectoryExists = host.directoryExists?.bind(host);
+  const defaultGetSourceFile = host.getSourceFile.bind(host);
+  const defaultReadFile = host.readFile.bind(host);
+  const virtualDirectories = new Set([...sourceFiles.keys()].map((fileName) => dirname(fileName)));
+
+  host.directoryExists = (directoryName) => virtualDirectories.has(directoryName) || defaultDirectoryExists?.(directoryName) === true;
+  host.fileExists = (fileName) => sourceFiles.has(fileName) || defaultFileExists(fileName);
+  host.readFile = (fileName) => sourceFiles.get(fileName) ?? defaultReadFile(fileName);
+  host.getSourceFile = (fileName, languageVersion, onError, shouldCreateNewSourceFile) => {
+    const source = sourceFiles.get(fileName);
+
+    return source === undefined
+      ? defaultGetSourceFile(fileName, languageVersion, onError, shouldCreateNewSourceFile)
+      : createSourceFile(fileName, source, languageVersion, true, ScriptKind.TS);
+  };
+
+  const program = createProgram([sourcePath], options, host);
+
+  return getPreEmitDiagnostics(program)
+    .filter((diagnostic) => diagnostic.category === DiagnosticCategory.Error && diagnostic.file?.fileName === sourcePath)
+    .map((diagnostic) => {
+      const message = flattenDiagnosticMessageText(diagnostic.messageText, '\n');
+
+      if (diagnostic.file === undefined || diagnostic.start === undefined) {
+        return message;
+      }
+
+      const position = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
+      return `${position.line + 1}:${position.character + 1} ${message}`;
+    });
+}
+
+export function exportedHttpNames() {
+  const options = compilerOptions();
+  const program = createProgram([httpEntrypointPath], options);
+  const entrypoint = program.getSourceFile(httpEntrypointPath);
+
+  if (entrypoint === undefined) {
+    throw new TypeError('Missing HTTP public entry point.');
+  }
+
+  const symbol = program.getTypeChecker().getSymbolAtLocation(entrypoint);
+
+  if (symbol === undefined) {
+    throw new TypeError('Could not resolve HTTP public entry point exports.');
+  }
+
+  return new Set(program.getTypeChecker().getExportsOfModule(symbol).map((exported) => exported.getName()));
+}
+
+function decoratorCall(node, name) {
+  if (!isCallExpression(node.expression) || !isIdentifier(node.expression.expression)) {
+    return undefined;
+  }
+
+  return node.expression.expression.text === name ? node.expression : undefined;
+}
+
+function decorators(node) {
+  return canHaveDecorators(node) ? getDecorators(node) ?? [] : [];
+}
+
+function decorator(node, name) {
+  return decorators(node)
+    .map((candidate) => decoratorCall(candidate, name))
+    .find((candidate) => candidate !== undefined);
+}
+
+function identifierArgument(call) {
+  const [argument] = call?.arguments ?? [];
+  return argument && isIdentifier(argument) ? argument.text : undefined;
+}
+
+function classDeclarations(sourceFile) {
+  return new Map(
+    sourceFile.statements
+      .filter(isClassDeclaration)
+      .flatMap((declaration) => declaration.name ? [[declaration.name.text, declaration]] : []),
+  );
+}
+
+function dtoBindings(declaration) {
+  return declaration.members
+    .filter(isPropertyDeclaration)
+    .flatMap((member) => {
+      const source = ['FromBody', 'FromPath']
+        .find((candidate) => decorator(member, candidate) !== undefined);
+
+      return member.name && isIdentifier(member.name) && source
+        ? [{ member: member.name.text, source }]
+        : [];
+    });
+}
+
+export function routeBindings(sourceText) {
+  const sourceFile = createSourceFile('snippet.ts', sourceText, ScriptTarget.ES2022, true, ScriptKind.TS);
+  const classes = classDeclarations(sourceFile);
+  const routes = [];
+
+  for (const declaration of classes.values()) {
+    if (decorator(declaration, 'Controller') === undefined) {
+      continue;
+    }
+
+    for (const member of declaration.members.filter(isMethodDeclaration)) {
+      const method = ['Get', 'Post']
+        .find((candidate) => decorator(member, candidate) !== undefined);
+
+      if (method === undefined || member.name === undefined || !isIdentifier(member.name)) {
+        continue;
+      }
+
+      const requestDto = identifierArgument(decorator(member, 'RequestDto'));
+      const parameterType = member.parameters[0]?.type;
+      const parameterDto = parameterType && isTypeReferenceNode(parameterType) && isIdentifier(parameterType.typeName)
+        ? parameterType.typeName.text
+        : undefined;
+      const dto = requestDto ? classes.get(requestDto) : undefined;
+
+      routes.push({
+        bindings: dto ? dtoBindings(dto) : [],
+        method,
+        name: member.name.text,
+        parameterDto,
+        requestDto,
+      });
+    }
+  }
+
+  return routes;
+}
+
+export function classDecoratorArguments(sourceText, className, decoratorName) {
+  const sourceFile = createSourceFile('snippet.ts', sourceText, ScriptTarget.ES2022, true, ScriptKind.TS);
+  const declaration = classDeclarations(sourceFile).get(className);
+  const call = declaration ? decorator(declaration, decoratorName) : undefined;
+
+  return call?.arguments.map((argument) => argument.getText(sourceFile)) ?? [];
+}

--- a/tooling/governance/http-website-guide-snippets.mjs
+++ b/tooling/governance/http-website-guide-snippets.mjs
@@ -13,6 +13,7 @@ import {
   isIdentifier,
   isMethodDeclaration,
   isPropertyDeclaration,
+  isStringLiteral,
   isTypeReferenceNode,
   ModuleKind,
   ModuleResolutionKind,
@@ -45,6 +46,13 @@ function compilerOptions() {
 
 function virtualSnippetPath(relativePath) {
   return join(repoRoot, '.virtual-http-docs', relativePath.replace(/\.(?:md|mdx)$/u, '.ts'));
+}
+
+export function intendedHttpSnippets(markdown) {
+  return [...markdown.matchAll(/```ts\n([\s\S]*?)```/gu)]
+    .map((match) => match[1])
+    .filter((source) => source !== undefined)
+    .filter((source) => /\b(?:Controller|FromBody|FromPath|Get|Post|RequestDto)\b/u.test(source));
 }
 
 function virtualFixtures(relativePath) {
@@ -148,6 +156,11 @@ function identifierArgument(call) {
   return argument && isIdentifier(argument) ? argument.text : undefined;
 }
 
+function stringArgument(call) {
+  const [argument] = call?.arguments ?? [];
+  return argument && isStringLiteral(argument) ? argument.text : undefined;
+}
+
 function classDeclarations(sourceFile) {
   return new Map(
     sourceFile.statements
@@ -156,22 +169,50 @@ function classDeclarations(sourceFile) {
   );
 }
 
+/**
+ * @typedef {{
+ *   readonly key: string | undefined;
+ *   readonly member: string;
+ *   readonly source: 'FromBody' | 'FromPath';
+ * }} DtoBinding
+ */
+
+/**
+ * @typedef {{
+ *   readonly bindings: readonly DtoBinding[];
+ *   readonly method: 'Get' | 'Post';
+ *   readonly name: string;
+ *   readonly parameterDto: string | undefined;
+ *   readonly pathPlaceholders: readonly string[];
+ *   readonly requestDto: string | undefined;
+ *   readonly routePath: string;
+ * }} GuideRouteBinding
+ */
+
+/** @returns {DtoBinding[]} */
 function dtoBindings(declaration) {
   return declaration.members
     .filter(isPropertyDeclaration)
     .flatMap((member) => {
-      const source = ['FromBody', 'FromPath']
-        .find((candidate) => decorator(member, candidate) !== undefined);
+      const fromBody = decorator(member, 'FromBody');
+      const fromPath = decorator(member, 'FromPath');
+      const source = fromBody ? 'FromBody' : fromPath ? 'FromPath' : undefined;
 
       return member.name && isIdentifier(member.name) && source
-        ? [{ member: member.name.text, source }]
+        ? [{
+          key: source === 'FromPath' ? stringArgument(fromPath) ?? member.name.text : undefined,
+          member: member.name.text,
+          source,
+        }]
         : [];
     });
 }
 
+/** @returns {GuideRouteBinding[]} */
 export function routeBindings(sourceText) {
   const sourceFile = createSourceFile('snippet.ts', sourceText, ScriptTarget.ES2022, true, ScriptKind.TS);
   const classes = classDeclarations(sourceFile);
+  /** @type {GuideRouteBinding[]} */
   const routes = [];
 
   for (const declaration of classes.values()) {
@@ -193,13 +234,18 @@ export function routeBindings(sourceText) {
         ? parameterType.typeName.text
         : undefined;
       const dto = requestDto ? classes.get(requestDto) : undefined;
+      const routePath = stringArgument(decorator(member, method)) ?? '';
+      const pathPlaceholders = routePath.split('/')
+        .flatMap((segment) => segment.startsWith(':') ? [segment.slice(1)] : []);
 
       routes.push({
         bindings: dto ? dtoBindings(dto) : [],
         method,
         name: member.name.text,
         parameterDto,
+        pathPlaceholders,
         requestDto,
+        routePath,
       });
     }
   }

--- a/tooling/governance/http-website-guide-snippets.test.ts
+++ b/tooling/governance/http-website-guide-snippets.test.ts
@@ -3,23 +3,21 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
-  canHaveDecorators,
   createSourceFile,
-  forEachChild,
-  getDecorators,
-  isCallExpression,
-  isExportDeclaration,
-  isIdentifier,
   isImportDeclaration,
-  isNamedExports,
   isNamedImports,
   isStringLiteral,
-  ModuleKind,
   ScriptKind,
   ScriptTarget,
-  transpileModule,
 } from 'typescript';
 import { describe, expect, it } from 'vitest';
+
+import {
+  classDecoratorArguments,
+  exportedHttpNames,
+  routeBindings,
+  semanticDiagnostics,
+} from './http-website-guide-snippets.mjs';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const guidePaths = [
@@ -29,152 +27,108 @@ const guidePaths = [
   'apps/docs/content/docs/guides/first-feature.ko.mdx',
 ] as const;
 
-interface Snippet {
-  readonly file: string;
-  readonly source: string;
-}
-
 function read(relativePath: string): string {
   return readFileSync(join(repoRoot, relativePath), 'utf8');
 }
 
-function codeSnippets(relativePath: string): readonly Snippet[] {
+function codeSnippets(relativePath: string): readonly string[] {
   return [...read(relativePath).matchAll(/```ts\n([\s\S]*?)```/gu)]
     .map((match) => match[1])
     .filter((source): source is string => source !== undefined)
-    .filter((source) => source.includes("from '@fluojs/http'"))
-    .map((source) => ({ file: relativePath, source }));
-}
-
-function exportedHttpNames(): ReadonlySet<string> {
-  const source = createSourceFile(
-    'packages/http/src/index.portable.ts',
-    read('packages/http/src/index.portable.ts'),
-    ScriptTarget.ES2022,
-    true,
-    ScriptKind.TS,
-  );
-  const names = new Set<string>();
-
-  for (const statement of source.statements) {
-    if (!isExportDeclaration(statement) || !statement.exportClause || !isNamedExports(statement.exportClause)) {
-      continue;
-    }
-
-    for (const element of statement.exportClause.elements) {
-      names.add(element.name.text);
-    }
-  }
-
-  return names;
+    .filter((source) => source.includes("from '@fluojs/http'"));
 }
 
 function importedHttpNames(source: string): readonly string[] {
   const file = createSourceFile('snippet.ts', source, ScriptTarget.ES2022, true, ScriptKind.TS);
-  const names: string[] = [];
 
-  for (const statement of file.statements) {
-    if (!isImportDeclaration(statement) || !isStringLiteral(statement.moduleSpecifier) || statement.moduleSpecifier.text !== '@fluojs/http') {
-      continue;
-    }
+  return file.statements
+    .filter(isImportDeclaration)
+    .filter((statement) => isStringLiteral(statement.moduleSpecifier) && statement.moduleSpecifier.text === '@fluojs/http')
+    .flatMap((statement) => {
+      const bindings = statement.importClause?.namedBindings;
 
-    const bindings = statement.importClause?.namedBindings;
-
-    if (!bindings || !isNamedImports(bindings)) {
-      continue;
-    }
-
-    for (const element of bindings.elements) {
-      names.push(element.propertyName?.text ?? element.name.text);
-    }
-  }
-
-  return names;
-}
-
-function decoratorNames(source: string): ReadonlySet<string> {
-  const file = createSourceFile('snippet.ts', source, ScriptTarget.ES2022, true, ScriptKind.TS);
-  const names = new Set<string>();
-
-  const visit = (node: Parameters<typeof forEachChild>[0]): void => {
-    if (canHaveDecorators(node)) {
-      for (const decorator of getDecorators(node) ?? []) {
-        if (isCallExpression(decorator.expression) && isIdentifier(decorator.expression.expression)) {
-          names.add(decorator.expression.expression.text);
-        }
-      }
-    }
-
-    forEachChild(node, visit);
-  };
-
-  visit(file);
-  return names;
-}
-
-function routePaths(source: string): readonly string[] {
-  const file = createSourceFile('snippet.ts', source, ScriptTarget.ES2022, true, ScriptKind.TS);
-  const paths: string[] = [];
-
-  const visit = (node: Parameters<typeof forEachChild>[0]): void => {
-    if (canHaveDecorators(node)) {
-      for (const decorator of getDecorators(node) ?? []) {
-        if (
-          !isCallExpression(decorator.expression) ||
-          !isIdentifier(decorator.expression.expression) ||
-          !['Get', 'Post'].includes(decorator.expression.expression.text)
-        ) {
-          continue;
-        }
-
-        const [path] = decorator.expression.arguments;
-        paths.push(path && isStringLiteral(path) ? path.text : '');
-      }
-    }
-
-    forEachChild(node, visit);
-  };
-
-  visit(file);
-  return paths;
+      return bindings && isNamedImports(bindings)
+        ? bindings.elements.map((element) => element.propertyName?.text ?? element.name.text)
+        : [];
+    });
 }
 
 describe('HTTP website guide snippets', () => {
-  it('compile with shipped HTTP exports and explicit DTO route bindings', () => {
+  it.each(guidePaths)('%s compiles against real public package types', (relativePath) => {
     // Given
-    const snippets = guidePaths.flatMap(codeSnippets);
-    const exportedNames = exportedHttpNames();
-    const controllerSnippets = snippets.filter((snippet) => snippet.source.includes('@Controller'));
+    const snippets = codeSnippets(relativePath);
 
     // When
-    const diagnostics = snippets.flatMap((snippet) =>
-      transpileModule(snippet.source, {
-        compilerOptions: {
-          experimentalDecorators: true,
-          module: ModuleKind.ESNext,
-          target: ScriptTarget.ES2022,
-        },
-        reportDiagnostics: true,
-      }).diagnostics ?? [],
+    const diagnostics = snippets.flatMap((source) => semanticDiagnostics(relativePath, source));
+
+    // Then
+    expect(diagnostics).toEqual([]);
+  });
+
+  it.each([
+    ['unresolved HTTP imports', "import { Missing } from '@fluojs/http';\nMissing;\n"],
+    ['invalid route decorator arguments', "import { Controller, Get } from '@fluojs/http';\n@Controller('/')\nclass Example { @Get() handler() {} }\n"],
+    ['invalid DTO member access', "import { Controller, FromBody, Post, RequestDto } from '@fluojs/http';\nclass Input { @FromBody() name!: string; }\n@Controller('/')\nclass Example { @Post('/') @RequestDto(Input) create(input: Input) { return input.missing; } }\n"],
+  ])('%s produce semantic diagnostics', (relativePath, source) => {
+    // Given
+    const fixturePath = `tooling/governance/fixtures/${relativePath}.ts`;
+
+    // When
+    const diagnostics = semanticDiagnostics(fixturePath, source);
+
+    // Then
+    expect(diagnostics).not.toEqual([]);
+  });
+
+  it('imports only symbols resolved from the public HTTP entry point', () => {
+    // Given
+    const exportedNames = exportedHttpNames();
+    const snippets = guidePaths.flatMap((relativePath) => codeSnippets(relativePath));
+
+    // When
+    const importedNames = snippets.flatMap(importedHttpNames);
+
+    // Then
+    for (const name of importedNames) {
+      expect(exportedNames).toContain(name);
+    }
+  });
+
+  it('declares the First Feature controller injection token explicitly', () => {
+    // Given
+    const firstFeatureGuides = guidePaths.filter((path) => path.includes('first-feature'));
+
+    // When
+    const injectionArguments = firstFeatureGuides.map((relativePath) =>
+      classDecoratorArguments(codeSnippets(relativePath)[0] ?? '', 'UsersController', 'Inject'),
     );
 
     // Then
-    expect(controllerSnippets).toHaveLength(4);
-    expect(diagnostics).toEqual([]);
+    expect(injectionArguments).toEqual([['UsersService'], ['UsersService']]);
+  });
 
-    for (const snippet of snippets) {
-      for (const name of importedHttpNames(snippet.source)) {
-        expect(exportedNames, `${snippet.file} imports ${name} from @fluojs/http`).toContain(name);
+  it('binds every Get and Post handler to its own request DTO source', () => {
+    // Given
+    const routes = guidePaths.flatMap((relativePath) =>
+      codeSnippets(relativePath).flatMap((source) => routeBindings(source)),
+    );
+
+    // When
+    const expectedSources = new Map([
+      ['Get', 'FromPath'],
+      ['Post', 'FromBody'],
+    ]);
+
+    // Then
+    expect(routes).toHaveLength(8);
+
+    for (const route of routes) {
+      expect(route.requestDto).toBe(route.parameterDto);
+      expect(route.bindings.length).toBeGreaterThan(0);
+
+      for (const binding of route.bindings) {
+        expect(binding.source, `${route.method} ${route.name} binds ${binding.member}`).toBe(expectedSources.get(route.method));
       }
-    }
-
-    for (const snippet of controllerSnippets) {
-      const decorators = decoratorNames(snippet.source);
-      const paths = routePaths(snippet.source);
-
-      expect([...decorators]).toEqual(expect.arrayContaining(['FromBody', 'FromPath', 'RequestDto']));
-      expect(paths).toEqual(expect.arrayContaining(['/']));
-      expect(paths.every((path) => path.startsWith('/'))).toBe(true);
     }
   });
 });

--- a/tooling/governance/http-website-guide-snippets.test.ts
+++ b/tooling/governance/http-website-guide-snippets.test.ts
@@ -1,0 +1,180 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  canHaveDecorators,
+  createSourceFile,
+  forEachChild,
+  getDecorators,
+  isCallExpression,
+  isExportDeclaration,
+  isIdentifier,
+  isImportDeclaration,
+  isNamedExports,
+  isNamedImports,
+  isStringLiteral,
+  ModuleKind,
+  ScriptKind,
+  ScriptTarget,
+  transpileModule,
+} from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const guidePaths = [
+  'apps/docs/content/docs/guides/http-api.mdx',
+  'apps/docs/content/docs/guides/http-api.ko.mdx',
+  'apps/docs/content/docs/guides/first-feature.mdx',
+  'apps/docs/content/docs/guides/first-feature.ko.mdx',
+] as const;
+
+interface Snippet {
+  readonly file: string;
+  readonly source: string;
+}
+
+function read(relativePath: string): string {
+  return readFileSync(join(repoRoot, relativePath), 'utf8');
+}
+
+function codeSnippets(relativePath: string): readonly Snippet[] {
+  return [...read(relativePath).matchAll(/```ts\n([\s\S]*?)```/gu)]
+    .map((match) => match[1])
+    .filter((source): source is string => source !== undefined)
+    .filter((source) => source.includes("from '@fluojs/http'"))
+    .map((source) => ({ file: relativePath, source }));
+}
+
+function exportedHttpNames(): ReadonlySet<string> {
+  const source = createSourceFile(
+    'packages/http/src/index.portable.ts',
+    read('packages/http/src/index.portable.ts'),
+    ScriptTarget.ES2022,
+    true,
+    ScriptKind.TS,
+  );
+  const names = new Set<string>();
+
+  for (const statement of source.statements) {
+    if (!isExportDeclaration(statement) || !statement.exportClause || !isNamedExports(statement.exportClause)) {
+      continue;
+    }
+
+    for (const element of statement.exportClause.elements) {
+      names.add(element.name.text);
+    }
+  }
+
+  return names;
+}
+
+function importedHttpNames(source: string): readonly string[] {
+  const file = createSourceFile('snippet.ts', source, ScriptTarget.ES2022, true, ScriptKind.TS);
+  const names: string[] = [];
+
+  for (const statement of file.statements) {
+    if (!isImportDeclaration(statement) || !isStringLiteral(statement.moduleSpecifier) || statement.moduleSpecifier.text !== '@fluojs/http') {
+      continue;
+    }
+
+    const bindings = statement.importClause?.namedBindings;
+
+    if (!bindings || !isNamedImports(bindings)) {
+      continue;
+    }
+
+    for (const element of bindings.elements) {
+      names.push(element.propertyName?.text ?? element.name.text);
+    }
+  }
+
+  return names;
+}
+
+function decoratorNames(source: string): ReadonlySet<string> {
+  const file = createSourceFile('snippet.ts', source, ScriptTarget.ES2022, true, ScriptKind.TS);
+  const names = new Set<string>();
+
+  const visit = (node: Parameters<typeof forEachChild>[0]): void => {
+    if (canHaveDecorators(node)) {
+      for (const decorator of getDecorators(node) ?? []) {
+        if (isCallExpression(decorator.expression) && isIdentifier(decorator.expression.expression)) {
+          names.add(decorator.expression.expression.text);
+        }
+      }
+    }
+
+    forEachChild(node, visit);
+  };
+
+  visit(file);
+  return names;
+}
+
+function routePaths(source: string): readonly string[] {
+  const file = createSourceFile('snippet.ts', source, ScriptTarget.ES2022, true, ScriptKind.TS);
+  const paths: string[] = [];
+
+  const visit = (node: Parameters<typeof forEachChild>[0]): void => {
+    if (canHaveDecorators(node)) {
+      for (const decorator of getDecorators(node) ?? []) {
+        if (
+          !isCallExpression(decorator.expression) ||
+          !isIdentifier(decorator.expression.expression) ||
+          !['Get', 'Post'].includes(decorator.expression.expression.text)
+        ) {
+          continue;
+        }
+
+        const [path] = decorator.expression.arguments;
+        paths.push(path && isStringLiteral(path) ? path.text : '');
+      }
+    }
+
+    forEachChild(node, visit);
+  };
+
+  visit(file);
+  return paths;
+}
+
+describe('HTTP website guide snippets', () => {
+  it('compile with shipped HTTP exports and explicit DTO route bindings', () => {
+    // Given
+    const snippets = guidePaths.flatMap(codeSnippets);
+    const exportedNames = exportedHttpNames();
+    const controllerSnippets = snippets.filter((snippet) => snippet.source.includes('@Controller'));
+
+    // When
+    const diagnostics = snippets.flatMap((snippet) =>
+      transpileModule(snippet.source, {
+        compilerOptions: {
+          experimentalDecorators: true,
+          module: ModuleKind.ESNext,
+          target: ScriptTarget.ES2022,
+        },
+        reportDiagnostics: true,
+      }).diagnostics ?? [],
+    );
+
+    // Then
+    expect(controllerSnippets).toHaveLength(4);
+    expect(diagnostics).toEqual([]);
+
+    for (const snippet of snippets) {
+      for (const name of importedHttpNames(snippet.source)) {
+        expect(exportedNames, `${snippet.file} imports ${name} from @fluojs/http`).toContain(name);
+      }
+    }
+
+    for (const snippet of controllerSnippets) {
+      const decorators = decoratorNames(snippet.source);
+      const paths = routePaths(snippet.source);
+
+      expect([...decorators]).toEqual(expect.arrayContaining(['FromBody', 'FromPath', 'RequestDto']));
+      expect(paths).toEqual(expect.arrayContaining(['/']));
+      expect(paths.every((path) => path.startsWith('/'))).toBe(true);
+    }
+  });
+});

--- a/tooling/governance/http-website-guide-snippets.test.ts
+++ b/tooling/governance/http-website-guide-snippets.test.ts
@@ -15,6 +15,7 @@ import { describe, expect, it } from 'vitest';
 import {
   classDecoratorArguments,
   exportedHttpNames,
+  intendedHttpSnippets,
   routeBindings,
   semanticDiagnostics,
 } from './http-website-guide-snippets.mjs';
@@ -32,10 +33,7 @@ function read(relativePath: string): string {
 }
 
 function codeSnippets(relativePath: string): readonly string[] {
-  return [...read(relativePath).matchAll(/```ts\n([\s\S]*?)```/gu)]
-    .map((match) => match[1])
-    .filter((source): source is string => source !== undefined)
-    .filter((source) => source.includes("from '@fluojs/http'"));
+  return intendedHttpSnippets(read(relativePath));
 }
 
 function importedHttpNames(source: string): readonly string[] {
@@ -54,6 +52,22 @@ function importedHttpNames(source: string): readonly string[] {
 }
 
 describe('HTTP website guide snippets', () => {
+  it.each([
+    ['apps/docs/content/docs/guides/http-api.mdx', 1],
+    ['apps/docs/content/docs/guides/http-api.ko.mdx', 1],
+    ['apps/docs/content/docs/guides/first-feature.mdx', 2],
+    ['apps/docs/content/docs/guides/first-feature.ko.mdx', 2],
+  ])('%s selects every intended HTTP TypeScript snippet', (relativePath, expectedCount) => {
+    // Given
+    const snippets = codeSnippets(relativePath);
+
+    // When
+    const count = snippets.length;
+
+    // Then
+    expect(count).toBe(expectedCount);
+  });
+
   it.each(guidePaths)('%s compiles against real public package types', (relativePath) => {
     // Given
     const snippets = codeSnippets(relativePath);
@@ -66,6 +80,7 @@ describe('HTTP website guide snippets', () => {
   });
 
   it.each([
+    ['malformed HTTP module specifier', "import { Controller } from '@fluojs/htp';\n@Controller('/')\nclass Example {}\n"],
     ['unresolved HTTP imports', "import { Missing } from '@fluojs/http';\nMissing;\n"],
     ['invalid route decorator arguments', "import { Controller, Get } from '@fluojs/http';\n@Controller('/')\nclass Example { @Get() handler() {} }\n"],
     ['invalid DTO member access', "import { Controller, FromBody, Post, RequestDto } from '@fluojs/http';\nclass Input { @FromBody() name!: string; }\n@Controller('/')\nclass Example { @Post('/') @RequestDto(Input) create(input: Input) { return input.missing; } }\n"],
@@ -77,6 +92,21 @@ describe('HTTP website guide snippets', () => {
     const diagnostics = semanticDiagnostics(fixturePath, source);
 
     // Then
+    expect(diagnostics).not.toEqual([]);
+  });
+
+  it('selects malformed HTTP module specifiers for semantic compilation', () => {
+    // Given
+    const source = "import { Controller } from '@fluojs/htp';\n@Controller('/')\nclass Example {}\n";
+    const markdown = `\`\`\`ts
+${source}\`\`\``;
+
+    // When
+    const snippets = intendedHttpSnippets(markdown);
+    const diagnostics = snippets.flatMap((snippet) => semanticDiagnostics('tooling/governance/fixtures/malformed-http-module.ts', snippet));
+
+    // Then
+    expect(snippets).toEqual([source]);
     expect(diagnostics).not.toEqual([]);
   });
 
@@ -128,7 +158,32 @@ describe('HTTP website guide snippets', () => {
 
       for (const binding of route.bindings) {
         expect(binding.source, `${route.method} ${route.name} binds ${binding.member}`).toBe(expectedSources.get(route.method));
+
+        if (binding.source === 'FromPath') {
+          expect(route.pathPlaceholders, `${route.method} ${route.name} includes ${binding.key}`).toContain(binding.key);
+        }
       }
     }
+  });
+
+  it.each([
+    ['wrong DTO path key', `import { Controller, FromPath, Get, RequestDto } from '@fluojs/http';
+class Input { @FromPath('slug') id!: string; }
+@Controller('/') class Example { @Get('/:id') @RequestDto(Input) handler(input: Input) {} }`],
+    ['wrong handler placeholder', `import { Controller, FromPath, Get, RequestDto } from '@fluojs/http';
+class Input { @FromPath() id!: string; }
+@Controller('/') class Example { @Get('/:slug') @RequestDto(Input) handler(input: Input) {} }`],
+  ])('%s exposes an unmatched FromPath key', (_name, source) => {
+    // Given
+    const [route] = routeBindings(source);
+
+    // When
+    const unmatchedKeys = route?.bindings
+      .filter((binding) => binding.source === 'FromPath')
+      .filter((binding) => !route.pathPlaceholders.includes(binding.key ?? binding.member))
+      .map((binding) => binding.key ?? binding.member);
+
+    // Then
+    expect(unmatchedKeys).not.toEqual([]);
   });
 });


### PR DESCRIPTION
Closes #3188

Rewrites EN/KO HTTP guide snippets to the shipped DTO/decorator contract and adds semantic TypeScript governance for imports, per-handler DTO bindings, DI tokens, and path placeholders.

Verification: governance 18/18, tools tsc, HTTP typecheck, docs locale/typecheck/build 88/88, and unanimous exact-head full triad review.