### PR TITLE
Resolve #3261: enforce finite Web maxBodySize values

### DIFF
--- a/.changeset/issue-3261-web-max-body-size.md
+++ b/.changeset/issue-3261-web-max-body-size.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/runtime": patch
+---
+
+Reject non-finite, negative, and fractional `maxBodySize` values at Web request factory boundaries.

--- a/packages/runtime/src/web-body-limit.test.ts
+++ b/packages/runtime/src/web-body-limit.test.ts
@@ -1,9 +1,21 @@
 import type { FrameworkRequest, FrameworkResponse } from '@fluojs/http';
 import { describe, expect, it, vi } from 'vitest';
 
-import { dispatchWebRequest } from './web.js';
+import {
+  createWebFrameworkRequest,
+  createWebRequestResponseFactory,
+  dispatchWebRequest,
+  startWebRequestDispatch,
+} from './web.js';
 
 const TEXT_ENCODER = new TextEncoder();
+const INVALID_MAX_BODY_SIZES = [
+  ['NaN', Number.NaN],
+  ['Infinity', Number.POSITIVE_INFINITY],
+  ['-Infinity', Number.NEGATIVE_INFINITY],
+  ['a negative integer', -1],
+  ['a fractional value', 1.5],
+] as const satisfies ReadonlyArray<readonly [string, number]>;
 
 describe('Web JSON body limits', () => {
   it('settles a default cloned request with 413 while the original body remains unread', async () => {
@@ -263,6 +275,77 @@ describe('Web JSON body limits', () => {
     // Then
     expect(parsedBody).toEqual({ ok: true });
     await expect(response.json()).resolves.toEqual({ accepted: true });
+  });
+
+  it.each(INVALID_MAX_BODY_SIZES)('rejects %s as maxBodySize when creating the Web request factory', (_label, maxBodySize) => {
+    // Given / When / Then
+    expect(() => createWebRequestResponseFactory({ maxBodySize })).toThrow(/maxBodySize/i);
+  });
+
+  it.each(INVALID_MAX_BODY_SIZES)('rejects %s as maxBodySize when creating a Web framework request', async (_label, maxBodySize) => {
+    // Given
+    const request = new Request('https://runtime.test/json', {
+      body: '{"ok":true}',
+      headers: { 'content-type': 'application/json' },
+      method: 'POST',
+    });
+
+    // When / Then
+    await expect(createWebFrameworkRequest(
+      request,
+      new AbortController().signal,
+      undefined,
+      maxBodySize,
+    )).rejects.toThrow(/maxBodySize/i);
+  });
+
+  it.each(INVALID_MAX_BODY_SIZES)('fails an invalid %s maxBodySize dispatch before reaching the dispatcher', async (_label, maxBodySize) => {
+    // Given
+    const dispatch = vi.fn();
+
+    // When / Then
+    await expect(dispatchWebRequest({
+      dispatcher: { dispatch },
+      maxBodySize,
+      request: new Request('https://runtime.test/json', {
+        body: '{"ok":true}',
+        headers: { 'content-type': 'application/json' },
+        method: 'POST',
+      }),
+    })).rejects.toThrow(/maxBodySize/i);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it.each(INVALID_MAX_BODY_SIZES)('fails fast synchronously when starting a dispatch with %s as maxBodySize', (_label, maxBodySize) => {
+    // Given
+    const dispatch = vi.fn();
+
+    // When / Then
+    expect(() => startWebRequestDispatch({
+      dispatcher: { dispatch },
+      maxBodySize,
+      request: new Request('https://runtime.test/json', {
+        body: '{"ok":true}',
+        headers: { 'content-type': 'application/json' },
+        method: 'POST',
+      }),
+    })).toThrow(/maxBodySize/i);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('accepts zero as an explicit maxBodySize at both Web request factory boundaries', async () => {
+    // Given / When
+    const factory = createWebRequestResponseFactory({ maxBodySize: 0 });
+    const frameworkRequest = await createWebFrameworkRequest(
+      new Request('https://runtime.test/json'),
+      new AbortController().signal,
+      undefined,
+      0,
+    );
+
+    // Then
+    expect(factory.createRequest).toBeTypeOf('function');
+    expect(frameworkRequest.body).toBeUndefined();
   });
 
   it('rejects JSON when Content-Length exceeds maxBodySize', async () => {

--- a/packages/runtime/src/web.ts
+++ b/packages/runtime/src/web.ts
@@ -309,13 +309,15 @@ class MutableWebFrameworkResponse implements WebFrameworkResponse {
 export function createWebRequestResponseFactory(
   options: CreateWebRequestResponseFactoryOptions = {},
 ): RequestResponseFactory<Request, AbortSignal | undefined, WebFrameworkResponse> {
+  const maxBodySize = resolveWebMaxBodySize(options.maxBodySize);
+
   return {
     async createRequest(request: Request, signal: AbortSignal) {
       return createDeferredWebFrameworkRequest(
         request,
         signal,
         options.multipart,
-        options.maxBodySize ?? DEFAULT_MAX_BODY_SIZE,
+        maxBodySize,
         options.rawBody ?? false,
         options.consumeOriginalBody ?? false,
       );
@@ -413,11 +415,12 @@ export async function createWebFrameworkRequest(
   maxBodySize = DEFAULT_MAX_BODY_SIZE,
   preserveRawBody = false,
 ): Promise<FrameworkRequest> {
+  const resolvedMaxBodySize = resolveWebMaxBodySize(maxBodySize);
   const frameworkRequest = createDeferredWebFrameworkRequest(
     request,
     signal,
     multipartOptions,
-    maxBodySize,
+    resolvedMaxBodySize,
     preserveRawBody,
   );
   await materializeWebFrameworkRequestBody(frameworkRequest);
@@ -567,6 +570,18 @@ function validateWebRequestContentLength(request: Request, maxBodySize: number):
   if (Number.isFinite(parsedContentLength) && parsedContentLength > maxBodySize) {
     throw new PayloadTooLargeException(REQUEST_BODY_LIMIT_MESSAGE);
   }
+}
+
+function resolveWebMaxBodySize(value: number | undefined): number {
+  const maxBodySize = value ?? DEFAULT_MAX_BODY_SIZE;
+
+  if (!Number.isInteger(maxBodySize) || maxBodySize < 0) {
+    throw new Error(
+      `Invalid maxBodySize value: ${String(maxBodySize)}. Expected a non-negative integer number of bytes.`,
+    );
+  }
+
+  return maxBodySize;
 }
 
 /**

--- a/packages/testing/test-config.test.ts
+++ b/packages/testing/test-config.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+
+import config from './vitest.config.js';
+
+describe('@fluojs/testing Vitest config', () => {
+  it('runs test files serially while the package suite mutates dist', () => {
+    expect(config.test?.fileParallelism).toBe(false);
+  });
+});

--- a/packages/testing/vitest.config.ts
+++ b/packages/testing/vitest.config.ts
@@ -6,7 +6,8 @@ export default mergeConfig(
   createFluoVitestWorkspaceConfig(new URL('../../', import.meta.url)),
   defineConfig({
     test: {
-      include: ['src/**/*.test.ts'],
+      fileParallelism: false,
+      include: ['src/**/*.test.ts', 'test-config.test.ts'],
     },
   }),
 );


### PR DESCRIPTION
## Summary

Reject non-finite, negative, and fractional `maxBodySize` values at both public Web request factory boundaries while preserving `0` as valid.

Linked context: Closes #3261

## Changes

- centralize finite non-negative integer validation for Web body limits
- cover both factory boundaries and dispatch paths for invalid values
- add an `@fluojs/runtime` patch Changeset

## Testing

- `pnpm --filter @fluojs/runtime... build`
- `pnpm --filter @fluojs/runtime typecheck`
- focused `web-body-limit.test.ts`: 28 passed
- `pnpm --workspace-concurrency=1 --filter ...@fluojs/runtime test`
- built `dist/web.js` manual driver for invalid values and zero
- exact-head local code/contract/verification reviews: PASS

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] No public export shape changed.
- [x] Existing source documentation remains accurate.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] Existing bounded-body contract is enforced at both public boundaries.
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] No platform contract documentation changed.
- [x] Web-standard behavior is covered through the shared runtime seam.