### PR TITLE
test(bun): add native runtime conformance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,6 +390,37 @@ jobs:
         if: matrix.runtime == 'cloudflare-workers'
         run: node --test tooling/native-runtime/cloudflare-workers-response-cookie-conformance.test.mjs
 
+  bun-native-routing-and-lifecycle-conformance:
+    name: Bun native routing and lifecycle conformance
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+          cache: pnpm
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.2.3"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Bun adapter dependency closure
+        run: node tooling/scripts/run-workspace-build-closure.mjs @fluojs/platform-bun
+
+      - name: Run Bun native routing and lifecycle conformance
+        run: bun test tooling/native-runtime/platform-bun-native-conformance.test.mjs
+
   verify-platform-consistency-governance:
     name: Verify platform consistency governance
     runs-on: ubuntu-latest
@@ -426,6 +457,7 @@ jobs:
       - studio-browser
       - official-web-runtime-adapter-portability
       - native-response-cookie-conformance
+      - bun-native-routing-and-lifecycle-conformance
       - verify-platform-consistency-governance
       - resolve-pr-verification-scope
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,14 @@ jobs:
       - name: Build packages
         run: pnpm build
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: '1.2.3'
+
+      - name: Verify Bun native routing and lifecycle
+        run: bun test tooling/native-runtime/platform-bun-native-conformance.test.mjs
+
       - name: Verify changeset release lane
         run: pnpm verify:changeset-release-lane -- --lane=stable --base-ref=${{ github.event.before }}
 

