### PR TITLE
fix(studio): contain EventSource construction failures

### DIFF
--- a/.changeset/guard-studio-eventsource.md
+++ b/.changeset/guard-studio-eventsource.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/studio': patch
+---
+
+Contain browser EventSource construction failures in Studio live mode.

--- a/packages/studio/src/features/live-connection/model/useStudioLiveConnection.test.ts
+++ b/packages/studio/src/features/live-connection/model/useStudioLiveConnection.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { createElement, useReducer } from 'react';
+import { act, createElement, useReducer } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { StudioLiveEvent } from '../../../contracts.js';
@@ -8,6 +8,10 @@ import type { StudioDashboardState } from '../../../entities/studio/model.js';
 import { initialStudioState } from '../../../entities/studio/model.js';
 import { studioReducer } from './reducer.js';
 import { useStudioLiveConnection } from './useStudioLiveConnection.js';
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean | undefined;
+}
 
 class FakeEventSource {
   static readonly instances: FakeEventSource[] = [];
@@ -116,6 +120,7 @@ describe('useStudioLiveConnection', () => {
     vi.useRealTimers();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    globalThis.IS_REACT_ACT_ENVIRONMENT = undefined;
     FakeEventSource.instances.length = 0;
   });
 
@@ -322,6 +327,8 @@ describe('useStudioLiveConnection', () => {
   });
 
   it('reports a controlled error when direct EventSource construction fails', async () => {
+    vi.useFakeTimers();
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
     let constructionCount = 0;
     class ThrowingEventSource {
       constructor() {
@@ -345,24 +352,34 @@ describe('useStudioLiveConnection', () => {
     const container = document.createElement('div');
     document.body.append(container);
     const root: Root = createRoot(container);
-    root.render(createElement(Harness));
 
     try {
-      await vi.waitFor(() => {
-        expect(observedStates).toContainEqual(expect.objectContaining({
-          connection: {
-            message: 'EventSource construction failed.',
-            status: 'error',
-          },
-        }));
+      await act(async () => {
+        root.render(createElement(Harness));
       });
+      expect(observedStates).toContainEqual(expect.objectContaining({
+        connection: {
+          message: 'EventSource construction failed.',
+          status: 'error',
+        },
+      }));
+      expect(constructionCount).toBe(1);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(25_001);
+      });
+      expect(observedStates.at(-1)?.connection.status).toBe('error');
       expect(constructionCount).toBe(1);
     } finally {
-      root.unmount();
+      await act(async () => {
+        root.unmount();
+      });
     }
   });
 
   it('reports a controlled error without retrying EventSource after state replay', async () => {
+    vi.useFakeTimers();
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
     let constructionCount = 0;
     class ThrowingEventSource {
       constructor() {
@@ -391,21 +408,33 @@ describe('useStudioLiveConnection', () => {
     const container = document.createElement('div');
     document.body.append(container);
     const root: Root = createRoot(container);
-    root.render(createElement(Harness));
 
     try {
-      await vi.waitFor(() => {
-        expect(observedStates).toContainEqual(expect.objectContaining({
-          connection: expect.objectContaining({
-            message: 'EventSource construction failed.',
-            status: 'error',
-          }),
-        }));
+      await act(async () => {
+        root.render(createElement(Harness));
       });
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(observedStates).toContainEqual(expect.objectContaining({
+        connection: expect.objectContaining({
+          message: 'EventSource construction failed.',
+          status: 'error',
+        }),
+      }));
       expect(constructionCount).toBe(1);
       expect(observedStates.at(-1)?.events).toHaveLength(1);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(25_001);
+      });
+      expect(observedStates.at(-1)?.connection.status).toBe('error');
+      expect(constructionCount).toBe(1);
     } finally {
-      root.unmount();
+      await act(async () => {
+        root.unmount();
+      });
     }
   });
 });

--- a/packages/studio/src/features/live-connection/model/useStudioLiveConnection.test.ts
+++ b/packages/studio/src/features/live-connection/model/useStudioLiveConnection.test.ts
@@ -320,4 +320,92 @@ describe('useStudioLiveConnection', () => {
       expect(source?.listeners.get(eventType)?.size).toBe(0);
     }
   });
+
+  it('reports a controlled error when direct EventSource construction fails', async () => {
+    let constructionCount = 0;
+    class ThrowingEventSource {
+      constructor() {
+        constructionCount += 1;
+        throw new Error('EventSource construction failed.');
+      }
+    }
+    vi.stubGlobal('EventSource', ThrowingEventSource);
+    (window as typeof window & { __FLUO_STUDIO__?: { eventsUrl: string } }).__FLUO_STUDIO__ = {
+      eventsUrl: '/api/events?token=test-token',
+    };
+
+    const observedStates: StudioDashboardState[] = [];
+    function Harness() {
+      const [state, dispatch] = useReducer(studioReducer, initialStudioState);
+      observedStates.push(state);
+      useStudioLiveConnection(dispatch);
+      return createElement('output', null, state.connection.status);
+    }
+
+    const container = document.createElement('div');
+    document.body.append(container);
+    const root: Root = createRoot(container);
+    root.render(createElement(Harness));
+
+    try {
+      await vi.waitFor(() => {
+        expect(observedStates).toContainEqual(expect.objectContaining({
+          connection: {
+            message: 'EventSource construction failed.',
+            status: 'error',
+          },
+        }));
+      });
+      expect(constructionCount).toBe(1);
+    } finally {
+      root.unmount();
+    }
+  });
+
+  it('reports a controlled error without retrying EventSource after state replay', async () => {
+    let constructionCount = 0;
+    class ThrowingEventSource {
+      constructor() {
+        constructionCount += 1;
+        throw new Error('EventSource construction failed.');
+      }
+    }
+    vi.stubGlobal('EventSource', ThrowingEventSource);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ events: [liveSnapshotEvent()], sequence: 1 }), { status: 200 })),
+    );
+    (window as typeof window & { __FLUO_STUDIO__?: { eventsUrl: string; stateUrl: string } }).__FLUO_STUDIO__ = {
+      eventsUrl: '/api/events?token=test-token',
+      stateUrl: '/api/state?token=test-token',
+    };
+
+    const observedStates: StudioDashboardState[] = [];
+    function Harness() {
+      const [state, dispatch] = useReducer(studioReducer, initialStudioState);
+      observedStates.push(state);
+      useStudioLiveConnection(dispatch);
+      return createElement('output', null, state.connection.status);
+    }
+
+    const container = document.createElement('div');
+    document.body.append(container);
+    const root: Root = createRoot(container);
+    root.render(createElement(Harness));
+
+    try {
+      await vi.waitFor(() => {
+        expect(observedStates).toContainEqual(expect.objectContaining({
+          connection: expect.objectContaining({
+            message: 'EventSource construction failed.',
+            status: 'error',
+          }),
+        }));
+      });
+      expect(constructionCount).toBe(1);
+      expect(observedStates.at(-1)?.events).toHaveLength(1);
+    } finally {
+      root.unmount();
+    }
+  });
 });

