### PR TITLE
fix(release): retry transient GitHub API failures; require lint+governance in verify-local

### DIFF
--- a/.agents/skills/execute-lane/SKILL.md
+++ b/.agents/skills/execute-lane/SKILL.md
@@ -138,6 +138,22 @@ The operator (human or agent session):
    broke on a react/runtime seam change that http/react/runtime suites
    could not see).
 
+   Package-scoped closures never execute the cheap global gates, and a
+   300-run CI-failure audit (2026-09) showed those gaps are exactly where
+   PRs burn fix-back rounds. Every `verify-local` run MUST finish with the
+   two second-cost global gates:
+
+   ```text
+   pnpm lint                                    # Biome rules
+   pnpm verify:platform-consistency-governance  # contract companion-update rules
+   ```
+
+   When the change touches `docs/` or `tooling/governance/`, also run the
+   governance suites that consume those files directly —
+   `pnpm vitest run tooling/governance/<related>.test.ts` — because doc
+   fences and contract texts are validated there, not by any package's
+   vitest project.
+
    Additional verification rules, each earned by a live incident
    (lane-30x10, 30 issues):
 

--- a/.agents/skills/issue-to-pr/references/implementer.md
+++ b/.agents/skills/issue-to-pr/references/implementer.md
@@ -95,7 +95,15 @@ canonical contract, stop and report the conflict instead of silently choosing on
 5. Run the focused test to GREEN, then run changed-file diagnostics and the
    closest canonical verifier for the affected domain.
 6. Update required README, EN/KO, docs, book, example, TSDoc, or migration
-   companions in the same change.
+   companions in the same change. When the change touches a
+   contract-governing document, satisfy the platform consistency governance
+   companions in the same commit: the `docs/CONTEXT.md` and
+   `docs/CONTEXT.ko.md` discoverability lines, CI/tooling enforcement
+   updates, and any named companion test (for example
+   `tooling/governance/http-runtime-isolation.test.ts` for HTTP runtime
+   contract changes). Contract-governing doc edits also require running
+   `pnpm verify:platform-consistency-governance` before committing —
+   skipping it is the single most common cause of CI fix-back rounds.
 7. Add a Changeset for consumer-facing changes to public `@fluojs/*` packages.
    Otherwise report a concrete no-release rationale tied to policy.
 8. Inspect the scoped diff and required-file checklist before committing.

--- a/tooling/release/version-packages.d.mts
+++ b/tooling/release/version-packages.d.mts
@@ -9,10 +9,28 @@ export type WorkspacePackageManifestRecord = {
   readonly packageJsonPath: string;
 };
 
+export type ChangesetsVersionSpawnResult = {
+  readonly status: number | null;
+  readonly stdout?: string;
+  readonly stderr?: string;
+  readonly error?: Error | undefined;
+};
+
+export type ChangesetsVersionDependencies = {
+  readonly attempts?: number;
+  readonly sleep?: (milliseconds: number) => void;
+  readonly spawn?: (
+    command: string,
+    args: readonly string[],
+    options: { readonly cwd: string; readonly encoding: 'utf8' },
+  ) => ChangesetsVersionSpawnResult;
+  readonly writeOutput?: (stream: { readonly write: (chunk: string) => unknown }, chunk: string) => unknown;
+};
+
 export type VersionPackagesDependencies = {
   readonly existsSync?: (targetPath: string) => boolean;
   readonly readFileSync?: (targetPath: string, encoding: 'utf8') => string;
-  readonly runChangesetsVersion?: () => void;
+  readonly runChangesetsVersion?: (dependencies?: ChangesetsVersionDependencies) => void;
   readonly workspacePackageManifests?: () => readonly WorkspacePackageManifestRecord[];
   readonly writeFileSync?: (targetPath: string, content: string, encoding: 'utf8') => void;
 };
@@ -22,5 +40,6 @@ export type VersionPackagesResult = {
 };
 
 export function normalizePackageChangelog(changelog: string): string;
+export function runChangesetsVersion(dependencies?: ChangesetsVersionDependencies): void;
 export function runVersionPackages(dependencies?: VersionPackagesDependencies): VersionPackagesResult;
 export function main(): void;

