### PR TITLE
docs(prisma): fix README DI examples (#3247)

### DIFF
--- a/.changeset/fix-prisma-readme-examples.md
+++ b/.changeset/fix-prisma-readme-examples.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/prisma': patch
+---
+
+Correct Prisma README examples to include their required explicit dependencies.

--- a/packages/prisma/README.ko.md
+++ b/packages/prisma/README.ko.md
@@ -66,6 +66,7 @@ import { PrismaService, Transaction, type PrismaServiceFacade } from '@fluojs/pr
 import { PrismaClient } from '@prisma/client';
 import { UserRepository } from './user.repository';
 
+@Inject(UserRepository)
 export class UserService {
   constructor(private readonly repo: UserRepository) {}
 
@@ -100,11 +101,16 @@ export class UserRepository {
 `PrismaTransactionInterceptor`는 기존 `@UseInterceptors(...)` request-wide boundary를 위한 deprecated 1.x 호환성 export로 복원되었습니다. 이름 없는 `PrismaModule.forRoot(...)`와 `forRootAsync(...)` 등록이 이 interceptor를 provider 및 export로 제공하며, `PrismaService.requestTransaction(...)`에 위임하고 request `AbortSignal`을 전달합니다.
 
 ```typescript
+import { Inject } from '@fluojs/core';
 import { Controller, Post, UseInterceptors } from '@fluojs/http';
 import { PrismaTransactionInterceptor } from '@fluojs/prisma';
+import { OrdersService } from './orders.service';
 
 @Controller('/orders')
+@Inject(OrdersService)
 export class OrdersController {
+  constructor(private readonly orders: OrdersService) {}
+
   @Post('/')
   @UseInterceptors(PrismaTransactionInterceptor)
   createOrder() {

--- a/packages/prisma/README.ko.md
+++ b/packages/prisma/README.ko.md
@@ -77,21 +77,6 @@ export class UserService {
     return user;
   }
 }
-
-@Inject(PrismaService)
-export class UserRepository {
-  constructor(private readonly prisma: PrismaServiceFacade<PrismaClient>) {}
-
-  async create(data: any) {
-    // facade 타입은 표준 PrismaClient delegate를 노출합니다.
-    // @Transaction() 내부에서 호출되면 자동으로 활성 트랜잭션에 참여합니다.
-    return this.prisma.user.create({ data });
-  }
-
-  async initProfile(userId: string) {
-    return this.prisma.profile.create({ data: { userId } });
-  }
-}
 ```
 
 `@Transaction()` 메서드 호출은 재진입(reentrant)이 가능합니다. 데코레이터가 적용된 메서드가 다른 데코레이터 적용 메서드를 호출하더라도 하나의 동일한 Prisma 트랜잭션 안에서 실행됩니다.

--- a/packages/prisma/README.md
+++ b/packages/prisma/README.md
@@ -66,6 +66,7 @@ import { PrismaService, Transaction, type PrismaServiceFacade } from '@fluojs/pr
 import { PrismaClient } from '@prisma/client';
 import { UserRepository } from './user.repository';
 
+@Inject(UserRepository)
 export class UserService {
   constructor(private readonly repo: UserRepository) {}
 
@@ -100,11 +101,16 @@ Calls to `@Transaction()` methods are reentrant. If a decorated method calls ano
 `PrismaTransactionInterceptor` is restored as a deprecated 1.x compatibility export for existing `@UseInterceptors(...)` request-wide boundaries. The unnamed `PrismaModule.forRoot(...)` and `forRootAsync(...)` registrations provide and export it. It delegates to `PrismaService.requestTransaction(...)` and forwards the request `AbortSignal`.
 
 ```typescript
+import { Inject } from '@fluojs/core';
 import { Controller, Post, UseInterceptors } from '@fluojs/http';
 import { PrismaTransactionInterceptor } from '@fluojs/prisma';
+import { OrdersService } from './orders.service';
 
 @Controller('/orders')
+@Inject(OrdersService)
 export class OrdersController {
+  constructor(private readonly orders: OrdersService) {}
+
   @Post('/')
   @UseInterceptors(PrismaTransactionInterceptor)
   createOrder() {

--- a/packages/prisma/README.md
+++ b/packages/prisma/README.md
@@ -77,21 +77,6 @@ export class UserService {
     return user;
   }
 }
-
-@Inject(PrismaService)
-export class UserRepository {
-  constructor(private readonly prisma: PrismaServiceFacade<PrismaClient>) {}
-
-  async create(data: any) {
-    // The facade type exposes standard PrismaClient delegates.
-    // When called inside @Transaction(), they automatically participate in the ambient transaction.
-    return this.prisma.user.create({ data });
-  }
-
-  async initProfile(userId: string) {
-    return this.prisma.profile.create({ data: { userId } });
-  }
-}
 ```
 
 Calls to `@Transaction()` methods are reentrant. If a decorated method calls another decorated method, they share the same underlying Prisma transaction.

--- a/packages/prisma/src/readme-snippets.test.ts
+++ b/packages/prisma/src/readme-snippets.test.ts
@@ -26,6 +26,19 @@ const readmes = [
   { file: 'README.md', locale: 'English' },
   { file: 'README.ko.md', locale: 'Korean' },
 ] as const;
+const userRepositorySource = `
+type CreateUserInput = { readonly email: string };
+
+export class UserRepository {
+  async create(data: CreateUserInput) {
+    return { id: 'user-1', ...data };
+  }
+
+  async initProfile(userId: string) {
+    return { userId };
+  }
+}
+`;
 
 function codeFences(markdown: string): string[] {
   return [...markdown.matchAll(/```typescript\n([\s\S]*?)```/gu)]
@@ -46,13 +59,13 @@ function readmeSnippet(file: string, fragments: readonly string[]): string {
 function readmeSnippetDiagnostics(
   relativePath: string,
   sourceText: string,
-  companionSource?: string,
+  companionSources: ReadonlyMap<string, string> = new Map(),
 ): string[] {
   const sourcePath = join(repoRoot, '.virtual-prisma-readme', relativePath.replace(/\.md$/u, '.ts'));
   const virtualFiles = new Map([[sourcePath, sourceText]]);
 
-  if (companionSource !== undefined) {
-    virtualFiles.set(join(dirname(sourcePath), 'orders.service.ts'), companionSource);
+  for (const [relativePath, companionSource] of companionSources) {
+    virtualFiles.set(join(dirname(sourcePath), relativePath), companionSource);
   }
 
   const options = {
@@ -130,7 +143,10 @@ function expectInjectedConstructorDependency(
     throw new TypeError(`Missing @Inject(...) on ${className}.`);
   }
 
-  expect(injectDecorator.expression.arguments.map((argument) => argument.getText(sourceFile))).toEqual([token]);
+  const injectedTokens = injectDecorator.expression.arguments.map((argument) => argument.getText(sourceFile));
+  if (injectedTokens.length !== 1 || injectedTokens[0] !== token) {
+    throw new TypeError(`Expected @Inject(${token}) on ${className}; received @Inject(${injectedTokens.join(', ')}).`);
+  }
 
   const constructor = declaration.members.find(isConstructorDeclaration);
   const parameter = constructor?.parameters.find(
@@ -141,21 +157,37 @@ function expectInjectedConstructorDependency(
     throw new TypeError(`Missing ${parameterName}: ${token} constructor dependency on ${className}.`);
   }
 
-  expect(parameter.type.typeName.getText(sourceFile)).toBe(token);
+  const parameterType = parameter.type.typeName.getText(sourceFile);
+  if (parameterType !== token) {
+    throw new TypeError(`Expected ${parameterName}: ${token} constructor dependency on ${className}; received ${parameterType}.`);
+  }
 }
 
 describe('@fluojs/prisma README DI snippets', () => {
   for (const { file, locale } of readmes) {
     it(`compiles the ${locale} @Transaction() service example against public package types`, () => {
-      const snippet = readmeSnippet(file, ['class UserService', 'class UserRepository', '@Transaction()']);
+      const snippet = readmeSnippet(file, ['class UserService', "from './user.repository'", '@Transaction()']);
 
       expectInjectedConstructorDependency(snippet, 'UserService', 'repo', 'UserRepository');
       expect(
         readmeSnippetDiagnostics(
           `${file}-transaction`,
           `${snippet}\n\ntype CreateUserDto = { readonly email: string };`,
+          new Map([['user.repository.ts', userRepositorySource]]),
         ),
       ).toEqual([]);
+    });
+
+    it(`rejects the ${locale} @Transaction() service example with the wrong injected token`, () => {
+      const snippet = readmeSnippet(file, ['class UserService', "from './user.repository'", '@Transaction()']);
+      const malformedSnippet = snippet.replace('@Inject(UserRepository)', '@Inject(PrismaService)');
+
+      expect(() => expectInjectedConstructorDependency(
+        malformedSnippet,
+        'UserService',
+        'repo',
+        'UserRepository',
+      )).toThrowError('Expected @Inject(UserRepository) on UserService; received @Inject(PrismaService).');
     });
 
     it(`compiles the ${locale} interceptor compatibility example against public package types`, () => {
@@ -166,7 +198,9 @@ describe('@fluojs/prisma README DI snippets', () => {
         readmeSnippetDiagnostics(
           `${file}-interceptor`,
           snippet,
-          'export class OrdersService { create(): { readonly id: string } { return { id: "order-1" }; } }',
+          new Map([
+            ['orders.service.ts', 'export class OrdersService { create(): { readonly id: string } { return { id: "order-1" }; } }'],
+          ]),
         ),
       ).toEqual([]);
     });

--- a/packages/prisma/src/readme-snippets.test.ts
+++ b/packages/prisma/src/readme-snippets.test.ts
@@ -1,0 +1,174 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import {
+  canHaveDecorators,
+  createCompilerHost,
+  createProgram,
+  createSourceFile,
+  DiagnosticCategory,
+  flattenDiagnosticMessageText,
+  getDecorators,
+  getPreEmitDiagnostics,
+  isCallExpression,
+  isClassDeclaration,
+  isConstructorDeclaration,
+  isIdentifier,
+  isTypeReferenceNode,
+  ModuleKind,
+  ModuleResolutionKind,
+  ScriptKind,
+  ScriptTarget,
+} from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = resolve(import.meta.dirname, '..', '..', '..');
+const readmes = [
+  { file: 'README.md', locale: 'English' },
+  { file: 'README.ko.md', locale: 'Korean' },
+] as const;
+
+function codeFences(markdown: string): string[] {
+  return [...markdown.matchAll(/```typescript\n([\s\S]*?)```/gu)]
+    .flatMap((match) => match[1] === undefined ? [] : [match[1]]);
+}
+
+function readmeSnippet(file: string, fragments: readonly string[]): string {
+  const snippets = codeFences(readFileSync(join(repoRoot, 'packages/prisma', file), 'utf8'))
+    .filter((snippet) => fragments.every((fragment) => snippet.includes(fragment)));
+
+  if (snippets.length !== 1 || snippets[0] === undefined) {
+    throw new TypeError(`Expected one README snippet in ${file} containing ${fragments.join(', ')}.`);
+  }
+
+  return snippets[0];
+}
+
+function readmeSnippetDiagnostics(
+  relativePath: string,
+  sourceText: string,
+  companionSource?: string,
+): string[] {
+  const sourcePath = join(repoRoot, '.virtual-prisma-readme', relativePath.replace(/\.md$/u, '.ts'));
+  const virtualFiles = new Map([[sourcePath, sourceText]]);
+
+  if (companionSource !== undefined) {
+    virtualFiles.set(join(dirname(sourcePath), 'orders.service.ts'), companionSource);
+  }
+
+  const options = {
+    baseUrl: repoRoot,
+    exactOptionalPropertyTypes: true,
+    module: ModuleKind.ESNext,
+    moduleResolution: ModuleResolutionKind.Bundler,
+    noEmit: true,
+    noUncheckedIndexedAccess: true,
+    paths: {
+      '@fluojs/core/internal': ['packages/core/src/internal.ts'],
+      '@fluojs/core/request-pipeline': ['packages/core/src/request-pipeline.ts'],
+      '@fluojs/*': ['packages/*/src/index.ts'],
+    },
+    skipLibCheck: true,
+    strict: true,
+    target: ScriptTarget.ES2022,
+    types: ['node'],
+  };
+  const host = createCompilerHost(options, true);
+  const defaultDirectoryExists = host.directoryExists?.bind(host);
+  const defaultFileExists = host.fileExists.bind(host);
+  const defaultGetSourceFile = host.getSourceFile.bind(host);
+  const defaultReadFile = host.readFile.bind(host);
+  const virtualDirectories = new Set([...virtualFiles.keys()].map((fileName) => dirname(fileName)));
+
+  host.directoryExists = (directoryName) => virtualDirectories.has(directoryName) || defaultDirectoryExists?.(directoryName) === true;
+  host.fileExists = (fileName) => virtualFiles.has(fileName) || defaultFileExists(fileName);
+  host.readFile = (fileName) => virtualFiles.get(fileName) ?? defaultReadFile(fileName);
+  host.getSourceFile = (fileName, languageVersion, onError, shouldCreateNewSourceFile) => {
+    const source = virtualFiles.get(fileName);
+
+    return source === undefined
+      ? defaultGetSourceFile(fileName, languageVersion, onError, shouldCreateNewSourceFile)
+      : createSourceFile(fileName, source, languageVersion, true, ScriptKind.TS);
+  };
+
+  const program = createProgram([sourcePath], options, host);
+
+  return getPreEmitDiagnostics(program)
+    .filter((diagnostic) => diagnostic.category === DiagnosticCategory.Error && diagnostic.file?.fileName === sourcePath)
+    .map((diagnostic) => {
+      const message = flattenDiagnosticMessageText(diagnostic.messageText, '\n');
+
+      if (diagnostic.file === undefined || diagnostic.start === undefined) {
+        return message;
+      }
+
+      const position = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
+      return `${position.line + 1}:${position.character + 1} ${message}`;
+    });
+}
+
+function expectInjectedConstructorDependency(
+  sourceText: string,
+  className: string,
+  parameterName: string,
+  token: string,
+): void {
+  const sourceFile = createSourceFile('readme-snippet.ts', sourceText, ScriptTarget.ES2022, true, ScriptKind.TS);
+  const declaration = sourceFile.statements
+    .filter(isClassDeclaration)
+    .find((statement) => statement.name?.text === className);
+
+  if (declaration === undefined) {
+    throw new TypeError(`Missing ${className} declaration.`);
+  }
+
+  const injectDecorator = (canHaveDecorators(declaration) ? getDecorators(declaration) ?? [] : [])
+    .find((decorator) => isCallExpression(decorator.expression)
+      && isIdentifier(decorator.expression.expression)
+      && decorator.expression.expression.text === 'Inject');
+
+  if (injectDecorator === undefined || !isCallExpression(injectDecorator.expression)) {
+    throw new TypeError(`Missing @Inject(...) on ${className}.`);
+  }
+
+  expect(injectDecorator.expression.arguments.map((argument) => argument.getText(sourceFile))).toEqual([token]);
+
+  const constructor = declaration.members.find(isConstructorDeclaration);
+  const parameter = constructor?.parameters.find(
+    (candidate) => isIdentifier(candidate.name) && candidate.name.text === parameterName,
+  );
+
+  if (parameter === undefined || parameter.type === undefined || !isTypeReferenceNode(parameter.type)) {
+    throw new TypeError(`Missing ${parameterName}: ${token} constructor dependency on ${className}.`);
+  }
+
+  expect(parameter.type.typeName.getText(sourceFile)).toBe(token);
+}
+
+describe('@fluojs/prisma README DI snippets', () => {
+  for (const { file, locale } of readmes) {
+    it(`compiles the ${locale} @Transaction() service example against public package types`, () => {
+      const snippet = readmeSnippet(file, ['class UserService', 'class UserRepository', '@Transaction()']);
+
+      expectInjectedConstructorDependency(snippet, 'UserService', 'repo', 'UserRepository');
+      expect(
+        readmeSnippetDiagnostics(
+          `${file}-transaction`,
+          `${snippet}\n\ntype CreateUserDto = { readonly email: string };`,
+        ),
+      ).toEqual([]);
+    });
+
+    it(`compiles the ${locale} interceptor compatibility example against public package types`, () => {
+      const snippet = readmeSnippet(file, ['class OrdersController', '@UseInterceptors(PrismaTransactionInterceptor)']);
+
+      expectInjectedConstructorDependency(snippet, 'OrdersController', 'orders', 'OrdersService');
+      expect(
+        readmeSnippetDiagnostics(
+          `${file}-interceptor`,
+          snippet,
+          'export class OrdersService { create(): { readonly id: string } { return { id: "order-1" }; } }',
+        ),
+      ).toEqual([]);
+    });
+  }
+});

--- a/packages/prisma/src/vertical-slice.test.ts
+++ b/packages/prisma/src/vertical-slice.test.ts
@@ -7,11 +7,18 @@ import {
   HttpCode,
   Post,
   RequestDto,
+  UseInterceptors,
 } from '@fluojs/http';
 import { bootstrapApplication, defineModule } from '@fluojs/runtime';
 import { describe, expect, it } from 'vitest';
 
-import { PrismaModule, PrismaService, type PrismaServiceFacade, Transaction } from './index.js';
+import {
+  PrismaModule,
+  PrismaService,
+  type PrismaServiceFacade,
+  PrismaTransactionInterceptor,
+  Transaction,
+} from './index.js';
 
 function createResponse(events?: string[]): FrameworkResponse & { body?: unknown } {
   return {
@@ -285,6 +292,73 @@ describe('@fluojs/prisma service boundary primary flow', () => {
         'connect',
         'transaction:start',
         'tx:create:grace@example.com',
+        'transaction:commit',
+        'response:send',
+      ]);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('injects the compatibility interceptor controller dependency before creating an order', async () => {
+    const events: string[] = [];
+    const transactionClient = { source: 'transaction' } as const;
+    const client = {
+      source: 'root' as const,
+      async $connect() {
+        events.push('connect');
+      },
+      async $disconnect() {
+        events.push('disconnect');
+      },
+      async $transaction<T>(callback: (value: typeof transactionClient) => Promise<T>): Promise<T> {
+        events.push('transaction:start');
+        const result = await callback(transactionClient);
+        events.push('transaction:commit');
+        return result;
+      },
+    };
+
+    @Inject(PrismaService)
+    class OrdersService {
+      constructor(private readonly prisma: PrismaService<typeof client, typeof transactionClient>) {}
+
+      create() {
+        events.push(`orders:create:${this.prisma.current().source}`);
+        return { id: 'order-1' };
+      }
+    }
+
+    @Controller('/orders')
+    @Inject(OrdersService)
+    class OrdersController {
+      constructor(private readonly orders: OrdersService) {}
+
+      @Post('/')
+      @UseInterceptors(PrismaTransactionInterceptor)
+      createOrder() {
+        return this.orders.create();
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [OrdersController],
+      imports: [PrismaModule.forRoot({ client })],
+      providers: [OrdersService],
+    });
+    const app = await bootstrapApplication({ rootModule: AppModule });
+
+    try {
+      const response = createResponse(events);
+
+      await app.dispatch(createRequest('/orders', 'POST'), response);
+
+      expect(response.body).toEqual({ id: 'order-1' });
+      expect(events).toEqual([
+        'connect',
+        'transaction:start',
+        'orders:create:transaction',
         'transaction:commit',
         'response:send',
       ]);


### PR DESCRIPTION
## Summary

Two primary Prisma README examples could not be copied as working TypeScript: the `@Transaction()` service example omitted the required explicit `@Inject(UserRepository)` token, and the interceptor compatibility example called `this.orders.create()` without any declared/injected `OrdersService`.

Linked context: Closes #3247

## Changes

- `packages/prisma/README.md` + `README.ko.md`: service example now declares class-level `@Inject(UserRepository)` (explicit DI contract per docs/CONTEXT.md); interceptor example declares and injects `OrdersService`; EN/KO kept synchronized with identical code.
- `packages/prisma/src/readme-snippets.test.ts` (new): deterministic drift guard that machine-consumes the EN and KO README code fences — compiles both transaction examples as standalone units (virtual `./user.repository.ts` companion module), asserts the structural DI wiring, and ships EN/KO NEGATIVE-CONTROL cases (malformed `@Inject(PrismaService)` rejected with the exact failure) plus mutation evidence that disabling the validator fails the guard.
- `packages/prisma/src/vertical-slice.test.ts`: interceptor compatibility example now executable.
- Changeset: `.changeset/fix-prisma-readme-examples.md` (patch — package README ships in the npm tarball).

## Testing

- pnpm --filter '@fluojs/prisma...' build → exit 0; typecheck → exit 0; test → exit 0 (10 files, 71 tests; base 64 → +1 vertical-slice → +4 guard cases → +2 negative controls)
- node tooling/docs/verify-docs-locale-parity.mjs → exit 0; pnpm exec biome lint → 0 errors
- Local review triad at head 96b2f8e6195da41896b1fea4911976ff8116b0e3: code PASS / contract PASS / verification PASS (3 rounds; final blockers: snippet compile-unit validity + committed negative control — both remediated in 462a918f + 96b2f8e6)

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] No public exports changed (docs-only + test-only; no runtime API change).

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README (examples now match the documented explicit-DI contract).
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests (README snippet drift guard, both locales).

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (parity verifier green)
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. (no platform contract docs changed)
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests (no new claims).