### PR TITLE
docs(studio): correct README source-entry map (#3343)

### DIFF
--- a/.changeset/correct-studio-readme-source-entry-map.md
+++ b/.changeset/correct-studio-readme-source-entry-map.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/studio": patch
+---
+
+Correct the packaged Studio README source-entry map.

--- a/packages/studio/README.ko.md
+++ b/packages/studio/README.ko.md
@@ -181,6 +181,5 @@ MVP는 local runtime-connected devtool입니다. 향후 릴리스에서는 cloud
 
 ## 예제 소스
 
-- [main.ts](./src/main.ts) - 테스트 호환 애플리케이션 진입점
 - [main.tsx](./src/main.tsx) - React 브라우저 viewer 진입점
 - [contracts.ts](./src/contracts.ts) - static/live Studio 계약 정의

--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -181,6 +181,5 @@ The MVP is local and runtime-connected. Future releases should consider, but do 
 
 ## Example Sources
 
-- [main.ts](./src/main.ts) - Test-compatible application entry point.
 - [main.tsx](./src/main.tsx) - React browser viewer entry point.
 - [contracts.ts](./src/contracts.ts) - Static and live Studio contract definitions.


### PR DESCRIPTION
## Summary
- correct the Studio README source-entry map to identify src/main.tsx as the browser entry
- keep English and Korean package documentation aligned
- add the required patch Changeset for the shipped README correction

## Verification
- pnpm --filter @fluojs/studio... build
- pnpm --filter @fluojs/studio typecheck
- pnpm --filter @fluojs/studio test (68/68)
- pnpm --filter @fluojs/cli test (444/444)
- pnpm lint
- pnpm verify:platform-consistency-governance

Closes #3343