--- a/tooling/release/version-packages.mjs
+++ b/tooling/release/version-packages.mjs
@@ -13,6 +13,25 @@ export { normalizePackageChangelog } from './package-changelog.mjs';
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDirectory, '..', '..');
+
+const CHANGESETS_VERSION_RETRY_LIMIT = 3;
+const CHANGESETS_TRANSIENT_FAILURE_SIGNATURES = [
+  'Failed to parse data from GitHub',
+  'invalid json response body',
+];
+
+function sleepSync(milliseconds) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function changesetsFailureIsTransient(output) {
+  return CHANGESETS_TRANSIENT_FAILURE_SIGNATURES.some((signature) => output.includes(signature));
+}
+
+function changesetsRetryDelayMilliseconds(attempt) {
+  return attempt === 1 ? 2_000 : 5_000;
+}
+
 function publicPackageChangelogPaths(packageManifests) {
   return packageManifests
     .filter(
@@ -25,18 +44,47 @@ function publicPackageChangelogPaths(packageManifests) {
     .sort((left, right) => left.localeCompare(right));
 }
 
-function runChangesetsVersion() {
-  const result = spawnSync('pnpm', ['exec', 'changeset', 'version'], {
-    cwd: repoRoot,
-    stdio: 'inherit',
-  });
+export function runChangesetsVersion(dependencies = {}) {
+  const {
+    attempts = CHANGESETS_VERSION_RETRY_LIMIT,
+    sleep = sleepSync,
+    spawn = spawnSync,
+    writeOutput = (stream, chunk) => stream.write(chunk),
+  } = dependencies;
 
-  if (result.error) {
-    throw result.error;
-  }
+  for (let attempt = 1; ; attempt += 1) {
+    const result = spawn('pnpm', ['exec', 'changeset', 'version'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
 
-  if (result.status !== 0) {
-    throw new Error(`Changesets version command failed with exit code ${result.status ?? 'unknown'}.`);
+    if (result.stdout) {
+      writeOutput(process.stdout, result.stdout);
+    }
+
+    if (result.stderr) {
+      writeOutput(process.stderr, result.stderr);
+    }
+
+    if (result.error) {
+      throw result.error;
+    }
+
+    if (result.status === 0) {
+      return;
+    }
+
+    const output = `${result.stdout ?? ''}\n${result.stderr ?? ''}`;
+
+    if (attempt >= attempts || !changesetsFailureIsTransient(output)) {
+      throw new Error(`Changesets version command failed with exit code ${result.status ?? 'unknown'}.`);
+    }
+
+    writeOutput(
+      process.stderr,
+      `Changesets version command hit a transient GitHub API failure (attempt ${attempt}/${attempts}); retrying.\n`,
+    );
+    sleep(changesetsRetryDelayMilliseconds(attempt));
   }
 }
 

--- a/tooling/release/version-packages.test.ts
+++ b/tooling/release/version-packages.test.ts
@@ -1,5 +1,67 @@
 import { describe, expect, it } from 'vitest';
-import { normalizePackageChangelog, runVersionPackages } from './version-packages.mjs';
+import { normalizePackageChangelog, runChangesetsVersion, runVersionPackages } from './version-packages.mjs';
+
+describe('runChangesetsVersion', () => {
+  const transientStderr = [
+    '🦋  error Error: Failed to parse data from GitHub',
+    '🦋  error invalid json response body at https://api.github.com/graphql reason: Unexpected end of JSON input',
+  ].join('\n');
+
+  function createSpawnScript(script: readonly ('transient' | 'success' | 'fatal')[]) {
+    const spawnCalls: string[][] = [];
+    return {
+      spawnCalls,
+      spawn: (_command: string, args: readonly string[]) => {
+        spawnCalls.push([...args]);
+        const outcome = script[Math.min(spawnCalls.length - 1, script.length - 1)];
+        if (outcome === 'success') {
+          return { status: 0, stdout: '🦋  All changesets have been consumed.\n', stderr: '' };
+        }
+        return {
+          status: 1,
+          stdout: '',
+          stderr: outcome === 'transient' ? transientStderr : '🦋  error Could not resolve changesets config.',
+        };
+      },
+    };
+  }
+
+  it('retries transient GitHub API failures until the command succeeds', () => {
+    const { spawn, spawnCalls } = createSpawnScript(['transient', 'transient', 'success']);
+    const sleeps: number[] = [];
+    const outputChunks: string[] = [];
+
+    expect(() =>
+      runChangesetsVersion({
+        spawn,
+        sleep: (milliseconds) => {
+          sleeps.push(milliseconds);
+        },
+        writeOutput: () => {},
+      }),
+    ).not.toThrow();
+    expect(spawnCalls).toHaveLength(3);
+    expect(sleeps).toEqual([2_000, 5_000]);
+  });
+
+  it('does not retry non-transient failures', () => {
+    const { spawn, spawnCalls } = createSpawnScript(['fatal']);
+
+    expect(() => runChangesetsVersion({ spawn, sleep: () => {}, writeOutput: () => {} })).toThrowError(
+      'Changesets version command failed with exit code 1.',
+    );
+    expect(spawnCalls).toHaveLength(1);
+  });
+
+  it('throws after exhausting every retry attempt on persistent transient failures', () => {
+    const { spawn, spawnCalls } = createSpawnScript(['transient', 'transient', 'transient']);
+
+    expect(() =>
+      runChangesetsVersion({ attempts: 3, spawn, sleep: () => {}, writeOutput: () => {} }),
+    ).toThrowError('Changesets version command failed with exit code 1.');
+    expect(spawnCalls).toHaveLength(3);
+  });
+});
 
 describe('normalizePackageChangelog', () => {
   it('adds Unreleased below a foundation package title when the section is missing', () => {


### PR DESCRIPTION
## Summary

A 300-run CI-failure audit (2026-09) identified two live, chronic failure sources this PR fixes:

1. `Changesets Release` failed on 6 of the last 6 `main` pushes when `@changesets/get-github-info` hit a truncated GitHub GraphQL response (`invalid json response body at https://api.github.com/graphql reason: Unexpected end of JSON input`). Changesets escapes without applying files on this failure, so retrying the whole `changeset version` command is safe.
2. `verify-local` (the pre-PR local verification gate) never executes the cheap global CI gates, and the top two chronic CI-failure buckets — Biome lint violations and platform-consistency-governance companion-update misses — sit exactly in that gap (80 governance failures and 8 lint failures out of the audited 300).

Linked context: CI failure audit, 2026-09 (lead-session analysis; no tracking issue).

## Changes

- `tooling/release/version-packages.mjs`: `runChangesetsVersion` now captures child output and retries up to 3 attempts (2s/5s backoff) when the failure matches the observed transient signatures (`Failed to parse data from GitHub`, `invalid json response body`). Non-transient failures still fail fast on the first attempt, and child output is still forwarded to the workflow log.
- `tooling/release/version-packages.d.mts`: type declarations for the new injectable `runChangesetsVersion` dependencies.
- `.agents/skills/execute-lane/SKILL.md`: `verify-local` MUST now finish with `pnpm lint` and `pnpm verify:platform-consistency-governance`; changes touching `docs/` or `tooling/governance/` also run the consuming governance test suites directly.
- `.agents/skills/issue-to-pr/references/implementer.md`: implementation step 6 now requires the platform-consistency-governance companions (EN/KO `docs/CONTEXT.*.md` discoverability, CI/tooling enforcement, named companion tests) in the same commit, plus running the governance verifier before committing.

## Testing

- `pnpm vitest run tooling/release/version-packages.test.ts` — 8/8 passed (3 new: retry-until-success, no-retry on non-transient, exhaust-attempts).
- `pnpm vitest run tooling/release/ tooling/governance/omo-native-assets.test.ts` — 164/164 passed.
- `pnpm vitest run tooling/governance/issue-to-pr-native.test.ts tooling/governance/create-lane-invocation.test.ts` — 10/10 passed.
- `pnpm verify:platform-consistency-governance` — passed.
- `pnpm lint` (incl. public-export TSDoc verifier) — passed.
- `tsc -p tsconfig.tools.json --noEmit` after a clean full `pnpm build` — passed.
- `pnpm docs:sync-check` — passed.
- `node tooling/release/verify-changeset-release-lane.mjs --lane=stable --base-ref=origin/main` — passed.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Tooling (release script) and workflow skill documentation only; no public `@fluojs/*` package behavior, API surface, or release metadata changes.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports changed (`tooling/release` internals and workflow skill docs only).

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The `verify-local` gate additions are documented in `.agents/skills/execute-lane/SKILL.md`, which is the behavioral contract for that workflow.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests.

No platform contract docs changed; workflow skill docs under `.agents/` were updated and verified against `pnpm verify:platform-consistency-governance`.