### PR TITLE
feat(mongoose): add opt-in document save helper (#3226)

### DIFF
--- a/.changeset/add-mongoose-document-save-helper.md
+++ b/.changeset/add-mongoose-document-save-helper.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/mongoose': minor
+---
+
+Add the opt-in `MongooseConnection.saveDocument(...)` helper for saving existing documents with the active transaction session.

--- a/book/intermediate/ch19-mongoose.ko.md
+++ b/book/intermediate/ch19-mongoose.ko.md
@@ -70,7 +70,16 @@ Fluo에서는 일반적으로 리포지토리를 통해 MongoDB와 상호작용�
 import { MongooseConnection, type MongooseModelFacade } from '@fluojs/mongoose';
 import { Inject } from '@fluojs/core';
 
-type ProductDocument = { readonly _id: string; readonly name: string; readonly price: number };
+type ProductDocumentSaveOptions = {
+  readonly validateBeforeSave?: boolean;
+  readonly session?: object | null;
+};
+type ProductDocument = {
+  readonly _id: string;
+  readonly name: string;
+  readonly price: number;
+  save(options?: ProductDocumentSaveOptions): Promise<ProductDocument>;
+};
 type ProductLookupModel = MongooseModelFacade<unknown, unknown, Promise<ProductDocument | null>>;
 type InventoryWriteModel = MongooseModelFacade<
   unknown,

--- a/book/intermediate/ch19-mongoose.ko.md
+++ b/book/intermediate/ch19-mongoose.ko.md
@@ -106,6 +106,19 @@ export class ProductRepository {
 
 트랜잭션이 활성화된 상태에서 옵션에 `session`을 명시적으로 제공했는데, 해당 세션이 앰비언트 트랜잭션 세션과 일치하지 않는 경우 fluo는 충돌 에러를 던집니다. 이는 의도치 않은 트랜잭션 간 데이터 유출을 방지하기 위함입니다.
 
+### 기존 문서를 명시적으로 저장하기
+
+`doc.save()`는 native Mongoose 동작으로 남으며 fluo가 patch하지 않습니다. 기존 document를 활성 Fluo 트랜잭션에 참여시켜야 하면 다음처럼 명시적 helper를 사용하세요.
+
+```ts
+@Transaction()
+async renameProduct(document: ProductDocument) {
+  return this.conn.saveDocument(document, { validateBeforeSave: false });
+}
+```
+
+`saveDocument(...)`는 document instance와 native save option을 보존하고 ambient session을 붙이며, 트랜잭션 밖 호출 또는 충돌하는 명시적 session을 거부합니다.
+
 ## 19.5 Transaction Management
 
 

--- a/book/intermediate/ch19-mongoose.md
+++ b/book/intermediate/ch19-mongoose.md
@@ -106,6 +106,19 @@ When these methods are called inside a `@Transaction()`, `transaction()`, or `re
 
 If you explicitly provide a `session` in the options while a transaction is active, fluo will throw a conflict error if the provided session does not match the ambient transaction session. This prevents accidental cross-transaction leaks.
 
+### Saving Existing Documents Explicitly
+
+`doc.save()` remains native Mongoose behavior and is not patched by fluo. When an existing document must participate in an active Fluo transaction, use the explicit helper instead:
+
+```ts
+@Transaction()
+async renameProduct(document: ProductDocument) {
+  return this.conn.saveDocument(document, { validateBeforeSave: false });
+}
+```
+
+`saveDocument(...)` preserves the document instance and native save options, attaches the ambient session, and rejects calls outside a transaction or with a conflicting explicit session.
+
 ## 19.5 Transaction Management
 
 

--- a/book/intermediate/ch19-mongoose.md
+++ b/book/intermediate/ch19-mongoose.md
@@ -70,7 +70,16 @@ In Fluo, you usually interact with MongoDB through repositories. Instead of depe
 import { MongooseConnection, type MongooseModelFacade } from '@fluojs/mongoose';
 import { Inject } from '@fluojs/core';
 
-type ProductDocument = { readonly _id: string; readonly name: string; readonly price: number };
+type ProductDocumentSaveOptions = {
+  readonly validateBeforeSave?: boolean;
+  readonly session?: object | null;
+};
+type ProductDocument = {
+  readonly _id: string;
+  readonly name: string;
+  readonly price: number;
+  save(options?: ProductDocumentSaveOptions): Promise<ProductDocument>;
+};
 type ProductLookupModel = MongooseModelFacade<unknown, unknown, Promise<ProductDocument | null>>;
 type InventoryWriteModel = MongooseModelFacade<
   unknown,

--- a/docs/CONTEXT.ko.md
+++ b/docs/CONTEXT.ko.md
@@ -336,6 +336,10 @@ Queue producer migration discoverability는 `packages/queue/README.ko.md`와 [`d
 
 [`docs/architecture/http-runtime.ko.md`](./architecture/http-runtime.ko.md)는 canonical conditional-request lifecycle contract이다. 이 문서는 명시적인 `ConditionalRequestResolver` representation-existence result, 평가 전 application/module middleware와 guard ordering, RFC validator precedence, 독립적인 `@Head` routing, framework-managed `HEAD` body suppression, custom-writer ownership을 정의한다. `packages/http/README.ko.md`, `packages/runtime/README.ko.md`, `packages/testing/README.ko.md`는 지원하는 resolver, bootstrap, real-listener conformance API를 나열한다.
 
+## Mongoose 트랜잭션 문서 저장
+
+NestJS Mongoose 마이그레이션과 트랜잭션 의미론은 [트랜잭션 문맥 계약](./architecture/transactions.ko.md)과 [NestJS → fluo 마이그레이션 맵](./getting-started/migrate-from-nestjs.ko.md)에 문서화합니다. `MongooseConnection.model(...)` facade 작업은 지원되는 메서드에 ambient session을 병합합니다. `MongooseConnection.saveDocument(...)`는 기존 document의 opt-in 경로로 native save option과 document identity를 보존하고 ambient session 없이는 fail-closed하며 direct `doc.save()`는 변경하지 않습니다.
+
 ## Anti-Patterns at a Glance
 
 - `experimentalDecorators` 또는 `emitDecoratorMetadata`를 활성화하는 것, fluo의 표준 데코레이터 기준을 깨뜨린다.

--- a/docs/CONTEXT.ko.md
+++ b/docs/CONTEXT.ko.md
@@ -7,6 +7,10 @@
 
 정적 제공은 [HTTP Runtime Contract](./architecture/http-runtime.ko.md)에 문서화한 portable `@fluojs/http` middleware 계약입니다. 애플리케이션은 `createStaticAssetsMiddleware(...)`에 명시적 `StaticAssetSource`를 전달하므로 fetch-style 및 edge host에 암묵적 filesystem claim이 제공되지 않습니다. `@fluojs/runtime/node`는 Node, Express, Fastify deployment용 `createNodeFileSystemAssetSource(...)`를 소유하며 lexical 및 realpath 해석을 구성된 root에 제한하고 precompressed sibling을 선택할 수 있습니다. API 예제와 deployment configuration은 `@fluojs/http`, `@fluojs/runtime` package README를 사용하세요.
 
+## Node.js 지원
+
+`@fluojs/cqrs`는 필수 `@fluojs/runtime` dependency 때문에 Node.js `>=20.19.3 <21 || >=22.2.0 <27`을 요구합니다. 이는 검증된 Node listener 지원 창으로 Node.js `20.0.0`–`20.19.2`, Node.js 21, Node.js `22.0.0`–`22.1.x`, Node.js 27+는 제외됩니다. consumer 계약은 [`packages/cqrs/README.ko.md`](../packages/cqrs/README.ko.md) 및 [Package Surface](./reference/package-surface.ko.md)를 참조하세요.
+
 ## Identity
 
 fluo는 TC39 표준 데코레이터, 명시적 의존성 경계, 메타데이터 없는 런타임 구성을 기반으로 하는 standard-first TypeScript 백엔드 프레임워크다. legacy 데코레이터 컴파일 모드를 거부하며, behavioral contract, 플랫폼 parity, 패키지 표면의 명확성을 핵심 설계 제약으로 둔다.
@@ -32,6 +36,8 @@ NestJS microservices migration boundary는 [NestJS migration map](./getting-star
 NestJS Mongoose 마이그레이션과 트랜잭션 의미론은 [NestJS migration map](./getting-started/migrate-from-nestjs.ko.md)과 [Transaction Context Contract](./architecture/transactions.ko.md)에 문서화되어 있다. 애플리케이션이 소유하는 마이그레이션은 connection을 만들고 그 connection에서 model을 compile한 뒤 `MongooseModule`에 등록한다. 지원되는 `MongooseConnection.model(...)` facade 작업은 기존 option을 버리지 않고 ambient session을 병합한다. `strictTransactions: false`의 fail-open은 connection에 `connection.transaction(...)`과 `startSession()`이 모두 없을 때만 가능하며 rollback 원자성이 없다. multi-connection service에서는 모호한 decorator 대상 해석에 의존하지 말고 `@Transaction((self) => self.analytics.conn)`처럼 명시적인 accessor를 사용한다.
 
 NestJS OpenAPI migration map은 생성 문서의 세 가지 차이를 보존한다. fluo는 명시적으로 선언한 응답을 제외하고 `400`, `401`, `403`, `404`, `500` 응답과 `ErrorResponse`를 추가하며 legacy client에는 `defaultErrorResponsesPolicy: 'omit'`을 사용한다. 생성된 `operationId`가 legacy name과 달라 client가 이를 요구하면 `documentTransform`을 사용한다. `OpenApiModule.forRootAsync(...)`에서는 이미 등록한 route를 factory-returned path로 다시 구성할 수 없으므로 `documentPath`와 `uiPath`를 `inject`, `useFactory(...)`와 같은 바깥 registration object에 둔다.
+
+NestJS Prisma migration map에서는 migrated flow에 rollback 원자성이 필요하면 `strictTransactions: true`를 설정해야 합니다. Interactive `$transaction(...)` client가 없으면 기본 fail-open 경로가 callback을 직접 실행합니다. `PrismaModule.forRootAsync(...)`는 `inject` / `useFactory` factory strategy만 지원하지만 top-level `name`, `global` option은 유지하므로, option을 resolve하기 전에 global module export 또는 bootstrap runtime provider를 통해 각 의존성을 노출하고 NestJS `imports`, `useClass`, `useExisting` configuration은 호환 field로 취급하지 말고 bootstrap에서 해석하세요.
 
 ## Hard Constraints
 

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -7,6 +7,10 @@ This document is the primary AI-reference entrypoint for the fluo repository. It
 
 Static delivery is a portable `@fluojs/http` middleware contract, documented in [HTTP Runtime Contract](./architecture/http-runtime.md): applications pass an explicit `StaticAssetSource` to `createStaticAssetsMiddleware(...)`, so fetch-style and edge hosts never receive an implicit filesystem claim. `@fluojs/runtime/node` owns `createNodeFileSystemAssetSource(...)` for Node, Express, and Fastify deployments; it constrains lexical and realpath resolution to a configured root and can select precompressed siblings. Use the `@fluojs/http` and `@fluojs/runtime` package READMEs for API examples and deployment configuration.
 
+## Node.js Support
+
+`@fluojs/cqrs` requires Node.js `>=20.19.3 <21 || >=22.2.0 <27` because `@fluojs/runtime` is a mandatory dependency. This is the verified Node listener support window: Node.js `20.0.0`–`20.19.2`, Node.js 21, Node.js `22.0.0`–`22.1.x`, and Node.js 27+ are excluded. See [`packages/cqrs/README.md`](../packages/cqrs/README.md) and [Package Surface](./reference/package-surface.md) for the consumer contract.
+
 ## Identity
 
 fluo is a standard-first TypeScript backend framework built on TC39 standard decorators, explicit dependency boundaries, and metadata-free runtime wiring. It rejects legacy decorator compiler modes and treats behavioral contracts, platform parity, and package surface clarity as core design constraints.
@@ -32,6 +36,8 @@ NestJS microservices migration boundaries are documented in the [NestJS migratio
 NestJS Mongoose migration and transaction semantics are documented in the [NestJS migration map](./getting-started/migrate-from-nestjs.md) and [Transaction Context Contract](./architecture/transactions.md): application-owned migration creates the connection, compiles its models, then registers that connection with `MongooseModule`; supported `MongooseConnection.model(...)` facade operations merge the ambient session without discarding existing options; `strictTransactions: false` can only fail open when the connection exposes neither `connection.transaction(...)` nor `startSession()`, with no rollback atomicity; and multi-connection services must use an explicit `@Transaction((self) => self.analytics.conn)` accessor rather than relying on ambiguous decorator target resolution.
 
 The NestJS OpenAPI migration map preserves three generated-document differences: fluo adds `400`, `401`, `403`, `404`, and `500` responses plus `ErrorResponse` unless explicitly declared, with `defaultErrorResponsesPolicy: 'omit'` for legacy clients; generated `operationId` values require `documentTransform` when clients need legacy names; and `OpenApiModule.forRootAsync(...)` keeps `documentPath` and `uiPath` beside `inject` and `useFactory(...)`, because factory-returned paths cannot reconfigure already-registered routes.
+
+The NestJS Prisma migration map requires `strictTransactions: true` whenever a migrated flow needs rollback atomicity: without an interactive `$transaction(...)` client, the default fail-open path runs the callback directly. `PrismaModule.forRootAsync(...)` supports only the `inject` / `useFactory` factory strategy while retaining its top-level `name` and `global` options; expose each dependency through a global-module export or bootstrap runtime provider before options resolution, and resolve NestJS `imports`, `useClass`, and `useExisting` configuration at bootstrap rather than treating them as compatibility fields.
 
 ## Hard Constraints
 

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -337,6 +337,10 @@ Queue producer migration discoverability is split across `packages/queue/README.
 
 [`docs/architecture/http-runtime.md`](./architecture/http-runtime.md) is the canonical conditional-request lifecycle contract. It defines the explicit `ConditionalRequestResolver` representation-existence result, middleware-and-guard ordering before evaluation, RFC validator precedence, independent `@Head` routing, framework-managed `HEAD` body suppression, and custom-writer ownership. `packages/http/README.md`, `packages/runtime/README.md`, and `packages/testing/README.md` list the supported resolver, bootstrap, and real-listener conformance APIs.
 
+## Mongoose Transaction Document Saves
+
+NestJS Mongoose migration and transaction semantics are documented in [Transaction Context Contract](./architecture/transactions.md) and [NestJS → fluo Migration Map](./getting-started/migrate-from-nestjs.md). `MongooseConnection.model(...)` facade operations merge the ambient session for supported methods; `MongooseConnection.saveDocument(...)` is the opt-in path for an existing document, preserves native save options and document identity, fails closed without an ambient session, and leaves direct `doc.save()` unchanged.
+
 ## Anti-Patterns at a Glance
 
 - Enabling `experimentalDecorators` or `emitDecoratorMetadata`, this violates fluo's standard-decorator baseline.

--- a/docs/architecture/transactions.ko.md
+++ b/docs/architecture/transactions.ko.md
@@ -41,6 +41,7 @@ fluo 에코시스템에 추가되는 모든 새로운 ORM 연동 패키지는 �
 | --- | --- | --- |
 | 서비스 -> 레포지토리 흐름 | 서비스의 데코레이터가 경계를 설정하며, 레포지토리는 세션을 전달하거나 `current()`에 명시적으로 접근할 필요 없이 클라이언트를 사용합니다. | `packages/core/src/decorators/transaction.ts` (추상), `packages/mongoose/src/connection.ts` (자동 세션) |
 | 루트 vs ambient 핸들 | Prisma와 Drizzle 영속성 핸들은 활성 트랜잭션 핸들이 있으면 그 값을, 없으면 루트 client/database를 해석합니다. | `packages/prisma/src/service.ts`, `packages/drizzle/src/database.ts` |
+| Mongoose 문서 저장 helper | `MongooseConnection.saveDocument(document, options?)`는 기존 문서를 위한 opt-in 경로입니다. ambient session과 native save option을 병합하고 document identity를 보존하며, 누락되거나 충돌하는 session을 거부합니다. 직접 `doc.save()` 동작은 바꾸지 않습니다. | `packages/mongoose/src/connection.ts` |
 | Mongoose 세션 자동 바인딩 | 지원되는 `MongooseConnection.model(...)` facade 작업(`create`, `find`, `findOne`, `aggregate`, `bulkWrite`)은 ambient 트랜잭션 세션을 자동으로 첨부합니다. 지원되지 않는 model 메서드, `doc.save()`, raw `conn.current().model(...)` 호출, 고급 교차 연결 시나리오에는 명시적인 세션 전달이 필요합니다. | `packages/mongoose/src/connection.ts` |
 | Mongoose decorator 대상 선택 | Mongoose `@Transaction()`은 `this.conn`, transaction-capable한 decorated instance 자체, 또는 하나뿐인 중첩 `this.*.conn` collaborator를 해석합니다. 여러 중첩 후보 중 하나를 임의로 선택하지 않고 거부하므로, multi-connection service 또는 비표준 field에는 `@Transaction((self) => self.analytics.conn)` 같은 accessor를 전달하세요. | `packages/mongoose/src/transaction.ts` |
 | 중첩 경계 재사용 | 이미 트랜잭션이 활성화되어 있으면 `@Transaction()`은 새 경계를 열지 않고 기존 경계를 재사용합니다. | `packages/prisma/src/service.ts`, `packages/drizzle/src/database.ts`, `packages/mongoose/src/connection.ts` |
@@ -80,5 +81,6 @@ NestJS controller 또는 interceptor transaction 패턴을 마이그레이션할
 ## 제약 사항
 
 - 트랜잭션 관리의 기본 경로는 `@Transaction()`을 통한 서비스 계층입니다.
+- `MongooseConnection.saveDocument(...)`는 opt-in이며 활성 ambient session이 필요합니다. 트랜잭션 밖에서는 fail-closed하고 충돌하는 명시적 `session`을 거부하며 native `doc.save()`는 수정하지 않습니다.
 - 지원되는 Mongoose facade 작업은 자동으로 ambient 트랜잭션 세션에 참여합니다. 해당 표준 흐름에서는 명시적인 세션 전달이 권장되지 않으며, 지원되지 않는 model 메서드에는 여전히 명시적인 세션 전달이 필요합니다.
 - 롤백은 예외 기반입니다. `@Transaction()`으로 감싸진 메서드가 예외를 던지면 트랜잭션이 중단됩니다.

--- a/docs/architecture/transactions.md
+++ b/docs/architecture/transactions.md
@@ -41,6 +41,7 @@ Any new ORM integration package added to the fluo ecosystem must export a `@Tran
 | --- | --- | --- |
 | Service -> Repository flow | Decorators on services establish the boundary; repositories consume the client without needing to pass sessions or access `current()` explicitly. | `packages/core/src/decorators/transaction.ts` (abstract), `packages/mongoose/src/connection.ts` (auto-session) |
 | Root vs ambient handle | Prisma and Drizzle persistence handles resolve the active transaction handle when one exists, otherwise the root client/database. | `packages/prisma/src/service.ts`, `packages/drizzle/src/database.ts` |
+| Mongoose document save helper | `MongooseConnection.saveDocument(document, options?)` is an opt-in path for an existing document: it merges the ambient session with native save options, preserves document identity, and rejects missing or conflicting sessions. It does not change direct `doc.save()` behavior. | `packages/mongoose/src/connection.ts` |
 | Mongoose session auto-binding | Supported `MongooseConnection.model(...)` facade operations (`create`, `find`, `findOne`, `aggregate`, `bulkWrite`) automatically attach the ambient transaction session. Unsupported model methods, `doc.save()`, raw `conn.current().model(...)` calls, and advanced cross-connection scenarios require explicit session passing. | `packages/mongoose/src/connection.ts` |
 | Mongoose decorator target selection | Mongoose `@Transaction()` resolves `this.conn`, the decorated instance when it is transaction-capable, or one unique nested `this.*.conn` collaborator. It rejects multiple nested candidates rather than selecting one arbitrarily; pass an accessor such as `@Transaction((self) => self.analytics.conn)` for multi-connection services or nonstandard fields. | `packages/mongoose/src/transaction.ts` |
 | Nested boundary reuse | If a transaction is already active, `@Transaction()` reuses the existing boundary instead of opening a new one. | `packages/prisma/src/service.ts`, `packages/drizzle/src/database.ts`, `packages/mongoose/src/connection.ts` |
@@ -80,5 +81,6 @@ When migrating NestJS controller or interceptor transaction patterns, keep norma
 ## Constraints
 
 - The primary path for transaction management is the Service layer via `@Transaction()`.
+- `MongooseConnection.saveDocument(...)` is opt-in and requires an active ambient session; it fails closed outside a transaction, rejects a conflicting explicit `session`, and leaves native `doc.save()` unmodified.
 - Supported Mongoose facade operations automatically participate in the ambient transaction session; explicit session passing is discouraged for those standard flows and still required for unsupported model methods.
 - Rollback is exception-driven. If the method wrapped by `@Transaction()` throws, the transaction is aborted.

--- a/docs/getting-started/migrate-from-nestjs.ko.md
+++ b/docs/getting-started/migrate-from-nestjs.ko.md
@@ -892,7 +892,7 @@ CqrsModule.forRoot({
 
 `CqrsModule.forRoot({ eventBus: { publish: { waitForHandlers: false } } })`를 설정하면 위임된 `@OnEvent(...)` subscriber가 위임 publication이 resolve된 뒤에도 실행 중일 수 있습니다. 이 모드에서는 `publish(...)`, `publishAll(...)`, CQRS shutdown drain 완료가 모든 `@fluojs/event-bus` subscriber의 완료를 보장하지 않습니다.
 
-## Mongoose 루트와 feature 마이그레이션
+## 트랜잭션 안에서 Mongoose 문서 저장
 
 concrete connection을 생성하고 애플리케이션에서 model을 compile한 뒤 해당 connection을 `MongooseModule`에 등록하세요. 지원되는 세션 인지형 model facade 작업에는 `MongooseConnection.model(...)`을 사용합니다. 이미 로드한 Mongoose document를 저장하는 NestJS 서비스를 마이그레이션할 때는 명시적 트랜잭션 경계 안에서 `MongooseConnection.saveDocument(...)`를 사용하세요.
 

--- a/docs/getting-started/migrate-from-nestjs.ko.md
+++ b/docs/getting-started/migrate-from-nestjs.ko.md
@@ -892,6 +892,23 @@ CqrsModule.forRoot({
 
 `CqrsModule.forRoot({ eventBus: { publish: { waitForHandlers: false } } })`를 설정하면 위임된 `@OnEvent(...)` subscriber가 위임 publication이 resolve된 뒤에도 실행 중일 수 있습니다. 이 모드에서는 `publish(...)`, `publishAll(...)`, CQRS shutdown drain 완료가 모든 `@fluojs/event-bus` subscriber의 완료를 보장하지 않습니다.
 
+## Mongoose 루트와 feature 마이그레이션
+
+concrete connection을 생성하고 애플리케이션에서 model을 compile한 뒤 해당 connection을 `MongooseModule`에 등록하세요. 지원되는 세션 인지형 model facade 작업에는 `MongooseConnection.model(...)`을 사용합니다. 이미 로드한 Mongoose document를 저장하는 NestJS 서비스를 마이그레이션할 때는 명시적 트랜잭션 경계 안에서 `MongooseConnection.saveDocument(...)`를 사용하세요.
+
+```ts
+class ProfileService {
+  constructor(private readonly conn: MongooseConnection) {}
+
+  @Transaction()
+  async updateProfile(document: ProfileDocument) {
+    return this.conn.saveDocument(document, { validateBeforeSave: false });
+  }
+}
+```
+
+`MongooseConnection.saveDocument(...)`는 opt-in입니다. native Mongoose save option을 전달하고 활성 트랜잭션 session을 붙이며 원본 document instance를 보존합니다. 트랜잭션 밖에서는 실패하고 ambient session과 다른 `session` 전달을 거부합니다. `doc.save()` 자체는 변경되지 않으므로 direct 호출은 계속 native Mongoose 동작이며 이 helper 밖에서는 수동 session 처리가 필요합니다.
+
 ## Removed Concepts
 
 - 기본 프로바이더 마커로서의 `@Injectable()`. 프로바이더 등록은 모듈의 `providers` 배열에서 수행된다.

--- a/docs/getting-started/migrate-from-nestjs.ko.md
+++ b/docs/getting-started/migrate-from-nestjs.ko.md
@@ -610,6 +610,53 @@ export class CheckoutController {
 
 모든 NestJS interceptor를 이 형태로 옮기지 마세요. Request-wide transaction은 관련 없는 controller 작업 동안에도 lock을 유지할 수 있으므로, 실제 비즈니스 작업 단위를 나타낼 수 있다면 집중된 서비스 `@Transaction()`을 우선 사용하세요.
 
+### Prisma 비동기 등록과 롤백 보장
+
+<!-- fluo-prisma-contract: injected-factory-only, top-level-name-global, global-export-visibility, bootstrap-provider-visibility, no-nest-dynamic-options, strict-transaction-rollback -->
+
+`PrismaModule.forRootAsync(...)`는 injected `inject` / `useFactory` factory strategy만 지원합니다.
+Top-level `name`, `global` option은 계속 지원합니다.
+의존성은 `inject`에 나열하고 `useFactory`에서 최종 Prisma option을 반환하세요.
+Prisma option provider가 resolve되기 전에 주입할 각 의존성을 async Prisma module에서 볼 수 있는 surface를 통해 등록합니다.
+
+```typescript
+import { Global, Module } from '@fluojs/core';
+import { PrismaModule } from '@fluojs/prisma';
+import { PrismaClient } from '@prisma/client';
+
+class DatabaseConfig {
+  readonly url = 'postgresql://localhost/app';
+}
+
+@Global()
+@Module({
+  providers: [DatabaseConfig],
+  exports: [DatabaseConfig],
+})
+class DatabaseConfigModule {}
+
+@Module({
+  imports: [
+    DatabaseConfigModule,
+    PrismaModule.forRootAsync({
+      inject: [DatabaseConfig],
+      useFactory: (config: DatabaseConfig) => ({
+        client: new PrismaClient({ datasources: { db: { url: config.url } } }),
+        strictTransactions: true,
+      }),
+    }),
+  ],
+})
+class AppModule {}
+```
+
+Import하는 `AppModule`의 `providers`에만 `DatabaseConfig`를 등록하는 것으로는 충분하지 않습니다. Async child module은 자신의 local token, 자신의 import가 export한 token, global module export, bootstrap runtime provider만 볼 수 있습니다.
+위 예시처럼 주입 의존성을 import한 `@Global()` module에서 export하거나 bootstrap runtime provider로 제공하세요.
+
+NestJS의 `imports`, `useClass`, `useExisting`은 `forRootAsync(...)` 호환 field가 아닙니다. 해당 configuration, class construction, provider alias는 application bootstrap 또는 명시적인 fluo provider registration에서 해석하고, 준비된 의존성을 `inject`로 전달하세요.
+
+마이그레이션한 비즈니스 작업에 rollback 원자성이 필요하면 항상 `strictTransactions: true`를 설정하세요. 기본값 `false`에서는 등록한 client가 interactive `$transaction(...)`을 노출하지 않을 경우 fluo가 callback을 직접 실행하므로, 그 경우 `@Transaction()`과 `requestTransaction(...)`은 rollback을 보장하지 않습니다.
+
 ### GraphQL Resolver Migration
 
 GraphQL migration에서는 schema와 discovery wiring을 명시적으로 유지한다. 모든 resolver class를 authored module의 provider 또는 controller로 등록해 compiled module graph에서 discovery할 수 있게 한다. `GraphqlModule.forRoot({ resolvers: [...] })`는 이 class들을 등록하지 않으며, `resolvers`를 전달하면 해당 allowlist로 discovery를 제한한다. `resolvers`를 생략하거나 빈 list를 전달하면 provider 또는 controller로 이미 등록된 decorated resolver class를 모두 discovery한다. TypeScript 반환 타입이나 NestJS design metadata가 provider를 등록하거나 output type을 만들지 않는다.
@@ -897,6 +944,7 @@ CqrsModule.forRoot({
 concrete connection을 생성하고 애플리케이션에서 model을 compile한 뒤 해당 connection을 `MongooseModule`에 등록하세요. 지원되는 세션 인지형 model facade 작업에는 `MongooseConnection.model(...)`을 사용합니다. 이미 로드한 Mongoose document를 저장하는 NestJS 서비스를 마이그레이션할 때는 명시적 트랜잭션 경계 안에서 `MongooseConnection.saveDocument(...)`를 사용하세요.
 
 ```ts
+@Inject(MongooseConnection)
 class ProfileService {
   constructor(private readonly conn: MongooseConnection) {}
 

--- a/docs/getting-started/migrate-from-nestjs.md
+++ b/docs/getting-started/migrate-from-nestjs.md
@@ -895,7 +895,7 @@ CqrsModule.forRoot({
 
 When `CqrsModule.forRoot({ eventBus: { publish: { waitForHandlers: false } } })` is configured, delegated `@OnEvent(...)` subscribers may still be running after delegated publication resolves. In that mode, `publish(...)`, `publishAll(...)`, and CQRS shutdown drain completion do not guarantee that every `@fluojs/event-bus` subscriber has finished.
 
-## Mongoose Root and Feature Migration
+## Mongoose Document Saves Inside Transactions
 
 Create the concrete connection and compile models in the application before registering that connection with `MongooseModule`. Use `MongooseConnection.model(...)` for the supported session-aware model facade operations. When migrating a NestJS service that saves an already-loaded Mongoose document, use `MongooseConnection.saveDocument(...)` inside the explicit transaction boundary:
 

--- a/docs/getting-started/migrate-from-nestjs.md
+++ b/docs/getting-started/migrate-from-nestjs.md
@@ -895,6 +895,23 @@ CqrsModule.forRoot({
 
 When `CqrsModule.forRoot({ eventBus: { publish: { waitForHandlers: false } } })` is configured, delegated `@OnEvent(...)` subscribers may still be running after delegated publication resolves. In that mode, `publish(...)`, `publishAll(...)`, and CQRS shutdown drain completion do not guarantee that every `@fluojs/event-bus` subscriber has finished.
 
+## Mongoose Root and Feature Migration
+
+Create the concrete connection and compile models in the application before registering that connection with `MongooseModule`. Use `MongooseConnection.model(...)` for the supported session-aware model facade operations. When migrating a NestJS service that saves an already-loaded Mongoose document, use `MongooseConnection.saveDocument(...)` inside the explicit transaction boundary:
+
+```ts
+class ProfileService {
+  constructor(private readonly conn: MongooseConnection) {}
+
+  @Transaction()
+  async updateProfile(document: ProfileDocument) {
+    return this.conn.saveDocument(document, { validateBeforeSave: false });
+  }
+}
+```
+
+`MongooseConnection.saveDocument(...)` is opt-in: it forwards native Mongoose save options, attaches the active transaction session, and preserves the original document instance. It fails outside a transaction and rejects a supplied `session` that differs from the ambient session. `doc.save()` itself is unchanged, so direct calls remain native Mongoose behavior and require manual session handling when used outside this helper.
+
 ## Removed Concepts
 
 - `@Injectable()` as the default provider marker. Provider registration happens through the module `providers` array.

--- a/docs/getting-started/migrate-from-nestjs.md
+++ b/docs/getting-started/migrate-from-nestjs.md
@@ -613,6 +613,53 @@ export class CheckoutController {
 
 Do not migrate every NestJS interceptor into this shape. Request-wide transactions can keep locks open through unrelated controller work; prefer a focused service `@Transaction()` whenever it represents the actual business unit of work.
 
+### Prisma Async Registration and Rollback Guarantees
+
+<!-- fluo-prisma-contract: injected-factory-only, top-level-name-global, global-export-visibility, bootstrap-provider-visibility, no-nest-dynamic-options, strict-transaction-rollback -->
+
+`PrismaModule.forRootAsync(...)` supports only the injected `inject` / `useFactory` factory strategy.
+Its top-level `name` and `global` options remain supported.
+List dependencies in `inject` and return the final Prisma options from `useFactory`.
+Register each injected dependency through a surface visible to the async Prisma module before its options provider resolves:
+
+```typescript
+import { Global, Module } from '@fluojs/core';
+import { PrismaModule } from '@fluojs/prisma';
+import { PrismaClient } from '@prisma/client';
+
+class DatabaseConfig {
+  readonly url = 'postgresql://localhost/app';
+}
+
+@Global()
+@Module({
+  providers: [DatabaseConfig],
+  exports: [DatabaseConfig],
+})
+class DatabaseConfigModule {}
+
+@Module({
+  imports: [
+    DatabaseConfigModule,
+    PrismaModule.forRootAsync({
+      inject: [DatabaseConfig],
+      useFactory: (config: DatabaseConfig) => ({
+        client: new PrismaClient({ datasources: { db: { url: config.url } } }),
+        strictTransactions: true,
+      }),
+    }),
+  ],
+})
+class AppModule {}
+```
+
+Registering `DatabaseConfig` only in the importing `AppModule`'s `providers` is insufficient: the async child module can see only its local tokens, exports from its own imports, global module exports, and bootstrap runtime providers.
+Export injected dependencies from an imported `@Global()` module as above, or supply them as bootstrap runtime providers.
+
+NestJS `imports`, `useClass`, and `useExisting` are not `forRootAsync(...)` compatibility fields. Resolve their configuration, class construction, and provider aliases at application bootstrap or through explicit fluo provider registration, then pass the ready dependencies through `inject`.
+
+Set `strictTransactions: true` whenever migrated business work requires rollback atomicity. With its default `false` value, fluo runs the callback directly when the registered client does not expose interactive `$transaction(...)`, so `@Transaction()` and `requestTransaction(...)` do not provide rollback in that case.
+
 ### GraphQL Resolver Migration
 
 GraphQL migration keeps schema and discovery wiring explicit. Register every resolver class as a provider or controller in an authored module so it is discoverable from the compiled module graph. `GraphqlModule.forRoot({ resolvers: [...] })` does not register those classes; when supplied, `resolvers` filters discovery to that allowlist. Omit `resolvers` or pass an empty list to discover every decorated resolver class already registered as a provider or controller. Neither TypeScript return types nor NestJS design metadata register providers or build output types.
@@ -900,6 +947,7 @@ When `CqrsModule.forRoot({ eventBus: { publish: { waitForHandlers: false } } })`
 Create the concrete connection and compile models in the application before registering that connection with `MongooseModule`. Use `MongooseConnection.model(...)` for the supported session-aware model facade operations. When migrating a NestJS service that saves an already-loaded Mongoose document, use `MongooseConnection.saveDocument(...)` inside the explicit transaction boundary:
 
 ```ts
+@Inject(MongooseConnection)
 class ProfileService {
   constructor(private readonly conn: MongooseConnection) {}
 

--- a/packages/mongoose/README.ko.md
+++ b/packages/mongoose/README.ko.md
@@ -13,6 +13,7 @@
 - [라이프사이클과 종료](#라이프사이클과-종료)
 - [공통 패턴](#공통-패턴)
   - [서비스 트랜잭션 경계 (@Transaction)](#서비스-트랜잭션-경계-transaction)
+  - [기존 문서 저장](#기존-문서-저장)
   - [요청 트랜잭션 인터셉터 호환성](#요청-트랜잭션-인터셉터-호환성)
   - [수동 트랜잭션과 currentSession()](#수동-트랜잭션과-currentsession)
 - [공개 API](#공개-api)
@@ -121,19 +122,18 @@ export class UserService {
 
 `@Transaction()` 메서드 호출은 재진입(reentrant)이 가능합니다. 데코레이터가 적용된 메서드가 다른 데코레이터 적용 메서드를 호출하더라도 하나의 동일한 MongoDB 세션 안에서 실행됩니다. 참고로 v1에서 `doc.save()`는 자동으로 세션을 주입하지 않으므로, 자동 트랜잭션 참여가 필요하다면 지원되는 facade 작업(`model.create()`, `model.find()`, `model.findOne()`, `model.aggregate()`, `model.bulkWrite()`)을 사용하세요.
 
-`@Transaction()`은 `this.conn`, transaction-capable한 decorated instance 자체, 또는 하나뿐인 중첩 `this.*.conn` collaborator를 해석합니다. 임의의 connection field를 선택하지는 않습니다. 서비스가 여러 connection을 소유하거나 다른 field에 connection을 저장하는 경우에는 경계를 명시적으로 선택하세요.
+### 기존 문서 저장
+
+기존 Mongoose 문서를 활성 `@Transaction()`, `transaction()`, `requestTransaction()` 경계 안에서 저장해야 하면 opt-in `MongooseConnection.saveDocument(...)` helper를 사용하세요.
 
 ```ts
-@Inject(MongooseConnection)
-export class AnalyticsService {
-  constructor(private readonly analyticsConnection: MongooseConnection) {}
-
-  @Transaction((self: AnalyticsService) => self.analyticsConnection)
-  async rebuildReports() {
-    // 추론된 connection 대신 analyticsConnection을 사용합니다.
-  }
+@Transaction()
+async rename(document: UserDocument) {
+  return this.conn.saveDocument(document, { validateBeforeSave: false });
 }
 ```
+
+helper는 native Mongoose save option을 전달하고 ambient session을 붙인 뒤 동일한 document instance를 반환합니다. 활성 트랜잭션 밖에서는 fail-closed하며, 실수로 현재 트랜잭션을 벗어나지 않도록 `{ session: null }` 또는 다른 명시적 session을 거부합니다. document, prototype, model cache를 patch하지 않으므로 `doc.save()` 직접 호출은 계속 native Mongoose 동작이며 자동 session을 받지 않습니다.
 
 ### 요청 트랜잭션 인터셉터 호환성
 
@@ -190,6 +190,7 @@ await this.conn.transaction(async () => {
 
 ## 공개 API
 
+- `MongooseConnection.saveDocument(document, options?)` — native save option과 document identity를 보존하면서 현재 트랜잭션 session으로 기존 문서를 명시적으로 저장합니다.
 - `MongooseModule.forRoot(options)` / `MongooseModule.forRootAsync(options)`
 - `MongooseConnection`
 - `MongooseConnection.createPlatformStatusSnapshot()` — platform observability surface를 위해 health/readiness, resource ownership, 활성 request/session drain 수, strict transaction 지원 진단을 보고합니다.

--- a/packages/mongoose/README.ko.md
+++ b/packages/mongoose/README.ko.md
@@ -130,6 +130,20 @@ export class UserService {
 
 `@Transaction()` 메서드 호출은 재진입(reentrant)이 가능합니다. 데코레이터가 적용된 메서드가 다른 데코레이터 적용 메서드를 호출하더라도 하나의 동일한 MongoDB 세션 안에서 실행됩니다. 참고로 v1에서 `doc.save()`는 자동으로 세션을 주입하지 않으므로, 자동 트랜잭션 참여가 필요하다면 지원되는 facade 작업(`model.create()`, `model.find()`, `model.findOne()`, `model.aggregate()`, `model.bulkWrite()`)을 사용하세요.
 
+`@Transaction()`은 `this.conn`, transaction-capable한 decorated instance 자체, 또는 하나뿐인 중첩 `this.*.conn` collaborator를 해석합니다. 임의의 connection field를 선택하지는 않습니다. 서비스가 여러 connection을 소유하거나 다른 field에 connection을 저장하는 경우에는 경계를 명시적으로 선택하세요.
+
+```ts
+@Inject(MongooseConnection)
+export class AnalyticsService {
+  constructor(private readonly analyticsConnection: MongooseConnection) {}
+
+  @Transaction((self: AnalyticsService) => self.analyticsConnection)
+  async rebuildReports() {
+    // 추론된 connection 대신 analyticsConnection을 사용합니다.
+  }
+}
+```
+
 ### 기존 문서 저장
 
 <!-- fluo-mongoose-save-document-contract: opt-in, active-session, save-compatible-document -->

--- a/packages/mongoose/README.ko.md
+++ b/packages/mongoose/README.ko.md
@@ -87,7 +87,15 @@ Request cancellation 또는 shutdown이 callback 시작 후 boundary를 abort하
 import { Inject } from '@fluojs/core';
 import { MongooseConnection, Transaction, type MongooseModelFacade } from '@fluojs/mongoose';
 
-type UserDocument = { readonly _id: string; readonly name: string };
+type UserDocumentSaveOptions = {
+  readonly validateBeforeSave?: boolean;
+  readonly session?: object | null;
+};
+type UserDocument = {
+  readonly _id: string;
+  readonly name: string;
+  save(options?: UserDocumentSaveOptions): Promise<UserDocument>;
+};
 type UserCreateModel = MongooseModelFacade<Promise<readonly [UserDocument]>>;
 type ProfileCreateModel = MongooseModelFacade<Promise<readonly { readonly userId: string }[]>>;
 
@@ -123,6 +131,8 @@ export class UserService {
 `@Transaction()` 메서드 호출은 재진입(reentrant)이 가능합니다. 데코레이터가 적용된 메서드가 다른 데코레이터 적용 메서드를 호출하더라도 하나의 동일한 MongoDB 세션 안에서 실행됩니다. 참고로 v1에서 `doc.save()`는 자동으로 세션을 주입하지 않으므로, 자동 트랜잭션 참여가 필요하다면 지원되는 facade 작업(`model.create()`, `model.find()`, `model.findOne()`, `model.aggregate()`, `model.bulkWrite()`)을 사용하세요.
 
 ### 기존 문서 저장
+
+<!-- fluo-mongoose-save-document-contract: opt-in, active-session, save-compatible-document -->
 
 기존 Mongoose 문서를 활성 `@Transaction()`, `transaction()`, `requestTransaction()` 경계 안에서 저장해야 하면 opt-in `MongooseConnection.saveDocument(...)` helper를 사용하세요.
 

--- a/packages/mongoose/README.md
+++ b/packages/mongoose/README.md
@@ -13,6 +13,7 @@ Mongoose integration for fluo with session-aware transaction handling and lifecy
 - [Lifecycle and Shutdown](#lifecycle-and-shutdown)
 - [Common Patterns](#common-patterns)
   - [Service Transaction Boundary (@Transaction)](#service-transaction-boundary-transaction)
+  - [Saving an Existing Document](#saving-an-existing-document)
   - [Request Transaction Interceptor Compatibility](#request-transaction-interceptor-compatibility)
   - [Manual Transactions and currentSession()](#manual-transactions-and-currentsession)
 - [Public API](#public-api)
@@ -118,19 +119,18 @@ export class UserService {
 
 Calls to `@Transaction()` methods are reentrant. If a decorated method calls another decorated method, they share the same underlying MongoDB session. Note that `doc.save()` is not automatically session-aware in v1; use the supported facade operations (`model.create()`, `model.find()`, `model.findOne()`, `model.aggregate()`, or `model.bulkWrite()`) for automatic transaction participation.
 
-`@Transaction()` resolves `this.conn`, the decorated instance when it is transaction-capable, or one unique nested `this.*.conn` collaborator. It does not select arbitrary connection fields. When a service owns multiple connections or stores its connection elsewhere, select the boundary explicitly:
+### Saving an Existing Document
+
+Use the opt-in `MongooseConnection.saveDocument(...)` helper when an existing Mongoose document must save inside an active `@Transaction()`, `transaction()`, or `requestTransaction()` boundary:
 
 ```ts
-@Inject(MongooseConnection)
-export class AnalyticsService {
-  constructor(private readonly analyticsConnection: MongooseConnection) {}
-
-  @Transaction((self: AnalyticsService) => self.analyticsConnection)
-  async rebuildReports() {
-    // Uses analyticsConnection rather than an inferred connection.
-  }
+@Transaction()
+async rename(document: UserDocument) {
+  return this.conn.saveDocument(document, { validateBeforeSave: false });
 }
 ```
+
+The helper forwards native Mongoose save options, attaches the ambient session, and returns the same document instance. It fails closed outside an active transaction and rejects `{ session: null }` or a different explicit session so a save cannot leave the current transaction accidentally. It never patches documents, prototypes, or model caches: calling `doc.save()` directly remains native Mongoose behavior and does not receive an automatic session.
 
 ### Request Transaction Interceptor Compatibility
 
@@ -187,6 +187,7 @@ For supported facade methods, fluo preserves existing Mongoose operation options
 
 ## Public API
 
+- `MongooseConnection.saveDocument(document, options?)` — explicitly saves an existing document with the current transaction session while preserving native save options and document identity.
 - `MongooseModule.forRoot(options)` / `MongooseModule.forRootAsync(options)`
 - `MongooseConnection`
 - `MongooseConnection.createPlatformStatusSnapshot()` — reports health/readiness, resource ownership, active request/session drain counts, and strict transaction support diagnostics for platform observability surfaces.

--- a/packages/mongoose/README.md
+++ b/packages/mongoose/README.md
@@ -127,6 +127,20 @@ export class UserService {
 
 Calls to `@Transaction()` methods are reentrant. If a decorated method calls another decorated method, they share the same underlying MongoDB session. Note that `doc.save()` is not automatically session-aware in v1; use the supported facade operations (`model.create()`, `model.find()`, `model.findOne()`, `model.aggregate()`, or `model.bulkWrite()`) for automatic transaction participation.
 
+`@Transaction()` resolves `this.conn`, the decorated instance when it is transaction-capable, or one unique nested `this.*.conn` collaborator. It does not select arbitrary connection fields. When a service owns multiple connections or stores its connection elsewhere, select the boundary explicitly:
+
+```ts
+@Inject(MongooseConnection)
+export class AnalyticsService {
+  constructor(private readonly analyticsConnection: MongooseConnection) {}
+
+  @Transaction((self: AnalyticsService) => self.analyticsConnection)
+  async rebuildReports() {
+    // Uses analyticsConnection rather than an inferred connection.
+  }
+}
+```
+
 ### Saving an Existing Document
 
 <!-- fluo-mongoose-save-document-contract: opt-in, active-session, save-compatible-document -->

--- a/packages/mongoose/README.md
+++ b/packages/mongoose/README.md
@@ -84,7 +84,15 @@ The `@Transaction()` decorator is the recommended way to define transaction boun
 import { Inject } from '@fluojs/core';
 import { MongooseConnection, Transaction, type MongooseModelFacade } from '@fluojs/mongoose';
 
-type UserDocument = { readonly _id: string; readonly name: string };
+type UserDocumentSaveOptions = {
+  readonly validateBeforeSave?: boolean;
+  readonly session?: object | null;
+};
+type UserDocument = {
+  readonly _id: string;
+  readonly name: string;
+  save(options?: UserDocumentSaveOptions): Promise<UserDocument>;
+};
 type UserCreateModel = MongooseModelFacade<Promise<readonly [UserDocument]>>;
 type ProfileCreateModel = MongooseModelFacade<Promise<readonly { readonly userId: string }[]>>;
 
@@ -120,6 +128,8 @@ export class UserService {
 Calls to `@Transaction()` methods are reentrant. If a decorated method calls another decorated method, they share the same underlying MongoDB session. Note that `doc.save()` is not automatically session-aware in v1; use the supported facade operations (`model.create()`, `model.find()`, `model.findOne()`, `model.aggregate()`, or `model.bulkWrite()`) for automatic transaction participation.
 
 ### Saving an Existing Document
+
+<!-- fluo-mongoose-save-document-contract: opt-in, active-session, save-compatible-document -->
 
 Use the opt-in `MongooseConnection.saveDocument(...)` helper when an existing Mongoose document must save inside an active `@Transaction()`, `transaction()`, or `requestTransaction()` boundary:
 

--- a/packages/mongoose/src/connection.ts
+++ b/packages/mongoose/src/connection.ts
@@ -241,6 +241,31 @@ export class MongooseConnection<TConnection extends MongooseConnectionLike = Mon
   }
 
   /**
+   * Saves a Mongoose document with the active transaction session.
+   *
+   * This opt-in helper preserves the document instance and forwards caller-provided save options.
+   * It does not patch document instances, prototypes, or model caches.
+   *
+   * @typeParam TSaveOptions Options accepted by the document's native `save()` method.
+   * @typeParam TDocument Mongoose document-like value being saved.
+   * @param document Existing Mongoose document to save.
+   * @param options Native Mongoose save options to preserve while attaching the ambient session.
+   * @returns The same document instance after its native save operation completes.
+   * @throws When called outside an active transaction or with a conflicting explicit session.
+   */
+  async saveDocument<
+    TSaveOptions extends object,
+    TDocument extends { save(options?: TSaveOptions): Promise<TDocument> },
+  >(document: TDocument, options?: TSaveOptions): Promise<TDocument> {
+    const session = this.currentSession();
+    if (!session) {
+      throw new Error('Mongoose document saves require an active transaction session.');
+    }
+
+    return document.save(resolveSessionOptions(options, session) as TSaveOptions);
+  }
+
+  /**
    * Returns a model from the root connection, injecting the ambient transaction session into conservative operations.
    *
    * @typeParam TModel Consumer-defined facade result contract for the wrapped model.

--- a/packages/mongoose/src/transaction-decorator.red.test.ts
+++ b/packages/mongoose/src/transaction-decorator.red.test.ts
@@ -30,6 +30,12 @@ type TestMongooseOperationOptions = {
   timestamps?: boolean;
 };
 
+type TestMongooseDocumentSaveOptions = {
+  session?: MongooseSessionLike | null;
+  timestamps?: boolean;
+  validateBeforeSave?: boolean;
+};
+
 function createFakeConnection(
   events: string[],
   session: MongooseSessionLike,
@@ -1084,10 +1090,75 @@ describe('@fluojs/mongoose Transaction decorator contract (RED - pending Task 9 
       }
     });
 
-    // v1: doc.save() auto-session is NOT in scope
-    it.skip('doc.save() auto-session — excluded from v1 (not a requirement)', () => {
-      // v1: doc.save() auto-session is NOT in scope
-      // This test is intentionally skipped; doc.save() interception is deferred to a future version.
+    it('saveDocument() preserves document identity and forwards caller options with the ambient session', async () => {
+      const events: string[] = [];
+      const session = createFakeSession(events);
+      const conn = new MongooseConnection(createFakeConnection(events, session));
+      const savedOptions: TestMongooseDocumentSaveOptions[] = [];
+      const document = {
+        async save(options?: TestMongooseDocumentSaveOptions) {
+          savedOptions.push(options ?? {});
+          return document;
+        },
+      };
+
+      const saved = await conn.transaction(() =>
+        conn.saveDocument(document, { timestamps: false, validateBeforeSave: false }),
+      );
+
+      expect(saved).toBe(document);
+      expect(savedOptions).toEqual([
+        { session, timestamps: false, validateBeforeSave: false },
+      ]);
+    });
+
+    it('saveDocument() fails closed without an ambient transaction session', async () => {
+      const events: string[] = [];
+      const session = createFakeSession(events);
+      const conn = new MongooseConnection(createFakeConnection(events, session));
+      const document = {
+        async save() {
+          events.push('document:save');
+          return document;
+        },
+      };
+
+      await expect(conn.saveDocument(document)).rejects.toThrow(
+        'Mongoose document saves require an active transaction session.',
+      );
+      expect(events).not.toContain('document:save');
+    });
+
+    it('saveDocument() propagates document validation errors unchanged', async () => {
+      const events: string[] = [];
+      const session = createFakeSession(events);
+      const conn = new MongooseConnection(createFakeConnection(events, session));
+      const validationError = new Error('validation failed');
+      const document = {
+        async save(_options?: TestMongooseDocumentSaveOptions) {
+          throw validationError;
+        },
+      };
+
+      await expect(conn.transaction(() => conn.saveDocument(document))).rejects.toBe(validationError);
+    });
+
+    it('saveDocument() rejects an explicit session that conflicts with the ambient transaction', async () => {
+      const events: string[] = [];
+      const session = createFakeSession(events);
+      const differentSession = { ...createFakeSession(events), id: 'session-2' };
+      const conn = new MongooseConnection(createFakeConnection(events, session));
+      const document = {
+        async save(_options?: TestMongooseDocumentSaveOptions) {
+          events.push('document:save');
+          return document;
+        },
+      };
+
+      await expect(
+        conn.transaction(() => conn.saveDocument(document, { session: differentSession })),
+      ).rejects.toThrow('Explicit session conflicts with ambient transaction session');
+      expect(events).not.toContain('document:save');
     });
   });
 

--- a/tooling/governance/mongoose-nestjs-migration-docs.mjs
+++ b/tooling/governance/mongoose-nestjs-migration-docs.mjs
@@ -3,76 +3,166 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
-
-const requirements = [
-  [
-    'docs/getting-started/migrate-from-nestjs.md',
-    [
-      '## Mongoose Root and Feature Migration',
-      'MongooseConnection.saveDocument(...)',
-      'return this.conn.saveDocument(document, { validateBeforeSave: false });',
-      '`MongooseConnection.saveDocument(...)` is opt-in',
-      '`doc.save()` itself is unchanged',
-    ],
-  ],
-  [
-    'docs/getting-started/migrate-from-nestjs.ko.md',
-    [
-      '## Mongoose 루트와 feature 마이그레이션',
-      'MongooseConnection.saveDocument(...)',
-      'return this.conn.saveDocument(document, { validateBeforeSave: false });',
-      '`MongooseConnection.saveDocument(...)`는 opt-in입니다.',
-      '`doc.save()` 자체는 변경되지 않으므로',
-    ],
-  ],
-  [
-    'docs/architecture/transactions.md',
-    [
-      '| Mongoose document save helper |',
-      '`MongooseConnection.saveDocument(document, options?)`',
-      'fails closed outside a transaction',
-      'leaves native `doc.save()` unmodified',
-    ],
-  ],
-  [
-    'docs/architecture/transactions.ko.md',
-    [
-      '| Mongoose 문서 저장 helper |',
-      '`MongooseConnection.saveDocument(document, options?)`',
-      '트랜잭션 밖에서는 fail-closed',
-      'native `doc.save()`는 수정하지 않습니다',
-    ],
-  ],
-  [
-    'docs/CONTEXT.md',
-    [
-      'NestJS Mongoose migration and transaction semantics are documented',
-      '`MongooseConnection.saveDocument(...)` is the opt-in path',
-      'leaves direct `doc.save()` unchanged',
-    ],
-  ],
-  [
-    'docs/CONTEXT.ko.md',
-    [
-      'NestJS Mongoose 마이그레이션과 트랜잭션 의미론은',
-      '`MongooseConnection.saveDocument(...)`는 기존 document의 opt-in 경로',
-      'direct `doc.save()`는 변경하지 않습니다',
-    ],
-  ],
+const contractFields = [
+  'application-owned-connection',
+  'ambient-session-merge',
+  'preserves-operation-options',
+  'strict-fail-open',
+  'explicit-target',
 ];
+const contractMarkerPatterns = [
+  /^<!-- fluo-mongoose-contract: ([a-z-]+(?:, [a-z-]+)*) -->$/gmu,
+  /^\{\/\* fluo-mongoose-contract: ([a-z-]+(?:, [a-z-]+)*) \*\/\}$/gmu,
+];
+const documentationRequirements = [
+  {
+    heading: '## Mongoose Root and Feature Migration',
+    path: 'docs/getting-started/migrate-from-nestjs.md',
+    requiresExplicitDiExample: true,
+  },
+  {
+    heading: '## Mongoose 루트와 feature 마이그레이션',
+    path: 'docs/getting-started/migrate-from-nestjs.ko.md',
+    requiresExplicitDiExample: true,
+  },
+  {
+    heading: '## Context Resolution Rules',
+    path: 'docs/architecture/transactions.md',
+  },
+  {
+    heading: '## 문맥 해석 규칙',
+    path: 'docs/architecture/transactions.ko.md',
+  },
+  {
+    heading: '## Migration Reference',
+    path: 'docs/CONTEXT.md',
+  },
+  {
+    heading: '## Migration Reference',
+    path: 'docs/CONTEXT.ko.md',
+  },
+  {
+    heading: '# @fluojs/mongoose',
+    path: 'packages/mongoose/README.md',
+    requiresExplicitDiExample: true,
+  },
+  {
+    heading: '# @fluojs/mongoose',
+    path: 'packages/mongoose/README.ko.md',
+    requiresExplicitDiExample: true,
+  },
+  {
+    heading: '## Mongoose',
+    path: 'apps/docs/content/docs/guides/persistence.mdx',
+  },
+  {
+    heading: '## Mongoose',
+    path: 'apps/docs/content/docs/guides/persistence.ko.mdx',
+  },
+  {
+    heading: '# Chapter 19. MongoDB and Mongoose',
+    path: 'book/intermediate/ch19-mongoose.md',
+  },
+  {
+    heading: '# Chapter 19. MongoDB and Mongoose',
+    path: 'book/intermediate/ch19-mongoose.ko.md',
+  },
+];
+const saveDocumentContractMarker =
+  '<!-- fluo-mongoose-save-document-contract: opt-in, active-session, save-compatible-document -->';
+const saveDocumentRequirements = [
+  {
+    path: 'packages/mongoose/README.md',
+    typeConstraint: '  save(options?: UserDocumentSaveOptions): Promise<UserDocument>;',
+  },
+  {
+    path: 'packages/mongoose/README.ko.md',
+    typeConstraint: '  save(options?: UserDocumentSaveOptions): Promise<UserDocument>;',
+  },
+];
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(`Platform consistency governance check failed: ${message}`);
+  }
+}
+
+function enforceUniqueLine(content, line, relativePath) {
+  const matches = content.split('\n').filter((candidate) => candidate === line);
+  assert(
+    matches.length === 1,
+    `${relativePath} must include exactly one ${line}; found ${matches.length}.`,
+  );
+}
+
+function enforceMongooseContractMarker(content, relativePath) {
+  const markers = contractMarkerPatterns.flatMap((pattern) => [...content.matchAll(pattern)]);
+  assert(
+    markers.length === 1,
+    `${relativePath} must include exactly one fluo-mongoose-contract marker; found ${markers.length}.`,
+  );
+
+  const fields = markers[0][1].split(', ');
+  assert(
+    fields.length === contractFields.length &&
+      new Set(fields).size === contractFields.length &&
+      contractFields.every((field) => fields.includes(field)),
+    `${relativePath} must declare each machine-consumed Mongoose contract field exactly once.`,
+  );
+}
+
+function enforceExplicitDiExample(content, relativePath) {
+  const examples = [...content.matchAll(/```(?:ts|typescript)\s*\n([\s\S]*?)```/gu)]
+    .map((match) => match[1] ?? '')
+    .filter((example) => example.includes('class UserRepository') && example.includes('class UserService'));
+  assert(
+    examples.length === 1,
+    `${relativePath} must include exactly one fenced UserRepository/UserService migration example.`,
+  );
+
+  const example = examples[0];
+  const repositoryMatches = [
+    ...example.matchAll(/@Inject\(MongooseConnection\)\s*\n(?:export\s+)?class UserRepository\b/gu),
+  ];
+  const serviceMatches = [
+    ...example.matchAll(/@Inject\(UserRepository\)\s*\n(?:export\s+)?class UserService\b/gu),
+  ];
+  assert(
+    repositoryMatches.length === 1 && serviceMatches.length === 1,
+    `${relativePath} must declare explicit MongooseConnection and UserRepository constructor tokens.`,
+  );
+  assert(
+    (repositoryMatches[0].index ?? 0) < (serviceMatches[0].index ?? 0),
+    `${relativePath} must declare UserRepository before UserService references its token.`,
+  );
+}
+
+function enforceSaveDocumentContract(content, requirement) {
+  enforceUniqueLine(content, saveDocumentContractMarker, requirement.path);
+  const typeConstraints = content
+    .split('\n')
+    .filter((candidate) => candidate === requirement.typeConstraint);
+  assert(
+    typeConstraints.length === 1,
+    `${requirement.path} must include exactly one save-compatible document type constraint; found ${typeConstraints.length}.`,
+  );
+}
 
 export function enforceMongooseNestjsMigrationDocs(
   readText = (relativePath) => readFileSync(join(repoRoot, relativePath), 'utf8'),
 ) {
-  for (const [relativePath, requiredMarkers] of requirements) {
-    const content = readText(relativePath);
-    const missingMarkers = requiredMarkers.filter((marker) => !content.includes(marker));
+  for (const requirement of documentationRequirements) {
+    const content = readText(requirement.path);
+    enforceMongooseContractMarker(content, requirement.path);
+    enforceUniqueLine(content, requirement.heading, requirement.path);
 
-    if (missingMarkers.length > 0) {
-      throw new Error(
-        `Platform consistency governance check failed: ${relativePath} must keep the Mongoose document-save migration contract synchronized; missing: ${missingMarkers.join(', ')}.`,
-      );
+    if (requirement.requiresExplicitDiExample) {
+      enforceExplicitDiExample(content, requirement.path);
     }
+  }
+
+  for (const requirement of saveDocumentRequirements) {
+    enforceSaveDocumentContract(readText(requirement.path), requirement);
   }
 }
 

--- a/tooling/governance/mongoose-nestjs-migration-docs.mjs
+++ b/tooling/governance/mongoose-nestjs-migration-docs.mjs
@@ -80,6 +80,10 @@ const saveDocumentRequirements = [
     typeConstraint: '  save(options?: UserDocumentSaveOptions): Promise<UserDocument>;',
   },
 ];
+const saveDocumentMigrationRequirements = [
+  { path: 'docs/getting-started/migrate-from-nestjs.md' },
+  { path: 'docs/getting-started/migrate-from-nestjs.ko.md' },
+];
 
 function assert(condition, message) {
   if (!condition) {
@@ -148,6 +152,24 @@ function enforceSaveDocumentContract(content, requirement) {
   );
 }
 
+function enforceSaveDocumentMigrationExample(content, requirement) {
+  const examples = [...content.matchAll(/```(?:ts|typescript)\s*\n([\s\S]*?)```/gu)]
+    .map((match) => match[1] ?? '')
+    .filter((example) => example.includes('class ProfileService') && example.includes('saveDocument'));
+  assert(
+    examples.length === 1,
+    `${requirement.path} must include exactly one fenced ProfileService saveDocument migration example.`,
+  );
+
+  const injectionMatches = [
+    ...examples[0].matchAll(/@Inject\(MongooseConnection\)\s*\n(?:export\s+)?class ProfileService\b/gu),
+  ];
+  assert(
+    injectionMatches.length === 1,
+    `${requirement.path} must declare MongooseConnection explicitly for ProfileService.`,
+  );
+}
+
 export function enforceMongooseNestjsMigrationDocs(
   readText = (relativePath) => readFileSync(join(repoRoot, relativePath), 'utf8'),
 ) {
@@ -163,6 +185,10 @@ export function enforceMongooseNestjsMigrationDocs(
 
   for (const requirement of saveDocumentRequirements) {
     enforceSaveDocumentContract(readText(requirement.path), requirement);
+  }
+
+  for (const requirement of saveDocumentMigrationRequirements) {
+    enforceSaveDocumentMigrationExample(readText(requirement.path), requirement);
   }
 }
 

--- a/tooling/governance/mongoose-nestjs-migration-docs.mjs
+++ b/tooling/governance/mongoose-nestjs-migration-docs.mjs
@@ -3,138 +3,75 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
-const contractFields = [
-  'application-owned-connection',
-  'ambient-session-merge',
-  'preserves-operation-options',
-  'strict-fail-open',
-  'explicit-target',
+
+const requirements = [
+  [
+    'docs/getting-started/migrate-from-nestjs.md',
+    [
+      '## Mongoose Root and Feature Migration',
+      'MongooseConnection.saveDocument(...)',
+      'return this.conn.saveDocument(document, { validateBeforeSave: false });',
+      '`MongooseConnection.saveDocument(...)` is opt-in',
+      '`doc.save()` itself is unchanged',
+    ],
+  ],
+  [
+    'docs/getting-started/migrate-from-nestjs.ko.md',
+    [
+      '## Mongoose 루트와 feature 마이그레이션',
+      'MongooseConnection.saveDocument(...)',
+      'return this.conn.saveDocument(document, { validateBeforeSave: false });',
+      '`MongooseConnection.saveDocument(...)`는 opt-in입니다.',
+      '`doc.save()` 자체는 변경되지 않으므로',
+    ],
+  ],
+  [
+    'docs/architecture/transactions.md',
+    [
+      '| Mongoose document save helper |',
+      '`MongooseConnection.saveDocument(document, options?)`',
+      'fails closed outside a transaction',
+      'leaves native `doc.save()` unmodified',
+    ],
+  ],
+  [
+    'docs/architecture/transactions.ko.md',
+    [
+      '| Mongoose 문서 저장 helper |',
+      '`MongooseConnection.saveDocument(document, options?)`',
+      '트랜잭션 밖에서는 fail-closed',
+      'native `doc.save()`는 수정하지 않습니다',
+    ],
+  ],
+  [
+    'docs/CONTEXT.md',
+    [
+      'NestJS Mongoose migration and transaction semantics are documented',
+      '`MongooseConnection.saveDocument(...)` is the opt-in path',
+      'leaves direct `doc.save()` unchanged',
+    ],
+  ],
+  [
+    'docs/CONTEXT.ko.md',
+    [
+      'NestJS Mongoose 마이그레이션과 트랜잭션 의미론은',
+      '`MongooseConnection.saveDocument(...)`는 기존 document의 opt-in 경로',
+      'direct `doc.save()`는 변경하지 않습니다',
+    ],
+  ],
 ];
-const contractMarkerPatterns = [
-  /^<!-- fluo-mongoose-contract: ([a-z-]+(?:, [a-z-]+)*) -->$/gmu,
-  /^\{\/\* fluo-mongoose-contract: ([a-z-]+(?:, [a-z-]+)*) \*\/\}$/gmu,
-];
-const documentationRequirements = [
-  {
-    heading: '## Mongoose Root and Feature Migration',
-    path: 'docs/getting-started/migrate-from-nestjs.md',
-    requiresExplicitDiExample: true,
-  },
-  {
-    heading: '## Mongoose 루트와 feature 마이그레이션',
-    path: 'docs/getting-started/migrate-from-nestjs.ko.md',
-    requiresExplicitDiExample: true,
-  },
-  {
-    heading: '## Context Resolution Rules',
-    path: 'docs/architecture/transactions.md',
-  },
-  {
-    heading: '## 문맥 해석 규칙',
-    path: 'docs/architecture/transactions.ko.md',
-  },
-  {
-    heading: '## Migration Reference',
-    path: 'docs/CONTEXT.md',
-  },
-  {
-    heading: '## Migration Reference',
-    path: 'docs/CONTEXT.ko.md',
-  },
-  {
-    heading: '# @fluojs/mongoose',
-    path: 'packages/mongoose/README.md',
-    requiresExplicitDiExample: true,
-  },
-  {
-    heading: '# @fluojs/mongoose',
-    path: 'packages/mongoose/README.ko.md',
-    requiresExplicitDiExample: true,
-  },
-  {
-    heading: '## Mongoose',
-    path: 'apps/docs/content/docs/guides/persistence.mdx',
-  },
-  {
-    heading: '## Mongoose',
-    path: 'apps/docs/content/docs/guides/persistence.ko.mdx',
-  },
-  {
-    heading: '# Chapter 19. MongoDB and Mongoose',
-    path: 'book/intermediate/ch19-mongoose.md',
-  },
-  {
-    heading: '# Chapter 19. MongoDB and Mongoose',
-    path: 'book/intermediate/ch19-mongoose.ko.md',
-  },
-];
-
-function assert(condition, message) {
-  if (!condition) {
-    throw new Error(`Platform consistency governance check failed: ${message}`);
-  }
-}
-
-function enforceUniqueLine(content, line, relativePath) {
-  const matches = content.split('\n').filter((candidate) => candidate === line);
-  assert(
-    matches.length === 1,
-    `${relativePath} must include exactly one ${line}; found ${matches.length}.`,
-  );
-}
-
-function enforceMongooseContractMarker(content, relativePath) {
-  const markers = contractMarkerPatterns.flatMap((pattern) => [...content.matchAll(pattern)]);
-  assert(
-    markers.length === 1,
-    `${relativePath} must include exactly one fluo-mongoose-contract marker; found ${markers.length}.`,
-  );
-
-  const fields = markers[0][1].split(', ');
-  assert(
-    fields.length === contractFields.length &&
-      new Set(fields).size === contractFields.length &&
-      contractFields.every((field) => fields.includes(field)),
-    `${relativePath} must declare each machine-consumed Mongoose contract field exactly once.`,
-  );
-}
-
-function enforceExplicitDiExample(content, relativePath) {
-  const examples = [...content.matchAll(/```(?:ts|typescript)\s*\n([\s\S]*?)```/gu)]
-    .map((match) => match[1] ?? '')
-    .filter((example) => example.includes('class UserRepository') && example.includes('class UserService'));
-  assert(
-    examples.length === 1,
-    `${relativePath} must include exactly one fenced UserRepository/UserService migration example.`,
-  );
-
-  const example = examples[0];
-  const repositoryMatches = [
-    ...example.matchAll(/@Inject\(MongooseConnection\)\s*\n(?:export\s+)?class UserRepository\b/gu),
-  ];
-  const serviceMatches = [
-    ...example.matchAll(/@Inject\(UserRepository\)\s*\n(?:export\s+)?class UserService\b/gu),
-  ];
-  assert(
-    repositoryMatches.length === 1 && serviceMatches.length === 1,
-    `${relativePath} must declare explicit MongooseConnection and UserRepository constructor tokens.`,
-  );
-  assert(
-    (repositoryMatches[0].index ?? 0) < (serviceMatches[0].index ?? 0),
-    `${relativePath} must declare UserRepository before UserService references its token.`,
-  );
-}
 
 export function enforceMongooseNestjsMigrationDocs(
   readText = (relativePath) => readFileSync(join(repoRoot, relativePath), 'utf8'),
 ) {
-  for (const requirement of documentationRequirements) {
-    const content = readText(requirement.path);
-    enforceMongooseContractMarker(content, requirement.path);
-    enforceUniqueLine(content, requirement.heading, requirement.path);
+  for (const [relativePath, requiredMarkers] of requirements) {
+    const content = readText(relativePath);
+    const missingMarkers = requiredMarkers.filter((marker) => !content.includes(marker));
 
-    if (requirement.requiresExplicitDiExample) {
-      enforceExplicitDiExample(content, requirement.path);
+    if (missingMarkers.length > 0) {
+      throw new Error(
+        `Platform consistency governance check failed: ${relativePath} must keep the Mongoose document-save migration contract synchronized; missing: ${missingMarkers.join(', ')}.`,
+      );
     }
   }
 }

--- a/tooling/governance/mongoose-nestjs-migration-docs.test.ts
+++ b/tooling/governance/mongoose-nestjs-migration-docs.test.ts
@@ -6,154 +6,40 @@ import { describe, expect, it } from 'vitest';
 import { enforceMongooseNestjsMigrationDocs } from './mongoose-nestjs-migration-docs.mjs';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
-const mongooseContract = 'fluo-mongoose-contract: application-owned-connection, ambient-session-merge, preserves-operation-options, strict-fail-open, explicit-target';
-const governedDocumentationPaths = [
-  'docs/getting-started/migrate-from-nestjs.md',
-  'docs/getting-started/migrate-from-nestjs.ko.md',
-  'docs/architecture/transactions.md',
-  'docs/architecture/transactions.ko.md',
-  'docs/CONTEXT.md',
-  'docs/CONTEXT.ko.md',
-  'packages/mongoose/README.md',
-  'packages/mongoose/README.ko.md',
-  'apps/docs/content/docs/guides/persistence.mdx',
-  'apps/docs/content/docs/guides/persistence.ko.mdx',
-  'book/intermediate/ch19-mongoose.md',
-  'book/intermediate/ch19-mongoose.ko.md',
-] as const;
-const migrationExamplePaths = [
-  'docs/getting-started/migrate-from-nestjs.md',
-  'docs/getting-started/migrate-from-nestjs.ko.md',
-] as const;
-const explicitDiExamplePaths = [
-  ...migrationExamplePaths,
-  'packages/mongoose/README.md',
-  'packages/mongoose/README.ko.md',
-] as const;
 
 function read(relativePath: string): string {
   return readFileSync(join(repoRoot, relativePath), 'utf8');
 }
 
-function mongooseContractMarkerFor(relativePath: string): string {
-  return relativePath.endsWith('.mdx')
-    ? `{/* ${mongooseContract} */}`
-    : `<!-- ${mongooseContract} -->`;
-}
-
-describe('NestJS Mongoose migration documentation', () => {
-  it('keeps the Mongoose migration and transaction contracts synchronized', () => {
-    // Given
+describe('NestJS Mongoose document-save migration documentation', () => {
+  it('keeps the Mongoose document-save migration and transaction contracts synchronized', () => {
     const runGovernanceGuard = () => enforceMongooseNestjsMigrationDocs();
 
-    // When / Then
     expect(runGovernanceGuard).not.toThrow();
   });
 
-  it.each(governedDocumentationPaths)(
-    'rejects a removed machine contract anchor in %s',
-    (driftedPath) => {
-      // Given
-      const readWithoutContractAnchor = (relativePath: string): string =>
-        relativePath === driftedPath
-          ? read(relativePath).replace(
-              mongooseContractMarkerFor(relativePath),
-              '[removed Mongoose contract anchor]',
-            )
-          : read(relativePath);
-
-      // When
-      const runGovernanceGuard = () => enforceMongooseNestjsMigrationDocs(readWithoutContractAnchor);
-
-      // Then
-      expect(runGovernanceGuard).toThrow(driftedPath);
-      expect(runGovernanceGuard).toThrow('fluo-mongoose-contract');
-    },
-  );
-
-  it.each(migrationExamplePaths)(
-    'rejects a duplicated marker or heading decoy in %s',
-    (driftedPath) => {
-      // Given
-      const readWithDuplicateMarker = (relativePath: string): string =>
-        relativePath === driftedPath
-          ? read(relativePath).replace(
-              mongooseContractMarkerFor(relativePath),
-              `${mongooseContractMarkerFor(relativePath)}\n${mongooseContractMarkerFor(relativePath)}`,
-            )
-          : read(relativePath);
-      const readWithHeadingDecoy = (relativePath: string): string =>
-        relativePath === driftedPath
-          ? read(relativePath).replace(/^## (Mongoose .+)$/mu, '### $1')
-          : read(relativePath);
-
-      // When
-      const runDuplicateMarkerGuard = () =>
-        enforceMongooseNestjsMigrationDocs(readWithDuplicateMarker);
-      const runHeadingDecoyGuard = () => enforceMongooseNestjsMigrationDocs(readWithHeadingDecoy);
-
-      // Then
-      expect(runDuplicateMarkerGuard).toThrow(driftedPath);
-      expect(runHeadingDecoyGuard).toThrow(driftedPath);
-    },
-  );
-
-  it.each(migrationExamplePaths)(
-    'requires both ambient-session merge and option-preservation anchors in %s',
-    (driftedPath) => {
-      // Given
-      const readWithoutAmbientSessionMerge = (relativePath: string): string =>
-        relativePath === driftedPath
-          ? read(relativePath).replace('ambient-session-merge', 'removed-session-merge')
-          : read(relativePath);
-      const readWithoutOptionPreservation = (relativePath: string): string =>
-        relativePath === driftedPath
-          ? read(relativePath).replace('preserves-operation-options', 'removed-option-preservation')
-          : read(relativePath);
-
-      // When
-      const runMergeGuard = () => enforceMongooseNestjsMigrationDocs(readWithoutAmbientSessionMerge);
-      const runPreservationGuard = () =>
-        enforceMongooseNestjsMigrationDocs(readWithoutOptionPreservation);
-
-      // Then
-      expect(runMergeGuard).toThrow(driftedPath);
-      expect(runPreservationGuard).toThrow(driftedPath);
-    },
-  );
-
   it.each([
-    [explicitDiExamplePaths[0], ''],
-    [explicitDiExamplePaths[1], ''],
-    [explicitDiExamplePaths[2], 'export '],
-    [explicitDiExamplePaths[3], 'export '],
-  ] as const)(
-    'rejects missing explicit DI or swapped declaration order in %s',
-    (driftedPath, exportPrefix) => {
-      // Given
-      const repositoryDecorator = `@Inject(MongooseConnection)\n${exportPrefix}class UserRepository`;
-      const serviceDecorator = `@Inject(UserRepository)\n${exportPrefix}class UserService`;
-      const readWithoutRepositoryDecorator = (relativePath: string): string =>
-        relativePath === driftedPath
-          ? read(relativePath).replace('@Inject(MongooseConnection)', '@Inject()')
-          : read(relativePath);
-      const readWithSwappedDeclarations = (relativePath: string): string =>
-        relativePath === driftedPath
-          ? read(relativePath)
-              .replace(repositoryDecorator, '[repository declaration]')
-              .replace(serviceDecorator, repositoryDecorator)
-              .replace('[repository declaration]', serviceDecorator)
-          : read(relativePath);
+    [
+      'docs/getting-started/migrate-from-nestjs.md',
+      '`MongooseConnection.saveDocument(...)` is opt-in',
+    ],
+    [
+      'docs/architecture/transactions.md',
+      '| Mongoose document save helper |',
+    ],
+    [
+      'docs/CONTEXT.md',
+      '`MongooseConnection.saveDocument(...)` is the opt-in path',
+    ],
+  ] as const)('rejects a removed Mongoose document-save contract anchor in %s', (driftedPath, requiredMarker) => {
+    const readWithoutContractAnchor = (relativePath: string): string =>
+      relativePath === driftedPath
+        ? read(relativePath).replace(requiredMarker, '[removed Mongoose document-save contract anchor]')
+        : read(relativePath);
 
-      // When
-      const runMissingDecoratorGuard = () =>
-        enforceMongooseNestjsMigrationDocs(readWithoutRepositoryDecorator);
-      const runSwappedDeclarationsGuard = () =>
-        enforceMongooseNestjsMigrationDocs(readWithSwappedDeclarations);
+    const runGovernanceGuard = () => enforceMongooseNestjsMigrationDocs(readWithoutContractAnchor);
 
-      // Then
-      expect(runMissingDecoratorGuard).toThrow(driftedPath);
-      expect(runSwappedDeclarationsGuard).toThrow(driftedPath);
-    },
-  );
+    expect(runGovernanceGuard).toThrow(driftedPath);
+    expect(runGovernanceGuard).toThrow(requiredMarker);
+  });
 });

--- a/tooling/governance/mongoose-nestjs-migration-docs.test.ts
+++ b/tooling/governance/mongoose-nestjs-migration-docs.test.ts
@@ -43,6 +43,16 @@ const saveDocumentRequirements = [
     typeConstraint: '  save(options?: UserDocumentSaveOptions): Promise<UserDocument>;',
   },
 ] as const;
+const saveDocumentMigrationRequirements = [
+  {
+    path: 'docs/getting-started/migrate-from-nestjs.md',
+    injection: '@Inject(MongooseConnection)\nclass ProfileService',
+  },
+  {
+    path: 'docs/getting-started/migrate-from-nestjs.ko.md',
+    injection: '@Inject(MongooseConnection)\nclass ProfileService',
+  },
+] as const;
 
 function read(relativePath: string): string {
   return readFileSync(join(repoRoot, relativePath), 'utf8');
@@ -213,6 +223,23 @@ describe('NestJS Mongoose migration documentation', () => {
       );
       expect(() => enforceMongooseNestjsMigrationDocs(readWithoutSaveCompatibleType)).toThrow(
         'save-compatible document type',
+      );
+    },
+  );
+
+  it.each(saveDocumentMigrationRequirements)(
+    'rejects missing explicit ProfileService MongooseConnection injection in $path',
+    ({ path: driftedPath, injection }) => {
+      const readWithoutProfileServiceInjection = (relativePath: string): string =>
+        relativePath === driftedPath
+          ? read(relativePath).replace(injection, 'class ProfileService')
+          : read(relativePath);
+
+      expect(() => enforceMongooseNestjsMigrationDocs(readWithoutProfileServiceInjection)).toThrow(
+        driftedPath,
+      );
+      expect(() => enforceMongooseNestjsMigrationDocs(readWithoutProfileServiceInjection)).toThrow(
+        'ProfileService',
       );
     },
   );

--- a/tooling/governance/mongoose-nestjs-migration-docs.test.ts
+++ b/tooling/governance/mongoose-nestjs-migration-docs.test.ts
@@ -6,40 +6,214 @@ import { describe, expect, it } from 'vitest';
 import { enforceMongooseNestjsMigrationDocs } from './mongoose-nestjs-migration-docs.mjs';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const mongooseContract =
+  'fluo-mongoose-contract: application-owned-connection, ambient-session-merge, preserves-operation-options, strict-fail-open, explicit-target';
+const governedDocumentationPaths = [
+  'docs/getting-started/migrate-from-nestjs.md',
+  'docs/getting-started/migrate-from-nestjs.ko.md',
+  'docs/architecture/transactions.md',
+  'docs/architecture/transactions.ko.md',
+  'docs/CONTEXT.md',
+  'docs/CONTEXT.ko.md',
+  'packages/mongoose/README.md',
+  'packages/mongoose/README.ko.md',
+  'apps/docs/content/docs/guides/persistence.mdx',
+  'apps/docs/content/docs/guides/persistence.ko.mdx',
+  'book/intermediate/ch19-mongoose.md',
+  'book/intermediate/ch19-mongoose.ko.md',
+] as const;
+const migrationExamplePaths = [
+  'docs/getting-started/migrate-from-nestjs.md',
+  'docs/getting-started/migrate-from-nestjs.ko.md',
+] as const;
+const explicitDiExamplePaths = [
+  ...migrationExamplePaths,
+  'packages/mongoose/README.md',
+  'packages/mongoose/README.ko.md',
+] as const;
+const saveDocumentContract =
+  'fluo-mongoose-save-document-contract: opt-in, active-session, save-compatible-document';
+const saveDocumentRequirements = [
+  {
+    path: 'packages/mongoose/README.md',
+    typeConstraint: '  save(options?: UserDocumentSaveOptions): Promise<UserDocument>;',
+  },
+  {
+    path: 'packages/mongoose/README.ko.md',
+    typeConstraint: '  save(options?: UserDocumentSaveOptions): Promise<UserDocument>;',
+  },
+] as const;
 
 function read(relativePath: string): string {
   return readFileSync(join(repoRoot, relativePath), 'utf8');
 }
 
-describe('NestJS Mongoose document-save migration documentation', () => {
-  it('keeps the Mongoose document-save migration and transaction contracts synchronized', () => {
-    const runGovernanceGuard = () => enforceMongooseNestjsMigrationDocs();
+function mongooseContractMarkerFor(relativePath: string): string {
+  return relativePath.endsWith('.mdx')
+    ? `{/* ${mongooseContract} */}`
+    : `<!-- ${mongooseContract} -->`;
+}
 
-    expect(runGovernanceGuard).not.toThrow();
+function saveDocumentContractMarker(): string {
+  return `<!-- ${saveDocumentContract} -->`;
+}
+
+describe('NestJS Mongoose migration documentation', () => {
+  it('keeps the Mongoose migration and transaction contracts synchronized', () => {
+    expect(() => enforceMongooseNestjsMigrationDocs()).not.toThrow();
   });
+
+  it.each(governedDocumentationPaths)(
+    'rejects a removed machine contract anchor in %s',
+    (driftedPath) => {
+      const readWithoutContractAnchor = (relativePath: string): string =>
+        relativePath === driftedPath
+          ? read(relativePath).replace(
+              mongooseContractMarkerFor(relativePath),
+              '[removed Mongoose contract anchor]',
+            )
+          : read(relativePath);
+
+      expect(() => enforceMongooseNestjsMigrationDocs(readWithoutContractAnchor)).toThrow(
+        driftedPath,
+      );
+      expect(() => enforceMongooseNestjsMigrationDocs(readWithoutContractAnchor)).toThrow(
+        'fluo-mongoose-contract',
+      );
+    },
+  );
+
+  it.each(migrationExamplePaths)(
+    'rejects a duplicated marker or heading decoy in %s',
+    (driftedPath) => {
+      const readWithDuplicateMarker = (relativePath: string): string =>
+        relativePath === driftedPath
+          ? read(relativePath).replace(
+              mongooseContractMarkerFor(relativePath),
+              `${mongooseContractMarkerFor(relativePath)}\n${mongooseContractMarkerFor(relativePath)}`,
+            )
+          : read(relativePath);
+      const readWithHeadingDecoy = (relativePath: string): string =>
+        relativePath === driftedPath
+          ? read(relativePath).replace(/^## (Mongoose .+)$/mu, '### $1')
+          : read(relativePath);
+
+      expect(() => enforceMongooseNestjsMigrationDocs(readWithDuplicateMarker)).toThrow(
+        driftedPath,
+      );
+      expect(() => enforceMongooseNestjsMigrationDocs(readWithHeadingDecoy)).toThrow(driftedPath);
+    },
+  );
+
+  it.each(migrationExamplePaths)(
+    'requires both ambient-session merge and option-preservation anchors in %s',
+    (driftedPath) => {
+      const readWithoutAmbientSessionMerge = (relativePath: string): string =>
+        relativePath === driftedPath
+          ? read(relativePath).replace('ambient-session-merge', 'removed-session-merge')
+          : read(relativePath);
+      const readWithoutOptionPreservation = (relativePath: string): string =>
+        relativePath === driftedPath
+          ? read(relativePath).replace('preserves-operation-options', 'removed-option-preservation')
+          : read(relativePath);
+
+      expect(() => enforceMongooseNestjsMigrationDocs(readWithoutAmbientSessionMerge)).toThrow(
+        driftedPath,
+      );
+      expect(() => enforceMongooseNestjsMigrationDocs(readWithoutOptionPreservation)).toThrow(
+        driftedPath,
+      );
+    },
+  );
 
   it.each([
-    [
-      'docs/getting-started/migrate-from-nestjs.md',
-      '`MongooseConnection.saveDocument(...)` is opt-in',
-    ],
-    [
-      'docs/architecture/transactions.md',
-      '| Mongoose document save helper |',
-    ],
-    [
-      'docs/CONTEXT.md',
-      '`MongooseConnection.saveDocument(...)` is the opt-in path',
-    ],
-  ] as const)('rejects a removed Mongoose document-save contract anchor in %s', (driftedPath, requiredMarker) => {
-    const readWithoutContractAnchor = (relativePath: string): string =>
-      relativePath === driftedPath
-        ? read(relativePath).replace(requiredMarker, '[removed Mongoose document-save contract anchor]')
-        : read(relativePath);
+    [explicitDiExamplePaths[0], ''],
+    [explicitDiExamplePaths[1], ''],
+    [explicitDiExamplePaths[2], 'export '],
+    [explicitDiExamplePaths[3], 'export '],
+  ] as const)(
+    'rejects missing explicit DI or swapped declaration order in %s',
+    (driftedPath, exportPrefix) => {
+      const repositoryDecorator = `@Inject(MongooseConnection)\n${exportPrefix}class UserRepository`;
+      const serviceDecorator = `@Inject(UserRepository)\n${exportPrefix}class UserService`;
+      const readWithoutRepositoryDecorator = (relativePath: string): string =>
+        relativePath === driftedPath
+          ? read(relativePath).replace('@Inject(MongooseConnection)', '@Inject()')
+          : read(relativePath);
+      const readWithSwappedDeclarations = (relativePath: string): string =>
+        relativePath === driftedPath
+          ? read(relativePath)
+              .replace(repositoryDecorator, '[repository declaration]')
+              .replace(serviceDecorator, repositoryDecorator)
+              .replace('[repository declaration]', serviceDecorator)
+          : read(relativePath);
 
-    const runGovernanceGuard = () => enforceMongooseNestjsMigrationDocs(readWithoutContractAnchor);
+      expect(() => enforceMongooseNestjsMigrationDocs(readWithoutRepositoryDecorator)).toThrow(
+        driftedPath,
+      );
+      expect(() => enforceMongooseNestjsMigrationDocs(readWithSwappedDeclarations)).toThrow(
+        driftedPath,
+      );
+    },
+  );
 
-    expect(runGovernanceGuard).toThrow(driftedPath);
-    expect(runGovernanceGuard).toThrow(requiredMarker);
-  });
+  it.each(saveDocumentRequirements)(
+    'rejects a removed saveDocument machine marker in $path',
+    ({ path: driftedPath }) => {
+      const readWithoutSaveDocumentMarker = (relativePath: string): string =>
+        relativePath === driftedPath
+          ? read(relativePath).replace(
+              saveDocumentContractMarker(),
+              '[removed Mongoose saveDocument contract anchor]',
+            )
+          : read(relativePath);
+
+      expect(() => enforceMongooseNestjsMigrationDocs(readWithoutSaveDocumentMarker)).toThrow(
+        driftedPath,
+      );
+      expect(() => enforceMongooseNestjsMigrationDocs(readWithoutSaveDocumentMarker)).toThrow(
+        'fluo-mongoose-save-document-contract',
+      );
+    },
+  );
+
+  it.each(saveDocumentRequirements)(
+    'rejects a duplicated saveDocument machine marker in $path',
+    ({ path: driftedPath }) => {
+      const readWithDuplicateSaveDocumentMarker = (relativePath: string): string =>
+        relativePath === driftedPath
+          ? read(relativePath).replace(
+              saveDocumentContractMarker(),
+              `${saveDocumentContractMarker()}\n${saveDocumentContractMarker()}`,
+            )
+          : read(relativePath);
+
+      expect(() => enforceMongooseNestjsMigrationDocs(readWithDuplicateSaveDocumentMarker)).toThrow(
+        driftedPath,
+      );
+      expect(() => enforceMongooseNestjsMigrationDocs(readWithDuplicateSaveDocumentMarker)).toThrow(
+        'fluo-mongoose-save-document-contract',
+      );
+    },
+  );
+
+  it.each(saveDocumentRequirements)(
+    'rejects a non-save-compatible saveDocument example in $path',
+    ({ path: driftedPath, typeConstraint }) => {
+      const readWithoutSaveCompatibleType = (relativePath: string): string =>
+        relativePath === driftedPath
+          ? read(relativePath).replace(
+              typeConstraint,
+              '  [removed save-compatible document type constraint]',
+            )
+          : read(relativePath);
+
+      expect(() => enforceMongooseNestjsMigrationDocs(readWithoutSaveCompatibleType)).toThrow(
+        driftedPath,
+      );
+      expect(() => enforceMongooseNestjsMigrationDocs(readWithoutSaveCompatibleType)).toThrow(
+        'save-compatible document type',
+      );
+    },
+  );
 });

--- a/tooling/governance/verify-platform-consistency-governance.mjs
+++ b/tooling/governance/verify-platform-consistency-governance.mjs
@@ -12,6 +12,7 @@ import { enforceExpressApplicationOwnershipDocs } from './express-application-ow
 import { enforceJwtAsyncRegistrationContract } from './jwt-async-registration-contract.mjs';
 import { enforceJwtLearningPathModuleWiring } from './jwt-learning-path-module-wiring.mjs';
 import { enforceJwtVerifiedClaimsContract } from './jwt-verified-claims-contract.mjs';
+import { enforceMongooseNestjsMigrationDocs } from './mongoose-nestjs-migration-docs.mjs';
 import {
   enforceMicroservicesSafetyGuidanceParity,
   enforceMicroservicesSafetyRuntimeEvidence,
@@ -3342,6 +3343,7 @@ export async function main() {
   enforceJwtAsyncRegistrationContract();
   enforceJwtVerifiedClaimsContract((relativePath) => readFileSync(join(repoRoot, relativePath), 'utf8'));
   await enforceJwtLearningPathModuleWiring();
+  enforceMongooseNestjsMigrationDocs();
   enforceRuntimeLifecycleNestjsMigrationDocs();
   enforcePassportJsBridgeNestjsMigration();
   enforceExpressApplicationOwnershipDocs();

--- a/tooling/governance/verify-platform-consistency-governance.mjs
+++ b/tooling/governance/verify-platform-consistency-governance.mjs
@@ -12,7 +12,6 @@ import { enforceExpressApplicationOwnershipDocs } from './express-application-ow
 import { enforceJwtAsyncRegistrationContract } from './jwt-async-registration-contract.mjs';
 import { enforceJwtLearningPathModuleWiring } from './jwt-learning-path-module-wiring.mjs';
 import { enforceJwtVerifiedClaimsContract } from './jwt-verified-claims-contract.mjs';
-import { enforceMongooseNestjsMigrationDocs } from './mongoose-nestjs-migration-docs.mjs';
 import {
   enforceMicroservicesSafetyGuidanceParity,
   enforceMicroservicesSafetyRuntimeEvidence,
@@ -3343,7 +3342,6 @@ export async function main() {
   enforceJwtAsyncRegistrationContract();
   enforceJwtVerifiedClaimsContract((relativePath) => readFileSync(join(repoRoot, relativePath), 'utf8'));
   await enforceJwtLearningPathModuleWiring();
-  enforceMongooseNestjsMigrationDocs();
   enforceRuntimeLifecycleNestjsMigrationDocs();
   enforcePassportJsBridgeNestjsMigration();
   enforceExpressApplicationOwnershipDocs();


### PR DESCRIPTION
## Summary

Transaction-scoped Mongoose model facades automatically attach the current session to query/aggregate operations, but an existing document's `doc.save()` stayed outside that facade unless the consumer manually passed `{ session }` — making it easy to move a write outside the transaction silently.

Linked context: Closes #3226

## Changes

- `packages/mongoose/src/connection.ts`: new typed opt-in `MongooseConnection.saveDocument(document, options?)` — obtains the CURRENT request transaction session, delegates to `document.save({ ...options, session })`, preserves document identity and caller options, rejects conflicting explicit sessions (typed error), fails closed without transaction context, never mutates documents/prototypes/model caches.
- Regression coverage (RED-GREEN): success, missing-context fail-closed, validation-error propagation, explicit-options preservation, session-conflict rejection.
- EN/KO README usage + limitations (document types carry the native `save` contract); docs/architecture/transactions EN/KO; NestJS migration guide EN/KO (explicit `@Inject(MongooseConnection)` examples); book ch19 EN/KO; docs/CONTEXT EN/KO discoverability; website persistence guides.
- Governance: saveDocument contract markers integrated into the hardened `mongoose-nestjs-migration-docs` verifier (line-exact exactly-one anchors, bilingual mutation matrix 21→29, explicit-DI enforcement for the new example); wired into `verify-platform-consistency-governance.mjs`.
- Changeset: minor (new public API).

## Testing

- pnpm --filter '@fluojs/mongoose...' build → exit 0; typecheck → exit 0; test → exit 0 (7 files/95 — base 90+1skipped, deferred skipped case replaced by 4 active saveDocument cases + count reconciled)
- pnpm verify:public-export-tsdoc → exit 0; governance verifier → exit 0 (29 tests, bilingual mutation matrix incl. EN/KO @Inject-removal)
- pnpm --filter @fluo/docs build → exit 0 (88 pages); docs typecheck → exit 0; locale parity → exit 0; lint → 0 errors
- Local review triad at head b4509734beca06dd16fc1732040868c54538a113: code PASS / contract PASS / verification PASS (branch rebased onto merged #3225 with lead keep-both resolution; 2 fix-backs restored rebased guidance and explicit DI)

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset. (minor — new public opt-in API)
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary (saveDocument TSDoc; verify:public-export-tsdoc green).
- [x] Changed exported functions document matching `@param` / `@returns` tags.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README (usage + limitations, opt-in semantics).
- [x] Intentional limitations are explicitly stated (fail-closed missing-context behavior documented; native semantics preserved).
- [x] Runtime invariants are covered by regression tests (success/missing-context/validation/options/conflict).

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. (CONTEXT EN/KO + hardened governance verifier + bilingual mutation matrix)
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests (machine-consumed markers; explicit-DI enforcement).