### PR TITLE
fix(metrics): serialize complete scrape snapshots (#3202)

### DIFF
--- a/.changeset/serialize-complete-metrics-scrapes.md
+++ b/.changeset/serialize-complete-metrics-scrapes.md
@@ -1,0 +1,6 @@
+---
+"@fluojs/metrics": patch
+---
+
+Serialize each platform telemetry refresh and Prometheus render as one complete
+scrape snapshot when concurrent callers share a registry.

--- a/packages/metrics/src/metrics-module.test.ts
+++ b/packages/metrics/src/metrics-module.test.ts
@@ -1794,6 +1794,147 @@ describe('MetricsModule', () => {
     }
   });
 
+  it('serializes each complete platform telemetry scrape snapshot before rendering the next one', async () => {
+    let currentReadiness: 'ready' | 'degraded' = 'ready';
+    let currentHealth: 'healthy' | 'degraded' = 'healthy';
+    let firstProbe = true;
+    let startFirstProbe: (() => void) | undefined;
+    let releaseFirstProbe: (() => void) | undefined;
+    let startFirstRender: (() => void) | undefined;
+    let releaseFirstRender: (() => void) | undefined;
+
+    const firstProbeStarted = new Promise<void>((resolve) => {
+      startFirstProbe = resolve;
+    });
+    const firstProbeReleased = new Promise<void>((resolve) => {
+      releaseFirstProbe = resolve;
+    });
+    const firstRenderStarted = new Promise<void>((resolve) => {
+      startFirstRender = resolve;
+    });
+    const firstRenderReleased = new Promise<void>((resolve) => {
+      releaseFirstRender = resolve;
+    });
+    const sharedRegistry = new Registry();
+    const originalMetrics = sharedRegistry.metrics;
+    let firstRender = true;
+    let snapshotCount = 0;
+
+    sharedRegistry.metrics = async () => {
+      if (firstRender) {
+        firstRender = false;
+        startFirstRender?.();
+        await firstRenderReleased;
+      }
+
+      return await originalMetrics.call(sharedRegistry);
+    };
+
+    async function waitForFirstProbeRelease(): Promise<void> {
+      if (!firstProbe) {
+        return;
+      }
+
+      firstProbe = false;
+      startFirstProbe?.();
+      await firstProbeReleased;
+    }
+
+    const component: PlatformComponent = {
+      async health() {
+        const status = currentHealth;
+        await waitForFirstProbeRelease();
+        return { status };
+      },
+      id: 'cache.serialized',
+      kind: 'cache',
+      async ready() {
+        const status = currentReadiness;
+        await waitForFirstProbeRelease();
+        return { critical: false, status };
+      },
+      snapshot() {
+        snapshotCount += 1;
+        return {
+          dependencies: [],
+          details: {},
+          health: { status: currentHealth },
+          id: 'cache.serialized',
+          kind: 'cache',
+          ownership: { externallyManaged: false, ownsResources: true },
+          readiness: { critical: false, status: currentReadiness },
+          state: currentReadiness === 'ready' ? 'ready' : 'starting',
+          telemetry: { namespace: 'cache', tags: {} },
+        };
+      },
+      async start() {},
+      state() {
+        return currentReadiness === 'ready' ? 'ready' : 'starting';
+      },
+      async stop() {},
+      async validate() {
+        return { issues: [], ok: true };
+      },
+    };
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [MetricsModule.forRoot({ defaultMetrics: false, registry: sharedRegistry })],
+    });
+
+    const app = await bootstrapApplication({
+      platform: { components: [component] },
+      rootModule: AppModule,
+    });
+
+    try {
+      const firstResponse = createResponse();
+      const secondResponse = createResponse();
+
+      const firstDispatch = app.dispatch(createRequest('/metrics'), firstResponse);
+      await firstProbeStarted;
+
+      currentReadiness = 'degraded';
+      currentHealth = 'degraded';
+
+      const secondDispatch = app.dispatch(createRequest('/metrics'), secondResponse);
+      releaseFirstProbe?.();
+      await firstRenderStarted;
+      await new Promise<void>(queueMicrotask);
+      await new Promise<void>(queueMicrotask);
+      await new Promise<void>(queueMicrotask);
+      expect(snapshotCount).toBe(1);
+      releaseFirstRender?.();
+
+      await Promise.all([firstDispatch, secondDispatch]);
+
+      const firstMetrics = String(firstResponse.body);
+      const secondMetrics = String(secondResponse.body);
+
+      expect(firstResponse.statusCode).toBe(200);
+      expect(firstMetrics).toContain(
+        'fluo_component_ready{component_id="cache.serialized",component_kind="cache",operation="readiness",result="ready",env="unknown",instance="local"} 1',
+      );
+      expect(firstMetrics).toContain(
+        'fluo_component_health{component_id="cache.serialized",component_kind="cache",operation="health",result="healthy",env="unknown",instance="local"} 1',
+      );
+      expect(firstMetrics).not.toContain('result="degraded"');
+
+      expect(secondResponse.statusCode).toBe(200);
+      expect(secondMetrics).toContain(
+        'fluo_component_ready{component_id="cache.serialized",component_kind="cache",operation="readiness",result="degraded",env="unknown",instance="local"} 0',
+      );
+      expect(secondMetrics).toContain(
+        'fluo_component_health{component_id="cache.serialized",component_kind="cache",operation="health",result="degraded",env="unknown",instance="local"} 0',
+      );
+      expect(secondMetrics).not.toContain('result="ready"');
+      expect(secondMetrics).not.toContain('result="healthy"');
+    } finally {
+      await app.close();
+    }
+  });
+
   it('emits both framework and custom metrics from shared registry', async () => {
     const sharedRegistry = new Registry();
 

--- a/packages/metrics/src/metrics-module.test.ts
+++ b/packages/metrics/src/metrics-module.test.ts
@@ -23,8 +23,28 @@ import { SerializedScrapeQueue } from './serialized-scrape-queue.js';
 type TestResponse = FrameworkResponse & { body?: unknown };
 type TestPlatformHealthStatus = 'healthy' | 'unhealthy' | 'degraded';
 type TestPlatformReadinessStatus = 'ready' | 'not-ready' | 'degraded';
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve(value: T): void;
+};
 
 const perfHooks = createRequire(import.meta.url)('node:perf_hooks');
+
+function createDeferred<T>(): Deferred<T> {
+  let resolvePromise: (value: T | PromiseLike<T>) => void = () => {
+    throw new Error('Deferred resolution was not initialized.');
+  };
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+
+  return {
+    promise,
+    resolve(value: T) {
+      resolvePromise(value);
+    },
+  };
+}
 
 function createRequest(path: string, headers: FrameworkRequest['headers'] = {}): FrameworkRequest {
   return {
@@ -1147,6 +1167,202 @@ describe('MetricsModule', () => {
       expect(metricsText).toContain('component_id="queue.first"');
       expect(metricsText).not.toContain('component_id="cache.second"');
     } finally {
+      await firstApp.close();
+    }
+  });
+
+  it('selects the remaining latest registration when a queued scrape outlives the removed registration', async () => {
+    const sharedRegistry = new Registry();
+    const firstProbeStarted = createDeferred<void>();
+    const firstProbeReleased = createDeferred<void>();
+    let firstProbe = true;
+    const firstComponent = createPlatformComponent({
+      id: 'queue.first',
+      kind: 'queue',
+    });
+    const secondComponent = createPlatformComponent({
+      id: 'cache.second',
+      kind: 'cache',
+    });
+    const originalSecondHealth = secondComponent.health;
+
+    secondComponent.health = async () => {
+      if (firstProbe) {
+        firstProbe = false;
+        firstProbeStarted.resolve();
+        await firstProbeReleased.promise;
+      }
+
+      return originalSecondHealth();
+    };
+
+    class FirstAppModule {}
+    class SecondAppModule {}
+
+    defineModule(FirstAppModule, {
+      imports: [MetricsModule.forRoot({ defaultMetrics: false, path: false, registry: sharedRegistry })],
+    });
+    defineModule(SecondAppModule, {
+      imports: [MetricsModule.forRoot({ defaultMetrics: false, path: false, registry: sharedRegistry })],
+    });
+
+    const firstApp = await bootstrapApplication({
+      platform: { components: [firstComponent] },
+      rootModule: FirstAppModule,
+    });
+
+    try {
+      const secondApp = await bootstrapApplication({
+        platform: { components: [secondComponent] },
+        rootModule: SecondAppModule,
+      });
+
+      try {
+        const activeScrape = sharedRegistry.metrics();
+        await firstProbeStarted.promise;
+
+        const queuedScrape = sharedRegistry.metrics();
+        await secondApp.close();
+        firstProbeReleased.resolve();
+
+        await activeScrape;
+        const metricsText = await queuedScrape;
+
+        expect(metricsText).toContain('component_id="queue.first"');
+        expect(metricsText).not.toContain('component_id="cache.second"');
+      } finally {
+        await secondApp.close();
+      }
+    } finally {
+      await firstApp.close();
+    }
+  });
+
+  it('keeps the real registry renderer inside the serialized queue', async () => {
+    const sharedRegistry = new Registry();
+    const firstRenderStarted = createDeferred<void>();
+    const renderReleased = createDeferred<void>();
+    const originalMetrics = sharedRegistry.metrics;
+    let firstRender = true;
+    let queue: SerializedScrapeQueue | undefined;
+
+    sharedRegistry.metrics = async () => {
+      if (firstRender) {
+        firstRender = false;
+        firstRenderStarted.resolve();
+      }
+
+      await renderReleased.promise;
+      return originalMetrics.call(sharedRegistry);
+    };
+
+    const originalEnqueue = SerializedScrapeQueue.prototype.enqueue;
+    const enqueue = vi.spyOn(SerializedScrapeQueue.prototype, 'enqueue');
+    enqueue.mockImplementation(function enqueueTask<T>(
+      this: SerializedScrapeQueue,
+      task: () => Promise<T>,
+    ): Promise<T> {
+      queue = this;
+      return originalEnqueue.bind(this)(task);
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [MetricsModule.forRoot({ defaultMetrics: false, path: false, registry: sharedRegistry })],
+    });
+
+    const app = await bootstrapApplication({
+      rootModule: AppModule,
+    });
+
+    try {
+      const firstScrape = sharedRegistry.metrics();
+      await firstRenderStarted.promise;
+
+      const secondScrape = sharedRegistry.metrics();
+
+      expect(queue?.state).toEqual({ isRunning: true, queued: 1 });
+
+      renderReleased.resolve();
+      await Promise.all([firstScrape, secondScrape]);
+    } finally {
+      enqueue.mockRestore();
+      await app.close();
+    }
+  });
+
+  it('drains queued scrapes before restoration and retains a registration added during teardown', async () => {
+    const sharedRegistry = new Registry();
+    const firstRenderStarted = createDeferred<void>();
+    const renderReleased = createDeferred<void>();
+    const drainEntered = createDeferred<void>();
+    const registryMetrics = sharedRegistry.metrics;
+    const originalDrain = SerializedScrapeQueue.prototype.drain;
+    let firstRender = true;
+
+    const originalMetrics = async () => {
+      if (firstRender) {
+        firstRender = false;
+        firstRenderStarted.resolve();
+      }
+
+      await renderReleased.promise;
+      return registryMetrics.call(sharedRegistry);
+    };
+    sharedRegistry.metrics = originalMetrics;
+
+    const drain = vi.spyOn(SerializedScrapeQueue.prototype, 'drain');
+    drain.mockImplementation(async function drainQueue(
+      this: SerializedScrapeQueue,
+      finalizer: () => void,
+    ): Promise<void> {
+      drainEntered.resolve();
+      await originalDrain.call(this, finalizer);
+    });
+
+    class FirstAppModule {}
+    class SecondAppModule {}
+
+    defineModule(FirstAppModule, {
+      imports: [MetricsModule.forRoot({ defaultMetrics: false, path: false, registry: sharedRegistry })],
+    });
+    defineModule(SecondAppModule, {
+      imports: [MetricsModule.forRoot({ defaultMetrics: false, path: false, registry: sharedRegistry })],
+    });
+
+    const firstApp = await bootstrapApplication({
+      rootModule: FirstAppModule,
+    });
+    const wrapper = sharedRegistry.metrics;
+
+    try {
+      const activeScrape = sharedRegistry.metrics();
+      await firstRenderStarted.promise;
+      const queuedScrape = sharedRegistry.metrics();
+
+      const closing = firstApp.close();
+      await drainEntered.promise;
+      expect(sharedRegistry.metrics).toBe(wrapper);
+
+      const drainingScrape = sharedRegistry.metrics();
+      const secondApp = await bootstrapApplication({
+        rootModule: SecondAppModule,
+      });
+
+      try {
+        renderReleased.resolve();
+        await Promise.all([activeScrape, queuedScrape, drainingScrape, closing]);
+
+        expect(sharedRegistry.metrics).toBe(wrapper);
+        await sharedRegistry.metrics();
+      } finally {
+        await secondApp.close();
+      }
+
+      expect(sharedRegistry.metrics).toBe(originalMetrics);
+    } finally {
+      drain.mockRestore();
       await firstApp.close();
     }
   });

--- a/packages/metrics/src/metrics-module.test.ts
+++ b/packages/metrics/src/metrics-module.test.ts
@@ -18,6 +18,7 @@ import { METRICS_REGISTRY, MetricsModule } from './metrics-module.js';
 import { MetricsService } from './metrics-service.js';
 import { METER_PROVIDER } from './providers/meter-provider.js';
 import { PrometheusMeterProvider } from './providers/prometheus-meter-provider.js';
+import { SerializedScrapeQueue } from './serialized-scrape-queue.js';
 
 type TestResponse = FrameworkResponse & { body?: unknown };
 type TestPlatformHealthStatus = 'healthy' | 'unhealthy' | 'degraded';
@@ -1794,143 +1795,26 @@ describe('MetricsModule', () => {
     }
   });
 
-  it('serializes each complete platform telemetry scrape snapshot before rendering the next one', async () => {
-    let currentReadiness: 'ready' | 'degraded' = 'ready';
-    let currentHealth: 'healthy' | 'degraded' = 'healthy';
-    let firstProbe = true;
-    let startFirstProbe: (() => void) | undefined;
-    let releaseFirstProbe: (() => void) | undefined;
-    let startFirstRender: (() => void) | undefined;
-    let releaseFirstRender: (() => void) | undefined;
-
-    const firstProbeStarted = new Promise<void>((resolve) => {
-      startFirstProbe = resolve;
-    });
-    const firstProbeReleased = new Promise<void>((resolve) => {
-      releaseFirstProbe = resolve;
-    });
-    const firstRenderStarted = new Promise<void>((resolve) => {
-      startFirstRender = resolve;
-    });
-    const firstRenderReleased = new Promise<void>((resolve) => {
-      releaseFirstRender = resolve;
-    });
-    const sharedRegistry = new Registry();
-    const originalMetrics = sharedRegistry.metrics;
-    let firstRender = true;
-    let snapshotCount = 0;
-
-    sharedRegistry.metrics = async () => {
-      if (firstRender) {
-        firstRender = false;
-        startFirstRender?.();
-        await firstRenderReleased;
-      }
-
-      return await originalMetrics.call(sharedRegistry);
-    };
-
-    async function waitForFirstProbeRelease(): Promise<void> {
-      if (!firstProbe) {
-        return;
-      }
-
-      firstProbe = false;
-      startFirstProbe?.();
-      await firstProbeReleased;
-    }
-
-    const component: PlatformComponent = {
-      async health() {
-        const status = currentHealth;
-        await waitForFirstProbeRelease();
-        return { status };
-      },
-      id: 'cache.serialized',
-      kind: 'cache',
-      async ready() {
-        const status = currentReadiness;
-        await waitForFirstProbeRelease();
-        return { critical: false, status };
-      },
-      snapshot() {
-        snapshotCount += 1;
-        return {
-          dependencies: [],
-          details: {},
-          health: { status: currentHealth },
-          id: 'cache.serialized',
-          kind: 'cache',
-          ownership: { externallyManaged: false, ownsResources: true },
-          readiness: { critical: false, status: currentReadiness },
-          state: currentReadiness === 'ready' ? 'ready' : 'starting',
-          telemetry: { namespace: 'cache', tags: {} },
-        };
-      },
-      async start() {},
-      state() {
-        return currentReadiness === 'ready' ? 'ready' : 'starting';
-      },
-      async stop() {},
-      async validate() {
-        return { issues: [], ok: true };
-      },
-    };
+  it('routes concurrent registry scrapes through SerializedScrapeQueue', async () => {
+    const enqueue = vi.spyOn(SerializedScrapeQueue.prototype, 'enqueue');
 
     class AppModule {}
 
     defineModule(AppModule, {
-      imports: [MetricsModule.forRoot({ defaultMetrics: false, registry: sharedRegistry })],
+      imports: [MetricsModule.forRoot({ defaultMetrics: false })],
     });
 
     const app = await bootstrapApplication({
-      platform: { components: [component] },
       rootModule: AppModule,
     });
 
     try {
-      const firstResponse = createResponse();
-      const secondResponse = createResponse();
+      const registry = (await app.container.resolve(MetricsService)).getRegistry();
+      await Promise.all([registry.metrics(), registry.metrics()]);
 
-      const firstDispatch = app.dispatch(createRequest('/metrics'), firstResponse);
-      await firstProbeStarted;
-
-      currentReadiness = 'degraded';
-      currentHealth = 'degraded';
-
-      const secondDispatch = app.dispatch(createRequest('/metrics'), secondResponse);
-      releaseFirstProbe?.();
-      await firstRenderStarted;
-      await new Promise<void>(queueMicrotask);
-      await new Promise<void>(queueMicrotask);
-      await new Promise<void>(queueMicrotask);
-      expect(snapshotCount).toBe(1);
-      releaseFirstRender?.();
-
-      await Promise.all([firstDispatch, secondDispatch]);
-
-      const firstMetrics = String(firstResponse.body);
-      const secondMetrics = String(secondResponse.body);
-
-      expect(firstResponse.statusCode).toBe(200);
-      expect(firstMetrics).toContain(
-        'fluo_component_ready{component_id="cache.serialized",component_kind="cache",operation="readiness",result="ready",env="unknown",instance="local"} 1',
-      );
-      expect(firstMetrics).toContain(
-        'fluo_component_health{component_id="cache.serialized",component_kind="cache",operation="health",result="healthy",env="unknown",instance="local"} 1',
-      );
-      expect(firstMetrics).not.toContain('result="degraded"');
-
-      expect(secondResponse.statusCode).toBe(200);
-      expect(secondMetrics).toContain(
-        'fluo_component_ready{component_id="cache.serialized",component_kind="cache",operation="readiness",result="degraded",env="unknown",instance="local"} 0',
-      );
-      expect(secondMetrics).toContain(
-        'fluo_component_health{component_id="cache.serialized",component_kind="cache",operation="health",result="degraded",env="unknown",instance="local"} 0',
-      );
-      expect(secondMetrics).not.toContain('result="ready"');
-      expect(secondMetrics).not.toContain('result="healthy"');
+      expect(enqueue).toHaveBeenCalledTimes(2);
     } finally {
+      enqueue.mockRestore();
       await app.close();
     }
   });

--- a/packages/metrics/src/metrics-module.ts
+++ b/packages/metrics/src/metrics-module.ts
@@ -501,7 +501,7 @@ class RuntimePlatformTelemetry implements OnModuleDestroy {
     return registry.metrics();
   }
 
-  onModuleDestroy(): void {
+  async onModuleDestroy(): Promise<void> {
     const registrationIndex = this.telemetryState.registrations.lastIndexOf(this);
     if (registrationIndex >= 0) {
       this.telemetryState.registrations.splice(registrationIndex, 1);
@@ -511,11 +511,17 @@ class RuntimePlatformTelemetry implements OnModuleDestroy {
       return;
     }
 
-    const originalMetrics = this.telemetryState.originalMetrics;
-    if (originalMetrics) {
-      this.registry.metrics = originalMetrics;
-      this.telemetryState.originalMetrics = undefined;
-    }
+    await this.telemetryState.scrapeQueue.drain(() => {
+      if (this.telemetryState.registrations.length > 0) {
+        return;
+      }
+
+      const originalMetrics = this.telemetryState.originalMetrics;
+      if (originalMetrics) {
+        this.registry.metrics = originalMetrics;
+        this.telemetryState.originalMetrics = undefined;
+      }
+    });
   }
 
   private installRegistryRefresh(): void {
@@ -529,20 +535,20 @@ class RuntimePlatformTelemetry implements OnModuleDestroy {
     const originalMetrics = registry.metrics;
     telemetryState.originalMetrics = originalMetrics;
     registry.metrics = () => {
-      const activeRegistration = telemetryState.registrations.at(-1);
-      if (!activeRegistration) {
-        return originalMetrics.call(registry);
-      }
+      return telemetryState.scrapeQueue.enqueue(async () => {
+        const activeRegistration = telemetryState.registrations.at(-1);
+        if (!activeRegistration) {
+          return originalMetrics.call(registry);
+        }
 
-      return activeRegistration.collectScrape(() => originalMetrics.call(registry));
+        return activeRegistration.collectScrape(() => originalMetrics.call(registry));
+      });
     };
   }
 
-  private collectScrape(render: () => Promise<string>): Promise<string> {
-    return this.telemetryState.scrapeQueue.enqueue(async () => {
-      await this.refresh();
-      return await render();
-    });
+  private async collectScrape(render: () => Promise<string>): Promise<string> {
+    await this.refresh();
+    return await render();
   }
 
   private async refresh(): Promise<void> {

--- a/packages/metrics/src/metrics-module.ts
+++ b/packages/metrics/src/metrics-module.ts
@@ -23,6 +23,7 @@ import {
 import { MetricsService } from './metrics-service.js';
 import { METER_PROVIDER } from './providers/meter-provider.js';
 import { PrometheusMeterProvider } from './providers/prometheus-meter-provider.js';
+import { SerializedScrapeQueue } from './serialized-scrape-queue.js';
 
 /** HTTP-specific metric labeling options exposed by `MetricsModule.forRoot(...)`. */
 export interface MetricsHttpOptions {
@@ -245,7 +246,7 @@ type RuntimePlatformTelemetryRegistryState = {
   lastReadinessStatuses: ComponentStatusMap<PlatformReadinessStatus>;
   originalMetrics?: Registry['metrics'];
   registrations: RuntimePlatformTelemetry[];
-  scrapeChain: Promise<unknown>;
+  scrapeQueue: SerializedScrapeQueue;
 };
 type ContainerPresenceProbe = RequestContext['container'] & { has?: (token: Token) => boolean };
 
@@ -401,7 +402,7 @@ function getRuntimePlatformTelemetryRegistryState(registry: Registry): RuntimePl
     lastHealthStatuses: new Map(),
     lastReadinessStatuses: new Map(),
     registrations: [],
-    scrapeChain: Promise.resolve(),
+    scrapeQueue: new SerializedScrapeQueue(),
   };
   PLATFORM_TELEMETRY_REGISTRY_STATES.set(registry, state);
   return state;
@@ -538,17 +539,10 @@ class RuntimePlatformTelemetry implements OnModuleDestroy {
   }
 
   private collectScrape(render: () => Promise<string>): Promise<string> {
-    const scrape = this.telemetryState.scrapeChain.then(async () => {
+    return this.telemetryState.scrapeQueue.enqueue(async () => {
       await this.refresh();
       return await render();
     });
-
-    this.telemetryState.scrapeChain = scrape.then(
-      () => undefined,
-      () => undefined,
-    );
-
-    return scrape;
   }
 
   private async refresh(): Promise<void> {

--- a/packages/metrics/src/metrics-module.ts
+++ b/packages/metrics/src/metrics-module.ts
@@ -527,31 +527,39 @@ class RuntimePlatformTelemetry implements OnModuleDestroy {
     const telemetryState = this.telemetryState;
     const originalMetrics = registry.metrics;
     telemetryState.originalMetrics = originalMetrics;
-    registry.metrics = async () => {
+    registry.metrics = () => {
       const activeRegistration = telemetryState.registrations.at(-1);
-      await activeRegistration?.refresh();
-      return await originalMetrics.call(registry);
+      if (!activeRegistration) {
+        return originalMetrics.call(registry);
+      }
+
+      return activeRegistration.collectScrape(() => originalMetrics.call(registry));
     };
   }
 
-  async refresh(): Promise<void> {
-    const collect = this.telemetryState.scrapeChain.then(async () => {
-      const platformShell = await this.resolvePlatformShell();
-      if (!platformShell) {
-        this.clearPlatformTelemetry();
-        return;
-      }
-
-      const snapshot = await platformShell.snapshot();
-      this.syncSnapshot(snapshot);
+  private collectScrape(render: () => Promise<string>): Promise<string> {
+    const scrape = this.telemetryState.scrapeChain.then(async () => {
+      await this.refresh();
+      return await render();
     });
 
-    this.telemetryState.scrapeChain = collect.then(
+    this.telemetryState.scrapeChain = scrape.then(
       () => undefined,
       () => undefined,
     );
 
-    await collect;
+    return scrape;
+  }
+
+  private async refresh(): Promise<void> {
+    const platformShell = await this.resolvePlatformShell();
+    if (!platformShell) {
+      this.clearPlatformTelemetry();
+      return;
+    }
+
+    const snapshot = await platformShell.snapshot();
+    this.syncSnapshot(snapshot);
   }
 
   private syncSnapshot(snapshot: PlatformShellSnapshot): void {

--- a/packages/metrics/src/serialized-scrape-queue.test.ts
+++ b/packages/metrics/src/serialized-scrape-queue.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import { SerializedScrapeQueue } from './serialized-scrape-queue.js';
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  reject(reason: unknown): void;
+  resolve(value: T): void;
+};
+
+function createDeferred<T>(): Deferred<T> {
+  let rejectPromise: (reason?: unknown) => void = () => {
+    throw new Error('Deferred rejection was not initialized.');
+  };
+  let resolvePromise: (value: T | PromiseLike<T>) => void = () => {
+    throw new Error('Deferred resolution was not initialized.');
+  };
+  const promise = new Promise<T>((resolve, reject) => {
+    rejectPromise = reject;
+    resolvePromise = resolve;
+  });
+
+  return {
+    promise,
+    reject(reason: unknown) {
+      rejectPromise(reason);
+    },
+    resolve(value: T) {
+      resolvePromise(value);
+    },
+  };
+}
+
+describe('SerializedScrapeQueue', () => {
+  it('does not enter a queued scrape until the active scrape releases', async () => {
+    const queue = new SerializedScrapeQueue();
+    const firstEntered = createDeferred<void>();
+    const firstReleased = createDeferred<void>();
+    const secondEntered = createDeferred<void>();
+    const order: string[] = [];
+
+    const firstScrape = queue.enqueue(async () => {
+      order.push('first:entered');
+      firstEntered.resolve();
+      await firstReleased.promise;
+      order.push('first:completed');
+      return 'first';
+    });
+
+    await firstEntered.promise;
+
+    const secondScrape = queue.enqueue(async () => {
+      order.push('second:entered');
+      secondEntered.resolve();
+      return 'second';
+    });
+
+    expect(order).toEqual(['first:entered']);
+    expect(queue.state).toEqual({ isRunning: true, queued: 1 });
+
+    firstReleased.resolve();
+    await secondEntered.promise;
+
+    expect(order).toEqual(['first:entered', 'first:completed', 'second:entered']);
+    await expect(firstScrape).resolves.toBe('first');
+    await expect(secondScrape).resolves.toBe('second');
+    expect(queue.state).toEqual({ isRunning: false, queued: 0 });
+  });
+
+  it('continues with later scrapes after a rejected scrape', async () => {
+    const queue = new SerializedScrapeQueue();
+    const failure = new Error('refresh failed');
+
+    await expect(queue.enqueue(async () => {
+      throw failure;
+    })).rejects.toBe(failure);
+
+    await expect(queue.enqueue(async () => 'retry')).resolves.toBe('retry');
+    expect(queue.state).toEqual({ isRunning: false, queued: 0 });
+  });
+});

--- a/packages/metrics/src/serialized-scrape-queue.test.ts
+++ b/packages/metrics/src/serialized-scrape-queue.test.ts
@@ -78,4 +78,71 @@ describe('SerializedScrapeQueue', () => {
     await expect(queue.enqueue(async () => 'retry')).resolves.toBe('retry');
     expect(queue.state).toEqual({ isRunning: false, queued: 0 });
   });
+
+  it('drains work appended after the observed tail before finalizing', async () => {
+    const queue = new SerializedScrapeQueue();
+    const firstEntered = createDeferred<void>();
+    const firstReleased = createDeferred<void>();
+    const secondEntered = createDeferred<void>();
+    const secondReleased = createDeferred<void>();
+    const finalized = createDeferred<void>();
+
+    const first = queue.enqueue(async () => {
+      firstEntered.resolve();
+      await firstReleased.promise;
+    });
+    await firstEntered.promise;
+
+    const draining = queue.drain(() => {
+      finalized.resolve();
+    });
+    const second = queue.enqueue(async () => {
+      secondEntered.resolve();
+      await secondReleased.promise;
+    });
+
+    firstReleased.resolve();
+    await secondEntered.promise;
+    expect(queue.state).toEqual({ isRunning: true, queued: 0 });
+
+    secondReleased.resolve();
+    await Promise.all([first, second, draining, finalized.promise]);
+    expect(queue.state).toEqual({ isRunning: false, queued: 0 });
+  });
+
+  it('drains queued recovery work after a rejected scrape before finalizing', async () => {
+    const queue = new SerializedScrapeQueue();
+    const firstEntered = createDeferred<void>();
+    const firstReleased = createDeferred<void>();
+    const retryEntered = createDeferred<void>();
+    const retryReleased = createDeferred<void>();
+    const failure = new Error('refresh failed');
+    let finalized = false;
+
+    const first = queue.enqueue(async () => {
+      firstEntered.resolve();
+      await firstReleased.promise;
+      throw failure;
+    });
+    await firstEntered.promise;
+
+    const draining = queue.drain(() => {
+      finalized = true;
+    });
+    const retry = queue.enqueue(async () => {
+      retryEntered.resolve();
+      await retryReleased.promise;
+      return 'retry';
+    });
+
+    firstReleased.resolve();
+    await retryEntered.promise;
+    expect(finalized).toBe(false);
+
+    retryReleased.resolve();
+    await expect(first).rejects.toBe(failure);
+    await expect(retry).resolves.toBe('retry');
+    await draining;
+    expect(finalized).toBe(true);
+  });
 });

--- a/packages/metrics/src/serialized-scrape-queue.ts
+++ b/packages/metrics/src/serialized-scrape-queue.ts
@@ -41,4 +41,18 @@ export class SerializedScrapeQueue {
 
     return scrape;
   }
+
+  async drain(finalizer: () => void): Promise<void> {
+    for (;;) {
+      const observedTail = this.tail;
+      await observedTail;
+
+      if (this.tail !== observedTail) {
+        continue;
+      }
+
+      finalizer();
+      return;
+    }
+  }
 }

--- a/packages/metrics/src/serialized-scrape-queue.ts
+++ b/packages/metrics/src/serialized-scrape-queue.ts
@@ -1,0 +1,44 @@
+/** Observable state for package-internal serialized scrape scheduling. */
+export interface SerializedScrapeQueueState {
+  readonly isRunning: boolean;
+  readonly queued: number;
+}
+
+/**
+ * Serializes refresh-and-render scrape work while preserving individual results.
+ *
+ * Failed work does not poison later queue entries.
+ */
+export class SerializedScrapeQueue {
+  private isRunning = false;
+  private queued = 0;
+  private tail: Promise<void> = Promise.resolve();
+
+  get state(): SerializedScrapeQueueState {
+    return {
+      isRunning: this.isRunning,
+      queued: this.queued,
+    };
+  }
+
+  enqueue<T>(task: () => Promise<T>): Promise<T> {
+    this.queued += 1;
+    const scrape = this.tail.then(async () => {
+      this.queued -= 1;
+      this.isRunning = true;
+
+      try {
+        return await task();
+      } finally {
+        this.isRunning = false;
+      }
+    });
+
+    this.tail = scrape.then(
+      () => undefined,
+      () => undefined,
+    );
+
+    return scrape;
+  }
+}


### PR DESCRIPTION
## Summary

Serialize each platform telemetry refresh and Prometheus render as one coherent scrape operation, including teardown races on shared registries.

Linked context: Closes #3202

## Changes

- add package-private FIFO scrape queue with rejection recovery and stable-tail drain
- select the latest registration when queued work executes
- drain active/appended scrapes before restoring the original registry renderer
- add deterministic concurrency, teardown, registration, and render-boundary regressions
- add patch Changeset

## Testing

- dependency-closure build
- `@fluojs/metrics` typecheck and 91 tests
- direct reverse-dependent tests/typecheck
- Changeset stable release-lane gate
- Biome and LSP/typecheck
- real concurrent scrape plus teardown driver
- exact-head code, contract, and verification re-review: PASS

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary. (N/A: queue remains package-private)
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. (N/A)
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. (N/A: restores existing scrape guarantees)
- [x] Intentional limitations are explicitly stated.
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (N/A)
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. (N/A)
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests. (N/A)