### PR TITLE
fix(cqrs): discover supported singleton provider forms

### DIFF
--- a/.changeset/issue-3115-cqrs-provider-discovery.md
+++ b/.changeset/issue-3115-cqrs-provider-discovery.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/cqrs': patch
+---
+
+Discover singleton command, query, event, and saga handlers registered through supported `useFactory` and `useValue` provider forms.

--- a/packages/cqrs/README.ko.md
+++ b/packages/cqrs/README.ko.md
@@ -180,7 +180,7 @@ Saga, command handler, query handler, event handler 안에서 다시 CQRS `execu
 
 Event class는 payload state를 clone 가능하고 enumerable하게 유지해야 합니다. 문자열 key와 symbol key를 가진 enumerable payload field는 shared core clone fallback으로 보존되지만, 열린 socket, function, process-local handle처럼 의도적으로 clone할 수 없는 resource는 발행 전에 ID나 다른 serializable boundary로 표현해야 합니다.
 
-CQRS handler, event handler, saga는 singleton provider에서만 discovery됩니다. Non-singleton registration은 경고와 함께 건너뜁니다. Event handler와 saga fan-out은 singleton provider token으로 구분되므로 같은 decorated class를 사용해도 서로 다른 token은 별도 route로 유지됩니다.
+CQRS handler, event handler, saga는 singleton provider에서만 discovery됩니다. Discovery는 direct class와 `useClass` provider, class token이 CQRS metadata를 가진 `useFactory` provider, instance constructor가 CQRS metadata를 가진 `useValue` provider를 지원합니다. Non-singleton registration은 경고와 함께 건너뜁니다. Event handler와 saga fan-out은 singleton provider token으로 구분되므로 같은 decorated class를 사용해도 서로 다른 token은 별도 route로 유지됩니다.
 
 ### 심볼 토큰
 

--- a/packages/cqrs/README.md
+++ b/packages/cqrs/README.md
@@ -180,7 +180,7 @@ Each CQRS event handler and saga receives an isolated event copy with the matche
 
 Event classes should keep their payload state cloneable and enumerable. String-keyed and symbol-keyed enumerable payload fields are preserved by the shared core clone fallback, while intentionally non-cloneable resources such as open sockets, functions, or process-local handles should be represented by IDs or other serializable boundaries before publishing.
 
-CQRS handlers, event handlers, and sagas are discovered only on singleton providers. Non-singleton registrations are skipped with warnings. Event-handler and saga fan-out is keyed by singleton provider token, so distinct tokens remain distinct routes even when they use the same decorated class.
+CQRS handlers, event handlers, and sagas are discovered only on singleton providers. Discovery supports direct class and `useClass` providers, `useFactory` providers whose class token carries CQRS metadata, and `useValue` providers whose instance constructor carries CQRS metadata. Non-singleton registrations are skipped with warnings. Event-handler and saga fan-out is keyed by singleton provider token, so distinct tokens remain distinct routes even when they use the same decorated class.
 
 ### Symbol Tokens
 

--- a/packages/cqrs/src/discovery.ts
+++ b/packages/cqrs/src/discovery.ts
@@ -1,7 +1,12 @@
 import { formatTokenName, type Token } from '@fluojs/core';
-import { getClassDiMetadata } from '@fluojs/core/internal';
 import type { Container, Provider } from '@fluojs/di';
 import type { ApplicationLogger, CompiledModule } from '@fluojs/runtime';
+import { getRuntimeClassDiMetadata } from '@fluojs/runtime/internal';
+
+import { getCommandHandlerMetadata } from './metadata.js';
+import { getEventHandlerMetadata } from './metadata.js';
+import { getQueryHandlerMetadata } from './metadata.js';
+import { getSagaMetadata } from './metadata.js';
 
 /**
  * Describes the discovery candidate contract.
@@ -13,13 +18,18 @@ export interface DiscoveryCandidate {
   token: Token;
 }
 
+interface ProviderDiscoveryCandidate {
+  moduleName: string;
+  provider: Provider;
+}
+
 function scopeFromProvider(provider: Provider): 'request' | 'singleton' | 'transient' {
   if (typeof provider === 'function') {
-    return getClassDiMetadata(provider)?.scope ?? 'singleton';
+    return getRuntimeClassDiMetadata(provider)?.scope ?? 'singleton';
   }
 
   if ('useClass' in provider) {
-    return provider.scope ?? getClassDiMetadata(provider.useClass)?.scope ?? 'singleton';
+    return provider.scope ?? getRuntimeClassDiMetadata(provider.useClass)?.scope ?? 'singleton';
   }
 
   return 'scope' in provider ? provider.scope ?? 'singleton' : 'singleton';
@@ -27,6 +37,21 @@ function scopeFromProvider(provider: Provider): 'request' | 'singleton' | 'trans
 
 function isClassProvider(provider: Provider): provider is Extract<Provider, { provide: Token; useClass: Function }> {
   return typeof provider === 'object' && provider !== null && 'useClass' in provider;
+}
+
+function isFactoryOrValueProvider(
+  provider: Provider,
+): provider is Extract<Provider, { useFactory: unknown } | { useValue: unknown }> {
+  return typeof provider === 'object' && provider !== null && ('useFactory' in provider || 'useValue' in provider);
+}
+
+function hasCqrsMetadata(targetType: Function): boolean {
+  return (
+    getCommandHandlerMetadata(targetType) !== undefined ||
+    getQueryHandlerMetadata(targetType) !== undefined ||
+    getEventHandlerMetadata(targetType) !== undefined ||
+    getSagaMetadata(targetType) !== undefined
+  );
 }
 
 /**
@@ -79,6 +104,7 @@ export abstract class CqrsBusBase {
 
   protected discoveryCandidates(): DiscoveryCandidate[] {
     const candidates: DiscoveryCandidate[] = [];
+    const providerCandidates: ProviderDiscoveryCandidate[] = [];
 
     for (const compiledModule of this.compiledModules) {
       for (const provider of compiledModule.definition.providers ?? []) {
@@ -99,11 +125,90 @@ export abstract class CqrsBusBase {
             targetType: provider.useClass,
             token: provider.provide,
           });
+          continue;
+        }
+
+        if (isFactoryOrValueProvider(provider)) {
+          providerCandidates.push({ moduleName: compiledModule.type.name, provider });
         }
       }
     }
 
+    for (const candidate of providerCandidates) {
+      const resolvedCandidate = this.resolveProviderDiscoveryCandidate(candidate);
+
+      if (resolvedCandidate) {
+        candidates.push(resolvedCandidate);
+      }
+    }
+
     return candidates;
+  }
+
+  private resolveProviderDiscoveryCandidate(candidate: ProviderDiscoveryCandidate): DiscoveryCandidate | undefined {
+    const provider = candidate.provider;
+
+    if (!('provide' in provider)) {
+      return undefined;
+    }
+
+    const scope = scopeFromProvider(provider);
+    const token = provider.provide;
+
+    if (scope !== 'singleton') {
+      return this.createUnresolvedProviderDiscoveryCandidate(candidate.moduleName, token, scope);
+    }
+
+    if ('useValue' in provider) {
+      const instance = provider.useValue;
+
+      if (typeof instance !== 'object' || instance === null) {
+        return undefined;
+      }
+
+      const targetType = instance.constructor;
+
+      if (typeof targetType !== 'function' || !hasCqrsMetadata(targetType)) {
+        return undefined;
+      }
+
+      return {
+        moduleName: candidate.moduleName,
+        scope,
+        targetType,
+        token,
+      };
+    }
+
+    if (typeof token !== 'function' || !hasCqrsMetadata(token)) {
+      return undefined;
+    }
+
+    return {
+      moduleName: candidate.moduleName,
+      scope,
+      targetType: token,
+      token,
+    };
+  }
+
+  private createUnresolvedProviderDiscoveryCandidate(
+    moduleName: string,
+    token: Token,
+    scope: 'request' | 'transient',
+  ): DiscoveryCandidate | undefined {
+    const tokenType = typeof token === 'function' ? token : undefined;
+
+    if (!tokenType) {
+      return undefined;
+    }
+
+    return {
+      moduleName,
+      scope,
+      targetType: tokenType,
+      token,
+    };
   }
 
   protected async preloadHandlerInstance(token: Token): Promise<void> {

--- a/packages/cqrs/src/discovery.ts
+++ b/packages/cqrs/src/discovery.ts
@@ -32,7 +32,13 @@ function scopeFromProvider(provider: Provider): 'request' | 'singleton' | 'trans
     return provider.scope ?? getRuntimeClassDiMetadata(provider.useClass)?.scope ?? 'singleton';
   }
 
-  return 'scope' in provider ? provider.scope ?? 'singleton' : 'singleton';
+  if ('useFactory' in provider) {
+    const resolverClass = provider.resolverClass;
+
+    return provider.scope ?? (resolverClass ? getRuntimeClassDiMetadata(resolverClass)?.scope : undefined) ?? 'singleton';
+  }
+
+  return 'singleton';
 }
 
 function isClassProvider(provider: Provider): provider is Extract<Provider, { provide: Token; useClass: Function }> {

--- a/packages/cqrs/src/provider-form-discovery-contract.test.ts
+++ b/packages/cqrs/src/provider-form-discovery-contract.test.ts
@@ -1,0 +1,172 @@
+import { bootstrapApplication, defineModule } from '@fluojs/runtime';
+import { describe, expect, it } from 'vitest';
+
+import { CommandHandler, EventHandler, QueryHandler, Saga } from './decorators.js';
+import { CqrsModule } from './module.js';
+import { COMMAND_BUS, EVENT_BUS, QUERY_BUS } from './tokens.js';
+import type {
+  CommandBus,
+  CqrsEventBus,
+  ICommand,
+  ICommandHandler,
+  IEvent,
+  IEventHandler,
+  IQuery,
+  IQueryHandler,
+  ISaga,
+  QueryBus,
+} from './types.js';
+
+class ArchiveUserCommand implements ICommand {
+  constructor(public readonly name: string) {}
+}
+
+class CountUsersQuery implements IQuery<number> {
+  readonly __queryResultType__?: number;
+}
+
+class UserArchivedEvent implements IEvent {
+  constructor(public readonly name: string) {}
+}
+
+describe('CQRS provider-form discovery contracts', () => {
+  it('discovers command and query handlers registered as singleton factory providers', async () => {
+    @CommandHandler(ArchiveUserCommand)
+    class ArchiveUserHandler implements ICommandHandler<ArchiveUserCommand, string> {
+      execute(command: ArchiveUserCommand): string {
+        return `factory-command:${command.name}`;
+      }
+    }
+
+    @QueryHandler(CountUsersQuery)
+    class CountUsersHandler implements IQueryHandler<CountUsersQuery, number> {
+      execute(): number {
+        return 7;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [CqrsModule.forRoot()],
+      providers: [
+        { provide: ArchiveUserHandler, useFactory: () => new ArchiveUserHandler() },
+        { provide: CountUsersHandler, useFactory: () => new CountUsersHandler() },
+      ],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const commandBus = await app.container.resolve<CommandBus>(COMMAND_BUS);
+    const queryBus = await app.container.resolve<QueryBus>(QUERY_BUS);
+
+    await expect(commandBus.execute<ArchiveUserCommand, string>(new ArchiveUserCommand('alice'))).resolves.toBe(
+      'factory-command:alice',
+    );
+    await expect(queryBus.execute<CountUsersQuery, number>(new CountUsersQuery())).resolves.toBe(7);
+
+    await app.close();
+  });
+
+  it('discovers command and query handlers registered as singleton value providers', async () => {
+    @CommandHandler(ArchiveUserCommand)
+    class ArchiveUserHandler implements ICommandHandler<ArchiveUserCommand, string> {
+      execute(command: ArchiveUserCommand): string {
+        return `value-command:${command.name}`;
+      }
+    }
+
+    @QueryHandler(CountUsersQuery)
+    class CountUsersHandler implements IQueryHandler<CountUsersQuery, number> {
+      execute(): number {
+        return 11;
+      }
+    }
+
+    const ARCHIVE_HANDLER_TOKEN = Symbol('ARCHIVE_HANDLER_TOKEN');
+    const COUNT_HANDLER_TOKEN = Symbol('COUNT_HANDLER_TOKEN');
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [CqrsModule.forRoot()],
+      providers: [
+        { provide: ARCHIVE_HANDLER_TOKEN, useValue: new ArchiveUserHandler() },
+        { provide: COUNT_HANDLER_TOKEN, useValue: new CountUsersHandler() },
+      ],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const commandBus = await app.container.resolve<CommandBus>(COMMAND_BUS);
+    const queryBus = await app.container.resolve<QueryBus>(QUERY_BUS);
+
+    await expect(commandBus.execute<ArchiveUserCommand, string>(new ArchiveUserCommand('bob'))).resolves.toBe(
+      'value-command:bob',
+    );
+    await expect(queryBus.execute<CountUsersQuery, number>(new CountUsersQuery())).resolves.toBe(11);
+
+    await app.close();
+  });
+
+  it('discovers event handlers and sagas registered as singleton factory and value providers', async () => {
+    const seen: string[] = [];
+
+    @EventHandler(UserArchivedEvent)
+    class ArchiveEventHandler implements IEventHandler<UserArchivedEvent> {
+      handle(event: UserArchivedEvent): void {
+        seen.push(`factory-event:${event.name}`);
+      }
+    }
+
+    @Saga(UserArchivedEvent)
+    class ArchiveSaga implements ISaga<UserArchivedEvent> {
+      handle(event: UserArchivedEvent): void {
+        seen.push(`value-saga:${event.name}`);
+      }
+    }
+
+    const SAGA_TOKEN = Symbol('SAGA_TOKEN');
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [CqrsModule.forRoot()],
+      providers: [
+        { provide: ArchiveEventHandler, useFactory: () => new ArchiveEventHandler() },
+        { provide: SAGA_TOKEN, useValue: new ArchiveSaga() },
+      ],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const eventBus = await app.container.resolve<CqrsEventBus>(EVENT_BUS);
+
+    await eventBus.publish(new UserArchivedEvent('carol'));
+
+    expect(seen).toEqual(['factory-event:carol', 'value-saga:carol']);
+
+    await app.close();
+  });
+
+  it('resolves factory-provided handlers through their own factory instance', async () => {
+    @CommandHandler(ArchiveUserCommand)
+    class ArchiveUserHandler implements ICommandHandler<ArchiveUserCommand, string> {
+      constructor(private readonly marker: string) {}
+
+      execute(command: ArchiveUserCommand): string {
+        return `${this.marker}:${command.name}`;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [CqrsModule.forRoot()],
+      providers: [{ provide: ArchiveUserHandler, useFactory: () => new ArchiveUserHandler('from-factory') }],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const commandBus = await app.container.resolve<CommandBus>(COMMAND_BUS);
+
+    await expect(commandBus.execute<ArchiveUserCommand, string>(new ArchiveUserCommand('dave'))).resolves.toBe(
+      'from-factory:dave',
+    );
+
+    await app.close();
+  });
+
+});

--- a/packages/cqrs/src/provider-form-discovery-contract.test.ts
+++ b/packages/cqrs/src/provider-form-discovery-contract.test.ts
@@ -105,31 +105,48 @@ describe('CQRS provider-form discovery contracts', () => {
     await app.close();
   });
 
-  it('discovers event handlers and sagas registered as singleton factory and value providers', async () => {
+  it('discovers event handlers and sagas across singleton factory and value providers', async () => {
     const seen: string[] = [];
 
     @EventHandler(UserArchivedEvent)
-    class ArchiveEventHandler implements IEventHandler<UserArchivedEvent> {
+    class FactoryArchiveEventHandler implements IEventHandler<UserArchivedEvent> {
       handle(event: UserArchivedEvent): void {
         seen.push(`factory-event:${event.name}`);
       }
     }
 
+    @EventHandler(UserArchivedEvent)
+    class ValueArchiveEventHandler implements IEventHandler<UserArchivedEvent> {
+      handle(event: UserArchivedEvent): void {
+        seen.push(`value-event:${event.name}`);
+      }
+    }
+
     @Saga(UserArchivedEvent)
-    class ArchiveSaga implements ISaga<UserArchivedEvent> {
+    class FactoryArchiveSaga implements ISaga<UserArchivedEvent> {
+      handle(event: UserArchivedEvent): void {
+        seen.push(`factory-saga:${event.name}`);
+      }
+    }
+
+    @Saga(UserArchivedEvent)
+    class ValueArchiveSaga implements ISaga<UserArchivedEvent> {
       handle(event: UserArchivedEvent): void {
         seen.push(`value-saga:${event.name}`);
       }
     }
 
+    const EVENT_HANDLER_TOKEN = Symbol('EVENT_HANDLER_TOKEN');
     const SAGA_TOKEN = Symbol('SAGA_TOKEN');
 
     class AppModule {}
     defineModule(AppModule, {
       imports: [CqrsModule.forRoot()],
       providers: [
-        { provide: ArchiveEventHandler, useFactory: () => new ArchiveEventHandler() },
-        { provide: SAGA_TOKEN, useValue: new ArchiveSaga() },
+        { provide: FactoryArchiveEventHandler, useFactory: () => new FactoryArchiveEventHandler() },
+        { provide: EVENT_HANDLER_TOKEN, useValue: new ValueArchiveEventHandler() },
+        { provide: FactoryArchiveSaga, useFactory: () => new FactoryArchiveSaga() },
+        { provide: SAGA_TOKEN, useValue: new ValueArchiveSaga() },
       ],
     });
 
@@ -138,7 +155,7 @@ describe('CQRS provider-form discovery contracts', () => {
 
     await eventBus.publish(new UserArchivedEvent('carol'));
 
-    expect(seen).toEqual(['factory-event:carol', 'value-saga:carol']);
+    expect(seen).toEqual(['factory-event:carol', 'value-event:carol', 'factory-saga:carol', 'value-saga:carol']);
 
     await app.close();
   });

--- a/packages/cqrs/src/provider-form-discovery-edge-contract.test.ts
+++ b/packages/cqrs/src/provider-form-discovery-edge-contract.test.ts
@@ -1,4 +1,4 @@
-import { Inject } from '@fluojs/core';
+import { Scope } from '@fluojs/core';
 import { Container } from '@fluojs/di';
 import { type ApplicationLogger, bootstrapApplication, type CompiledModule, defineModule } from '@fluojs/runtime';
 import { describe, expect, it } from 'vitest';
@@ -82,9 +82,11 @@ describe('CQRS provider-form discovery edge contracts', () => {
     expect(invoked).toEqual([]);
   });
 
-  it('skips non-singleton factory handler registrations with warnings', async () => {
+  it('inherits resolverClass scope metadata to skip and block non-singleton factory handlers', async () => {
     const loggerEvents: string[] = [];
+    const factoryCalls: string[] = [];
 
+    @Scope('transient')
     @CommandHandler(ArchiveUserCommand)
     class TransientArchiveHandler implements ICommandHandler<ArchiveUserCommand, string> {
       execute(command: ArchiveUserCommand): string {
@@ -92,6 +94,7 @@ describe('CQRS provider-form discovery edge contracts', () => {
       }
     }
 
+    @Scope('request')
     @QueryHandler(CountUsersQuery)
     class RequestCountHandler implements IQueryHandler<CountUsersQuery, number> {
       execute(): number {
@@ -105,13 +108,19 @@ describe('CQRS provider-form discovery edge contracts', () => {
       providers: [
         {
           provide: TransientArchiveHandler,
-          scope: 'transient',
-          useFactory: () => new TransientArchiveHandler(),
+          resolverClass: TransientArchiveHandler,
+          useFactory: () => {
+            factoryCalls.push('transient-command');
+            return new TransientArchiveHandler();
+          },
         },
         {
           provide: RequestCountHandler,
-          scope: 'request',
-          useFactory: () => new RequestCountHandler(),
+          resolverClass: RequestCountHandler,
+          useFactory: () => {
+            factoryCalls.push('request-query');
+            return new RequestCountHandler();
+          },
         },
       ],
     });
@@ -135,6 +144,18 @@ describe('CQRS provider-form discovery edge contracts', () => {
           entry.includes('RequestCountHandler') && entry.includes('@QueryHandler()') && entry.includes('request scope'),
       ),
     ).toBe(true);
+    expect(factoryCalls).toEqual([]);
+
+    const commandBus = await app.container.resolve<CommandBus>(COMMAND_BUS);
+    const queryBus = await app.container.resolve<QueryBus>(QUERY_BUS);
+
+    await expect(commandBus.execute<ArchiveUserCommand, string>(new ArchiveUserCommand('dave'))).rejects.toThrow(
+      'No command handler registered for ArchiveUserCommand.',
+    );
+    await expect(queryBus.execute<CountUsersQuery, number>(new CountUsersQuery())).rejects.toThrow(
+      'No query handler registered for CountUsersQuery.',
+    );
+    expect(factoryCalls).toEqual([]);
 
     await app.close();
   });
@@ -160,31 +181,6 @@ describe('CQRS provider-form discovery edge contracts', () => {
 
     await expect(commandBus.execute<ArchiveUserCommand, string>(new ArchiveUserCommand('frank'))).resolves.toBe(
       'alias-command:frank',
-    );
-
-    await app.close();
-  });
-
-  it('discovers singleton-defaulted factory tokens with class DI metadata', async () => {
-    @Inject()
-    @CommandHandler(ArchiveUserCommand)
-    class ScopedArchiveHandler implements ICommandHandler<ArchiveUserCommand, string> {
-      execute(command: ArchiveUserCommand): string {
-        return `scoped-command:${command.name}`;
-      }
-    }
-
-    class AppModule {}
-    defineModule(AppModule, {
-      imports: [CqrsModule.forRoot()],
-      providers: [{ provide: ScopedArchiveHandler, useFactory: () => new ScopedArchiveHandler() }],
-    });
-
-    const app = await bootstrapApplication({ rootModule: AppModule });
-    const commandBus = await app.container.resolve<CommandBus>(COMMAND_BUS);
-
-    await expect(commandBus.execute<ArchiveUserCommand, string>(new ArchiveUserCommand('gina'))).resolves.toBe(
-      'scoped-command:gina',
     );
 
     await app.close();

--- a/packages/cqrs/src/provider-form-discovery-edge-contract.test.ts
+++ b/packages/cqrs/src/provider-form-discovery-edge-contract.test.ts
@@ -5,17 +5,22 @@ import { describe, expect, it } from 'vitest';
 
 import { CommandHandler, QueryHandler } from './decorators.js';
 import { CqrsBusBase, type DiscoveryCandidate } from './discovery.js';
+import { CommandHandlerNotFoundException, QueryHandlerNotFoundException } from './errors.js';
 import { CqrsModule } from './module.js';
 import { COMMAND_BUS, QUERY_BUS } from './tokens.js';
 import type { CommandBus, ICommand, ICommandHandler, IQuery, IQueryHandler, QueryBus } from './types.js';
 
-function createLogger(events: string[]): ApplicationLogger {
+interface WarningEvent {
+  readonly context: string | undefined;
+}
+
+function createLogger(warnings: WarningEvent[]): ApplicationLogger {
   return {
     debug() {},
     error() {},
     log() {},
-    warn(message: string, context?: string) {
-      events.push(`warn:${context ?? 'none'}:${message}`);
+    warn(_message: string, context?: string) {
+      warnings.push({ context });
     },
   };
 }
@@ -71,19 +76,19 @@ describe('CQRS provider-form discovery edge contracts', () => {
     };
     const discoveryBus = new DiscoveryBus(new Container(), [compiledModule], createLogger([]));
 
-    expect(discoveryBus.discover()).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          targetType: ArchiveUserHandler,
-          token: ArchiveUserHandler,
-        }),
-      ]),
-    );
+    expect(discoveryBus.discover()).toEqual([
+      {
+        moduleName: AppModule.name,
+        scope: 'singleton',
+        targetType: ArchiveUserHandler,
+        token: ArchiveUserHandler,
+      },
+    ]);
     expect(invoked).toEqual([]);
   });
 
   it('inherits resolverClass scope metadata to skip and block non-singleton factory handlers', async () => {
-    const loggerEvents: string[] = [];
+    const warnings: WarningEvent[] = [];
     const factoryCalls: string[] = [];
 
     @Scope('transient')
@@ -126,35 +131,30 @@ describe('CQRS provider-form discovery edge contracts', () => {
     });
 
     const app = await bootstrapApplication({
-      logger: createLogger(loggerEvents),
+      logger: createLogger(warnings),
       rootModule: AppModule,
     });
 
-    expect(
-      loggerEvents.some(
-        (entry) =>
-          entry.includes('TransientArchiveHandler') &&
-          entry.includes('@CommandHandler()') &&
-          entry.includes('transient scope'),
-      ),
-    ).toBe(true);
-    expect(
-      loggerEvents.some(
-        (entry) =>
-          entry.includes('RequestCountHandler') && entry.includes('@QueryHandler()') && entry.includes('request scope'),
-      ),
-    ).toBe(true);
+    expect(warnings).toEqual([
+      { context: 'CommandBusLifecycleService' },
+      { context: 'QueryBusLifecycleService' },
+    ]);
     expect(factoryCalls).toEqual([]);
 
     const commandBus = await app.container.resolve<CommandBus>(COMMAND_BUS);
     const queryBus = await app.container.resolve<QueryBus>(QUERY_BUS);
 
-    await expect(commandBus.execute<ArchiveUserCommand, string>(new ArchiveUserCommand('dave'))).rejects.toThrow(
-      'No command handler registered for ArchiveUserCommand.',
-    );
-    await expect(queryBus.execute<CountUsersQuery, number>(new CountUsersQuery())).rejects.toThrow(
-      'No query handler registered for CountUsersQuery.',
-    );
+    const [commandError, queryError] = await Promise.all([
+      commandBus
+        .execute<ArchiveUserCommand, string>(new ArchiveUserCommand('dave'))
+        .then(() => undefined, (error: unknown) => error),
+      queryBus.execute<CountUsersQuery, number>(new CountUsersQuery()).then(() => undefined, (error: unknown) => error),
+    ]);
+
+    expect(commandError).toBeInstanceOf(CommandHandlerNotFoundException);
+    expect(commandError).toMatchObject({ code: 'CQRS_COMMAND_HANDLER_NOT_FOUND' });
+    expect(queryError).toBeInstanceOf(QueryHandlerNotFoundException);
+    expect(queryError).toMatchObject({ code: 'CQRS_QUERY_HANDLER_NOT_FOUND' });
     expect(factoryCalls).toEqual([]);
 
     await app.close();

--- a/packages/cqrs/src/provider-form-discovery-edge-contract.test.ts
+++ b/packages/cqrs/src/provider-form-discovery-edge-contract.test.ts
@@ -1,0 +1,192 @@
+import { Inject } from '@fluojs/core';
+import { Container } from '@fluojs/di';
+import { type ApplicationLogger, bootstrapApplication, type CompiledModule, defineModule } from '@fluojs/runtime';
+import { describe, expect, it } from 'vitest';
+
+import { CommandHandler, QueryHandler } from './decorators.js';
+import { CqrsBusBase, type DiscoveryCandidate } from './discovery.js';
+import { CqrsModule } from './module.js';
+import { COMMAND_BUS, QUERY_BUS } from './tokens.js';
+import type { CommandBus, ICommand, ICommandHandler, IQuery, IQueryHandler, QueryBus } from './types.js';
+
+function createLogger(events: string[]): ApplicationLogger {
+  return {
+    debug() {},
+    error() {},
+    log() {},
+    warn(message: string, context?: string) {
+      events.push(`warn:${context ?? 'none'}:${message}`);
+    },
+  };
+}
+
+class DiscoveryBus extends CqrsBusBase {
+  discover(): readonly DiscoveryCandidate[] {
+    return this.discoveryCandidates();
+  }
+}
+
+class ArchiveUserCommand implements ICommand {
+  constructor(public readonly name: string) {}
+}
+
+class CountUsersQuery implements IQuery<number> {
+  readonly __queryResultType__?: number;
+}
+
+describe('CQRS provider-form discovery edge contracts', () => {
+  it('does not invoke unrelated factory providers during handler discovery', () => {
+    const invoked: string[] = [];
+
+    @CommandHandler(ArchiveUserCommand)
+    class ArchiveUserHandler implements ICommandHandler<ArchiveUserCommand, string> {
+      execute(command: ArchiveUserCommand): string {
+        return `factory-command:${command.name}`;
+      }
+    }
+
+    const UNRELATED_TOKEN = Symbol('UNRELATED_TOKEN');
+    const EAGER_VALUE_TOKEN = Symbol('EAGER_VALUE_TOKEN');
+
+    class AppModule {}
+    const compiledModule: CompiledModule = {
+      accessibleTokens: new Set(),
+      definition: {
+        providers: [
+          { provide: ArchiveUserHandler, useFactory: () => new ArchiveUserHandler() },
+          {
+            provide: UNRELATED_TOKEN,
+            useFactory: () => {
+              invoked.push('unrelated-factory');
+              return { value: 'unrelated' };
+            },
+          },
+          { provide: EAGER_VALUE_TOKEN, useValue: { value: 'plain-object' } },
+        ],
+      },
+      exportedTokens: new Set(),
+      importedExportedTokens: new Set(),
+      providerTokens: new Set(),
+      type: AppModule,
+    };
+    const discoveryBus = new DiscoveryBus(new Container(), [compiledModule], createLogger([]));
+
+    expect(discoveryBus.discover()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          targetType: ArchiveUserHandler,
+          token: ArchiveUserHandler,
+        }),
+      ]),
+    );
+    expect(invoked).toEqual([]);
+  });
+
+  it('skips non-singleton factory handler registrations with warnings', async () => {
+    const loggerEvents: string[] = [];
+
+    @CommandHandler(ArchiveUserCommand)
+    class TransientArchiveHandler implements ICommandHandler<ArchiveUserCommand, string> {
+      execute(command: ArchiveUserCommand): string {
+        return `transient-command:${command.name}`;
+      }
+    }
+
+    @QueryHandler(CountUsersQuery)
+    class RequestCountHandler implements IQueryHandler<CountUsersQuery, number> {
+      execute(): number {
+        return 3;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [CqrsModule.forRoot()],
+      providers: [
+        {
+          provide: TransientArchiveHandler,
+          scope: 'transient',
+          useFactory: () => new TransientArchiveHandler(),
+        },
+        {
+          provide: RequestCountHandler,
+          scope: 'request',
+          useFactory: () => new RequestCountHandler(),
+        },
+      ],
+    });
+
+    const app = await bootstrapApplication({
+      logger: createLogger(loggerEvents),
+      rootModule: AppModule,
+    });
+
+    expect(
+      loggerEvents.some(
+        (entry) =>
+          entry.includes('TransientArchiveHandler') &&
+          entry.includes('@CommandHandler()') &&
+          entry.includes('transient scope'),
+      ),
+    ).toBe(true);
+    expect(
+      loggerEvents.some(
+        (entry) =>
+          entry.includes('RequestCountHandler') && entry.includes('@QueryHandler()') && entry.includes('request scope'),
+      ),
+    ).toBe(true);
+
+    await app.close();
+  });
+
+  it('keeps existing-provider aliases out of handler discovery', async () => {
+    @CommandHandler(ArchiveUserCommand)
+    class ArchiveUserHandler implements ICommandHandler<ArchiveUserCommand, string> {
+      execute(command: ArchiveUserCommand): string {
+        return `alias-command:${command.name}`;
+      }
+    }
+
+    const ALIAS_TOKEN = Symbol('ALIAS_TOKEN');
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [CqrsModule.forRoot()],
+      providers: [ArchiveUserHandler, { provide: ALIAS_TOKEN, useExisting: ArchiveUserHandler }],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const commandBus = await app.container.resolve<CommandBus>(COMMAND_BUS);
+
+    await expect(commandBus.execute<ArchiveUserCommand, string>(new ArchiveUserCommand('frank'))).resolves.toBe(
+      'alias-command:frank',
+    );
+
+    await app.close();
+  });
+
+  it('discovers singleton-defaulted factory tokens with class DI metadata', async () => {
+    @Inject()
+    @CommandHandler(ArchiveUserCommand)
+    class ScopedArchiveHandler implements ICommandHandler<ArchiveUserCommand, string> {
+      execute(command: ArchiveUserCommand): string {
+        return `scoped-command:${command.name}`;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [CqrsModule.forRoot()],
+      providers: [{ provide: ScopedArchiveHandler, useFactory: () => new ScopedArchiveHandler() }],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const commandBus = await app.container.resolve<CommandBus>(COMMAND_BUS);
+
+    await expect(commandBus.execute<ArchiveUserCommand, string>(new ArchiveUserCommand('gina'))).resolves.toBe(
+      'scoped-command:gina',
+    );
+
+    await app.close();
+  });
+});

--- a/tooling/governance/passport-js-bridge-nestjs-migration.test.ts
+++ b/tooling/governance/passport-js-bridge-nestjs-migration.test.ts
@@ -45,6 +45,13 @@ function replaceTypeScriptFenceAt(markdown: string, targetIndex: number): string
   });
 }
 
+const typeScriptFenceCases = migrationDocuments.flatMap((targetPath) =>
+  Array.from(
+    { length: countTypeScriptFences(read(targetPath)) },
+    (_, fenceIndex) => [targetPath, fenceIndex] as const,
+  ),
+);
+
 describe('Passport.js bridge NestJS migration contract', () => {
   it('enforces the current migration and book contract', () => {
     // Given
@@ -75,25 +82,20 @@ describe('Passport.js bridge NestJS migration contract', () => {
     expect(runGovernanceGuard).toThrowError(targetPath);
   });
 
-  it.each(migrationDocuments)(
-    'rejects invalid TypeScript in every fence from %s',
-    (targetPath) => {
+  it.each(typeScriptFenceCases)(
+    'rejects invalid TypeScript in %s fence %i',
+    (targetPath, fenceIndex) => {
       // Given
-      const fenceCount = countTypeScriptFences(read(targetPath));
-      expect(fenceCount).toBeGreaterThan(0);
+      const readWithInvalidFence = (relativePath: string): string =>
+        relativePath === targetPath
+          ? replaceTypeScriptFenceAt(read(relativePath), fenceIndex)
+          : read(relativePath);
 
-      for (let fenceIndex = 0; fenceIndex < fenceCount; fenceIndex++) {
-        const readWithInvalidFence = (relativePath: string): string =>
-          relativePath === targetPath
-            ? replaceTypeScriptFenceAt(read(relativePath), fenceIndex)
-            : read(relativePath);
+      // When
+      const runGovernanceGuard = () => enforcePassportJsBridgeNestjsMigration(readWithInvalidFence);
 
-        // When
-        const runGovernanceGuard = () => enforcePassportJsBridgeNestjsMigration(readWithInvalidFence);
-
-        // Then
-        expect(runGovernanceGuard).toThrowError(targetPath);
-      }
+      // Then
+      expect(runGovernanceGuard).toThrowError(targetPath);
     },
   );
 


### PR DESCRIPTION
## Summary

Discover CQRS handlers and sagas registered through supported singleton factory and value provider forms.

Linked context: Closes #3115

## Changes

- discover class-token `useFactory` and instance-backed `useValue` providers
- inherit factory `resolverClass` scope exactly like DI normalization
- warn and skip request/transient handlers without invoking their factories
- cover command, query, event, saga, aliases, metadata exclusion, and provider-token edges
- align EN/KO CQRS README contracts

## Testing

- `pnpm --filter "@fluojs/cqrs..." build`
- `pnpm --filter @fluojs/cqrs typecheck`
- `pnpm --filter "...@fluojs/cqrs" test` — 14 files, 94 tests
- `pnpm docs:sync-check`
- built factory-provider dispatch manual QA
- exact-head full triad: MERGE

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

`@fluojs/cqrs`: patch bug fix.

## Public export documentation

- [x] No public export signatures changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed.
- [x] New provider-form behavior is documented in both package READMEs.
- [x] Runtime invariants are covered by mutation-sensitive regression tests.

## Platform consistency governance (SSOT)

- [x] EN/KO package README scope remains synchronized.
- [x] No platform contract changed.