### PR TITLE
fix(runtime): drain shared telemetry before platform teardown

### DIFF
--- a/.changeset/drain-shared-platform-telemetry.md
+++ b/.changeset/drain-shared-platform-telemetry.md
@@ -1,0 +1,6 @@
+---
+"@fluojs/metrics": patch
+---
+
+Drain queued telemetry scrapes and remove framework-owned platform telemetry from
+a shared Registry after its final metrics module registration closes.

--- a/.changeset/drain-shared-platform-telemetry.md
+++ b/.changeset/drain-shared-platform-telemetry.md
@@ -1,6 +1,8 @@
 ---
 "@fluojs/metrics": patch
+"@fluojs/runtime": patch
 ---
 
 Drain queued telemetry scrapes and remove framework-owned platform telemetry from
-a shared Registry after its final metrics module registration closes.
+a shared Registry after its final metrics module registration closes. Delay platform
+component shutdown until module teardown, including telemetry scrape draining, completes.

--- a/packages/metrics/src/metrics-module.test.ts
+++ b/packages/metrics/src/metrics-module.test.ts
@@ -1367,6 +1367,184 @@ describe('MetricsModule', () => {
     }
   });
 
+  it('drains active and appended scrapes before clearing final shared registry telemetry', async () => {
+    const sharedRegistry = new Registry();
+    const applicationCounter = new Counter({
+      help: 'Application metric that must outlive framework telemetry teardown.',
+      name: 'app_lifecycle_requests_total',
+      registers: [sharedRegistry],
+    });
+    applicationCounter.inc();
+    const firstRenderStarted = createDeferred<void>();
+    const renderReleased = createDeferred<void>();
+    const drainEntered = createDeferred<void>();
+    const registryMetrics = sharedRegistry.metrics;
+    const originalDrain = SerializedScrapeQueue.prototype.drain;
+    let firstRender = true;
+
+    const originalMetrics = async () => {
+      if (firstRender) {
+        firstRender = false;
+        firstRenderStarted.resolve();
+      }
+
+      await renderReleased.promise;
+      return registryMetrics.call(sharedRegistry);
+    };
+    sharedRegistry.metrics = originalMetrics;
+
+    const drain = vi.spyOn(SerializedScrapeQueue.prototype, 'drain');
+    drain.mockImplementation(async function drainQueue(
+      this: SerializedScrapeQueue,
+      finalizer: () => void,
+    ): Promise<void> {
+      drainEntered.resolve();
+      await originalDrain.call(this, finalizer);
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [MetricsModule.forRoot({ defaultMetrics: false, path: false, registry: sharedRegistry })],
+    });
+
+    const app = await bootstrapApplication({
+      platform: {
+        components: [createPlatformComponent({ id: 'cache.draining', kind: 'cache' })],
+      },
+      rootModule: AppModule,
+    });
+    const wrapper = sharedRegistry.metrics;
+    const cleanupRenderers: Array<Registry['metrics']> = [];
+    const frameworkMetricNames = new Set([
+      'fluo_component_ready',
+      'fluo_component_health',
+      'fluo_metrics_registry_mode',
+    ]);
+    const originalRemoveSingleMetric = sharedRegistry.removeSingleMetric.bind(sharedRegistry);
+    const removeSingleMetric = vi.spyOn(sharedRegistry, 'removeSingleMetric').mockImplementation((metricName: string) => {
+      if (frameworkMetricNames.has(metricName)) {
+        cleanupRenderers.push(sharedRegistry.metrics);
+      }
+
+      originalRemoveSingleMetric(metricName);
+    });
+
+    try {
+      const activeScrape = sharedRegistry.metrics();
+      await firstRenderStarted.promise;
+      const queuedScrape = sharedRegistry.metrics();
+
+      const closing = app.close();
+      await drainEntered.promise;
+      const appendedScrape = sharedRegistry.metrics();
+
+      expect(sharedRegistry.metrics).toBe(wrapper);
+      expect(cleanupRenderers).toHaveLength(0);
+
+      renderReleased.resolve();
+      await Promise.all([activeScrape, queuedScrape, appendedScrape, closing]);
+
+      const metricsText = await sharedRegistry.metrics();
+
+      expect(cleanupRenderers).not.toHaveLength(0);
+      expect(cleanupRenderers.every((renderer) => renderer === wrapper)).toBe(true);
+      expect(sharedRegistry.metrics).toBe(originalMetrics);
+      expect(metricsText).toContain('app_lifecycle_requests_total 1');
+      expect(sharedRegistry.getSingleMetric('fluo_component_ready')).toBeUndefined();
+      expect(sharedRegistry.getSingleMetric('fluo_component_health')).toBeUndefined();
+      expect(sharedRegistry.getSingleMetric('fluo_metrics_registry_mode')).toBeUndefined();
+      expect(metricsText).not.toContain('fluo_component_ready{');
+      expect(metricsText).not.toContain('fluo_component_health{');
+      expect(metricsText).not.toContain('fluo_metrics_registry_mode{');
+    } finally {
+      removeSingleMetric.mockRestore();
+      drain.mockRestore();
+      await app.close();
+    }
+  });
+
+  it('keeps shared telemetry for an active registration and reboots without stale series', async () => {
+    const sharedRegistry = new Registry();
+    const applicationCounter = new Counter({
+      help: 'Application metric that survives framework telemetry lifecycle changes.',
+      name: 'app_shared_registry_lifecycle_total',
+      registers: [sharedRegistry],
+    });
+    applicationCounter.inc();
+
+    class FirstAppModule {}
+    class SecondAppModule {}
+    class RebootedAppModule {}
+
+    defineModule(FirstAppModule, {
+      imports: [MetricsModule.forRoot({ defaultMetrics: false, path: false, registry: sharedRegistry })],
+    });
+    defineModule(SecondAppModule, {
+      imports: [MetricsModule.forRoot({ defaultMetrics: false, path: false, registry: sharedRegistry })],
+    });
+    defineModule(RebootedAppModule, {
+      imports: [MetricsModule.forRoot({ defaultMetrics: false, path: false, registry: sharedRegistry })],
+    });
+
+    const firstApp = await bootstrapApplication({
+      platform: {
+        components: [createPlatformComponent({ id: 'cache.closed', kind: 'cache' })],
+      },
+      rootModule: FirstAppModule,
+    });
+
+    try {
+      const secondApp = await bootstrapApplication({
+        platform: {
+          components: [createPlatformComponent({ id: 'queue.active', kind: 'queue' })],
+        },
+        rootModule: SecondAppModule,
+      });
+
+      try {
+        await sharedRegistry.metrics();
+        await firstApp.close();
+
+        const activeMetrics = await sharedRegistry.metrics();
+
+        expect(activeMetrics).toContain('app_shared_registry_lifecycle_total 1');
+        expect(activeMetrics).toContain('component_id="queue.active"');
+        expect(activeMetrics).not.toContain('component_id="cache.closed"');
+
+        await secondApp.close();
+
+        const clearedMetrics = await sharedRegistry.metrics();
+
+        expect(clearedMetrics).toContain('app_shared_registry_lifecycle_total 1');
+        expect(clearedMetrics).not.toContain('fluo_component_ready{');
+        expect(clearedMetrics).not.toContain('fluo_component_health{');
+        expect(clearedMetrics).not.toContain('fluo_metrics_registry_mode{');
+
+        const rebootedApp = await bootstrapApplication({
+          platform: {
+            components: [createPlatformComponent({ id: 'worker.rebooted', kind: 'worker' })],
+          },
+          rootModule: RebootedAppModule,
+        });
+
+        try {
+          const rebootedMetrics = await sharedRegistry.metrics();
+
+          expect(rebootedMetrics).toContain('app_shared_registry_lifecycle_total 1');
+          expect(rebootedMetrics).toContain('component_id="worker.rebooted"');
+          expect(rebootedMetrics).not.toContain('component_id="queue.active"');
+        } finally {
+          await rebootedApp.close();
+        }
+      } finally {
+        await secondApp.close();
+      }
+    } finally {
+      await firstApp.close();
+    }
+  });
+
   it('reuses built-in HTTP metrics when multiple module instances share one registry', async () => {
     const sharedRegistry = new Registry();
 
@@ -1668,20 +1846,23 @@ describe('MetricsModule', () => {
     const firstApp = await bootstrapApplication({
       rootModule: FirstAppModule,
     });
-    const readinessGauge = sharedRegistry.getSingleMetric('fluo_component_ready') as Gauge<string> & { labelNames: string[] };
-    readinessGauge.labelNames = ['component_id'];
 
-    await firstApp.close();
+    try {
+      const readinessGauge = sharedRegistry.getSingleMetric('fluo_component_ready') as Gauge<string> & { labelNames: string[] };
+      readinessGauge.labelNames = ['component_id'];
 
-    class SecondAppModule {}
+      class SecondAppModule {}
 
-    defineModule(SecondAppModule, {
-      imports: [MetricsModule.forRoot({ defaultMetrics: false, path: '/metrics-b', registry: sharedRegistry })],
-    });
+      defineModule(SecondAppModule, {
+        imports: [MetricsModule.forRoot({ defaultMetrics: false, path: '/metrics-b', registry: sharedRegistry })],
+      });
 
-    await expect(bootstrapApplication({ rootModule: SecondAppModule })).rejects.toThrow(
-      'Metric name "fluo_component_ready" is already registered with labels [component_id]. Built-in platform telemetry requires labels [component_id,component_kind,operation,result,env,instance].',
-    );
+      await expect(bootstrapApplication({ rootModule: SecondAppModule })).rejects.toThrow(
+        'Metric name "fluo_component_ready" is already registered with labels [component_id]. Built-in platform telemetry requires labels [component_id,component_kind,operation,result,env,instance].',
+      );
+    } finally {
+      await firstApp.close();
+    }
   });
 
   it('exports runtime component readiness and health metrics with shared labels', async () => {

--- a/packages/metrics/src/metrics-module.test.ts
+++ b/packages/metrics/src/metrics-module.test.ts
@@ -1464,6 +1464,95 @@ describe('MetricsModule', () => {
     }
   });
 
+  it('drains telemetry snapshots before stopping platform probe resources', async () => {
+    const sharedRegistry = new Registry();
+    const probeStarted = createDeferred<void>();
+    const probeReleased = createDeferred<void>();
+    const drainEntered = createDeferred<void>();
+    const originalMetrics = sharedRegistry.metrics;
+    const originalDrain = SerializedScrapeQueue.prototype.drain;
+    const probeAccesses: string[] = [];
+    let resourceAvailable = true;
+    let firstHealthProbe = true;
+    let stopped = false;
+
+    const component = createPlatformComponent({ id: 'cache.live', kind: 'cache' });
+    component.health = async () => {
+      if (!resourceAvailable) {
+        throw new Error('Health probe accessed a stopped platform resource.');
+      }
+
+      probeAccesses.push('health');
+      if (firstHealthProbe) {
+        firstHealthProbe = false;
+        probeStarted.resolve();
+        await probeReleased.promise;
+      }
+
+      return { status: 'healthy' };
+    };
+    component.ready = async () => {
+      if (!resourceAvailable) {
+        throw new Error('Readiness probe accessed a stopped platform resource.');
+      }
+
+      probeAccesses.push('readiness');
+      return { critical: false, status: 'ready' };
+    };
+    component.stop = async () => {
+      stopped = true;
+      resourceAvailable = false;
+    };
+
+    const drain = vi.spyOn(SerializedScrapeQueue.prototype, 'drain');
+    drain.mockImplementation(async function drainQueue(
+      this: SerializedScrapeQueue,
+      finalizer: () => void,
+    ): Promise<void> {
+      drainEntered.resolve();
+      await originalDrain.call(this, finalizer);
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [MetricsModule.forRoot({ defaultMetrics: false, path: false, registry: sharedRegistry })],
+    });
+
+    const app = await bootstrapApplication({
+      platform: { components: [component] },
+      rootModule: AppModule,
+    });
+
+    try {
+      const activeScrape = sharedRegistry.metrics();
+      await probeStarted.promise;
+
+      const queuedScrape = sharedRegistry.metrics();
+      const closing = app.close();
+      await drainEntered.promise;
+
+      expect(stopped).toBe(false);
+
+      const appendedScrape = sharedRegistry.metrics();
+      probeReleased.resolve();
+
+      const [activeMetrics] = await Promise.all([activeScrape, queuedScrape, appendedScrape, closing]);
+
+      expect(activeMetrics).toContain('component_id="cache.live"');
+      expect(probeAccesses).toEqual(expect.arrayContaining(['health', 'readiness']));
+      expect(stopped).toBe(true);
+      expect(sharedRegistry.metrics).toBe(originalMetrics);
+      expect(sharedRegistry.getSingleMetric('fluo_component_ready')).toBeUndefined();
+      expect(sharedRegistry.getSingleMetric('fluo_component_health')).toBeUndefined();
+      expect(sharedRegistry.getSingleMetric('fluo_metrics_registry_mode')).toBeUndefined();
+    } finally {
+      probeReleased.resolve();
+      drain.mockRestore();
+      await app.close();
+    }
+  });
+
   it('keeps shared telemetry for an active registration and reboots without stale series', async () => {
     const sharedRegistry = new Registry();
     const applicationCounter = new Counter({

--- a/packages/metrics/src/metrics-module.ts
+++ b/packages/metrics/src/metrics-module.ts
@@ -464,6 +464,14 @@ function assertGaugeLabelSchema(
   }
 }
 
+function removeFrameworkGauge(registry: Registry, gauge: Gauge<string>, metricName: string): void {
+  if (!FRAMEWORK_PLATFORM_GAUGES.has(gauge) || registry.getSingleMetric(metricName) !== gauge) {
+    return;
+  }
+
+  registry.removeSingleMetric(metricName);
+}
+
 class RuntimePlatformTelemetry implements OnModuleDestroy {
   private readonly readinessGauge: Gauge<string>;
   private readonly healthGauge: Gauge<string>;
@@ -518,6 +526,10 @@ class RuntimePlatformTelemetry implements OnModuleDestroy {
 
       const originalMetrics = this.telemetryState.originalMetrics;
       if (originalMetrics) {
+        this.clearPlatformTelemetry();
+        removeFrameworkGauge(this.registry, this.readinessGauge, 'fluo_component_ready');
+        removeFrameworkGauge(this.registry, this.healthGauge, 'fluo_component_health');
+        removeFrameworkGauge(this.registry, this.registryModeGauge, 'fluo_metrics_registry_mode');
         this.registry.metrics = originalMetrics;
         this.telemetryState.originalMetrics = undefined;
       }

--- a/packages/runtime/src/bootstrap.test.ts
+++ b/packages/runtime/src/bootstrap.test.ts
@@ -21,6 +21,60 @@ function createDeferred<T = void>() {
   return { promise, reject, resolve };
 }
 
+function createBootstrapFailureComponent(
+  id: string,
+  events: string[],
+): PlatformComponent {
+  let currentState: PlatformState = 'created';
+
+  return {
+    async health() {
+      return { status: 'healthy' };
+    },
+    id,
+    kind: 'test',
+    async ready() {
+      return { critical: false, status: 'ready' };
+    },
+    snapshot() {
+      return {
+        dependencies: [],
+        details: {},
+        health: { status: 'healthy' },
+        id,
+        kind: 'test',
+        ownership: {
+          externallyManaged: false,
+          ownsResources: true,
+        },
+        readiness: {
+          critical: false,
+          status: 'ready',
+        },
+        state: currentState,
+        telemetry: {
+          namespace: 'fluo.test',
+          tags: {},
+        },
+      };
+    },
+    async start() {
+      currentState = 'ready';
+      events.push('platform:start');
+    },
+    state() {
+      return currentState;
+    },
+    async stop() {
+      currentState = 'stopped';
+      events.push('platform:stop');
+    },
+    async validate() {
+      return { issues: [], ok: true };
+    },
+  };
+}
+
 function createRequest(path: string, query: FrameworkRequest['query'] = {}): FrameworkRequest {
   return {
     body: undefined,
@@ -1082,6 +1136,110 @@ describe('FluoFactory.createApplicationContext', () => {
         '[fluo] ERROR [FluoFactory] Failed to clean up after application context bootstrap failure.',
       );
       expect(errorLog).toHaveBeenCalledWith(cleanupFailure);
+    } finally {
+      errorLog.mockRestore();
+    }
+  });
+
+  it('continues bootstrapApplication() cleanup after a provider destroy failure', async () => {
+    const events: string[] = [];
+    const destroyFailure = new Error('provider destroy failed');
+    const shutdownFailure = new Error('provider shutdown failed');
+    const bootstrapFailure = new Error('readiness publication failed');
+    const logger = { debug: vi.fn(), error: vi.fn(), log: vi.fn(), warn: vi.fn() };
+    const platformComponent = createBootstrapFailureComponent('platform.bootstrap', events);
+
+    class FailingLifecycleProvider {
+      onApplicationShutdown(signal?: string) {
+        events.push(`provider:shutdown:${signal ?? 'none'}`);
+        throw shutdownFailure;
+      }
+
+      onModuleDestroy() {
+        events.push('provider:destroy');
+        throw destroyFailure;
+      }
+    }
+
+    class AppModule {
+      static markReady() {
+        throw bootstrapFailure;
+      }
+
+      static markStarting() {}
+    }
+    defineRuntimeModuleMetadata(AppModule, {
+      providers: [FailingLifecycleProvider],
+    });
+
+    await expect(
+      bootstrapApplication({
+        logger,
+        platform: { components: [platformComponent] },
+        rootModule: AppModule,
+      }),
+    ).rejects.toBe(bootstrapFailure);
+
+    expect(events).toEqual([
+      'platform:start',
+      'provider:destroy',
+      'platform:stop',
+      'provider:shutdown:bootstrap-failed',
+    ]);
+
+    const cleanupFailure = logger.error.mock.calls.find(
+      ([message]) => message === 'Failed to clean up after application bootstrap failure.',
+    )?.[1];
+
+    expect(cleanupFailure).toBeInstanceOf(AggregateError);
+    if (cleanupFailure instanceof AggregateError) {
+      expect(cleanupFailure.errors).toEqual([destroyFailure, shutdownFailure]);
+    }
+  });
+
+  it('continues application context cleanup after a provider destroy failure', async () => {
+    const events: string[] = [];
+    const destroyFailure = new Error('context provider destroy failed');
+    const bootstrapFailure = new Error('context readiness publication failed');
+    const platformComponent = createBootstrapFailureComponent('platform.context', events);
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    class FailingLifecycleProvider {
+      onApplicationShutdown(signal?: string) {
+        events.push(`provider:shutdown:${signal ?? 'none'}`);
+      }
+
+      onModuleDestroy() {
+        events.push('provider:destroy');
+        throw destroyFailure;
+      }
+    }
+
+    class AppModule {
+      static markReady() {
+        throw bootstrapFailure;
+      }
+
+      static markStarting() {}
+    }
+    defineRuntimeModuleMetadata(AppModule, {
+      providers: [FailingLifecycleProvider],
+    });
+
+    try {
+      await expect(
+        FluoFactory.createApplicationContext(AppModule, {
+          platform: { components: [platformComponent] },
+        }),
+      ).rejects.toBe(bootstrapFailure);
+
+      expect(events).toEqual([
+        'platform:start',
+        'provider:destroy',
+        'platform:stop',
+        'provider:shutdown:bootstrap-failed',
+      ]);
+      expect(errorLog).toHaveBeenCalledWith(destroyFailure);
     } finally {
       errorLog.mockRestore();
     }

--- a/packages/runtime/src/bootstrap.ts
+++ b/packages/runtime/src/bootstrap.ts
@@ -1263,16 +1263,30 @@ async function runBootstrapHooks(instances: unknown[]): Promise<void> {
  * 종료 단계의 hook을 역순으로 실행해 이미 시작한 리소스를 정리한다.
  */
 async function runShutdownHooks(instances: readonly unknown[], signal?: string): Promise<void> {
+  const errors: unknown[] = [];
+
   for (const instance of [...instances].reverse()) {
-    if (isOnModuleDestroy(instance)) {
-      await instance.onModuleDestroy();
+    try {
+      if (isOnModuleDestroy(instance)) {
+        await instance.onModuleDestroy();
+      }
+    } catch (error) {
+      errors.push(error);
     }
   }
 
   for (const instance of [...instances].reverse()) {
-    if (isOnApplicationShutdown(instance)) {
-      await instance.onApplicationShutdown(signal);
+    try {
+      if (isOnApplicationShutdown(instance)) {
+        await instance.onApplicationShutdown(signal);
+      }
+    } catch (error) {
+      errors.push(error);
     }
+  }
+
+  if (errors.length > 0) {
+    throw createLifecycleCloseError(errors);
   }
 }
 

--- a/packages/runtime/src/bootstrap.ts
+++ b/packages/runtime/src/bootstrap.ts
@@ -1580,7 +1580,7 @@ export async function bootstrapApplication(options: BootstrapApplicationOptions)
 
     const resolveLifecycleStart = timingEnabled ? runtimePerformance.now() : 0;
     lifecycleInstances = await resolveBootstrapLifecycleInstances(bootstrapped, lifecycleInstances);
-    lifecycleInstances.push({
+    lifecycleInstances.unshift({
       onModuleDestroy() {
         return platformShell.stop();
       },
@@ -1746,7 +1746,7 @@ export class FluoFactory {
 
       const resolveLifecycleStart = timingEnabled ? runtimePerformance.now() : 0;
       lifecycleInstances = await resolveBootstrapLifecycleInstances(bootstrapped, lifecycleInstances);
-      lifecycleInstances.push({
+      lifecycleInstances.unshift({
         onModuleDestroy() {
           return platformShell.stop();
         },


### PR DESCRIPTION
## Summary
- drain queued shared telemetry scrapes before platform components stop
- clear framework-owned gauges while preserving application collectors and restoring the registry renderer
- continue every shutdown hook after provider failures so platform cleanup always runs

## Verification
- `@fluojs/runtime`: build, typecheck, full test suite
- `@fluojs/metrics`: typecheck, full test suite
- reverse dependents; `@fluojs/openapi` 90/90 twice after isolated closure build
- Changeset stable lane, Biome, LSP diagnostics
- exact-head contract/code/verification triad: PASS

Closes #3203