### PR TITLE
fix(mongoose): preserve aggregate facade session semantics (#3224)

### DIFF
--- a/.changeset/friendly-mongoose-aggregate.md
+++ b/.changeset/friendly-mongoose-aggregate.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/mongoose': patch
+---
+
+Preserve zero-argument aggregate calls while attaching ambient transaction sessions.

--- a/packages/mongoose/src/connection.ts
+++ b/packages/mongoose/src/connection.ts
@@ -73,9 +73,17 @@ function resolveCreateOptionsIndex(operationArgs: unknown[]): number | undefined
   return undefined;
 }
 
+function resolveAggregateOptionsIndex(): number {
+  return 1;
+}
+
 function resolveOptionsIndex(operation: PropertyKey, operationArgs: unknown[]): number | undefined {
   if (operation === 'create') {
     return resolveCreateOptionsIndex(operationArgs);
+  }
+
+  if (operation === 'aggregate') {
+    return resolveAggregateOptionsIndex();
   }
 
   if (!MODEL_OPERATIONS_WITH_PROJECTION.has(operation)) {

--- a/packages/mongoose/src/transaction-decorator.red.test.ts
+++ b/packages/mongoose/src/transaction-decorator.red.test.ts
@@ -39,7 +39,7 @@ function createFakeConnection(
     find(filter?: unknown, projection?: unknown, opts?: TestMongooseOperationOptions): Promise<unknown[]>;
     findOne(filter?: unknown, projection?: unknown, opts?: TestMongooseOperationOptions): Promise<unknown>;
     aggregate(
-      pipeline: unknown[],
+      pipeline?: unknown[],
       opts?: TestMongooseOperationOptions,
     ): Promise<unknown[]>;
     bulkWrite(
@@ -84,7 +84,12 @@ function createFakeConnection(
           events.push(`model:${name}:findOne:session=${opts?.session != null ? 'set' : 'unset'}`);
           return null;
         },
-        async aggregate(_pipeline: unknown[], opts?: TestMongooseOperationOptions) {
+        async aggregate(_pipeline?: unknown[], opts?: TestMongooseOperationOptions) {
+          events.push(
+            `model:${name}:aggregate:pipeline=${
+              _pipeline === undefined ? 'undefined' : Array.isArray(_pipeline) ? 'array' : 'invalid'
+            }`,
+          );
           events.push(
             `model:${name}:aggregate:session=${opts?.session != null ? 'set' : 'unset'}`,
           );
@@ -884,6 +889,51 @@ describe('@fluojs/mongoose Transaction decorator contract (RED - pending Task 9 
       }
     });
 
+    it('model.aggregate() preserves its empty pipeline slot while receiving the ambient session', async () => {
+      const events: string[] = [];
+      const session = createFakeSession(events);
+      const connection = createFakeConnection(events, session);
+
+      @Inject(MongooseConnection)
+      class UserRepository {
+        constructor(private readonly conn: MongooseConnection<typeof connection>) {}
+
+        async aggregate() {
+          const User = this.conn.model('User') as ReturnType<typeof connection.model>;
+          return User.aggregate();
+        }
+      }
+
+      @Inject(UserRepository)
+      class UserService {
+        constructor(private readonly repo: UserRepository) {}
+
+        @Transaction()
+        async aggregate() {
+          return this.repo.aggregate();
+        }
+      }
+
+      class AppModule {}
+
+      defineModule(AppModule, {
+        imports: [MongooseModule.forRoot({ connection })],
+        providers: [UserRepository, UserService],
+      });
+
+      const app = await bootstrapApplication({ rootModule: AppModule });
+      const service = await app.container.resolve(UserService);
+
+      try {
+        await service.aggregate();
+
+        expect(events).toContain('model:User:aggregate:pipeline=undefined');
+        expect(events).toContain('model:User:aggregate:session=set');
+      } finally {
+        await app.close();
+      }
+    });
+
     it('model.aggregate() preserves operation options while adding the ambient session', async () => {
       const mongoosePackage = await import('./index.js');
       const ExportedTransaction = (mongoosePackage as { Transaction?: unknown }).Transaction;
@@ -1552,7 +1602,8 @@ describe('@fluojs/mongoose Transaction decorator contract (RED - pending Task 9 
         async create(name: string) {
           // Passing the same ambient session is allowed
           const ambientSession = this.conn.currentSession();
-          return this.conn.current().model('User').create([{ name }], { session: ambientSession });
+          const User = this.conn.model('User') as ReturnType<typeof connection.model>;
+          return User.create([{ name }], { session: ambientSession });
         }
       }
 


### PR DESCRIPTION
## Summary

The transaction-scoped model facade bound Mongoose operations to the current session, but a zero-argument `aggregate()` call resolved its generic options index to 0 — writing the ambient session options object into the pipeline argument slot and altering aggregate construction before any query executed.

Linked context: Closes #3224

## Changes

- `packages/mongoose/src/connection.ts`: `aggregate` now has an operation-specific options index that preserves the zero-argument pipeline slot while still merging the ambient session into valid options (pipeline-only and pipeline+options calls unchanged).
- `packages/mongoose/src/transaction-decorator.red.test.ts`: zero-argument aggregate regression coverage; the explicitly-supplied-ambient-session acceptance test re-routed through `conn.model(...)` so both facade branches (facade-guarded and raw) are executable.
- Changeset: `.changeset/friendly-mongoose-aggregate.md` (patch, @fluojs/mongoose).

## Testing

- RED observed pre-fix: zero-argument aggregate received session options in the pipeline slot.
- pnpm --filter '@fluojs/mongoose...' build → exit 0 (dependency closure before typecheck)
- pnpm --filter @fluojs/mongoose typecheck → exit 0
- pnpm --filter @fluojs/mongoose test → exit 0 (7 files, 91 passed, 1 skipped)
- pnpm exec biome check on changed files → exit 0
- Local review triad at head aea070b4272a74ef7d4b6207d5536c4ad70318c1: code PASS / contract PASS / verification PASS.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] No public exports changed (internal facade index resolution; no API change).

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README (native call-semantics preservation contract unchanged in wording; now enforced for the zero-argument aggregate shape).
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests (zero-argument aggregate + both facade branches).

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (no governance docs changed)
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. (no platform contract docs changed)
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests (no new claims).