### PR TITLE
feat(prisma): export async and status input contracts (#3245)

### DIFF
--- a/.changeset/export-prisma-async-status-input-contracts.md
+++ b/.changeset/export-prisma-async-status-input-contracts.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/prisma': minor
+---
+
+Export reusable async module registration and platform status snapshot input contracts.

--- a/packages/prisma/README.ko.md
+++ b/packages/prisma/README.ko.md
@@ -309,6 +309,7 @@ Provider가 `current()`, `transaction(...)`, `requestTransaction(...)`, `createP
 
 ### 관련 export 타입
 
+- `PrismaAsyncModuleOptions<TClient, TTransactionClient, TTransactionOptions>`
 - `PrismaModuleOptions`
 - `PrismaClientLike`
 - `PrismaHandleProvider`
@@ -316,6 +317,8 @@ Provider가 `current()`, `transaction(...)`, `requestTransaction(...)`, `createP
 - `PrismaTransactionClient<TClient>`
 - `InferPrismaTransactionClient<TClient>`
 - `InferPrismaTransactionOptions<TClient>`
+- `PrismaPlatformStatusSnapshotInput`
+  - `createPrismaPlatformStatusSnapshot(...)`의 입력 계약입니다. 바깥 service 또는 manual transaction boundary가 열려 있지 않다면 `activeTransactionBoundaries`를 생략할 수 있으며 snapshot은 `0`으로 보고합니다.
 
 ## 관련 패키지
 

--- a/packages/prisma/README.md
+++ b/packages/prisma/README.md
@@ -312,6 +312,7 @@ token are deliberately not exported.
 
 ### Related exported types
 
+- `PrismaAsyncModuleOptions<TClient, TTransactionClient, TTransactionOptions>`
 - `PrismaModuleOptions`
 - `PrismaClientLike`
 - `PrismaHandleProvider`
@@ -319,6 +320,8 @@ token are deliberately not exported.
 - `PrismaTransactionClient<TClient>`
 - `InferPrismaTransactionClient<TClient>`
 - `InferPrismaTransactionOptions<TClient>`
+- `PrismaPlatformStatusSnapshotInput`
+  - The input contract for `createPrismaPlatformStatusSnapshot(...)`; omit `activeTransactionBoundaries` when no outer service or manual transaction boundary is open and the snapshot reports `0`.
 
 ## Related Packages
 

--- a/packages/prisma/src/module.ts
+++ b/packages/prisma/src/module.ts
@@ -27,7 +27,14 @@ interface NormalizedPrismaModuleOptions<
   strictTransactions: boolean;
 }
 
-type PrismaAsyncModuleOptions<
+/**
+ * Configures an async Prisma module registration through an injected factory.
+ *
+ * @typeParam TClient Root Prisma client shape registered in the module.
+ * @typeParam TTransactionClient Transaction-scoped client resolved inside transaction callbacks.
+ * @typeParam TTransactionOptions Options forwarded to Prisma interactive transactions.
+ */
+export type PrismaAsyncModuleOptions<
   TClient extends PrismaClientLike<TTransactionClient, TTransactionOptions>,
   TTransactionClient,
   TTransactionOptions,

--- a/packages/prisma/src/public-api.test.ts
+++ b/packages/prisma/src/public-api.test.ts
@@ -1,6 +1,26 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 
+import type {
+  PrismaAsyncModuleOptions as RootPrismaAsyncModuleOptions,
+  PrismaClientLike,
+  PrismaPlatformStatusSnapshotInput as RootPrismaPlatformStatusSnapshotInput,
+} from './index.js';
 import * as prismaPublicApi from './index.js';