--- a/tooling/native-runtime/platform-bun-native-conformance.test.mjs
+++ b/tooling/native-runtime/platform-bun-native-conformance.test.mjs
@@ -1,0 +1,168 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { defineControllerMetadata, defineRouteMetadata } from '../../packages/core/dist/internal.js';
+import { createDispatcher, createHandlerMapping } from '../../packages/http/dist/index.js';
+import { BunHttpApplicationAdapter } from '../../packages/platform-bun/dist/index.js';
+
+const activeAdapters = new Set();
+const activeSockets = new Set();
+
+afterEach(async () => {
+  for (const socket of activeSockets) {
+    socket.close();
+  }
+  activeSockets.clear();
+
+  await Promise.all([...activeAdapters].map((adapter) => adapter.close()));
+  activeAdapters.clear();
+});
+
+class NativeController {
+  getStatic() {
+    return { route: 'static' };
+  }
+
+  getParam(_input, context) {
+    return { value: context.request.params.value };
+  }
+
+  getSocketFallback() {
+    return { route: 'http-fallback' };
+  }
+}
+
+defineControllerMetadata(NativeController, { basePath: '/native' });
+defineRouteMetadata(NativeController.prototype, 'getStatic', {
+  method: 'GET',
+  path: '/static',
+});
+defineRouteMetadata(NativeController.prototype, 'getParam', {
+  method: 'GET',
+  path: '/params/:value',
+});
+defineRouteMetadata(NativeController.prototype, 'getSocketFallback', {
+  method: 'GET',
+  path: '/socket',
+});
+
+function createNativeDispatcher() {
+  return createDispatcher({
+    handlerMapping: createHandlerMapping([{ controllerToken: NativeController }]),
+    rootContainer: {
+      createRequestScope() {
+        return {
+          async dispose() {},
+          resolve() {
+            return new NativeController();
+          },
+        };
+      },
+    },
+  });
+}
+
+function waitForEvent(target, eventName, timeoutMs = 5_000) {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(`Timed out waiting for ${eventName}.`));
+    }, timeoutMs);
+    const onEvent = (event) => {
+      clearTimeout(timeout);
+      resolve(event);
+    };
+
+    target.addEventListener(eventName, onEvent, { once: true });
+  });
+}
+
+describe('real Bun native routing conformance', () => {
+  test('preserves static, parameter, encoded-separator, and method fallback semantics', async () => {
+    // Given: the built adapter is listening through the real Bun.serve routes host.
+    const adapter = new BunHttpApplicationAdapter({
+      hostname: '127.0.0.1',
+      port: 0,
+    });
+    activeAdapters.add(adapter);
+    await adapter.listen(createNativeDispatcher());
+
+    const server = adapter.getServer();
+    if (server?.port === undefined) {
+      throw new TypeError('Expected the real Bun server to expose its assigned port.');
+    }
+    const httpUrl = `http://127.0.0.1:${String(server.port)}`;
+
+    // When: Bun receives native static/parameter requests and a method miss.
+    const [staticResponse, paramResponse, encodedSeparatorResponse, methodFallbackResponse] = await Promise.all([
+      fetch(`${httpUrl}/native/static`),
+      fetch(`${httpUrl}/native/params/alpha`),
+      fetch(`${httpUrl}/native/params/a%2Fb`),
+      fetch(`${httpUrl}/native/params/alpha`, { method: 'POST' }),
+    ]);
+
+    // Then: native matching preserves the shared fluo dispatcher contract.
+    expect(staticResponse.status).toBe(200);
+    expect(await staticResponse.json()).toEqual({ route: 'static' });
+    expect(paramResponse.status).toBe(200);
+    expect(await paramResponse.json()).toEqual({ value: 'alpha' });
+    expect(encodedSeparatorResponse.status).toBe(200);
+    expect(await encodedSeparatorResponse.json()).toEqual({ value: 'a%2Fb' });
+    expect(methodFallbackResponse.status).toBe(404);
+    expect(await methodFallbackResponse.json()).toMatchObject({
+      error: {
+        code: 'NOT_FOUND',
+        status: 404,
+      },
+    });
+  });
+
+  test('upgrades a native route and closes its socket during adapter shutdown', async () => {
+    // Given: a real Bun websocket binding is installed before listen.
+    const adapter = new BunHttpApplicationAdapter({
+      hostname: '127.0.0.1',
+      port: 0,
+      stopActiveConnections: true,
+    });
+    activeAdapters.add(adapter);
+    adapter.configureRealtimeBinding({
+      fetch(request, server) {
+        if (request.headers.get('upgrade')?.toLowerCase() !== 'websocket') {
+          return undefined;
+        }
+
+        return server.upgrade(request, { data: { route: '/native/socket' } })
+          ? undefined
+          : new Response(null, { status: 400 });
+      },
+      websocket: {
+        open(socket) {
+          socket.send(JSON.stringify(socket.data));
+        },
+      },
+    });
+    await adapter.listen(createNativeDispatcher());
+
+    const server = adapter.getServer();
+    if (server?.port === undefined) {
+      throw new TypeError('Expected the real Bun websocket server to expose its assigned port.');
+    }
+
+    const socket = new WebSocket(`ws://127.0.0.1:${String(server.port)}/native/socket`);
+    activeSockets.add(socket);
+    const opened = waitForEvent(socket, 'open');
+    const message = waitForEvent(socket, 'message');
+
+    // When: the client upgrades and adapter shutdown starts after the connection opens.
+    await opened;
+    const received = await message;
+    const closed = waitForEvent(socket, 'close');
+    await adapter.close();
+    await closed;
+    activeAdapters.delete(adapter);
+    activeSockets.delete(socket);
+
+    // Then: Bun handled the upgrade payload and stop(true) closed the live socket.
+    expect(JSON.parse(received.data)).toEqual({ route: '/native/socket' });
+    expect(adapter.getServer()).toBeUndefined();
+    expect(socket.readyState).toBe(WebSocket.CLOSED);
+  });
+});

