### PR TITLE
fix(prisma): align Node engine dependency graph (#3243)

### DIFF
--- a/.changeset/quiet-prisma-engine-graph.md
+++ b/.changeset/quiet-prisma-engine-graph.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/prisma': patch
+---
+
+Preserve the published Node.js 20+ support contract without inheriting `@fluojs/runtime`'s narrower engine range.

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -45,8 +45,7 @@
   "dependencies": {
     "@fluojs/core": "workspace:^",
     "@fluojs/http": "workspace:^",
-    "@fluojs/di": "workspace:^",
-    "@fluojs/runtime": "workspace:^"
+    "@fluojs/di": "workspace:^"
   },
   "peerDependencies": {
     "@prisma/client": ">=5.0.0"
@@ -57,6 +56,7 @@
     }
   },
   "devDependencies": {
+    "@fluojs/runtime": "workspace:^",
     "@fluojs/validation": "workspace:^",
     "vitest": "^3.2.4"
   }

--- a/packages/prisma/src/integration.ts
+++ b/packages/prisma/src/integration.ts
@@ -1,0 +1,166 @@
+import { Module, type Constructor } from '@fluojs/core';
+
+/**
+ * Module class accepted by the Fluo runtime module graph.
+ */
+export type PrismaModuleType = Constructor;
+
+/**
+ * Defines the lifecycle hook invoked after module initialization.
+ */
+export interface OnModuleInit {
+  onModuleInit(): Promise<void> | void;
+}
+
+/**
+ * Defines the lifecycle hook invoked during application shutdown.
+ */
+export interface OnApplicationShutdown {
+  onApplicationShutdown(): Promise<void> | void;
+}
+
+/**
+ * Defines one active request transaction.
+ */
+export type ActiveRequestTransaction = {
+  abort(reason?: unknown): void;
+  settled: Promise<void>;
+};
+
+/**
+ * Defines one active request transaction registration.
+ */
+export type ActiveRequestTransactionHandle = {
+  active: ActiveRequestTransaction;
+  settle(): void;
+};
+
+/**
+ * Creates a module class with metadata consumed by the runtime module graph.
+ *
+ * @param definition Module composition metadata.
+ * @returns A new module class carrying the supplied metadata.
+ */
+export function definePrismaModule(
+  definition: Parameters<typeof Module>[0],
+): PrismaModuleType {
+  @Module(definition)
+  class PrismaModuleDefinition {}
+
+  return PrismaModuleDefinition;
+}
+
+/**
+ * Races an operation against an abort signal.
+ *
+ * @param fn Async operation to execute while observing the abort signal.
+ * @param signal Abort signal that can cancel the operation.
+ * @returns The resolved value from `fn` when no abort happens first.
+ */
+export async function raceWithAbort<T>(fn: () => Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) {
+    throw createAbortError(signal.reason);
+  }
+
+  return await new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      reject(createAbortError(signal.reason));
+    };
+
+    signal.addEventListener('abort', onAbort, { once: true });
+
+    let fnResultPromise: Promise<T>;
+    try {
+      fnResultPromise = Promise.resolve(fn());
+    } catch (syncError) {
+      fnResultPromise = Promise.reject(syncError);
+    }
+
+    fnResultPromise.then(resolve, reject).finally(() => {
+      signal.removeEventListener('abort', onAbort);
+    });
+  });
+}
+
+/**
+ * Normalizes an abort reason into an AbortError.
+ *
+ * @param reason Abort reason attached to the triggering signal.
+ * @returns A normalized abort error.
+ */
+export function createAbortError(reason: unknown): Error {
+  const message = reason instanceof Error ? reason.message : 'Request aborted before response commit.';
+  const error = new Error(message);
+  error.name = 'AbortError';
+  return error;
+}
+
+/**
+ * Creates an abort context that forwards an optional caller signal.
+ *
+ * @param signal Optional caller-owned abort signal.
+ * @returns The owned controller, signal, and listener cleanup.
+ */
+export function createRequestAbortContext(signal?: AbortSignal): {
+  controller: AbortController;
+  cleanup(): void;
+  signal: AbortSignal;
+} {
+  const controller = new AbortController();
+  const forwardAbort = () => controller.abort(signal?.reason);
+
+  if (signal?.aborted) {
+    forwardAbort();
+  } else {
+    signal?.addEventListener('abort', forwardAbort, { once: true });
+  }
+
+  return {
+    controller,
+    cleanup: () => {
+      signal?.removeEventListener('abort', forwardAbort);
+    },
+    signal: controller.signal,
+  };
+}
+
+/**
+ * Tracks a request transaction until its caller settles it.
+ *
+ * @param activeRequestTransactions Active request transaction set.
+ * @param controller Controller used to abort the transaction.
+ * @returns The tracked transaction and its settlement function.
+ */
+export function trackActiveRequestTransaction(
+  activeRequestTransactions: Set<ActiveRequestTransaction>,
+  controller: AbortController,
+): ActiveRequestTransactionHandle {
+  let settle!: () => void;
+  const settled = new Promise<void>((resolve) => {
+    settle = resolve;
+  });
+  const active: ActiveRequestTransaction = {
+    abort(reason?: unknown) {
+      controller.abort(reason);
+    },
+    settled,
+  };
+
+  activeRequestTransactions.add(active);
+
+  return { active, settle };
+}
+
+/**
+ * Stops tracking a settled request transaction.
+ *
+ * @param activeRequestTransactions Active request transaction set.
+ * @param handle Transaction registration to remove.
+ */
+export function untrackActiveRequestTransaction(
+  activeRequestTransactions: Set<ActiveRequestTransaction>,
+  handle: ActiveRequestTransactionHandle,
+): void {
+  activeRequestTransactions.delete(handle.active);
+  handle.settle();
+}