--- a/packages/studio/src/features/live-connection/model/useStudioLiveConnection.ts
+++ b/packages/studio/src/features/live-connection/model/useStudioLiveConnection.ts
@@ -70,19 +70,7 @@ export function useStudioLiveConnection(dispatch: Dispatch<StudioAction>): void 
 
     let closed = false;
     let lastEventAt = Date.now();
-    const staleTimer = window.setInterval(() => {
-      if (closed) {
-        return;
-      }
-
-      if (Date.now() - lastEventAt > 20_000) {
-        dispatchConnection(dispatch, {
-          lastEventAt: new Date(lastEventAt).toISOString(),
-          message: 'No Studio event has arrived for 20s; showing stale data until the sidecar reconnects.',
-          status: 'stale',
-        });
-      }
-    }, 5_000);
+    let staleTimer: number | undefined;
 
     dispatchConnection(dispatch, {
       message: 'Connecting to the local Studio sidecar…',
@@ -120,6 +108,19 @@ export function useStudioLiveConnection(dispatch: Dispatch<StudioAction>): void 
         });
         return;
       }
+      staleTimer = window.setInterval(() => {
+        if (closed) {
+          return;
+        }
+
+        if (Date.now() - lastEventAt > 20_000) {
+          dispatchConnection(dispatch, {
+            lastEventAt: new Date(lastEventAt).toISOString(),
+            message: 'No Studio event has arrived for 20s; showing stale data until the sidecar reconnects.',
+            status: 'stale',
+          });
+        }
+      }, 5_000);
       source.onopen = () => {
         if (closed) {
           return;
@@ -193,7 +194,9 @@ export function useStudioLiveConnection(dispatch: Dispatch<StudioAction>): void 
       if (config.stateUrl && typeof fetch === 'function') {
         abortController?.abort();
       }
-      window.clearInterval(staleTimer);
+      if (staleTimer !== undefined) {
+        window.clearInterval(staleTimer);
+      }
       if (source) {
         for (const eventType of LIVE_EVENT_TYPES) {
           source.removeEventListener(eventType, handleMessage);

--- a/packages/studio/src/features/live-connection/model/useStudioLiveConnection.ts
+++ b/packages/studio/src/features/live-connection/model/useStudioLiveConnection.ts
@@ -111,7 +111,15 @@ export function useStudioLiveConnection(dispatch: Dispatch<StudioAction>): void 
         return;
       }
 
-      source = new EventSource(eventsUrl);
+      try {
+        source = new EventSource(eventsUrl);
+      } catch (error: unknown) {
+        dispatchConnection(dispatch, {
+          message: error instanceof Error ? error.message : 'Failed to connect to the Studio event stream.',
+          status: 'error',
+        });
+        return;
+      }
       source.onopen = () => {
         if (closed) {
           return;


### PR DESCRIPTION
## Summary
- guard synchronous EventSource construction failures in Studio live mode
- preserve controlled error state after replay fallback without stale overwrite
- cover direct and post-replay constructor failures

## Verification
- Studio dependency build and typecheck
- Studio tests: 70 passed
- reverse-dependent CLI tests: 444 passed
- lint and platform consistency governance
- real browser QA for direct, replay, and stale-threshold cases

Closes #3339