### PR TITLE
fix(queue): require queue context marker during scope discovery (#3253)

### DIFF
--- a/.changeset/queue-marker-aware-scope-discovery.md
+++ b/.changeset/queue-marker-aware-scope-discovery.md
@@ -1,0 +1,9 @@
+---
+'@fluojs/queue': patch
+---
+
+Use the marker-aware registration context to detect duplicate scopes during bootstrap.
+
+`QueueLifecycleService` previously counted duplicate queue scopes using a structural check (`moduleType` function + `scope` string) that matched any `useValue` provider with those two fields. An unrelated application provider that happened to have the same shape and the same scope string as a real queue registration could trigger a false "duplicate scope" bootstrap failure.
+
+The marker-backed scope scan in `worker-ownership.ts` (`collectQueueModuleContexts` + `assertUniqueQueueScopes`) already runs in the same module factory before the service is constructed, so the service-level redundant scan has been removed. Queue registrations without the `QUEUE_MODULE_CONTEXT_MARKER` symbol are no longer counted.

--- a/packages/queue/src/module.test.ts
+++ b/packages/queue/src/module.test.ts
@@ -772,6 +772,48 @@ describe('@fluojs/queue', () => {
     ).rejects.toThrow('Duplicate @fluojs/queue scope "jobs" registered. Provide a unique QueueModule.forRoot({ scope }) value for each scoped queue registration.');
   });
 
+  it('ignores unrelated application values that structurally resemble queue registration metadata', async () => {
+    class LookalikeModuleType {}
+
+    const LOOKALIKE_TOKEN = Symbol('app.lookalike-queue-context');
+
+    class LookalikeContextModule {}
+    defineModule(LookalikeContextModule, {
+      providers: [
+        {
+          provide: LOOKALIKE_TOKEN,
+          useValue: {
+            moduleType: LookalikeModuleType,
+            options: {},
+            registrationTokens: [],
+            scope: 'jobs',
+          },
+        },
+      ],
+    });
+
+    class QueueFeatureModule {}
+    defineModule(QueueFeatureModule, {
+      imports: [QueueModule.forRoot({ global: false, scope: 'jobs' })],
+    });
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [LookalikeContextModule, QueueFeatureModule],
+    });
+
+    const redis = new MockRedisClient();
+
+    const app = await bootstrapApplication({
+      providers: [{ provide: REDIS_CLIENT, useValue: redis }],
+      rootModule: AppModule,
+    });
+
+    await expect(app.container.resolve(getQueueToken('jobs'))).resolves.toBeDefined();
+
+    await app.close();
+  });
+
   it('keeps distinct explicit queue scopes isolated through public scoped token helpers', async () => {
     class FirstScopedJob {
       constructor(public readonly id: string) {}

--- a/packages/queue/src/service.ts
+++ b/packages/queue/src/service.ts
@@ -145,34 +145,6 @@ function toBullBackoff(backoff: QueueBackoffOptions | undefined): JobsOptions['b
   };
 }
 
-function isQueueModuleContext(value: unknown): value is QueueModuleContext {
-  if (typeof value !== 'object' || value === null) {
-    return false;
-  }
-
-  const context = value as { moduleType?: unknown; scope?: unknown };
-
-  return typeof context.moduleType === 'function' && typeof context.scope === 'string';
-}
-
-function collectQueueModuleScopeCount(compiledModules: readonly CompiledModule[], scope: string): number {
-  let count = 0;
-
-  for (const compiledModule of compiledModules) {
-    for (const provider of compiledModule.definition.providers ?? []) {
-      if (typeof provider !== 'object' || provider === null || !('useValue' in provider)) {
-        continue;
-      }
-
-      if (isQueueModuleContext(provider.useValue) && provider.useValue.scope === scope) {
-        count += 1;
-      }
-    }
-  }
-
-  return count;
-}
-
 async function closeConnection(connection: QueueOwnedConnection): Promise<void> {
   if (connection.status === 'end') {
     return;
@@ -222,7 +194,6 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
   ) {
     this.compiledModulesByType = new Map(this.compiledModules.map((compiledModule) => [compiledModule.type, compiledModule]));
     this.deadLetterManager = new QueueDeadLetterManager(this.options, this.logger, () => this.getRedisClient());
-    this.assertUniqueQueueScope();
   }
 
   async onApplicationBootstrap(): Promise<void> {
@@ -395,16 +366,6 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
       compiledModule.exportedTokens.has(getQueueLifecycleServiceToken(this.options.scope)) ||
       compiledModule.exportedTokens.has(getQueueToken(this.options.scope))
     );
-  }
-
-  private assertUniqueQueueScope(): void {
-    const scopeCount = collectQueueModuleScopeCount(this.compiledModules, this.moduleContext.scope);
-
-    if (scopeCount > 1) {
-      throw new Error(
-        `Duplicate @fluojs/queue scope "${this.moduleContext.scope}" registered. Provide a unique QueueModule.forRoot({ scope }) value for each scoped queue registration.`,
-      );
-    }
   }
 
   private async handleStartupFailure(): Promise<void> {


### PR DESCRIPTION
## Summary

- stop structurally similar application providers from being counted as Queue registrations
- rely on the existing marker-backed duplicate-scope validation
- add regression coverage for an unmarked lookalike provider

## Verification

- `pnpm --filter @fluojs/queue... build`
- `pnpm --filter @fluojs/queue typecheck`
- `pnpm --filter ...@fluojs/queue test`
- targeted exact-worktree regression: 1 passed

Fixes #3253