### PR TITLE
fix(prisma): make shutdown retries idempotent (#3244)

### DIFF
--- a/.changeset/idempotent-prisma-shutdown.md
+++ b/.changeset/idempotent-prisma-shutdown.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/prisma': patch
+---
+
+Avoid duplicate Prisma disconnects when application shutdown lifecycle hooks retry.

--- a/packages/prisma/src/lifecycle-race.test.ts
+++ b/packages/prisma/src/lifecycle-race.test.ts
@@ -129,6 +129,55 @@ describe('Prisma lifecycle transition races', () => {
     }
   });
 
+  it('retries disconnect after a failed shutdown transition', async () => {
+    // Given
+    const disconnectFailure = new Error('disconnect failed');
+    let disconnectCalls = 0;
+    let releaseFirstDisconnect: () => void = () => undefined;
+    let notifyFirstDisconnectStarted: () => void = () => undefined;
+    const firstDisconnectReleased = new Promise<void>((resolve) => {
+      releaseFirstDisconnect = resolve;
+    });
+    const firstDisconnectStarted = new Promise<void>((resolve) => {
+      notifyFirstDisconnectStarted = resolve;
+    });
+    const client = {
+      async $disconnect() {
+        disconnectCalls += 1;
+
+        if (disconnectCalls === 1) {
+          notifyFirstDisconnectStarted();
+          await firstDisconnectReleased;
+          throw disconnectFailure;
+        }
+      },
+    };
+    const prisma = new PrismaService<typeof client>(client);
+    const firstShutdown = prisma.onApplicationShutdown();
+
+    try {
+      await firstDisconnectStarted;
+      expect(disconnectCalls).toBe(1);
+      expect(prisma.createPlatformStatusSnapshot().details).toMatchObject({ lifecycleState: 'shutting-down' });
+
+      releaseFirstDisconnect();
+      await expect(firstShutdown).rejects.toThrow(disconnectFailure);
+      expect(disconnectCalls).toBe(1);
+      expect(prisma.createPlatformStatusSnapshot().details).toMatchObject({ lifecycleState: 'shutting-down' });
+
+      // When
+      const retryShutdown = prisma.onApplicationShutdown();
+
+      // Then
+      await expect(retryShutdown).resolves.toBeUndefined();
+      expect(disconnectCalls).toBe(2);
+      expect(prisma.createPlatformStatusSnapshot().details).toMatchObject({ lifecycleState: 'stopped' });
+    } finally {
+      releaseFirstDisconnect();
+      await Promise.allSettled([firstShutdown]);
+    }
+  });
+
   it('shares an in-flight shutdown transition', async () => {
     // Given
     let disconnectCalls = 0;

--- a/packages/prisma/src/lifecycle-race.test.ts
+++ b/packages/prisma/src/lifecycle-race.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import { PrismaService } from './index.js';
+import { bootstrapApplication, defineModule } from '@fluojs/runtime';
+
+import { PrismaModule, PrismaService } from './index.js';
 
 describe('Prisma lifecycle transition races', () => {
   it('keeps shutdown terminal when connect settles late', async () => {
@@ -64,6 +66,104 @@ describe('Prisma lifecycle transition races', () => {
       releaseConnect();
       releaseDisconnect();
       await Promise.allSettled([initialize, shutdown]);
+    }
+  });
+
+  it('does not disconnect again when a later shutdown hook retries', async () => {
+    // Given
+    const events: string[] = [];
+    let disconnectCalls = 0;
+    let failLaterShutdownHook = true;
+    const client = {
+      async $connect() {
+        events.push('connect');
+      },
+      async $disconnect() {
+        disconnectCalls += 1;
+        events.push('disconnect');
+      },
+    };
+
+    class LaterShutdownHook {
+      onApplicationShutdown() {
+        events.push('later:shutdown');
+
+        if (failLaterShutdownHook) {
+          failLaterShutdownHook = false;
+          throw new Error('later shutdown hook failed');
+        }
+      }
+    }
+
+    class LaterShutdownModule {}
+    defineModule(LaterShutdownModule, {
+      providers: [LaterShutdownHook],
+    });
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [
+        LaterShutdownModule,
+        PrismaModule.forRoot({ client }),
+      ],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+
+    try {
+      // When
+      await expect(app.close()).rejects.toThrow('later shutdown hook failed');
+
+      // Then
+      expect(disconnectCalls).toBe(1);
+      await expect(app.close()).resolves.toBeUndefined();
+      expect(disconnectCalls).toBe(1);
+      expect(events).toEqual([
+        'connect',
+        'disconnect',
+        'later:shutdown',
+        'later:shutdown',
+      ]);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('shares an in-flight shutdown transition', async () => {
+    // Given
+    let disconnectCalls = 0;
+    let releaseDisconnect: () => void = () => undefined;
+    let notifyDisconnectStarted: () => void = () => undefined;
+    const disconnectReleased = new Promise<void>((resolve) => {
+      releaseDisconnect = resolve;
+    });
+    const disconnectStarted = new Promise<void>((resolve) => {
+      notifyDisconnectStarted = resolve;
+    });
+    const client = {
+      async $disconnect() {
+        disconnectCalls += 1;
+        notifyDisconnectStarted();
+        await disconnectReleased;
+      },
+    };
+    const prisma = new PrismaService<typeof client>(client);
+    const firstShutdown = prisma.onApplicationShutdown();
+
+    try {
+      await disconnectStarted;
+
+      // When
+      const secondShutdown = prisma.onApplicationShutdown();
+
+      // Then
+      expect(disconnectCalls).toBe(1);
+      releaseDisconnect();
+      await expect(Promise.all([firstShutdown, secondShutdown])).resolves.toEqual([undefined, undefined]);
+      expect(disconnectCalls).toBe(1);
+    } finally {
+      releaseDisconnect();
+      await Promise.allSettled([firstShutdown]);
     }
   });
 });

--- a/packages/prisma/src/service.ts
+++ b/packages/prisma/src/service.ts
@@ -163,6 +163,7 @@ export class PrismaService<
   private readonly activeRequestTransactions = new Set<ActiveRequestTransaction>();
   private readonly activeTransactionBoundaries = new Set<ActiveTransactionBoundary>();
   private connectTransition?: Promise<void>;
+  private shutdownTransition?: Promise<void>;
   private transactionAbortSignalSupport: TransactionAbortSignalSupport = 'unknown';
   private lifecycleState: 'created' | 'ready' | 'shutting-down' | 'stopped' = 'created';
 
@@ -291,7 +292,27 @@ export class PrismaService<
     }
   }
 
-  async onApplicationShutdown(): Promise<void> {
+  onApplicationShutdown(): Promise<void> {
+    if (this.lifecycleState === 'stopped') {
+      return Promise.resolve();
+    }
+
+    if (this.shutdownTransition) {
+      return this.shutdownTransition;
+    }
+
+    const shutdownTransition = this.completeApplicationShutdown();
+    this.shutdownTransition = shutdownTransition;
+    void shutdownTransition.then(undefined, () => {
+      if (this.shutdownTransition === shutdownTransition) {
+        this.shutdownTransition = undefined;
+      }
+    });
+
+    return shutdownTransition;
+  }
+
+  private async completeApplicationShutdown(): Promise<void> {
     this.lifecycleState = 'shutting-down';
 
     for (const transaction of this.activeRequestTransactions) {


### PR DESCRIPTION
## Summary

The runtime retries an incomplete shutdown-hook stage (packages/runtime/src/bootstrap.ts). `PrismaService.onApplicationShutdown()` called `()` on every invocation and marked the `stopped` transition complete only after disconnect — so if Prisma's disconnect succeeded but a LATER provider hook failed, the next `Application.close()` could re-invoke Prisma disconnect during another provider's retry, duplicating database cleanup.

Linked context: Closes #3244

## Changes

- `packages/prisma/src/service.ts`: return immediately after a completed `stopped` transition; share one in-flight shutdown promise across concurrent/retried shutdowns; retain a retryable incomplete state only when Prisma's own `()` fails (retry then re-invokes the disconnect exactly once and completes).
- `packages/prisma/src/lifecycle-race.test.ts` (new): deterministic deferred/barrier regressions — (1) Prisma succeeds + a later provider hook fails once + close() re-runs → `` exactly once; (2) concurrent close shares the in-flight shutdown promise; (3) failed `()` → retryable incomplete state → subsequent shutdown retries the disconnect and completes to `stopped`.
- Changeset: patch (`@fluojs/prisma` — observable shutdown behavior fix).

## Testing

- pnpm --filter '@fluojs/prisma...' build → exit 0 (dependency closure before typecheck)
- pnpm --filter @fluojs/prisma typecheck → exit 0
- pnpm --filter @fluojs/prisma test → exit 0 (10 files, 77 tests; base at 3315debb measured 74 + 3 = 77 reconciled)
- pnpm exec biome lint → 0 errors
- RED-GREEN observed: 2 regressions failed pre-fix (duplicate disconnect on retry).
- Manual built-package driver: disconnectCalls=1.
- Local review triad at head 9e10a7c817251a35d26463c215ce606375edfa3d: code PASS / contract PASS / verification PASS (1 fix-back added the failed-disconnect retry regression).

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset. (patch — observable shutdown behavior fix)
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] No public exports changed (internal lifecycle state machine).

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README (drain-before-disconnect and single-disconnect promises at packages/prisma/README.md unchanged in wording; now enforced across runtime retries).
- [x] Intentional limitations are explicitly stated (retryable incomplete state only when $disconnect itself fails).
- [x] Runtime invariants are covered by regression tests (retry, concurrency, failed-disconnect retry).

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (none changed)
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. (no platform contract docs changed)
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests (no new claims).