+import type { PrismaAsyncModuleOptions as ModulePrismaAsyncModuleOptions } from './module.js';
+import type { PrismaPlatformStatusSnapshotInput as StatusPrismaPlatformStatusSnapshotInput } from './status.js';
+
+type PrismaPublicApiTestTransactionClient = {
+  readonly transaction: true;
+};
+
+type PrismaPublicApiTestTransactionOptions = {
+  readonly isolationLevel: 'serializable';
+};
+
+type PrismaPublicApiTestClient = PrismaClientLike<
+  PrismaPublicApiTestTransactionClient,
+  PrismaPublicApiTestTransactionOptions
+>;
 
 describe('@fluojs/prisma public API surface', () => {
   it('keeps documented supported root-barrel exports', () => {
@@ -14,6 +34,20 @@ describe('@fluojs/prisma public API surface', () => {
     expect(prismaPublicApi).toHaveProperty('getPrismaClientToken');
     expect(prismaPublicApi).toHaveProperty('getPrismaOptionsToken');
     expect(prismaPublicApi).toHaveProperty('getPrismaServiceToken');
+  });
+
+  it('exports reusable async module and platform status input contracts', () => {
+    expectTypeOf<RootPrismaAsyncModuleOptions<
+      PrismaPublicApiTestClient,
+      PrismaPublicApiTestTransactionClient,
+      PrismaPublicApiTestTransactionOptions
+    >>().toEqualTypeOf<ModulePrismaAsyncModuleOptions<
+      PrismaPublicApiTestClient,
+      PrismaPublicApiTestTransactionClient,
+      PrismaPublicApiTestTransactionOptions
+    >>();
+    expectTypeOf<RootPrismaPlatformStatusSnapshotInput>()
+      .toEqualTypeOf<StatusPrismaPlatformStatusSnapshotInput>();
   });
 
   it('does not expose internal module wiring values from the root barrel', () => {

--- a/packages/prisma/src/status.ts
+++ b/packages/prisma/src/status.ts
@@ -23,7 +23,14 @@ type PersistencePlatformStatusSnapshot = {
 
 type PrismaPlatformLifecycleState = 'created' | 'ready' | 'shutting-down' | 'stopped';
 
-type PrismaPlatformStatusSnapshotInput = {
+/**
+ * Supplies lifecycle and transaction state for a Prisma platform status snapshot.
+ *
+ * @remarks
+ * Omit `activeTransactionBoundaries` when no outer service or manual transaction boundary is open;
+ * the snapshot reports it as `0`.
+ */
+export type PrismaPlatformStatusSnapshotInput = {
   activeTransactionBoundaries?: number;
   activeRequestTransactions: number;
   lifecycleState: PrismaPlatformLifecycleState;


### PR DESCRIPTION
## Summary

Two public Prisma APIs used declaration-local input aliases that consumers could not import or reuse as named contracts — `PrismaAsyncModuleOptions` (module registration) and `PrismaPlatformStatusSnapshotInput` (status snapshot input) were structurally inferable but not nameable.

Linked context: Closes #3245

## Changes

- `PrismaAsyncModuleOptions` (module.ts) and `PrismaPlatformStatusSnapshotInput` (status.ts) exported from their defining modules AND the package root barrel.
- TSDoc on both types (public-export-tsdoc changed-mode baseline green).
- Public API tests extended to pin the exported names.
- README EN/KO: both contracts listed in the public API surface.
- Changeset: minor (`@fluojs/prisma` — additive public type exports).
- Canonical docs assessment: `docs/reference/package-surface*.md` inventories package-level APIs, not individual type exports; no canonical-doc change required.

## Testing

- pnpm --filter '@fluojs/prisma...' build → exit 0 (dependency closure, cold dist)
- pnpm --filter @fluojs/prisma typecheck → exit 0
- pnpm --filter @fluojs/prisma test → exit 0 (10 files, 79 = 78 + 1 public-api case)
- pnpm verify:public-export-tsdoc → exit 0; parity → exit 0; governance → exit 0; lint → 0 errors
- Manual declaration QA: dist/module.d.ts, dist/status.d.ts, root dist/index.d.ts expose both contracts (pinned by the public-api test).
- Local review triad at head 3d09b74a31e125c70e601c23f3b33dac27f731aa: code PASS / contract PASS / verification PASS.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset. (minor — additive public type exports)
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests (public-api surface pins both exports).

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (none changed)
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. (no platform contract docs changed)
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests (public-api export tests).