### PR TITLE
test(prisma): cover fallback transaction shutdown drain (#3246)

### DIFF
--- a/packages/prisma/src/module.test.ts
+++ b/packages/prisma/src/module.test.ts
@@ -11,6 +11,7 @@ import {
   PRISMA_OPTIONS,
   PrismaModule,
   PrismaService,
+  Transaction,
   type PrismaServiceFacade,
   type PrismaTransactionClient,
 } from './index.js';
@@ -1064,6 +1065,124 @@ describe('@fluojs/prisma', () => {
 
       expect(events).toEqual(['connect', 'transaction:start', 'transaction:end', 'disconnect']);
     } finally {
+      await app.close();
+    }
+  });
+
+  it('waits for fallback manual transaction callbacks to settle before disconnecting on shutdown', async () => {
+    const events: string[] = [];
+    let releaseCallback: () => void = () => undefined;
+    const callbackBarrier = new Promise<void>((resolve) => {
+      releaseCallback = resolve;
+    });
+    let markCallbackStarted: () => void = () => undefined;
+    const callbackStarted = new Promise<void>((resolve) => {
+      markCallbackStarted = resolve;
+    });
+    const client = {
+      async $connect() {
+        events.push('connect');
+      },
+      async $disconnect() {
+        events.push('disconnect');
+      },
+    };
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [PrismaModule.forRoot({ client, strictTransactions: false })],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+
+    try {
+      const prisma = await app.container.resolve(PrismaService<typeof client>);
+      const openTransaction = prisma.transaction(async () => {
+        events.push('manual:callback-start');
+        markCallbackStarted();
+        await callbackBarrier;
+        events.push('manual:callback-settled');
+        return 'settled';
+      });
+
+      await callbackStarted;
+      const shutdown = app.close();
+
+      expect(events).toEqual(['connect', 'manual:callback-start']);
+
+      releaseCallback();
+
+      await expect(openTransaction).resolves.toBe('settled');
+      await shutdown;
+
+      expect(events).toEqual(['connect', 'manual:callback-start', 'manual:callback-settled', 'disconnect']);
+    } finally {
+      releaseCallback();
+      await app.close();
+    }
+  });
+
+  it('waits for fallback service transaction callbacks to settle before disconnecting on shutdown', async () => {
+    const events: string[] = [];
+    let releaseCallback: () => void = () => undefined;
+    const callbackBarrier = new Promise<void>((resolve) => {
+      releaseCallback = resolve;
+    });
+    let markCallbackStarted: () => void = () => undefined;
+    const callbackStarted = new Promise<void>((resolve) => {
+      markCallbackStarted = resolve;
+    });
+    const client = {
+      async $connect() {
+        events.push('connect');
+      },
+      async $disconnect() {
+        events.push('disconnect');
+      },
+    };
+
+    @Inject(PrismaService)
+    class UserService {
+      constructor(private readonly prisma: PrismaServiceFacade<typeof client>) {}
+
+      @Transaction()
+      async holdOpen() {
+        void this.prisma;
+        events.push('service:callback-start');
+        markCallbackStarted();
+        await callbackBarrier;
+        events.push('service:callback-settled');
+        return 'settled';
+      }
+    }
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [PrismaModule.forRoot({ client, strictTransactions: false })],
+      providers: [UserService],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+
+    try {
+      const service = await app.container.resolve(UserService);
+      const openTransaction = service.holdOpen();
+
+      await callbackStarted;
+      const shutdown = app.close();
+
+      expect(events).toEqual(['connect', 'service:callback-start']);
+
+      releaseCallback();
+
+      await expect(openTransaction).resolves.toBe('settled');
+      await shutdown;
+
+      expect(events).toEqual(['connect', 'service:callback-start', 'service:callback-settled', 'disconnect']);
+    } finally {
+      releaseCallback();
       await app.close();
     }
   });

--- a/packages/prisma/src/module.test.ts
+++ b/packages/prisma/src/module.test.ts
@@ -59,6 +59,49 @@ void prismaServiceCurrentInferenceChecked;
 void prismaTransactionClientInferenceChecked;
 void prismaServiceFacadeDelegateInferenceChecked;
 
