### PR TITLE
docs(metrics): document HTTP metrics constructor errors (#3207)

### DIFF
--- a/.changeset/document-http-metrics-constructor-errors.md
+++ b/.changeset/document-http-metrics-constructor-errors.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/metrics": patch
+---
+
+Document `HttpMetricsMiddleware` constructor parameters and configuration errors in published declarations.

--- a/packages/metrics/src/http-metrics-middleware.ts
+++ b/packages/metrics/src/http-metrics-middleware.ts
@@ -83,6 +83,16 @@ export class HttpMetricsMiddleware implements Middleware {
   private readonly pathLabelNormalizer?: HttpMetricsPathLabelNormalizer;
   private readonly unknownPathLabel: string;
 
+  /**
+   * Create the built-in HTTP request collectors in a Prometheus registry.
+   *
+   * @param registry Registry that owns or reuses the built-in HTTP collectors.
+   * @param options HTTP metric label and duration histogram configuration.
+   * @throws {Error} When raw path labels are configured without the explicit unsafe opt-in.
+   * @throws {Error} When duration histogram bucket boundaries are not finite and strictly increasing.
+   * @throws {Error} When an application-owned collector uses a built-in HTTP collector name.
+   * @throws {Error} When a reused framework collector has a different label schema or HTTP instrumentation configuration.
+   */
   constructor(registry: Registry, options: HttpMetricsMiddlewareOptions = {}) {
     const collectorConfiguration = resolveHttpMetricsCollectorConfiguration(options);
 


### PR DESCRIPTION
## Summary
- document HttpMetricsMiddleware constructor parameters
- document raw-path, duration-bucket, collector ownership, and reuse-configuration errors
- preserve the TSDoc in published declarations
- add a patch Changeset for @fluojs/metrics

## Verification
- dependency-closure build
- metrics typecheck and 76 tests
- reverse-dependent tests
- public TSDoc and Changeset release-lane validation
- emitted declaration manual inspection
- exact-head code/contract/verification reviews: merge

Closes #3207