### PR TITLE
fix(vite): run decorators plugin before the Vite transpiler

### DIFF
--- a/.changeset/run-vite-decorators-plugin-pre.md
+++ b/.changeset/run-vite-decorators-plugin-pre.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/vite": patch
+---
+
+Fix silently dropped field decorators on Vite 7+. `fluoDecoratorsPlugin()` ran in Vite's normal plugin stage, so Vite's own transpiler (oxc on Vite 7+) stripped field decorators such as `@FromBody`, `@FromQuery`, `@FromPath`, `@FromHeader`, `@FromCookie`, `@Optional`, and `@Convert` before Babel received the file. The plugin now sets `enforce: 'pre'` so Babel transforms the original TypeScript source and standard decorators keep their runtime behavior.

--- a/packages/vite/src/decorators-plugin.ts
+++ b/packages/vite/src/decorators-plugin.ts
@@ -109,6 +109,7 @@ function createFluoDecoratorsPlugin(importBabelCoreModule: BabelCoreImporter): P
 
   return {
     name: 'fluo-babel-decorators',
+    enforce: 'pre',
     configResolved(config) {
       shouldGenerateSourceMaps = shouldRequestBabelSourceMaps(config);
     },

--- a/packages/vite/src/plugin-stage.test.ts
+++ b/packages/vite/src/plugin-stage.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { createFluoDecoratorsPluginForTesting } from './decorators-plugin.js';
+import { fluoDecoratorsPlugin } from './index.js';
+
+function rejectBabelLoad(): Promise<never> {
+  return Promise.reject(new Error('Babel must not load while inspecting the plugin stage.'));
+}
+
+describe('fluoDecoratorsPlugin plugin stage', () => {
+  it('runs before the Vite transpiler so field decorators still reach Babel', () => {
+    expect(fluoDecoratorsPlugin().enforce).toBe('pre');
+  });
+
+  it('keeps the pre-transpiler stage on the injected-Babel test factory', () => {
+    expect(createFluoDecoratorsPluginForTesting(rejectBabelLoad).enforce).toBe('pre');
+  });
+});


### PR DESCRIPTION
## Summary

`fluoDecoratorsPlugin()` did not set `enforce`, so it ran in Vite's **normal** plugin stage — after Vite's own transpiler. On Vite 7+ that transpiler is oxc, which handles field decorators before Babel ever sees the file, so every DTO binding decorator (`@FromBody`, `@FromQuery`, `@FromPath`, `@FromHeader`, `@FromCookie`, `@Optional`, `@Convert`) became a silent no-op: no error, no warning, `input.<field>` just `undefined`, and `getDtoBindingSchema(Dto)` returning `[]`. The plugin now runs before Vite's transpiler, so Babel receives the original TypeScript source.

Linked context: Closes #3565

## Changes

- `packages/vite/src/decorators-plugin.ts`: `enforce: 'pre',` on the plugin object returned by `createFluoDecoratorsPlugin` (line 112, immediately after `name: 'fluo-babel-decorators'`). No other behavior is touched — Babel option handling, source-map handling, and peer-dependency diagnostics are unchanged.
- `packages/vite/src/plugin-stage.test.ts`: 2 tests pinning `enforce === 'pre'` on both the public factory `fluoDecoratorsPlugin()` and the injected-Babel factory `createFluoDecoratorsPluginForTesting(...)`. The injected stub rejects on Babel load, so the assertions read the stage without loading Babel at all.
- `.changeset/run-vite-decorators-plugin-pre.md`: `@fluojs/vite` patch.

Out of scope by design: the issue's "Suggested hardening" ideas (fail-fast on an empty DTO binding schema, upstream-transform decorator detection) and the `@fluojs/platform-nextjs` sibling check (that package is not in this repository).

## Testing

Local verification at head `20772fba557d118a241447a59607554a2f647e71`, each exit code captured individually:

- `pnpm --filter '@fluojs/vite...' build` → exit 0. Run before typecheck because workspace `types` entries point at emitted `dist/*.d.ts`. The package's `prebuild` runs `tooling/scripts/clean-dist.mjs`, so this was a clean-dist build.
- `pnpm --filter '@fluojs/vite' typecheck` → exit 0
- `pnpm --filter '@fluojs/vite' test` → exit 0, `Test Files 5 passed (5) / Tests 20 passed (20)`
- `pnpm --filter '...@fluojs/vite' test` (reverse dependents) → exit 0, `Scope: 2 of 55 workspace projects`

Regression evidence:

- **Pinned**: `plugin-stage.test.ts` was observed RED before the fix (`AssertionError: expected undefined to be 'pre'`, 2 failed) and GREEN after. `enforce` is the machine-consumed value Vite reads for plugin ordering, so this is the regression seam itself, not a proxy for it.
- **Manual, deliberately not pinned**: an isolated `vite@7.3.6` (oxc) project importing this plugin source was built with a real `vite build`, judging transform ownership in the emitted output — with the fix, Babel `_applyDecs` machinery is present and oxc `__decorateElement` is absent; without it, the inverse. The scratch project was removed and is not part of this diff.
- **Why there is no in-repo integration test**: this repository pins `vite@6.4.3`, which uses esbuild, and esbuild preserves field decorators — the defect cannot reproduce here. Worth recording for future readers: under `vite@7.3.6` oxc *transforms* the field decorator itself rather than dropping it, so a counter-only probe (`fieldCalls === 1`) returns 1 in both states and cannot detect this regression; the discriminating signal is which transformer owns the output.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

The public export surface is unchanged: `fluoDecoratorsPlugin()` still takes no arguments and still returns a Vite `Plugin`. `enforce` is a Vite-consumed field on the returned object, not a new export or signature.

- [ ] Changed public exports include a source-level summary. — N/A: no export was added or changed.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable. — N/A: no signature changed.
- [ ] Source `@example` blocks and README scenario examples still play complementary roles. — unchanged.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README. — N/A: this restores the decorator behavior `packages/vite/README.md` already documents rather than adding a new contract. `README.md` documents no plugin ordering or stage guarantee (its `direct esbuild decorator handling` line is a support exclusion, not a stage contract).
- [x] Intentional limitations are explicitly stated (not silently removed). — none were changed or removed by this PR.
- [x] Runtime invariants are covered by regression tests. — `plugin-stage.test.ts` pins the pre-transpiler stage on both factories.

## Platform consistency governance (SSOT)

- [ ] SSOT English/Korean mirror structure remains synchronized for changed governance docs. — N/A: no governance doc changed.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. — N/A: no platform contract doc changed.
- [ ] Any package README alignment/conformance claims are backed by the applicable platform harness tests. — N/A: no alignment or conformance claim was added or modified.
