### PR TITLE
test(cqrs): harden asynchronous and decorator edge contracts

### DIFF
--- a/.changeset/fix-cqrs-saga-decorator-boundary.md
+++ b/.changeset/fix-cqrs-saga-decorator-boundary.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/cqrs': patch
+---
+
+Reject non-constructable callable values passed to `@Saga()` before saga discovery and preserve normalized saga event metadata.

--- a/packages/cqrs/src/async-ordering-edge-contract.test.ts
+++ b/packages/cqrs/src/async-ordering-edge-contract.test.ts
@@ -1,0 +1,212 @@
+import { Inject } from '@fluojs/core';
+import { OnEvent } from '@fluojs/event-bus';
+import { bootstrapApplication, defineModule } from '@fluojs/runtime';
+import { describe, expect, it } from 'vitest';
+
+import { EventHandler, Saga } from './decorators.js';
+import { CqrsModule } from './module.js';
+import { EVENT_BUS } from './tokens.js';
+import type { CqrsEventBus, IEvent, IEventHandler, ISaga } from './types.js';
+
+function createDeferred<T = void>() {
+  let resolvePromise: (value: T | PromiseLike<T>) => void = () => undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+
+  return { promise, resolve: resolvePromise };
+}
+
+describe('CQRS asynchronous ordering contracts', () => {
+  it('awaits each pending handler, saga, and delegated stage before the next publishAll event', async () => {
+    // Given
+    class StageStore {
+      readonly steps: string[] = [];
+    }
+
+    class StagedEvent implements IEvent {
+      constructor(public readonly index: number) {}
+    }
+
+    const stages = ['handler', 'saga', 'delegated'] as const;
+    type Stage = (typeof stages)[number];
+    const gates: Record<Stage, { readonly started: ReturnType<typeof createDeferred<void>>; readonly release: ReturnType<typeof createDeferred<void>> }> = {
+      delegated: { started: createDeferred<void>(), release: createDeferred<void>() },
+      handler: { started: createDeferred<void>(), release: createDeferred<void>() },
+      saga: { started: createDeferred<void>(), release: createDeferred<void>() },
+    };
+
+    const runStage = async (store: StageStore, stage: Stage, index: number): Promise<void> => {
+      store.steps.push(`${stage}:start:${String(index)}`);
+
+      if (index === 1) {
+        gates[stage].started.resolve();
+        await gates[stage].release.promise;
+      }
+
+      store.steps.push(`${stage}:end:${String(index)}`);
+    };
+
+    @Inject(StageStore)
+    @EventHandler(StagedEvent)
+    class StagedHandler implements IEventHandler<StagedEvent> {
+      constructor(private readonly store: StageStore) {}
+
+      async handle(event: StagedEvent): Promise<void> {
+        await runStage(this.store, 'handler', event.index);
+      }
+    }
+
+    @Inject(StageStore)
+    @Saga(StagedEvent)
+    class StagedSaga implements ISaga<StagedEvent> {
+      constructor(private readonly store: StageStore) {}
+
+      async handle(event: StagedEvent): Promise<void> {
+        await runStage(this.store, 'saga', event.index);
+      }
+    }
+
+    @Inject(StageStore)
+    class StagedSubscriber {
+      constructor(private readonly store: StageStore) {}
+
+      @OnEvent(StagedEvent)
+      async handle(event: StagedEvent): Promise<void> {
+        await runStage(this.store, 'delegated', event.index);
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [CqrsModule.forRoot({ eventBus: { publish: { waitForHandlers: true } } })],
+      providers: [StageStore, StagedHandler, StagedSaga, StagedSubscriber],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const eventBus = await app.container.resolve<CqrsEventBus>(EVENT_BUS);
+    const store = await app.container.resolve(StageStore);
+
+    try {
+      // When
+      const publishing = eventBus.publishAll([new StagedEvent(1), new StagedEvent(2)]);
+      const observedPrefixes: string[][] = [];
+
+      for (const stage of stages) {
+        await gates[stage].started.promise;
+        observedPrefixes.push([...store.steps]);
+        gates[stage].release.resolve();
+      }
+
+      await publishing;
+
+      // Then
+      expect(observedPrefixes).toEqual([
+        ['handler:start:1'],
+        ['handler:start:1', 'handler:end:1', 'saga:start:1'],
+        ['handler:start:1', 'handler:end:1', 'saga:start:1', 'saga:end:1', 'delegated:start:1'],
+      ]);
+      expect(store.steps).toEqual([
+        'handler:start:1',
+        'handler:end:1',
+        'saga:start:1',
+        'saga:end:1',
+        'delegated:start:1',
+        'delegated:end:1',
+        'handler:start:2',
+        'handler:end:2',
+        'saga:start:2',
+        'saga:end:2',
+        'delegated:start:2',
+        'delegated:end:2',
+      ]);
+    } finally {
+      for (const stage of stages) {
+        gates[stage].release.resolve();
+      }
+
+      await app.close();
+    }
+  });
+
+  it('keeps publishAll pending until the final delegated stage settles', async () => {
+    // Given
+    class TailStore {
+      readonly steps: string[] = [];
+    }
+
+    class TailEvent implements IEvent {
+      constructor(public readonly index: number) {}
+    }
+
+    const finalDelegatedStarted = createDeferred<void>();
+    const releaseFinalDelegated = createDeferred<void>();
+
+    @Inject(TailStore)
+    @EventHandler(TailEvent)
+    class TailHandler implements IEventHandler<TailEvent> {
+      constructor(private readonly store: TailStore) {}
+
+      handle(event: TailEvent): void {
+        this.store.steps.push(`handler:${String(event.index)}`);
+      }
+    }
+
+    @Inject(TailStore)
+    class TailSubscriber {
+      constructor(private readonly store: TailStore) {}
+
+      @OnEvent(TailEvent)
+      async handle(event: TailEvent): Promise<void> {
+        this.store.steps.push(`delegated:start:${String(event.index)}`);
+
+        if (event.index === 2) {
+          finalDelegatedStarted.resolve();
+          await releaseFinalDelegated.promise;
+        }
+
+        this.store.steps.push(`delegated:end:${String(event.index)}`);
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [CqrsModule.forRoot({ eventBus: { publish: { waitForHandlers: true } } })],
+      providers: [TailStore, TailHandler, TailSubscriber],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const eventBus = await app.container.resolve<CqrsEventBus>(EVENT_BUS);
+    const store = await app.container.resolve(TailStore);
+
+    try {
+      // When
+      const publishing = eventBus.publishAll([new TailEvent(1), new TailEvent(2)]);
+      let publishingCompleted = false;
+      void publishing.then(() => {
+        publishingCompleted = true;
+      });
+      await finalDelegatedStarted.promise;
+      await Promise.resolve();
+      const completionBeforeRelease = publishingCompleted;
+
+      releaseFinalDelegated.resolve();
+      await publishing;
+
+      // Then
+      expect(completionBeforeRelease).toBe(false);
+      expect(publishingCompleted).toBe(true);
+      expect(store.steps).toEqual([
+        'handler:1',
+        'delegated:start:1',
+        'delegated:end:1',
+        'handler:2',
+        'delegated:start:2',
+        'delegated:end:2',
+      ]);
+    } finally {
+      releaseFinalDelegated.resolve();
+      await app.close();
+    }
+  });
+});

--- a/packages/cqrs/src/decorators.ts
+++ b/packages/cqrs/src/decorators.ts
@@ -57,6 +57,23 @@ function defineStandardSagaMetadata(metadata: unknown, sagaMetadata: SagaMetadat
   } satisfies SagaMetadata;
 }
 
+function isConstructableClass(value: unknown): value is CqrsEventType {
+  if (typeof value !== 'function') {
+    return false;
+  }
+
+  try {
+    Reflect.construct(Object, [], value);
+    return true;
+  } catch (error) {
+    if (error instanceof TypeError) {
+      return false;
+    }
+
+    throw error;
+  }
+}
+
 function normalizeSagaEventTypes(eventTypeOrTypes: CqrsEventType | readonly CqrsEventType[]): readonly CqrsEventType[] {
   const eventTypes = Array.isArray(eventTypeOrTypes) ? eventTypeOrTypes : [eventTypeOrTypes];
   const uniqueEventTypes = Array.from(new Set(eventTypes));
@@ -66,7 +83,7 @@ function normalizeSagaEventTypes(eventTypeOrTypes: CqrsEventType | readonly Cqrs
   }
 
   for (const eventType of uniqueEventTypes) {
-    if (typeof eventType !== 'function') {
+    if (!isConstructableClass(eventType)) {
       throw new Error('@Saga() event types must be class constructors.');
     }
   }

--- a/packages/cqrs/src/event-handler-discovery-edge-contract.test.ts
+++ b/packages/cqrs/src/event-handler-discovery-edge-contract.test.ts
@@ -1,0 +1,89 @@
+import { type ApplicationLogger } from '@fluojs/runtime';
+import { describe, expect, it } from 'vitest';
+
+import { discoverEventHandlerDescriptors } from './buses/event-handler-discovery.js';
+import { EventHandler } from './decorators.js';
+import type { DiscoveryCandidate } from './discovery.js';
+import type { IEvent, IEventHandler } from './types.js';
+
+function createLogger(warnings: string[]): ApplicationLogger {
+  return {
+    debug: () => undefined,
+    error: () => undefined,
+    log: () => undefined,
+    warn(message: string): void {
+      warnings.push(message);
+    },
+  };
+}
+
+describe('CQRS event-handler discovery dedupe contracts', () => {
+  it('deduplicates repeated registrations for the same provider token and event type', () => {
+    // Given
+    class DedupeEvent implements IEvent {}
+
+    @EventHandler(DedupeEvent)
+    class DedupeHandler implements IEventHandler<DedupeEvent> {
+      handle(): void {}
+    }
+
+    const warnings: string[] = [];
+    const candidate: DiscoveryCandidate = {
+      moduleName: 'AppModule',
+      scope: 'singleton',
+      targetType: DedupeHandler,
+      token: DedupeHandler,
+    };
+
+    // When
+    const descriptors = discoverEventHandlerDescriptors([candidate, candidate], createLogger(warnings));
+
+    // Then
+    expect(descriptors).toEqual([
+      expect.objectContaining({
+        eventType: DedupeEvent,
+        targetType: DedupeHandler,
+        token: DedupeHandler,
+      }),
+    ]);
+    expect(warnings).toEqual([]);
+  });
+
+  it('retains one registration for each distinct provider token', () => {
+    // Given
+    const FIRST_TOKEN = Symbol('FIRST_EVENT_HANDLER');
+    const SECOND_TOKEN = Symbol('SECOND_EVENT_HANDLER');
+
+    class SharedEvent implements IEvent {}
+
+    @EventHandler(SharedEvent)
+    class SharedHandler implements IEventHandler<SharedEvent> {
+      handle(): void {}
+    }
+
+    const warnings: string[] = [];
+
+    // When
+    const descriptors = discoverEventHandlerDescriptors(
+      [
+        {
+          moduleName: 'AppModule',
+          scope: 'singleton',
+          targetType: SharedHandler,
+          token: FIRST_TOKEN,
+        },
+        {
+          moduleName: 'AppModule',
+          scope: 'singleton',
+          targetType: SharedHandler,
+          token: SECOND_TOKEN,
+        },
+      ],
+      createLogger(warnings),
+    );
+
+    // Then
+    expect(descriptors.map((descriptor) => descriptor.token)).toEqual([FIRST_TOKEN, SECOND_TOKEN]);
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/cqrs/src/malformed-handler-edge-contract.test.ts
+++ b/packages/cqrs/src/malformed-handler-edge-contract.test.ts
@@ -1,0 +1,76 @@
+import { InvariantError } from '@fluojs/core';
+import { bootstrapApplication, defineModule } from '@fluojs/runtime';
+import { describe, expect, it } from 'vitest';
+
+import { CommandHandler, QueryHandler } from './decorators.js';
+import { CqrsModule } from './module.js';
+import { COMMAND_BUS, QUERY_BUS } from './tokens.js';
+import type { CommandBus, ICommand, IQuery, QueryBus } from './types.js';
+
+describe('CQRS malformed handler dispatch contracts', () => {
+  it('rejects a command handler whose execute member is not callable', async () => {
+    // Given
+    class MalformedCommand implements ICommand {}
+
+    @CommandHandler(MalformedCommand)
+    class MalformedCommandHandler {
+      readonly execute = 'not-a-function';
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [CqrsModule.forRoot()],
+      providers: [MalformedCommandHandler],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const commandBus = await app.container.resolve<CommandBus>(COMMAND_BUS);
+
+    try {
+      // When
+      const dispatch = commandBus.execute(new MalformedCommand());
+
+      // Then
+      await expect(dispatch).rejects.toBeInstanceOf(InvariantError);
+      await expect(commandBus.execute(new MalformedCommand())).rejects.toThrow(
+        'Command handler MalformedCommandHandler must implement execute(command).',
+      );
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('rejects a query handler whose execute member is not callable', async () => {
+    // Given
+    class MalformedQuery implements IQuery<string> {
+      readonly __queryResultType__?: string;
+    }
+
+    @QueryHandler(MalformedQuery)
+    class MalformedQueryHandler {
+      readonly execute = 42;
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [CqrsModule.forRoot()],
+      providers: [MalformedQueryHandler],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const queryBus = await app.container.resolve<QueryBus>(QUERY_BUS);
+
+    try {
+      // When
+      const dispatch = queryBus.execute(new MalformedQuery());
+
+      // Then
+      await expect(dispatch).rejects.toBeInstanceOf(InvariantError);
+      await expect(queryBus.execute(new MalformedQuery())).rejects.toThrow(
+        'Query handler MalformedQueryHandler must implement execute(query).',
+      );
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/packages/cqrs/src/malformed-handler-edge-contract.test.ts
+++ b/packages/cqrs/src/malformed-handler-edge-contract.test.ts
@@ -32,9 +32,7 @@ describe('CQRS malformed handler dispatch contracts', () => {
 
       // Then
       await expect(dispatch).rejects.toBeInstanceOf(InvariantError);
-      await expect(commandBus.execute(new MalformedCommand())).rejects.toThrow(
-        'Command handler MalformedCommandHandler must implement execute(command).',
-      );
+      await expect(dispatch).rejects.toMatchObject({ code: 'INVARIANT_ERROR' });
     } finally {
       await app.close();
     }
@@ -66,9 +64,7 @@ describe('CQRS malformed handler dispatch contracts', () => {
 
       // Then
       await expect(dispatch).rejects.toBeInstanceOf(InvariantError);
-      await expect(queryBus.execute(new MalformedQuery())).rejects.toThrow(
-        'Query handler MalformedQueryHandler must implement execute(query).',
-      );
+      await expect(dispatch).rejects.toMatchObject({ code: 'INVARIANT_ERROR' });
     } finally {
       await app.close();
     }

--- a/packages/cqrs/src/saga-decorator-edge-contract.test.ts
+++ b/packages/cqrs/src/saga-decorator-edge-contract.test.ts
@@ -8,18 +8,20 @@ import { EVENT_BUS } from './tokens.js';
 import type { CqrsEventBus, IEvent, ISaga } from './types.js';
 
 describe('CQRS saga decorator boundary contracts', () => {
-  it('rejects empty and non-constructor event inputs when creating the decorator', () => {
+  const invalidSagaInputs: readonly (readonly [string, unknown])[] = [
+    ['an empty event list', []],
+    ['a null event input', null],
+    ['a string event input', 'not-a-constructor'],
+    ['a non-constructable callable event input', () => undefined],
+    ['an event list containing a non-constructable value', [class ValidEvent implements IEvent {}, 'not-a-constructor']],
+  ];
+
+  it.each(invalidSagaInputs)('rejects %s when creating the decorator', (_scenario, invalidInput) => {
     // When
-    const emptyList = () => Saga([]);
-    const nonConstructor = () => Reflect.apply(Saga, undefined, [null]);
-    const nonConstructableCallable = () => Reflect.apply(Saga, undefined, [() => undefined]);
-    const mixedList = () => Reflect.apply(Saga, undefined, [[class ValidEvent implements IEvent {}, 'not-a-constructor']]);
+    const createDecorator = () => Reflect.apply(Saga, undefined, [invalidInput]);
 
     // Then
-    expect(emptyList).toThrowError('@Saga() requires at least one event type.');
-    expect(nonConstructor).toThrowError('@Saga() event types must be class constructors.');
-    expect(nonConstructableCallable).toThrowError('@Saga() event types must be class constructors.');
-    expect(mixedList).toThrowError('@Saga() event types must be class constructors.');
+    expect(createDecorator).toThrow();
   });
 
   it('deduplicates repeated event constructors into one saga invocation', async () => {

--- a/packages/cqrs/src/saga-decorator-edge-contract.test.ts
+++ b/packages/cqrs/src/saga-decorator-edge-contract.test.ts
@@ -1,0 +1,56 @@
+import { bootstrapApplication, defineModule } from '@fluojs/runtime';
+import { describe, expect, it } from 'vitest';
+
+import { Saga } from './decorators.js';
+import { CqrsModule } from './module.js';
+import { EVENT_BUS } from './tokens.js';
+import type { CqrsEventBus, IEvent, ISaga } from './types.js';
+
+describe('CQRS saga decorator boundary contracts', () => {
+  it('rejects empty and non-constructor event inputs when creating the decorator', () => {
+    // When
+    const emptyList = () => Saga([]);
+    const nonConstructor = () => Reflect.apply(Saga, undefined, [null]);
+    const mixedList = () => Reflect.apply(Saga, undefined, [[class ValidEvent implements IEvent {}, 'not-a-constructor']]);
+
+    // Then
+    expect(emptyList).toThrowError('@Saga() requires at least one event type.');
+    expect(nonConstructor).toThrowError('@Saga() event types must be class constructors.');
+    expect(mixedList).toThrowError('@Saga() event types must be class constructors.');
+  });
+
+  it('deduplicates repeated event constructors into one saga invocation', async () => {
+    // Given
+    const handled: string[] = [];
+
+    class RepeatedSagaEvent implements IEvent {
+      constructor(public readonly id: string) {}
+    }
+
+    @Saga([RepeatedSagaEvent, RepeatedSagaEvent])
+    class RepeatedEventSaga implements ISaga<RepeatedSagaEvent> {
+      handle(event: RepeatedSagaEvent): void {
+        handled.push(event.id);
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [CqrsModule.forRoot()],
+      providers: [RepeatedEventSaga],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const eventBus = await app.container.resolve<CqrsEventBus>(EVENT_BUS);
+
+    try {
+      // When
+      await eventBus.publish(new RepeatedSagaEvent('saga-1'));
+
+      // Then
+      expect(handled).toEqual(['saga-1']);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/packages/cqrs/src/saga-decorator-edge-contract.test.ts
+++ b/packages/cqrs/src/saga-decorator-edge-contract.test.ts
@@ -2,6 +2,7 @@ import { bootstrapApplication, defineModule } from '@fluojs/runtime';
 import { describe, expect, it } from 'vitest';
 
 import { Saga } from './decorators.js';
+import { getSagaMetadata } from './metadata.js';
 import { CqrsModule } from './module.js';
 import { EVENT_BUS } from './tokens.js';
 import type { CqrsEventBus, IEvent, ISaga } from './types.js';
@@ -11,11 +12,13 @@ describe('CQRS saga decorator boundary contracts', () => {
     // When
     const emptyList = () => Saga([]);
     const nonConstructor = () => Reflect.apply(Saga, undefined, [null]);
+    const nonConstructableCallable = () => Reflect.apply(Saga, undefined, [() => undefined]);
     const mixedList = () => Reflect.apply(Saga, undefined, [[class ValidEvent implements IEvent {}, 'not-a-constructor']]);
 
     // Then
     expect(emptyList).toThrowError('@Saga() requires at least one event type.');
     expect(nonConstructor).toThrowError('@Saga() event types must be class constructors.');
+    expect(nonConstructableCallable).toThrowError('@Saga() event types must be class constructors.');
     expect(mixedList).toThrowError('@Saga() event types must be class constructors.');
   });
 
@@ -33,6 +36,9 @@ describe('CQRS saga decorator boundary contracts', () => {
         handled.push(event.id);
       }
     }
+
+    // Then
+    expect(getSagaMetadata(RepeatedEventSaga)?.eventTypes).toEqual([RepeatedSagaEvent]);
 
     class AppModule {}
     defineModule(AppModule, {


### PR DESCRIPTION
## Summary

Harden CQRS asynchronous ordering, discovery, malformed-handler, and saga decorator edge contracts.

Linked context: Closes #3116

## Changes

- add deterministic deferred-signal tests for full `publishAll` ordering
- cover event-handler token discovery and malformed command/query handlers
- reject callable non-constructable `@Saga()` event inputs before runtime dispatch
- pin decorator-level event deduplication without natural-language prose assertions

## Testing

- `pnpm --filter "@fluojs/cqrs..." build`
- `pnpm --filter @fluojs/cqrs typecheck`
- `pnpm --filter "...@fluojs/cqrs" test` — 12 files, 87 tests
- built-package driver confirms arrow Saga input is rejected
- exact-head code, contract, and verification reviews: MERGE

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

`@fluojs/cqrs`: patch bug fix for invalid callable Saga inputs.

## Public export documentation

- [x] No public export signatures changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed.
- [x] Invalid Saga constructor boundaries are regression-tested.
- [x] Runtime invariants are covered by deterministic tests.

## Platform consistency governance (SSOT)

- [x] No platform contract documentation changed.