### PR TITLE
fix(microservices): remove Redis Pub/Sub timeout no-op

### DIFF
--- a/.changeset/issue-3219-remove-redis-pubsub-timeout.md
+++ b/.changeset/issue-3219-remove-redis-pubsub-timeout.md
@@ -1,0 +1,7 @@
+---
+"@fluojs/microservices": major
+---
+
+Remove the ineffective `requestTimeoutMs` option from `RedisPubSubMicroserviceTransportOptions`.
+
+Migration: Delete `requestTimeoutMs` from Redis Pub/Sub transport construction. Redis Pub/Sub is event-only and `send()` always rejects; use `RedisStreamsMicroserviceTransport` or another request-response transport when a request timeout is required.

--- a/packages/microservices/src/public-api.test.ts
+++ b/packages/microservices/src/public-api.test.ts
@@ -63,6 +63,7 @@ describe('@fluojs/microservices public API surface', () => {
     expectTypeOf<NatsMicroserviceTransportOptions>().toHaveProperty('client');
     expectTypeOf<RabbitMqMicroserviceTransportOptions>().toHaveProperty('consumer');
     expectTypeOf<RedisPubSubMicroserviceTransportOptions>().toHaveProperty('subscribeClient');
+    expectTypeOf<RedisPubSubMicroserviceTransportOptions>().not.toHaveProperty('requestTimeoutMs');
     expectTypeOf<RedisStreamsMicroserviceTransportOptions>().toHaveProperty('readerClient');
     expectTypeOf<RedisStreamClientLike>().toHaveProperty('xreadgroup');
     expectTypeOf<TcpMicroserviceTransportOptions>().toHaveProperty('port');

--- a/packages/microservices/src/transports/redis-transport.ts
+++ b/packages/microservices/src/transports/redis-transport.ts
@@ -31,7 +31,6 @@ interface RedisLike {
 export interface RedisPubSubMicroserviceTransportOptions {
   namespace?: string;
   publishClient: RedisLike;
-  requestTimeoutMs?: number;
   subscribeClient: RedisLike;
 }
 


### PR DESCRIPTION
Closes #3219

Removes the ineffective `requestTimeoutMs` option from the Redis Pub/Sub public type and pins its absence. Includes an explicitly approved major changeset directing request-response users to Redis Streams or another suitable transport.

Verification: closure build/typecheck; 263 tests; public export TSDoc; manual emit/send behavior; exact-head full triad PASS.