### PR TITLE
Resolve #3265 and #3266: make Node request drain test deterministic

### DIFF
--- a/packages/runtime/src/application.test.ts
+++ b/packages/runtime/src/application.test.ts
@@ -2078,6 +2078,7 @@ describe('bootstrapApplication', () => {
   it('waits for an in-flight request to finish before closing', async () => {
     const requestStarted = createDeferred<void>();
     const allowResponse = createDeferred<void>();
+    const order: string[] = [];
 
     @Controller('/slow')
     class SlowController {
@@ -2085,6 +2086,7 @@ describe('bootstrapApplication', () => {
       async getSlowResponse() {
         requestStarted.resolve();
         await allowResponse.promise;
+        order.push('handler-released');
         return { ok: true };
       }
     }
@@ -2108,30 +2110,61 @@ describe('bootstrapApplication', () => {
         throw new Error('Expected the runtime Node HTTP application adapter.');
       }
 
-      const address: AddressInfo | string | null = adapter.getServer().address();
+      const server = adapter.getServer();
+      const address: AddressInfo | string | null = server.address();
       if (!address || typeof address === 'string') {
         throw new Error('Failed to resolve the bound test port.');
       }
 
-      const responsePromise = fetchForTest(`http://127.0.0.1:${String(address.port)}/slow`);
-      await requestStarted.promise;
-
-      let closeResolved = false;
-      const closePromise = app.close().then(() => {
-        closeResolved = true;
+      const responseFinished = createDeferred<void>();
+      const serverClosed = createDeferred<void>();
+      const serverCloseStarted = createDeferred<void>();
+      server.once('request', (_request, response) => {
+        response.once('finish', () => {
+          order.push('response-finished');
+          responseFinished.resolve();
+        });
+      });
+      server.once('close', () => {
+        order.push('server-closed');
+        serverClosed.resolve();
+      });
+      const closeServer = server.close.bind(server);
+      const serverCloseSpy = vi.spyOn(server, 'close').mockImplementation((callback) => {
+        serverCloseStarted.resolve();
+        return closeServer(callback);
       });
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      expect(closeResolved).toBe(false);
+      try {
+        const responsePromise = fetchForTest(`http://127.0.0.1:${String(address.port)}/slow`);
+        await requestStarted.promise;
 
-      allowResponse.resolve();
+        let closeSettled = false;
+        const closePromise = app.close().then(() => {
+          closeSettled = true;
+          order.push('close-resolved');
+        });
 
-      const response = await responsePromise;
-      expect(response.status).toBe(200);
-      await expect(response.json()).resolves.toEqual({ ok: true });
+        await serverCloseStarted.promise;
+        expect(closeSettled).toBe(false);
+        expect(order).toEqual([]);
 
-      await closePromise;
-      expect(closeResolved).toBe(true);
+        allowResponse.resolve();
+
+        await responseFinished.promise;
+        const response = await responsePromise;
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toEqual({ ok: true });
+
+        await serverClosed.promise;
+        await closePromise;
+
+        expect(order).toEqual(['handler-released', 'response-finished', 'server-closed', 'close-resolved']);
+      } finally {
+        allowResponse.resolve();
+        await app.close();
+        serverCloseSpy.mockRestore();
+      }
     } finally {
       allowResponse.resolve();
       await app.close();


### PR DESCRIPTION
## Summary

Replace the wall-clock Node in-flight request drain assertion with causal request, response, server-close, and application-close signals.

Linked context: Closes #3265
Closes #3266

## Changes

- remove the fixed 50 ms wait from the runtime shutdown regression
- subscribe to response finish and server close before triggering shutdown
- prove application close remains pending while the handler is blocked
- assert response completion precedes server closure and close resolution

## Testing

- `pnpm --filter @fluojs/runtime... build`
- `pnpm --filter @fluojs/runtime typecheck`
- focused application drain test: 1 passed, 68 skipped
- serial reverse-dependent runtime suite: passed
- exact-head local code and verification reviews: PASS

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

## Public export documentation

- [x] No public exports changed.

## Behavioral contract

- [x] No documented behavioral contracts changed.
- [x] Existing shutdown drain behavior is covered deterministically.

## Platform consistency governance (SSOT)

- [x] No platform contract documentation changed.
- [x] Runtime Node drain ownership is exercised through the real listener.