--- a/packages/prisma/src/integration.ts
+++ b/packages/prisma/src/integration.ts
@@ -1,9 +1,21 @@
-import { Module, type Constructor } from '@fluojs/core';
+import { Module, type Constructor, type Token } from '@fluojs/core';
+import type { Provider } from '@fluojs/di';
+import type { MiddlewareLike } from '@fluojs/http';
+
+type PrismaModuleDefinition = Parameters<typeof Module>[0] & {
+  controllers?: Constructor[];
+  exports?: Token[];
+  imports?: PrismaModuleType[];
+  middleware?: MiddlewareLike[];
+  providers?: Provider[];
+};
 
 /**
  * Module class accepted by the Fluo runtime module graph.
  */
-export type PrismaModuleType = Constructor;
+export type PrismaModuleType = Constructor & {
+  definition?: PrismaModuleDefinition;
+};
 
 /**
  * Defines the lifecycle hook invoked after module initialization.

--- a/packages/prisma/src/integration.ts
+++ b/packages/prisma/src/integration.ts
@@ -51,15 +51,25 @@ export type ActiveRequestTransactionHandle = {
  * Creates a module class with metadata consumed by the runtime module graph.
  *
  * @param definition Module composition metadata.
+ * @param moduleName Constructor name used by runtime diagnostics.
  * @returns A new module class carrying the supplied metadata.
  */
 export function definePrismaModule(
   definition: Parameters<typeof Module>[0],
+  moduleName: string,
 ): PrismaModuleType {
-  @Module(definition)
-  class PrismaModuleDefinition {}
+  const moduleType = {
+    [moduleName]: class {},
+  }[moduleName];
 
-  return PrismaModuleDefinition;
+  Module(definition)(moduleType, {
+    addInitializer() {},
+    kind: 'class',
+    metadata: {},
+    name: moduleName,
+  });
+
+  return moduleType;
 }
 
 /**

--- a/packages/prisma/src/module.test.ts
+++ b/packages/prisma/src/module.test.ts
@@ -71,6 +71,21 @@ void staticPrismaModuleDefinitionCompatibilityChecked;
 void asyncPrismaModuleDefinitionCompatibilityChecked;
 
 describe('@fluojs/prisma', () => {
+  it('preserves distinct static and async module definition names', () => {
+    const client = {
+      async $connect() {},
+      async $disconnect() {},
+    };
+
+    const staticModule = PrismaModule.forRoot({ client });
+    const asyncModule = PrismaModule.forRootAsync({
+      useFactory: () => ({ client }),
+    });
+
+    expect(staticModule.name).toBe('PrismaRootModuleDefinition');
+    expect(asyncModule.name).toBe('PrismaAsyncModuleDefinition');
+  });
+
   it('connects, reuses transaction-scoped handles, and disconnects through lifecycle hooks', async () => {
     const events: string[] = [];
     const transactionClient = {

--- a/packages/prisma/src/module.test.ts
+++ b/packages/prisma/src/module.test.ts
@@ -41,6 +41,8 @@ type InferredPrismaServiceFacade = PrismaServiceFacade<GeneratedPrismaClient>;
 type InferredCurrentHandle = ReturnType<InferredPrismaService['current']>;
 type InferredTransactionHandle = PrismaTransactionClient<GeneratedPrismaClient>;
 type InferredFacadeFindUniqueResult = ReturnType<InferredPrismaServiceFacade['user']['findUnique']>;
+type StaticPrismaModuleDefinition = ReturnType<typeof PrismaModule.forRoot<GeneratedPrismaClient>>['definition'];
+type AsyncPrismaModuleDefinition = ReturnType<typeof PrismaModule.forRootAsync<GeneratedPrismaClient>>['definition'];
 
 type _PrismaServiceCurrentInference = Assert<
   IsEqual<InferredCurrentHandle, GeneratedPrismaClient | GeneratedTransactionClient>
@@ -49,14 +51,24 @@ type _PrismaTransactionClientInference = Assert<IsEqual<InferredTransactionHandl
 type _PrismaServiceFacadeDelegateInference = Assert<
   IsEqual<InferredFacadeFindUniqueResult, Promise<{ id: string } | null>>
 >;
+type _StaticPrismaModuleDefinitionCompatibility = Assert<
+  StaticPrismaModuleDefinition extends Parameters<typeof Module>[0] | undefined ? true : false
+>;
+type _AsyncPrismaModuleDefinitionCompatibility = Assert<
+  AsyncPrismaModuleDefinition extends Parameters<typeof Module>[0] | undefined ? true : false
+>;
 
 const prismaServiceCurrentInferenceChecked: _PrismaServiceCurrentInference = true;
 const prismaTransactionClientInferenceChecked: _PrismaTransactionClientInference = true;
 const prismaServiceFacadeDelegateInferenceChecked: _PrismaServiceFacadeDelegateInference = true;
+const staticPrismaModuleDefinitionCompatibilityChecked: _StaticPrismaModuleDefinitionCompatibility = true;
+const asyncPrismaModuleDefinitionCompatibilityChecked: _AsyncPrismaModuleDefinitionCompatibility = true;
 
 void prismaServiceCurrentInferenceChecked;
 void prismaTransactionClientInferenceChecked;
 void prismaServiceFacadeDelegateInferenceChecked;
+void staticPrismaModuleDefinitionCompatibilityChecked;
+void asyncPrismaModuleDefinitionCompatibilityChecked;
 
 describe('@fluojs/prisma', () => {
   it('connects, reuses transaction-scoped handles, and disconnects through lifecycle hooks', async () => {

--- a/packages/prisma/src/module.ts
+++ b/packages/prisma/src/module.ts
@@ -1,7 +1,7 @@
 import type { AsyncModuleOptions, Token } from '@fluojs/core';
 import type { Provider } from '@fluojs/di';
-import { defineModule, type ModuleType } from '@fluojs/runtime';
 
+import { definePrismaModule, type PrismaModuleType } from './integration.js';
 import { PrismaService } from './service.js';
 import {
   getPrismaClientToken,
@@ -164,15 +164,14 @@ function buildPrismaModule<
   TTransactionOptions = InferPrismaTransactionOptions<TClient>,
 >(
   options: PrismaModuleOptions<TClient, TTransactionClient, TTransactionOptions>,
-): ModuleType {
-  class PrismaRootModuleDefinition {}
+): PrismaModuleType {
   const normalizedOptions = normalizePrismaModuleOptions(options);
 
   if (normalizedOptions.name !== undefined && normalizedOptions.global) {
     throw new Error('Named Prisma registrations are scoped and cannot be registered globally.');
   }
 
-  return defineModule(PrismaRootModuleDefinition, {
+  return definePrismaModule({
     exports: normalizedOptions.name === undefined
       ? [
         PrismaService,
@@ -200,9 +199,7 @@ function buildPrismaModuleAsync<
   TTransactionOptions = InferPrismaTransactionOptions<TClient>,
 >(
   options: PrismaAsyncModuleOptions<TClient, TTransactionClient, TTransactionOptions>,
-): ModuleType {
-  class PrismaAsyncModuleDefinition {}
-
+): PrismaModuleType {
   const factory = options.useFactory;
   const normalizedName = normalizePrismaRegistrationName(options.name);
 
@@ -225,7 +222,7 @@ function buildPrismaModuleAsync<
     },
   };
 
-  return defineModule(PrismaAsyncModuleDefinition, {
+  return definePrismaModule({
     exports: normalizedName === undefined
       ? [
         PrismaService,
@@ -256,7 +253,7 @@ export class PrismaModule {
     TTransactionOptions = InferPrismaTransactionOptions<TClient>,
   >(
     options: PrismaModuleOptions<TClient, TTransactionClient, TTransactionOptions>,
-  ): ModuleType {
+  ): PrismaModuleType {
     return buildPrismaModule<TClient, TTransactionClient, TTransactionOptions>(options);
   }
 
@@ -272,7 +269,7 @@ export class PrismaModule {
     TTransactionOptions = InferPrismaTransactionOptions<TClient>,
   >(
     options: PrismaAsyncModuleOptions<TClient, TTransactionClient, TTransactionOptions>,
-  ): ModuleType {
+  ): PrismaModuleType {
     return buildPrismaModuleAsync<TClient, TTransactionClient, TTransactionOptions>(options);
   }
 }

--- a/packages/prisma/src/module.ts
+++ b/packages/prisma/src/module.ts
@@ -190,7 +190,7 @@ function buildPrismaModule<
       provide: getPrismaNormalizedOptionsToken(normalizedOptions.name),
       useValue: normalizedOptions,
     }, normalizedOptions.name),
-  });
+  }, 'PrismaRootModuleDefinition');
 }
 
 function buildPrismaModuleAsync<
@@ -234,7 +234,7 @@ function buildPrismaModuleAsync<
       : [getPrismaServiceToken(normalizedName), getPrismaClientToken(normalizedName), getPrismaOptionsToken(normalizedName)],
     global: normalizedName === undefined ? options.global ?? false : false,
     providers: createPrismaRuntimeProviders<TClient, TTransactionClient, TTransactionOptions>(normalizedOptionsProvider, normalizedName),
-  });
+  }, 'PrismaAsyncModuleDefinition');
 }
 
 /**

--- a/packages/prisma/src/service.ts
+++ b/packages/prisma/src/service.ts
@@ -1,12 +1,15 @@
 import { Inject } from '@fluojs/core';
-import type { OnApplicationShutdown, OnModuleInit } from '@fluojs/runtime';
 import {
+  type ActiveRequestTransaction,
+  type ActiveRequestTransactionHandle,
   createAbortError,
   createRequestAbortContext,
+  type OnApplicationShutdown,
+  type OnModuleInit,
   raceWithAbort,
   trackActiveRequestTransaction,
   untrackActiveRequestTransaction,
-} from '@fluojs/runtime';
+} from './integration.js';
 
 import { markPrismaServiceHandle } from './prisma-service-brand.js';
 import { createPrismaPlatformStatusSnapshot } from './status.js';
@@ -28,16 +31,6 @@ const TRANSACTION_CONTEXT_UNAVAILABLE_ERROR =
 interface PrismaServiceOptions {
   strictTransactions: boolean;
 }
-
-type ActiveRequestTransaction = {
-  abort(reason?: unknown): void;
-  settled: Promise<void>;
-};
-
-type ActiveRequestTransactionHandle = {
-  active: ActiveRequestTransaction;
-  settle(): void;
-};
 
 type ActiveTransactionBoundary = {
   settled: Promise<void>;

--- a/packages/prisma/src/status.ts
+++ b/packages/prisma/src/status.ts
@@ -1,8 +1,25 @@
-import type {
-  PersistencePlatformStatusSnapshot,
-  PlatformHealthReport,
-  PlatformReadinessReport,
-} from '@fluojs/runtime';
+type PlatformReadinessReport = {
+  checks?: Array<{ message?: string; name: string; status: 'pass' | 'fail' | 'degraded' }>;
+  critical: boolean;
+  reason?: string;
+  status: 'ready' | 'not-ready' | 'degraded';
+};
+
+type PlatformHealthReport = {
+  checks?: Array<{ message?: string; name: string; status: 'pass' | 'fail' | 'degraded' }>;
+  reason?: string;
+  status: 'healthy' | 'unhealthy' | 'degraded';
+};
+
+type PersistencePlatformStatusSnapshot = {
+  details: Record<string, unknown>;
+  health: PlatformHealthReport;
+  ownership: {
+    externallyManaged: boolean;
+    ownsResources: boolean;
+  };
+  readiness: PlatformReadinessReport;
+};
 
 type PrismaPlatformLifecycleState = 'created' | 'ready' | 'shutting-down' | 'stopped';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -885,13 +885,13 @@ importers:
       '@fluojs/http':
         specifier: workspace:^
         version: link:../http
-      '@fluojs/runtime':
-        specifier: workspace:^
-        version: link:../runtime
       '@prisma/client':
         specifier: '>=5.0.0'
         version: 7.5.0(typescript@6.0.2)
     devDependencies:
+      '@fluojs/runtime':
+        specifier: workspace:^
+        version: link:../runtime
       '@fluojs/validation':
         specifier: workspace:^
         version: link:../validation

--- a/tooling/governance/verify-platform-consistency-governance.d.mts
+++ b/tooling/governance/verify-platform-consistency-governance.d.mts
@@ -19,6 +19,10 @@ export function collectNodeGlobalBufferViolations(
   relativePaths: readonly string[],
   readSource: (relativePath: string) => string,
 ): NodeGlobalBufferViolation[];
+export function enforceMandatoryFirstPartyDependencyEngineAlignment(
+  readText?: (relativePath: string) => string,
+  packageNames?: ReadonlySet<string>,
+): void;
 export function enforceCliMigrationTransformDocs(
   readText?: (relativePath: string) => string,
 ): void;

--- a/tooling/governance/verify-platform-consistency-governance.mjs
+++ b/tooling/governance/verify-platform-consistency-governance.mjs
@@ -98,6 +98,176 @@ const nodeListenerEngineRange = nodeListenerEngineWindows
   .join(' || ');
 const nodeListenerEngineMarker = `engines.node ${nodeListenerEngineRange}`;
 
+function parseNodeEngineVersion(value) {
+  const match = /^(\d+)(?:\.(\d+))?(?:\.(\d+))?$/u.exec(value);
+  assert(match !== null, `Unsupported Node engine version "${value}".`);
+
+  return {
+    major: Number.parseInt(match[1], 10),
+    minor: Number.parseInt(match[2] ?? '0', 10),
+    patch: Number.parseInt(match[3] ?? '0', 10),
+  };
+}
+
+function compareNodeEngineVersions(left, right) {
+  for (const key of ['major', 'minor', 'patch']) {
+    if (left[key] !== right[key]) {
+      return left[key] < right[key] ? -1 : 1;
+    }
+  }
+
+  return 0;
+}
+
+function parseNodeEngineComparator(value) {
+  const match = /^(>=|>|<=|<|=)?(\d+(?:\.\d+){0,2})$/u.exec(value);
+  assert(match !== null, `Unsupported Node engine comparator "${value}".`);
+
+  return {
+    operator: match[1] ?? '=',
+    version: parseNodeEngineVersion(match[2]),
+  };
+}
+
+function parseNodeEngineRange(range) {
+  assert(typeof range === 'string' && range.trim().length > 0, 'engines.node must be a non-empty string.');
+
+  return range.split('||').map((group) => {
+    const comparators = group.trim().split(/\s+/u).filter(Boolean);
+    assert(comparators.length > 0, `Unsupported empty Node engine range "${range}".`);
+    return comparators.map(parseNodeEngineComparator);
+  });
+}
+
+function nodeEngineRangeIncludes(range, version) {
+  return parseNodeEngineRange(range).some((comparators) =>
+    comparators.every(({ operator, version: boundary }) => {
+      const comparison = compareNodeEngineVersions(version, boundary);
+
+      switch (operator) {
+        case '>':
+          return comparison > 0;
+        case '>=':
+          return comparison >= 0;
+        case '<':
+          return comparison < 0;
+        case '<=':
+          return comparison <= 0;
+        case '=':
+          return comparison === 0;
+        default:
+          return false;
+      }
+    }));
+}
+
+function previousNodeEngineVersion({ major, minor, patch }) {
+  if (patch > 0) {
+    return { major, minor, patch: patch - 1 };
+  }
+
+  if (minor > 0) {
+    return { major, minor: minor - 1, patch: 999 };
+  }
+
+  return { major: Math.max(0, major - 1), minor: 999, patch: 999 };
+}
+
+function nextNodeEngineVersion({ major, minor, patch }) {
+  return { major, minor, patch: patch + 1 };
+}
+
+function nodeEngineCandidates(...ranges) {
+  const candidates = new Map();
+  const addCandidate = (version) => {
+    candidates.set(`${version.major}.${version.minor}.${version.patch}`, version);
+  };
+
+  for (const range of ranges) {
+    for (const comparators of parseNodeEngineRange(range)) {
+      for (const { version } of comparators) {
+        addCandidate(previousNodeEngineVersion(version));
+        addCandidate(version);
+        addCandidate(nextNodeEngineVersion(version));
+      }
+    }
+  }
+
+  return [...candidates.values()];
+}
+
+function formatNodeEngineVersion({ major, minor, patch }) {
+  return `${major}.${minor}.${patch}`;
+}
+
+function changedPackageNames(changedFiles) {
+  return new Set(changedFiles.flatMap((relativePath) => {
+    const match = /^packages\/([^/]+)\//u.exec(relativePath);
+    return match === null ? [] : [`@fluojs/${match[1]}`];
+  }));
+}
+
+export function enforceMandatoryFirstPartyDependencyEngineAlignment(
+  readText = read,
+  packageNames = changedPackageNames(changedFilesFromGit()),
+) {
+  const packageManifests = new Map();
+
+  for (const entry of readdirSync(join(repoRoot, 'packages'), { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    const relativePath = `packages/${entry.name}/package.json`;
+    if (!existsSync(join(repoRoot, relativePath))) {
+      continue;
+    }
+
+    const manifest = JSON.parse(readText(relativePath));
+    packageManifests.set(manifest.name, { manifest, relativePath });
+  }
+
+  for (const { manifest: packageManifest, relativePath } of packageManifests.values()) {
+    if (
+      packageManifest.private ||
+      typeof packageManifest.name !== 'string' ||
+      !packageNames.has(packageManifest.name)
+    ) {
+      continue;
+    }
+
+    const packageRange = packageManifest.engines?.node;
+    assert(
+      typeof packageRange === 'string' && packageRange.length > 0,
+      `${packageManifest.name} (${relativePath}) must declare engines.node.`,
+    );
+
+    for (const dependencyName of Object.keys(packageManifest.dependencies ?? {})) {
+      const dependency = packageManifests.get(dependencyName);
+      if (dependency === undefined) {
+        continue;
+      }
+
+      const dependencyRange = dependency.manifest.engines?.node;
+      assert(
+        typeof dependencyRange === 'string' && dependencyRange.length > 0,
+        `${dependencyName} (${dependency.relativePath}) must declare engines.node.`,
+      );
+
+      const incompatibleVersion = nodeEngineCandidates(packageRange, dependencyRange).find((version) =>
+        nodeEngineRangeIncludes(packageRange, version) &&
+        !nodeEngineRangeIncludes(dependencyRange, version));
+
+      if (incompatibleVersion !== undefined) {
+        throw new Error(
+          `${packageManifest.name} engines.node ${packageRange} permits Node ${formatNodeEngineVersion(incompatibleVersion)} ` +
+            `but mandatory ${dependencyName} engines.node is ${dependencyRange}.`,
+        );
+      }
+    }
+  }
+}
+
 export function enforceSocketIoNodeEngineAlignment(readText = read) {
   const runtimeManifest = JSON.parse(readText('packages/runtime/package.json'));
   const canonicalNodeRange = runtimeManifest.engines?.node;
@@ -3298,6 +3468,7 @@ export async function main() {
   enforcePackageDirectoriesHaveManifests();
   enforceReleaseGovernancePublishSurfaceSync();
   enforceCanonicalPackageSurfaceSync();
+  enforceMandatoryFirstPartyDependencyEngineAlignment(read, changedPackageNames(changedFiles));
   enforceSocketIoNodeEngineAlignment();
   enforcePlatformFastifyEngineDocumentation();
   enforceDocsHubOfficialTransportLinks();

--- a/tooling/governance/verify-platform-consistency-governance.mjs
+++ b/tooling/governance/verify-platform-consistency-governance.mjs
@@ -124,19 +124,31 @@ function parseNodeEngineComparator(value) {
   assert(match !== null, `Unsupported Node engine comparator "${value}".`);
 
   const version = parseNodeEngineVersion(match[2]);
-  if (match[1] !== undefined || match[2].split('.').length === 3) {
+  const upperVersion = match[2].includes('.')
+    ? { major: version.major, minor: version.minor + 1, patch: 0 }
+    : { major: version.major + 1, minor: 0, patch: 0 };
+
+  if (match[2].split('.').length === 3) {
     return [{ operator: match[1] ?? '=', version }];
   }
 
-  return [
-    { operator: '>=', version },
-    {
-      operator: '<',
-      version: match[2].includes('.')
-        ? { major: version.major, minor: version.minor + 1, patch: 0 }
-        : { major: version.major + 1, minor: 0, patch: 0 },
-    },
-  ];
+  switch (match[1]) {
+    case '>':
+      return [{ operator: '>=', version: upperVersion }];
+    case '>=':
+    case '<':
+      return [{ operator: match[1], version }];
+    case '<=':
+      return [{ operator: '<', version: upperVersion }];
+    case '=':
+    case undefined:
+      return [
+        { operator: '>=', version },
+        { operator: '<', version: upperVersion },
+      ];
+    default:
+      assert(false, `Unsupported Node engine comparator "${value}".`);
+  }
 }
 
 function parseNodeEngineRange(range) {

--- a/tooling/governance/verify-platform-consistency-governance.mjs
+++ b/tooling/governance/verify-platform-consistency-governance.mjs
@@ -227,19 +227,44 @@ export function enforceMandatoryFirstPartyDependencyEngineAlignment(
     packageManifests.set(manifest.name, { manifest, relativePath });
   }
 
+  const selectedPackageNames = new Set(packageNames);
+  let addedReverseDependent = true;
+
+  while (addedReverseDependent) {
+    addedReverseDependent = false;
+
+    for (const [packageName, { manifest }] of packageManifests) {
+      if (
+        manifest.private ||
+        selectedPackageNames.has(packageName) ||
+        !Object.keys(manifest.dependencies ?? {}).some((dependencyName) =>
+          selectedPackageNames.has(dependencyName))
+      ) {
+        continue;
+      }
+
+      selectedPackageNames.add(packageName);
+      addedReverseDependent = true;
+    }
+  }
+
   for (const { manifest: packageManifest, relativePath } of packageManifests.values()) {
     if (
       packageManifest.private ||
       typeof packageManifest.name !== 'string' ||
-      !packageNames.has(packageManifest.name)
+      !selectedPackageNames.has(packageManifest.name)
     ) {
       continue;
     }
 
     const packageRange = packageManifest.engines?.node;
+    if (packageRange === undefined) {
+      continue;
+    }
+
     assert(
       typeof packageRange === 'string' && packageRange.length > 0,
-      `${packageManifest.name} (${relativePath}) must declare engines.node.`,
+      `${packageManifest.name} (${relativePath}) engines.node must be a non-empty string.`,
     );
 
     for (const dependencyName of Object.keys(packageManifest.dependencies ?? {})) {
@@ -249,9 +274,13 @@ export function enforceMandatoryFirstPartyDependencyEngineAlignment(
       }
 
       const dependencyRange = dependency.manifest.engines?.node;
+      if (dependencyRange === undefined) {
+        continue;
+      }
+
       assert(
         typeof dependencyRange === 'string' && dependencyRange.length > 0,
-        `${dependencyName} (${dependency.relativePath}) must declare engines.node.`,
+        `${dependencyName} (${dependency.relativePath}) engines.node must be a non-empty string.`,
       );
 
       const incompatibleVersion = nodeEngineCandidates(packageRange, dependencyRange).find((version) =>

--- a/tooling/governance/verify-platform-consistency-governance.mjs
+++ b/tooling/governance/verify-platform-consistency-governance.mjs
@@ -213,7 +213,8 @@ export function enforceMandatoryFirstPartyDependencyEngineAlignment(
 ) {
   const packageManifests = new Map();
 
-  for (const entry of readdirSync(join(repoRoot, 'packages'), { withFileTypes: true })) {
+  for (const entry of readdirSync(join(repoRoot, 'packages'), { withFileTypes: true })
+    .sort((left, right) => left.name.localeCompare(right.name))) {
     if (!entry.isDirectory()) {
       continue;
     }

--- a/tooling/governance/verify-platform-consistency-governance.mjs
+++ b/tooling/governance/verify-platform-consistency-governance.mjs
@@ -123,10 +123,20 @@ function parseNodeEngineComparator(value) {
   const match = /^(>=|>|<=|<|=)?(\d+(?:\.\d+){0,2})$/u.exec(value);
   assert(match !== null, `Unsupported Node engine comparator "${value}".`);
 
-  return {
-    operator: match[1] ?? '=',
-    version: parseNodeEngineVersion(match[2]),
-  };
+  const version = parseNodeEngineVersion(match[2]);
+  if (match[1] !== undefined || match[2].split('.').length === 3) {
+    return [{ operator: match[1] ?? '=', version }];
+  }
+
+  return [
+    { operator: '>=', version },
+    {
+      operator: '<',
+      version: match[2].includes('.')
+        ? { major: version.major, minor: version.minor + 1, patch: 0 }
+        : { major: version.major + 1, minor: 0, patch: 0 },
+    },
+  ];
 }
 
 function parseNodeEngineRange(range) {
@@ -135,7 +145,7 @@ function parseNodeEngineRange(range) {
   return range.split('||').map((group) => {
     const comparators = group.trim().split(/\s+/u).filter(Boolean);
     assert(comparators.length > 0, `Unsupported empty Node engine range "${range}".`);
-    return comparators.map(parseNodeEngineComparator);
+    return comparators.flatMap(parseNodeEngineComparator);
   });
 }
 

--- a/tooling/governance/verify-platform-consistency-governance.test.ts
+++ b/tooling/governance/verify-platform-consistency-governance.test.ts
@@ -22,6 +22,7 @@ import {
   enforceGraphqlRuntimeBoundaryDiscoverability,
   enforceHttpAdapterPortabilityDocumentationContract,
   enforceHttpCustomMethodContract,
+  enforceMandatoryFirstPartyDependencyEngineAlignment,
   enforceNoDirectProcessEnvInOrdinaryPackageSource,
   enforceNoNodeGlobalBufferInDenoAndCloudflareWorkerServices,
   enforcePassportJsBridgeNestjsMigration,
@@ -3762,5 +3763,45 @@ describe('Auth & JWT contract gate triggers', () => {
     expect(() => enforceContractCompanionUpdates([changedPath])).toThrow(
       'contract-governing doc updates must include docs/CONTEXT.md and docs/CONTEXT.ko.md discoverability updates.',
     );
+  });
+});
+
+describe('mandatory first-party dependency Node engine alignment', () => {
+  it('rejects a public package that advertises Node versions its required dependency excludes', () => {
+    // Given: Prisma's Node 20+ package contract and a required runtime dependency with a higher floor.
+    const readText = (relativePath: string): string => {
+      const content = readFileSync(join(repoRoot, relativePath), 'utf8');
+
+      if (relativePath === 'packages/prisma/package.json') {
+        const manifest = JSON.parse(content);
+
+        return JSON.stringify({
+          ...manifest,
+          dependencies: {
+            ...manifest.dependencies,
+            '@fluojs/runtime': 'workspace:^',
+          },
+        });
+      }
+
+      return content;
+    };
+
+    // When: release governance evaluates the mandatory first-party graph.
+    // Then: it rejects the false Node 20+ compatibility claim before release.
+    expect(() => enforceMandatoryFirstPartyDependencyEngineAlignment(readText, new Set(['@fluojs/prisma']))).toThrow(
+      /@fluojs\/prisma engines\.node >=20\.0\.0 permits Node 20\.0\.0.*@fluojs\/runtime/u,
+    );
+  });
+
+  it('accepts the current mandatory first-party dependency Node engine graph', () => {
+    // Given: the checked-in public package manifests.
+    // When: release governance evaluates their mandatory first-party dependency graph.
+    // Then: every advertised Node version is executable through the required first-party packages.
+    expect(() =>
+      enforceMandatoryFirstPartyDependencyEngineAlignment(
+        (relativePath) => readFileSync(join(repoRoot, relativePath), 'utf8'),
+        new Set(['@fluojs/prisma']),
+      )).not.toThrow();
   });
 });

--- a/tooling/governance/verify-platform-consistency-governance.test.ts
+++ b/tooling/governance/verify-platform-consistency-governance.test.ts
@@ -441,6 +441,35 @@ describe('enforceMandatoryFirstPartyDependencyEngineAlignment', () => {
         new Set(['@fluojs/prisma']),
       )).not.toThrow();
   });
+
+  it('rejects an explicit partial equality package range that exceeds a full-version dependency', () => {
+    expect(() =>
+      enforceMandatoryFirstPartyDependencyEngineAlignment(
+        readTextWithEngineRanges('=20', '20.0.0'),
+        new Set(['@fluojs/prisma']),
+      )).toThrow(/permits Node 20\.0\.1/u);
+  });
+
+  it.each([
+    ['>=20.1', '>=20.1.0'],
+    ['<20.2', '<20.2.0'],
+    ['>20', '>=21.0.0'],
+    ['20.0.0', '=20'],
+  ])('accepts npm-equivalent partial comparator ranges %s and %s', (packageRange, dependencyRange) => {
+    expect(() =>
+      enforceMandatoryFirstPartyDependencyEngineAlignment(
+        readTextWithEngineRanges(packageRange, dependencyRange),
+        new Set(['@fluojs/prisma']),
+      )).not.toThrow();
+  });
+
+  it('rejects a partial less-than-or-equal package range that exceeds a full-version dependency', () => {
+    expect(() =>
+      enforceMandatoryFirstPartyDependencyEngineAlignment(
+        readTextWithEngineRanges('<=20', '<=20.0.0'),
+        new Set(['@fluojs/prisma']),
+      )).toThrow(/permits Node 20\.999\.999/u);
+  });
 });
 
 describe('enforcePlatformFastifyEngineDocumentation', () => {

--- a/tooling/governance/verify-platform-consistency-governance.test.ts
+++ b/tooling/governance/verify-platform-consistency-governance.test.ts
@@ -398,6 +398,51 @@ describe('enforceSocketIoNodeEngineAlignment', () => {
   });
 });
 
+describe('enforceMandatoryFirstPartyDependencyEngineAlignment', () => {
+  function readTextWithEngineRanges(packageRange: string, dependencyRange: string): (relativePath: string) => string {
+    return (relativePath) => {
+      const content = readFileSync(join(repoRoot, relativePath), 'utf8');
+
+      if (relativePath === 'packages/prisma/package.json') {
+        const manifest = JSON.parse(content) as Record<string, unknown>;
+
+        return JSON.stringify({
+          ...manifest,
+          dependencies: { '@fluojs/core': 'workspace:*' },
+          engines: { node: packageRange },
+        });
+      }
+
+      if (relativePath === 'packages/core/package.json') {
+        const manifest = JSON.parse(content) as Record<string, unknown>;
+
+        return JSON.stringify({
+          ...manifest,
+          engines: { node: dependencyRange },
+        });
+      }
+
+      return content;
+    };
+  }
+
+  it('rejects a bare-major package range that exceeds a mandatory dependency cap', () => {
+    expect(() =>
+      enforceMandatoryFirstPartyDependencyEngineAlignment(
+        readTextWithEngineRanges('20', '<=20.0.0'),
+        new Set(['@fluojs/prisma']),
+      )).toThrow(/permits Node 20\.0\.1/u);
+  });
+
+  it('accepts compatible bare-major package and dependency ranges', () => {
+    expect(() =>
+      enforceMandatoryFirstPartyDependencyEngineAlignment(
+        readTextWithEngineRanges('20', '20'),
+        new Set(['@fluojs/prisma']),
+      )).not.toThrow();
+  });
+});
+
 describe('enforcePlatformFastifyEngineDocumentation', () => {
   const fastifyGuidePaths = [
     'apps/docs/content/docs/guides/runtime-adapters.mdx',

--- a/tooling/governance/verify-platform-consistency-governance.test.ts
+++ b/tooling/governance/verify-platform-consistency-governance.test.ts
@@ -3804,4 +3804,38 @@ describe('mandatory first-party dependency Node engine alignment', () => {
         new Set(['@fluojs/prisma']),
       )).not.toThrow();
   });
+
+  it('accepts a selected public package without an advertised Node engine floor', () => {
+    // Given: the documented runtime-neutral i18n package with no engines.node declaration.
+    // When: release governance evaluates its mandatory first-party dependency graph.
+    // Then: the absent public compatibility claim does not require an engine comparison.
+    expect(() =>
+      enforceMandatoryFirstPartyDependencyEngineAlignment(
+        (relativePath) => readFileSync(join(repoRoot, relativePath), 'utf8'),
+        new Set(['@fluojs/i18n']),
+      )).not.toThrow();
+  });
+
+  it('rejects an unchanged public dependent after its mandatory dependency narrows Node support', () => {
+    // Given: core narrows its advertised Node floor while only core's manifest is selected.
+    const readText = (relativePath: string): string => {
+      const content = readFileSync(join(repoRoot, relativePath), 'utf8');
+
+      if (relativePath !== 'packages/core/package.json') {
+        return content;
+      }
+
+      const manifest = JSON.parse(content);
+      return JSON.stringify({
+        ...manifest,
+        engines: { ...manifest.engines, node: '>=22.0.0' },
+      });
+    };
+
+    // When: release governance evaluates the changed package's public reverse dependencies.
+    // Then: an unchanged public dependent's Node 20+ advertisement is rejected.
+    expect(() =>
+      enforceMandatoryFirstPartyDependencyEngineAlignment(readText, new Set(['@fluojs/core'])))
+      .toThrow(/@fluojs\/cache-manager engines\.node .*permits Node 20\.19\.3.*@fluojs\/core/u);
+  });
 });


### PR DESCRIPTION
## Summary

`@fluojs/prisma` published Node.js `>=20.0.0` support while its mandatory dependency graph had a narrower floor: the package made `@fluojs/runtime` (engines `>=20.19.3 <21 || >=22.2.0 <27`) a mandatory dependency, so consumers inside the advertised range could receive an engine-strict rejection or an unsupported mandatory dependency graph.

Linked context: Closes #3243

## Changes

- Contract-preserving fix: `@fluojs/runtime` moved from `dependencies` to `devDependencies`; the runtime-neutral seams Prisma used (module metadata, lifecycle types, abort/request-transaction helpers) now live in in-package `packages/prisma/src/integration.ts` (core-owned `Module` seam only). Published engines.node `>=20.0.0` preserved; public API/types preserved (`PrismaModuleType = Constructor & { definition? }` keeps base `ModuleType` compatibility without runtime type references in the published d.ts — grep-verified).
- Release-governance coverage: new `enforceMandatoryFirstPartyDependencyEngineAlignment()` in the platform-consistency governance verifier — with npm-correct semver semantics (bare versions and partial comparators desugared to X-ranges: `20`/`=20` → 20.x, `>20` → >=21.0.0, etc.), reverse-dependent closure validation (a mandatory dependency's floor change checks unchanged dependents), absent-`engines.node` treated as no-advertised-floor (i18n contract honored), deterministic sorted enumeration.
- Changeset: patch (@fluojs/prisma).

## Testing

- CLEAN-dist full `pnpm build` → exit 0 (dependency-edge rule: all packages/*/dist deleted first, 0 dist dirs confirmed, cold dist)
- pnpm --filter @fluojs/prisma typecheck/test → exit 0 (9 files/65)
- pnpm --filter @fluojs/prisma build → exit 0; dist/*.d.ts contains NO @fluojs/runtime references
- Governance suite → 211 tests passed (base 199 + 12 added across the 5 fix-backs; arithmetic reconciled per-round by lead control runs)
- pnpm verify:platform-consistency-governance → exit 0; lint → 0 errors
- Local review triad at head f3b8893374089559c21cfc50df88a753289a539d: code PASS / contract PASS / verification PASS (fix-backs: governance closure + deterministic sort + ModuleType compat + npm X-range/partial-comparator semantics)

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset. (patch — dependency graph fix preserving the published contract)
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary (`PrismaModuleType` TSDoc).
- [x] Changed exported functions document matching `@param` / `@returns` tags.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README (Node 20+ promise now matches the dependency graph).
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests (consumer-style compile assertion; engine-graph governance guard with bypass regressions).

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (no governance docs changed)
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. (governance tooling + regression tests added; no docs changed)
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests (governance verifier enforces the documented alignment).