+type ObservableTransactionBoundary = {
+  settled: PromiseLike<void>;
+};
+
+function isObservableTransactionBoundary(value: unknown): value is ObservableTransactionBoundary {
+  if (typeof value !== 'object' || value === null || !('settled' in value)) {
+    return false;
+  }
+
+  const { settled } = value;
+
+  return typeof settled === 'object' && settled !== null && 'then' in settled;
+}
+
+function observeActiveTransactionBoundaryDrain(prisma: object): Promise<void> {
+  const activeTransactionBoundaries = Reflect.get(prisma, 'activeTransactionBoundaries');
+
+  if (!(activeTransactionBoundaries instanceof Set) || activeTransactionBoundaries.size !== 1) {
+    throw new Error('Expected exactly one active transaction boundary before shutdown.');
+  }
+
+  const [activeTransactionBoundary] = activeTransactionBoundaries;
+
+  if (!isObservableTransactionBoundary(activeTransactionBoundary)) {
+    throw new Error('Expected the active transaction boundary to expose its settlement promise.');
+  }
+
+  let markDrainStarted!: () => void;
+  const drainStarted = new Promise<void>((resolve) => {
+    markDrainStarted = resolve;
+  });
+  const settled = activeTransactionBoundary.settled;
+
+  activeTransactionBoundary.settled = {
+    then(onfulfilled, onrejected) {
+      markDrainStarted();
+      return settled.then(onfulfilled, onrejected);
+    },
+  };
+
+  return drainStarted;
+}
+
 describe('@fluojs/prisma', () => {
   it('connects, reuses transaction-scoped handles, and disconnects through lifecycle hooks', async () => {
     const events: string[] = [];
@@ -1107,8 +1150,10 @@ describe('@fluojs/prisma', () => {
       });
 
       await callbackStarted;
+      const boundaryDrainStarted = observeActiveTransactionBoundaryDrain(prisma);
       const shutdown = app.close();
 
+      await boundaryDrainStarted;
       expect(events).toEqual(['connect', 'manual:callback-start']);
 
       releaseCallback();
@@ -1171,8 +1216,11 @@ describe('@fluojs/prisma', () => {
       const openTransaction = service.holdOpen();
 
       await callbackStarted;
+      const prisma = await app.container.resolve(PrismaService<typeof client>);
+      const boundaryDrainStarted = observeActiveTransactionBoundaryDrain(prisma);
       const shutdown = app.close();
 
+      await boundaryDrainStarted;
       expect(events).toEqual(['connect', 'service:callback-start']);
 
       releaseCallback();

--- a/packages/prisma/src/module.test.ts
+++ b/packages/prisma/src/module.test.ts
@@ -92,12 +92,18 @@ function observeActiveTransactionBoundaryDrain(prisma: object): Promise<void> {
   });
   const settled = activeTransactionBoundary.settled;
 
-  activeTransactionBoundary.settled = {
-    then(onfulfilled, onrejected) {
-      markDrainStarted();
-      return settled.then(onfulfilled, onrejected);
+  activeTransactionBoundary.settled = new Proxy(settled, {
+    get(target, property) {
+      if (property === 'then') {
+        return (...args: Parameters<PromiseLike<void>['then']>) => {
+          markDrainStarted();
+          return target.then(...args);
+        };
+      }
+
+      return Reflect.get(target, property);
     },
-  };
+  });
 
   return drainStarted;
 }


### PR DESCRIPTION
## Summary

The README promises open manual and service transaction boundaries drain before `()`, but the existing shutdown-drain test only exercised a client WITH `(...)`. A refactor moving active-boundary tracking into the `` branch would have passed the suite while letting disconnect race active fallback work.

Linked context: Closes #3246

## Changes

- Deterministic barrier-based regression tests for the DIRECT fallback path (client WITHOUT `(...)`) covering both drain shapes the README promises: non-strict manual transaction AND `@Transaction()` service boundary.
- The tests await the exact moment the PrismaService drain subscribes to the active boundary's settled-thenable BEFORE releasing the callback, and assert callback settlement strictly precedes `()` — mutation-sensitive: removing the active boundary (simulating the regression) fails both tests with "Expected exactly one active transaction boundary before shutdown."
- No production source changes (test-only coverage; the implementation already behaves correctly).

## Testing

- pnpm --filter '@fluojs/prisma...' build → exit 0 (dependency closure, cold dist)
- pnpm --filter @fluojs/prisma typecheck → exit 0
- pnpm --filter @fluojs/prisma test → exit 0 (9 files, 66 tests; base 64, +2 fallback cases)
- pnpm --filter @fluojs/prisma exec vitest run --no-file-parallelism → exit 0 (deterministic mode)
- pnpm lint → exit 0 (biome + public-export-tsdoc)
- Local review triad (axes: code + verification; contract skipped — test-only diff) at head 79bf4f4d0bc18b104c370bfce507831d44657850: code PASS / verification PASS (both re-adjudicated after one fix-back that added exact shutdown-drain synchronization).

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact. (all changed files are package tests; excluded from the consumer-visible gate)

## Public export documentation

- [x] No public exports changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README (drain promise at packages/prisma/README.md:212 already documented; this PR pins it with executable regression evidence).
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests (fallback shutdown drain, both shapes).

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (no governance docs changed)
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. (no platform contract docs changed)
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests (no new claims).