--- a/tooling/native-runtime/platform-bun-native-conformance.test.mjs
+++ b/tooling/native-runtime/platform-bun-native-conformance.test.mjs
@@ -8,9 +8,15 @@ const activeAdapters = new Set();
 const activeSockets = new Set();
 
 afterEach(async () => {
-  for (const socket of activeSockets) {
+  await Promise.all([...activeSockets].map(async (socket) => {
+    if (socket.readyState === WebSocket.CLOSED) {
+      return;
+    }
+
+    const closed = waitForEvent(socket, 'close');
     socket.close();
-  }
+    await closed;
+  }));
   activeSockets.clear();
 
   await Promise.all([...activeAdapters].map((adapter) => adapter.close()));
@@ -45,9 +51,17 @@ defineRouteMetadata(NativeController.prototype, 'getSocketFallback', {
   path: '/socket',
 });
 
-function createNativeDispatcher() {
+function createNativeDispatcher(onHandlerMappingMatch) {
+  const handlerMapping = createHandlerMapping([{ controllerToken: NativeController }]);
+
   return createDispatcher({
-    handlerMapping: createHandlerMapping([{ controllerToken: NativeController }]),
+    handlerMapping: {
+      descriptors: handlerMapping.descriptors,
+      match(request) {
+        onHandlerMappingMatch?.(request);
+        return handlerMapping.match(request);
+      },
+    },
     rootContainer: {
       createRequestScope() {
         return {
@@ -63,27 +77,49 @@ function createNativeDispatcher() {
 
 function waitForEvent(target, eventName, timeoutMs = 5_000) {
   return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      clearTimeout(timeout);
+      target.removeEventListener(eventName, onEvent);
+      target.removeEventListener('error', onError);
+      target.removeEventListener('close', onClose);
+    };
+    const settle = (callback, value) => {
+      cleanup();
+      callback(value);
+    };
     const timeout = setTimeout(() => {
-      reject(new Error(`Timed out waiting for ${eventName}.`));
+      settle(reject, new Error(`Timed out waiting for ${eventName}.`));
     }, timeoutMs);
     const onEvent = (event) => {
-      clearTimeout(timeout);
-      resolve(event);
+      settle(resolve, event);
+    };
+    const onError = () => {
+      settle(reject, new Error(`WebSocket failed before ${eventName}.`));
+    };
+    const onClose = () => {
+      settle(reject, new Error(`WebSocket closed before ${eventName}.`));
     };
 
-    target.addEventListener(eventName, onEvent, { once: true });
+    target.addEventListener(eventName, onEvent);
+    target.addEventListener('error', onError);
+    if (eventName !== 'close') {
+      target.addEventListener('close', onClose);
+    }
   });
 }
 
 describe('real Bun native routing conformance', () => {
   test('preserves static, parameter, encoded-separator, and method fallback semantics', async () => {
     // Given: the built adapter is listening through the real Bun.serve routes host.
+    const handlerMappingMatches = [];
     const adapter = new BunHttpApplicationAdapter({
       hostname: '127.0.0.1',
       port: 0,
     });
     activeAdapters.add(adapter);
-    await adapter.listen(createNativeDispatcher());
+    await adapter.listen(createNativeDispatcher((request) => {
+      handlerMappingMatches.push({ method: request.method, path: request.path });
+    }));
 
     const server = adapter.getServer();
     if (server?.port === undefined) {
@@ -91,21 +127,36 @@ describe('real Bun native routing conformance', () => {
     }
     const httpUrl = `http://127.0.0.1:${String(server.port)}`;
 
-    // When: Bun receives native static/parameter requests and a method miss.
-    const [staticResponse, paramResponse, encodedSeparatorResponse, methodFallbackResponse] = await Promise.all([
-      fetch(`${httpUrl}/native/static`),
-      fetch(`${httpUrl}/native/params/alpha`),
-      fetch(`${httpUrl}/native/params/a%2Fb`),
-      fetch(`${httpUrl}/native/params/alpha`, { method: 'POST' }),
-    ]);
+    // When: Bun receives a static route native handoff.
+    const staticResponse = await fetch(`${httpUrl}/native/static`);
 
-    // Then: native matching preserves the shared fluo dispatcher contract.
+    // Then: the static route reaches the dispatcher without generic rematching.
     expect(staticResponse.status).toBe(200);
     expect(await staticResponse.json()).toEqual({ route: 'static' });
+    expect(handlerMappingMatches).toEqual([]);
+
+    // When: Bun receives an ordinary parameter route native handoff.
+    const paramResponse = await fetch(`${httpUrl}/native/params/alpha`);
+
+    // Then: the parameter handoff also bypasses generic rematching.
     expect(paramResponse.status).toBe(200);
     expect(await paramResponse.json()).toEqual({ value: 'alpha' });
+    expect(handlerMappingMatches).toEqual([]);
+
+    // When: the parameter contains an encoded separator.
+    const encodedSeparatorResponse = await fetch(`${httpUrl}/native/params/a%2Fb`);
+
+    // Then: normalization-sensitive parameters intentionally use the generic matcher.
     expect(encodedSeparatorResponse.status).toBe(200);
     expect(await encodedSeparatorResponse.json()).toEqual({ value: 'a%2Fb' });
+    expect(handlerMappingMatches).toEqual([
+      { method: 'GET', path: '/native/params/a%2Fb' },
+    ]);
+
+    // When: Bun receives a method miss for a native route shape.
+    const methodFallbackResponse = await fetch(`${httpUrl}/native/params/alpha`, { method: 'POST' });
+
+    // Then: the native method fallback intentionally rematches through the dispatcher.
     expect(methodFallbackResponse.status).toBe(404);
     expect(await methodFallbackResponse.json()).toMatchObject({
       error: {
@@ -113,6 +164,10 @@ describe('real Bun native routing conformance', () => {
         status: 404,
       },
     });
+    expect(handlerMappingMatches).toEqual([
+      { method: 'GET', path: '/native/params/a%2Fb' },
+      { method: 'POST', path: '/native/params/alpha' },
+    ]);
   });
 
   test('upgrades a native route and closes its socket during adapter shutdown', async () => {
@@ -134,7 +189,11 @@ describe('real Bun native routing conformance', () => {
           : new Response(null, { status: 400 });
       },
       websocket: {
-        open(socket) {
+        message(socket, message) {
+          if (message !== 'read-route') {
+            return;
+          }
+
           socket.send(JSON.stringify(socket.data));
         },
       },
@@ -148,12 +207,15 @@ describe('real Bun native routing conformance', () => {
 
     const socket = new WebSocket(`ws://127.0.0.1:${String(server.port)}/native/socket`);
     activeSockets.add(socket);
-    const opened = waitForEvent(socket, 'open');
-    const message = waitForEvent(socket, 'message');
 
-    // When: the client upgrades and adapter shutdown starts after the connection opens.
+    // When: the client opens, subscribes for its reply, and sends an explicit trigger.
+    const opened = waitForEvent(socket, 'open');
     await opened;
+    const message = waitForEvent(socket, 'message');
+    socket.send('read-route');
     const received = await message;
+
+    // When: adapter shutdown starts after the message has been received.
     const closed = waitForEvent(socket, 'close');
     await adapter.close();
     await closed;


### PR DESCRIPTION
## Summary

Add real-Bun routing and lifecycle conformance to CI and release gates.

Linked context: Closes #3360

## Changes

- Exercise built adapter under real Bun for static/parameter native handoff and intentional fallback cases.
- Exercise real WebSocket upgrade and deterministic shutdown cleanup.
- Run the native suite on Bun 1.2.3 in CI and before release.

## Testing

- dependency closure build
- Bun 1.4 native conformance: 2 tests / 15 assertions
- platform-bun typecheck and 80 tests
- reverse-dependent suites
- `pnpm lint`
- platform governance
- implementer evidence: Bun 1.2.3 native suite PASS

## Release impact

- [x] Test/CI-only; no consumer-visible package change or Changeset.

## Behavioral contract

- [x] Native route handoff cannot be replaced by generic fallback unnoticed.
- [x] WebSocket cleanup is event-driven and bounded.

## Platform consistency governance (SSOT)

- [x] CI and release execute the same native conformance suite.