### PR TITLE
docs(http): fix README DTO example to compile with shipped Babel decorators

### DIFF
--- a/.changeset/fix-http-readme-dto-example.md
+++ b/.changeset/fix-http-readme-dto-example.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/http": patch
+---
+
+Correct the README Quick Start DTO example so the documented snippet compiles with the Babel decorator configuration Fluo ships. Decorated DTO fields are now initialized instead of using a definite assignment assertion, and both READMEs state that constraint.

--- a/packages/http/README.ko.md
+++ b/packages/http/README.ko.md
@@ -67,12 +67,12 @@ class CreateUserDto {
   @FromBody()
   @IsString()
   @MinLength(3)
-  name!: string;
+  name = '';
 }
 
 class FindUserParamsDto {
   @FromPath('id')
-  id!: string;
+  id = '';
 }
 
 @Controller('/users')
@@ -90,6 +90,8 @@ export class UserController {
   }
 }
 ```
+
+데코레이터가 붙은 DTO 필드는 위 예시처럼 초기화하거나 optional로 선언하세요. `name!: string` 같은 definite assignment assertion은 Fluo가 제공하는 Babel decorator 설정에서 컴파일되지 않습니다. 해당 설정은 데코레이터가 붙은 클래스의 definitely assigned field를 `Definitely assigned fields cannot be initialized here, but only in the constructor` 오류로 거부합니다.
 
 ### 라우트 경로 계약
 

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -69,12 +69,12 @@ class CreateUserDto {
   @FromBody()
   @IsString()
   @MinLength(3)
-  name!: string;
+  name = '';
 }
 
 class FindUserParamsDto {
   @FromPath('id')
-  id!: string;
+  id = '';
 }
 
 @Controller('/users')
@@ -92,6 +92,8 @@ export class UserController {
   }
 }
 ```
+
+Initialize decorated DTO fields, as shown above, or declare them optional. A definite assignment assertion such as `name!: string` does not compile with the Babel decorator configuration Fluo ships, which rejects a definitely assigned field on a decorated class with `Definitely assigned fields cannot be initialized here, but only in the constructor`.
 
 ### Route path contract
 


### PR DESCRIPTION
## Summary

The `@fluojs/http` Quick Start DTO example could not be copied verbatim: it used definite assignment assertions (`name!: string`, `id!: string`), which the Babel decorator configuration Fluo itself ships rejects with `SyntaxError: Definitely assigned fields cannot be initialized here, but only in the constructor`. This corrects the documented example and states the constraint so readers do not reach for `!:` again.

Linked context: Closes #3566

## Changes

- `packages/http/README.md`, `packages/http/README.ko.md`: Quick Start DTO fields changed from `name!: string` / `id!: string` to `name = ''` / `id = ''`. The initialized form keeps the property type non-optional `string`, preserving the required-field semantics implied by `@MinLength(3)` (the optional `?` form would have changed the documented type).
- Both READMEs gain a constraint note directly after the Quick Start block, at the same position, stating that `!:` on a decorated DTO field does not compile with the shipped Babel decorator configuration. The Korean file carries a faithful Korean mirror.
- `.changeset/fix-http-readme-dto-example.md`: `@fluojs/http` patch. npm auto-includes package-root `README*` in the tarball regardless of the manifest `files` field, so this README correction is consumer-visible.

No `src/` file, no test, and no root `docs/**` file is touched.

## Testing

Verified at head `af485ec67fdc07e6240f73749014afc45be2d769`:

- Every fenced ` ```ts ` block was extracted from the **shipped README text** (not a hand-copied snippet) and each decorated block compiled through `@babel/core` `transformAsync` with the exact options `@fluojs/vite` uses (`packages/vite/src/decorators-plugin.ts:129-130`: `babelrc: false`, `configFile: false`, `plugins: [['@babel/plugin-proposal-decorators', { version: '2023-11' }]]`, `presets: [['@babel/preset-typescript', { allowDeclareFields: true }]]`).
  - `packages/http/README.md`: 6 of 6 decorated blocks compiled OK
  - `packages/http/README.ko.md`: 6 of 6 decorated blocks compiled OK
- Control run, old `name!: string` form under the same options: fails as expected with `Definitely assigned fields cannot be initialized here, but only in the constructor`.
- No residual `!:` remains in either README.
- Package build, typecheck, and tests were **not** run: the diff touches no source and no test file. The full matrix runs on CI.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

N/A — this PR changes no source file and no public export; only package READMEs and one changeset.

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [ ] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [ ] Runtime invariants are covered by regression tests. — N/A: no runtime behavior changes; the documented example is proven by compiling the shipped README text with the shipped Babel options (see Testing).

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. — N/A: no platform contract doc changed.
- [ ] Any package README alignment/conformance claims are backed by the applicable platform harness tests. — N/A: no alignment or conformance claim was added or modified.
