### PR TITLE
docs(studio): document deterministic Mermaid rendering (#3344)

### DIFF
--- a/.changeset/issue-3344-studio-mermaid-readme.md
+++ b/.changeset/issue-3344-studio-mermaid-readme.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/studio": patch
+---
+
+Correct Mermaid diagrams in the Studio README shipped with the package.

--- a/.changeset/issue-3344-studio-mermaid-readme.md
+++ b/.changeset/issue-3344-studio-mermaid-readme.md
@@ -2,4 +2,4 @@
 "@fluojs/studio": patch
 ---
 
-Correct Mermaid diagrams in the Studio README shipped with the package.
+Document deterministic filtered and serialized Mermaid rendering in the Studio README.

--- a/packages/studio/README.ko.md
+++ b/packages/studio/README.ko.md
@@ -123,7 +123,7 @@ Studio는 주로 CLI가 실행하는 sidecar와 browser viewer이지만, 배포�
 |---|---|
 | `parseStudioPayload(rawJson)` | raw snapshot JSON, standalone timing JSON, snapshot+timing envelope, `fluo inspect --report` artifact를 받아 parsed payload와 원본 JSON string을 반환합니다. |
 | `applyFilters(snapshot, filter)` | 원본 snapshot을 변경하지 않고 readiness/severity/query filter를 적용합니다. |
-| `renderMermaid(snapshot)` | 내부 component dependency edge와 외부 dependency node를 포함해 로드된 platform graph를 Mermaid text로 변환합니다. |
+| `renderMermaid(snapshot)` | 내부 component dependency edge와 외부 dependency node를 포함해 로드된 platform graph를 Mermaid text로 변환합니다. 필터링된 snapshot은 JSON 직렬화 전후에 동일한 Mermaid text로 결정론적으로 렌더링됩니다. |
 | `parseStudioLiveEvent(rawJson)` / `validateStudioLiveEvent(value)` | UI state가 사용하기 전에 runtime-connected sidecar/SSE envelope를 검증합니다. |
 | `isStudioLiveEvent(value)` | parsing 또는 dispatch 전에 sidecar/SSE envelope를 확인하는 runtime-safe type guard입니다. |
 | `StudioLiveSnapshot` | React UI가 소비하는 live graph/routes/requests/timing/diagnostics snapshot입니다. |

--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -123,7 +123,7 @@ Studio is primarily a CLI-launched sidecar and browser viewer, but the published
 |---|---|
 | `parseStudioPayload(rawJson)` | Accepts raw snapshot JSON, standalone timing JSON, snapshot+timing envelopes, and `fluo inspect --report` artifacts; returns the parsed payload plus the original JSON string. |
 | `applyFilters(snapshot, filter)` | Applies readiness/severity/query filters without mutating the source snapshot. |
-| `renderMermaid(snapshot)` | Produces Mermaid graph text from the loaded platform graph, including internal component dependency edges and external dependency nodes. |
+| `renderMermaid(snapshot)` | Produces Mermaid graph text from the loaded platform graph, including internal component dependency edges and external dependency nodes. Filtered snapshots render deterministically, producing identical Mermaid text before and after JSON serialization. |
 | `parseStudioLiveEvent(rawJson)` / `validateStudioLiveEvent(value)` | Validate runtime-connected sidecar/SSE envelopes before UI state consumes them. |
 | `isStudioLiveEvent(value)` | Runtime-safe type guard for checking sidecar/SSE envelopes before parsing or dispatch. |
 | `StudioLiveSnapshot` | Live graph/routes/requests/timing/diagnostics snapshot consumed by the React UI. |


### PR DESCRIPTION
## Summary
- document deterministic filtered Mermaid rendering in the Studio README
- keep English and Korean package documentation aligned
- add the required patch Changeset for shipped README content

## Verification
- pnpm --filter @fluojs/studio... build
- pnpm --filter @fluojs/studio typecheck
- pnpm --filter @fluojs/studio test (68/68)
- pnpm --filter @fluojs/cli test (444/444)
- pnpm lint
- pnpm verify:platform-consistency-governance

Closes #3344