### PR TITLE
docs(release): surface Express 2.0 Early Hints

### DIFF
--- a/.changeset/add-optional-http-early-hints.md
+++ b/.changeset/add-optional-http-early-hints.md
@@ -2,7 +2,6 @@
 "@fluojs/http": minor
 "@fluojs/runtime": minor
 "@fluojs/platform-nodejs": minor
-"@fluojs/platform-express": minor
 "@fluojs/platform-fastify": minor
 "@fluojs/platform-bun": minor
 "@fluojs/platform-deno": minor

--- a/.changeset/issue-3388-express-early-hints-release-note.md
+++ b/.changeset/issue-3388-express-early-hints-release-note.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/platform-express": minor
+---
+
+Add the optional request-scoped Early Hints capability to the Express 2.0.0 release. This backward-compatible adapter feature ships alongside the custom-route-methods Node.js migration: upgrade Node listener deployments to `>=20.19.3 <21 || >=22.2.0 <27` before using the release; Node 21, Node 22 before 22.2.0, and unverified Node 27+ are excluded.


### PR DESCRIPTION
## Summary

Ensure the Express 2.0 release notes surface Early Hints alongside the Node engines migration.

Linked context: Closes #3388

## Changes

- Split the Express Early Hints intent into a dedicated Changeset.
- Preserve the existing major migration while documenting the Early Hints addition and excluded versions.

## Testing

- `pnpm exec vitest run tooling/release/verify-changeset-release-lane.test.ts`
- `pnpm lint`
- `pnpm verify:platform-consistency-governance`
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`

## Release impact

- [x] This PR changes release metadata and includes a Changeset.

## Behavioral contract

- [x] Existing runtime behavior is unchanged.
- [x] Express 2.0 migration guidance and Early Hints release intent are explicit.

## Platform consistency governance (SSOT)

- [x] Platform consistency governance passed.