### PR TITLE
docs(platform-nodejs): point to Early Hints integration regression

### DIFF
--- a/.changeset/fix-platform-nodejs-early-hints-docs.md
+++ b/.changeset/fix-platform-nodejs-early-hints-docs.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/platform-nodejs": patch
+---
+
+Document the real-listener Early Hints regression source in the package README.

--- a/packages/platform-nodejs/README.ko.md
+++ b/packages/platform-nodejs/README.ko.md
@@ -105,7 +105,7 @@ await app.listen();
 
 ## Conformance 커버리지
 
-`packages/platform-nodejs/src/index.test.ts`와 `packages/platform-nodejs/src/lifecycle.test.ts`는 문서화된 Node.js 계약을 위한 package-local regression target입니다. Adapter portability suite는 공유 `createHttpAdapterPortabilityHarness(...)` 검사를 실행하여 malformed cookie 보존, JSON/text raw-body capture, byte-exact raw-body capture, 단일 byte-range status/header/body semantic, multipart raw-body 제외, multipart 전체 크기 기본값, SSE framing, response stream drain settlement, host 및 HTTPS startup logging, shutdown signal listener cleanup을 검증합니다.
+`packages/platform-nodejs/src/index.test.ts`, `packages/platform-nodejs/src/lifecycle.test.ts`, `packages/platform-nodejs/src/lifecycle.integration.test.ts`는 문서화된 Node.js 계약을 위한 package-local regression target입니다. Adapter portability suite는 공유 `createHttpAdapterPortabilityHarness(...)` 검사를 실행하여 malformed cookie 보존, JSON/text raw-body capture, byte-exact raw-body capture, 단일 byte-range status/header/body semantic, multipart raw-body 제외, multipart 전체 크기 기본값, SSE framing, response stream drain settlement, host 및 HTTPS startup logging, shutdown signal listener cleanup을 검증합니다.
 
 이 패키지는 `HttpApplicationAdapter`를 노출하며 `platform.components`에 등록되는 runtime-managed `PlatformComponent`가 아닙니다. 따라서 generic `createPlatformConformanceHarness(...)` component lifecycle 검사는 이 패키지의 지원 계약 범위에 포함되지 않고, `createHttpAdapterPortabilityHarness(...)`가 적용되는 공유 harness입니다.
 
@@ -138,4 +138,5 @@ Runtime route dispatch는 route를 위해 만든 iterator를 소유하며 handle
 
 - `packages/platform-nodejs/src/index.test.ts`
 - `packages/platform-nodejs/src/lifecycle.test.ts`
+- `packages/platform-nodejs/src/lifecycle.integration.test.ts`
 - `book/intermediate/ch21-express-node.ko.md`

--- a/packages/platform-nodejs/README.md
+++ b/packages/platform-nodejs/README.md
@@ -105,7 +105,7 @@ await app.listen();
 
 ## Conformance Coverage
 
-`packages/platform-nodejs/src/index.test.ts` and `packages/platform-nodejs/src/lifecycle.test.ts` are the package-local regression targets for the documented Node.js contract. The adapter portability suite runs the shared `createHttpAdapterPortabilityHarness(...)` checks for malformed cookie preservation, JSON/text raw-body capture, byte-exact raw-body capture, single byte-range status/header/body semantics, multipart raw-body exclusion, multipart total-size defaults, SSE framing, response stream drain settlement, host and HTTPS startup logging, and shutdown signal listener cleanup.
+`packages/platform-nodejs/src/index.test.ts`, `packages/platform-nodejs/src/lifecycle.test.ts`, and `packages/platform-nodejs/src/lifecycle.integration.test.ts` are the package-local regression targets for the documented Node.js contract. The adapter portability suite runs the shared `createHttpAdapterPortabilityHarness(...)` checks for malformed cookie preservation, JSON/text raw-body capture, byte-exact raw-body capture, single byte-range status/header/body semantics, multipart raw-body exclusion, multipart total-size defaults, SSE framing, response stream drain settlement, host and HTTPS startup logging, and shutdown signal listener cleanup.
 
 This package exposes an `HttpApplicationAdapter`; it is not a runtime-managed `PlatformComponent` registered under `platform.components`. Therefore the generic `createPlatformConformanceHarness(...)` component lifecycle checks are outside this package's supported contract, while `createHttpAdapterPortabilityHarness(...)` is the applicable shared harness.
 
@@ -138,4 +138,5 @@ Runtime route dispatch owns an iterator created for a route and automatically ca
 
 - `packages/platform-nodejs/src/index.test.ts`
 - `packages/platform-nodejs/src/lifecycle.test.ts`
+- `packages/platform-nodejs/src/lifecycle.integration.test.ts`
 - `book/intermediate/ch21-express-node.md`


### PR DESCRIPTION
## Summary

Repair the bilingual @fluojs/platform-nodejs README pointers so the real-listener Early Hints regression is discoverable.

Linked context: Closes #3401

## Changes

- Add `lifecycle.integration.test.ts` to EN/KO conformance coverage pointers.
- Add the integration test to EN/KO example source maps.
- Add a patch Changeset for the shipped package README update.

## Testing

- `pnpm --filter @fluojs/platform-nodejs... build`
- `pnpm --filter @fluojs/platform-nodejs typecheck`
- `pnpm --filter @fluojs/platform-nodejs test`
- `pnpm --filter ...@fluojs/platform-nodejs test`
- `pnpm lint`
- `pnpm verify:platform-consistency-governance`
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] No public exports changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] Existing Early Hints behavior remains unchanged.
- [x] The referenced real-listener regression was executed.

## Platform consistency governance (SSOT)

- [x] EN/KO package README structure remains synchronized.
- [x] Platform consistency governance passed.