### PR TITLE
fix(microservices): align Node engine range

### DIFF
--- a/.changeset/align-microservices-node-engines.md
+++ b/.changeset/align-microservices-node-engines.md
@@ -1,0 +1,7 @@
+---
+"@fluojs/microservices": major
+---
+
+Align `@fluojs/microservices` with the Node.js range required by its mandatory `@fluojs/runtime` dependency.
+
+Migration: Node.js 20 consumers must upgrade to Node.js 20.19.3 or newer. Node.js 21 is no longer supported; use Node.js 22.2.0 or newer (up to, but excluding, Node.js 27).

--- a/packages/microservices/README.ko.md
+++ b/packages/microservices/README.ko.md
@@ -7,6 +7,7 @@ fluo용 트랜스포트 기반 마이크로서비스 패키지입니다. TCP, Re
 ## 목차
 
 - [설치](#설치)
+- [요구 사항](#요구-사항)
 - [사용 시점](#사용-시점)
 - [빠른 시작](#빠른-시작)
 - [주요 기능](#주요-기능)
@@ -27,6 +28,10 @@ pnpm add @fluojs/microservices
 - 애플리케이션이 transport에 명시적으로 넘겨야 하는 caller-owned broker client: `nats`, `kafkajs`, `amqplib`
 
 gRPC transport는 `@grpc/grpc-js@^1.14.4`와 `@grpc/proto-loader@^0.8.0`을 요구합니다. 더 오래된 `@grpc/grpc-js` release를 사용하던 consumer는 이 major `@fluojs/microservices` release를 적용하기 전에 peer를 업그레이드하고 lockfile을 갱신해야 합니다. 갱신된 install은 proto-loader chain을 `protobufjs@7.6.5` 이상으로 resolve해 수정된 UTF-8 helper를 포함해야 합니다. fluo transport API는 그대로입니다.
+
+## 요구 사항
+
+`@fluojs/microservices`는 필수 `@fluojs/runtime` 의존성과 동일한 Node.js `>=20.19.3 <21 || >=22.2.0 <27`를 요구합니다. Node 21, 22.2.0 미만의 Node 22, 검증되지 않은 Node 27 이상은 지원하지 않습니다.
 
 ## 사용 시점
 

--- a/packages/microservices/README.md
+++ b/packages/microservices/README.md
@@ -7,6 +7,7 @@ Transport-driven microservices for fluo. Build scalable, message-driven architec
 ## Table of Contents
 
 - [Installation](#installation)
+- [Requirements](#requirements)
 - [When to Use](#when-to-use)
 - [Quick Start](#quick-start)
 - [Core Capabilities](#core-capabilities)
@@ -27,6 +28,10 @@ Optional transport-specific dependencies:
 - Caller-owned broker clients passed explicitly to transports: `nats`, `kafkajs`, `amqplib`
 
 The gRPC transport requires `@grpc/grpc-js@^1.14.4` and `@grpc/proto-loader@^0.8.0`. Consumers using an older `@grpc/grpc-js` release must upgrade the peer and refresh their lockfile before adopting this major `@fluojs/microservices` release. A refreshed install must resolve the proto-loader chain to `protobufjs@7.6.5` or newer so its patched UTF-8 helper is included; the fluo transport API is unchanged.
+
+## Requirements
+
+`@fluojs/microservices` requires Node.js `>=20.19.3 <21 || >=22.2.0 <27`, matching its mandatory `@fluojs/runtime` dependency. Node 21, Node 22 before 22.2.0, and unverified Node 27+ are excluded.
 
 ## When to Use
 

--- a/packages/microservices/package.json
+++ b/packages/microservices/package.json
@@ -22,7 +22,7 @@
     "directory": "packages/microservices"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.19.3 <21 || >=22.2.0 <27"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/microservices/src/runtime-support.test.ts
+++ b/packages/microservices/src/runtime-support.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+const nodeEngineFloorPattern = /"engines"\s*:\s*\{\s*"node"\s*:\s*">=(\d+)\.(\d+)\.(\d+)(?=\s|")/u;
+const nodeListenerEngine = '>=20.19.3 <21 || >=22.2.0 <27';
+const mandatoryFluoDependencyManifests = [
+  '../../core/package.json',
+  '../../di/package.json',
+  '../../runtime/package.json',
+] as const;
+
+function extractNodeEngineFloor(manifest: string): readonly [number, number, number] {
+  const match = nodeEngineFloorPattern.exec(manifest);
+  if (match === null) {
+    throw new TypeError('Expected the package manifest to declare a >=x.y.z Node.js engine floor.');
+  }
+
+  return [
+    Number.parseInt(match[1] ?? '', 10),
+    Number.parseInt(match[2] ?? '', 10),
+    Number.parseInt(match[3] ?? '', 10),
+  ];
+}
+
+function compareNodeEngineFloors(
+  left: readonly [number, number, number],
+  right: readonly [number, number, number],
+): number {
+  for (const index of [0, 1, 2] as const) {
+    const difference = left[index] - right[index];
+    if (difference !== 0) {
+      return difference;
+    }
+  }
+
+  return 0;
+}
+
+describe('@fluojs/microservices runtime support metadata', () => {
+  it('declares the Node.js range required by the published package contract', () => {
+    // Given: the published @fluojs/microservices manifest.
+    // When: its declared Node.js engine range is read.
+    // Then: it matches the Node range owned by its mandatory @fluojs/runtime dependency.
+    const manifest = readFileSync(new URL('../package.json', import.meta.url), 'utf8');
+
+    expect(JSON.parse(manifest)).toMatchObject({ engines: { node: nodeListenerEngine } });
+  });
+
+  it('matches the Node.js range declared by its mandatory runtime dependency', () => {
+    // Given: the microservices manifest and the runtime manifest it depends on.
+    // When: both declared Node.js engine ranges are read.
+    // Then: microservices advertises exactly the runtime requirement.
+    const microservicesManifest = readFileSync(new URL('../package.json', import.meta.url), 'utf8');
+    const runtimeManifest = readFileSync(new URL('../../runtime/package.json', import.meta.url), 'utf8');
+
+    expect(JSON.parse(microservicesManifest).engines.node).toBe(JSON.parse(runtimeManifest).engines.node);
+  });
+
+  it('covers the highest Node.js floor in the mandatory fluo dependency graph', () => {
+    // Given: every mandatory @fluojs dependency of the root entrypoint.
+    // When: their engine floors are compared with the microservices floor.
+    // Then: no dependency requires a newer Node.js release than microservices advertises.
+    const microservicesManifest = readFileSync(new URL('../package.json', import.meta.url), 'utf8');
+    const microservicesFloor = extractNodeEngineFloor(microservicesManifest);
+
+    for (const relativePath of mandatoryFluoDependencyManifests) {
+      const manifest = readFileSync(new URL(relativePath, import.meta.url), 'utf8');
+
+      expect(compareNodeEngineFloors(extractNodeEngineFloor(manifest), microservicesFloor)).toBeLessThanOrEqual(0);
+    }
+  });
+
+  it('documents the supported Node.js range in both README mirrors', () => {
+    // Given: the bilingual package README mirrors.
+    // When: each mirror is read.
+    // Then: both state the same supported Node.js range.
+    for (const relativePath of ['../README.md', '../README.ko.md'] as const) {
+      const readme = readFileSync(new URL(relativePath, import.meta.url), 'utf8');
+
+      expect(readme).toContain(`Node.js \`${nodeListenerEngine}\``);
+    }
+  });
+});


### PR DESCRIPTION
Closes #3220

Aligns `@fluojs/microservices` Node engine support with its mandatory runtime dependency. Includes an explicitly approved major changeset and migration guidance.

Verification: clean-dist full workspace build; microservices typecheck; 249/249 tests; exact-head code, contract, and verification reviews all MERGE.