### PR TITLE
fix(mongoose): preserve transaction shutdown ownership

### DIFF
--- a/.changeset/bright-hounds-dance.md
+++ b/.changeset/bright-hounds-dance.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/mongoose": patch
+---
+
+Preserve transaction shutdown ownership while a manual session is acquired and cleaned up.

--- a/packages/mongoose/src/connection.ts
+++ b/packages/mongoose/src/connection.ts
@@ -327,9 +327,7 @@ export class MongooseConnection<TConnection extends MongooseConnectionLike = Mon
       return this.runDirectTransaction(fn, activeCallback);
     }
 
-    activeCallback.settle();
-
-    return this.runManualSessionTransaction(session, fn);
+    return this.runManualSessionTransaction(session, fn, activeCallback);
   }
 
   /**
@@ -412,7 +410,11 @@ export class MongooseConnection<TConnection extends MongooseConnectionLike = Mon
     }
   }
 
-  private async runManualSessionTransaction<T>(session: MongooseSessionLike, fn: () => Promise<T>): Promise<T> {
+  private async runManualSessionTransaction<T>(
+    session: MongooseSessionLike,
+    fn: () => Promise<T>,
+    activeCallback?: ActiveTransactionCallbackHandle,
+  ): Promise<T> {
     const activeSession = this.trackActiveSession();
 
     try {
@@ -422,6 +424,7 @@ export class MongooseConnection<TConnection extends MongooseConnectionLike = Mon
         await session.endSession();
       } finally {
         activeSession.settle();
+        activeCallback?.settle();
       }
     }
   }

--- a/packages/mongoose/src/module.test.ts
+++ b/packages/mongoose/src/module.test.ts
@@ -1256,6 +1256,106 @@ describe('@fluojs/mongoose', () => {
     ]);
   });
 
+  it('keeps manual transaction shutdown ownership through deferred session acquisition', async () => {
+    const events: string[] = [];
+    let releaseSessionAcquisition!: () => void;
+    let resolveCallbackStarted!: () => void;
+    let releaseCallback!: () => void;
+    const sessionAcquisitionReleased = new Promise<void>((resolve) => {
+      releaseSessionAcquisition = resolve;
+    });
+    const callbackStarted = new Promise<void>((resolve) => {
+      resolveCallbackStarted = resolve;
+    });
+    const callbackReleased = new Promise<void>((resolve) => {
+      releaseCallback = resolve;
+    });
+    const session = createFakeSession(events);
+    const connection: MongooseConnectionLike = {
+      async startSession() {
+        events.push('connection:startSession:start');
+        await sessionAcquisitionReleased;
+        events.push('connection:startSession:end');
+        return session;
+      },
+    };
+    const mongoose = new MongooseConnection<typeof connection>(connection, () => {
+      events.push('dispose');
+    });
+
+    const transaction = mongoose.transaction(async () => {
+      events.push('transaction:callback:start');
+      resolveCallbackStarted();
+      await callbackReleased;
+      events.push('transaction:callback:end');
+      return 'transaction-result';
+    });
+    const shutdown = mongoose.onApplicationShutdown();
+
+    releaseSessionAcquisition();
+    await callbackStarted;
+    expect(events).not.toContain('dispose');
+
+    releaseCallback();
+
+    await expect(transaction).resolves.toBe('transaction-result');
+    await shutdown;
+
+    expect(events).toEqual([
+      'connection:startSession:start',
+      'connection:startSession:end',
+      'transaction:start',
+      'transaction:callback:start',
+      'transaction:callback:end',
+      'transaction:commit',
+      'session:end',
+      'dispose',
+    ]);
+  });
+
+  it('preserves fail-open request abort results until callback settlement releases shutdown ownership', async () => {
+    const events: string[] = [];
+    const controller = new AbortController();
+    let resolveCallbackStarted!: () => void;
+    let releaseCallback!: () => void;
+    const callbackStarted = new Promise<void>((resolve) => {
+      resolveCallbackStarted = resolve;
+    });
+    const callbackReleased = new Promise<void>((resolve) => {
+      releaseCallback = resolve;
+    });
+    const connection: MongooseConnectionLike = {};
+    const mongoose = new MongooseConnection<typeof connection>(connection, () => {
+      events.push(`dispose:activeRequests=${mongoose.createPlatformStatusSnapshot().details.activeRequestTransactions}`);
+    });
+
+    const request = mongoose.requestTransaction(async () => {
+      events.push('request:callback:start');
+      resolveCallbackStarted();
+      await callbackReleased;
+      events.push('request:callback:end');
+      return 'request-result';
+    }, controller.signal);
+    await callbackStarted;
+
+    const shutdown = mongoose.onApplicationShutdown();
+    const requestResult = expect(request).rejects.toThrow(
+      'Application shutdown interrupted an open request transaction.',
+    );
+    expect(events).toEqual(['request:callback:start']);
+
+    releaseCallback();
+
+    await requestResult;
+    await shutdown;
+
+    expect(events).toEqual([
+      'request:callback:start',
+      'request:callback:end',
+      'dispose:activeRequests=0',
+    ]);
+  });
+
   it('rejects new manual and request transactions after shutdown begins', async () => {
     const events: string[] = [];
     let resolveDisposeStarted!: () => void;


### PR DESCRIPTION
## Summary

`MongooseConnection.transaction()` settled the session-acquisition handle before `runManualSessionTransaction(...)` established active session ownership, so a transaction crossing that handoff after shutdown's single wait-set snapshot could outlive the drain that protects `dispose(connection)` — leaking a real MongoDB session during shutdown.

Linked context: Closes #3223

## Changes

- Preserve one tracked settlement across session acquisition, transaction callback execution, and `endSession()` cleanup in `packages/mongoose/src/connection.ts`, so shutdown draining observes the transaction for its whole lifetime instead of only the acquisition stage.
- Ownership of the in-flight transaction stays inside a wait primitive captured by shutdown before the acquisition handle settles.
- Deterministic deferred-session and fail-open request regressions in `packages/mongoose/src/module.test.ts`: abort results are preserved while callback settlement, session cleanup, active-request release, and `dispose(connection)` stay ordered.
- Changeset: `.changeset/bright-hounds-dance.md` (patch, @fluojs/mongoose — observable shutdown behavior).

## Testing

- `pnpm --filter '@fluojs/mongoose...' build` — exit 0 (dependency closure, cold dist).
- `pnpm --filter @fluojs/mongoose typecheck` — exit 0.
- `pnpm --filter @fluojs/mongoose test` — 7 files, 90 passed, 1 skipped (91).
- `pnpm exec biome check packages/mongoose/src/connection.ts packages/mongoose/src/module.test.ts` — exit 0.
- RED-GREEN regression: deferred-session test failed pre-fix (dispose before callback settlement), passed post-fix.
- Local review triad at head 3e2fb9fd6c7a17d98db7021f34ff15d0a46af562: code PASS / contract PASS / verification PASS.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] No public exports changed (internal lifecycle fix in `packages/mongoose/src/connection.ts`).

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README (drain promise at `packages/mongoose/README.md:63` unchanged; now actually enforced across the handoff).
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests (deferred-session + fail-open request ordering).

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs (none changed).
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests (no new conformance claims).