### PR TITLE
fix(platform-bun): add stable diagnostic codes

### DIFF
--- a/.changeset/stable-bun-adapter-diagnostics.md
+++ b/.changeset/stable-bun-adapter-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/platform-bun": patch
+---
+
+Add stable diagnostic codes to package-generated Bun adapter option, realtime binding, runtime availability, and shutdown timeout failures while preserving their existing error classes and messages.

--- a/.changeset/stable-bun-adapter-diagnostics.md
+++ b/.changeset/stable-bun-adapter-diagnostics.md
@@ -1,5 +1,5 @@
 ---
-"@fluojs/platform-bun": patch
+"@fluojs/platform-bun": minor
 ---
 
 Add stable diagnostic codes to package-generated Bun adapter option, realtime binding, runtime availability, and shutdown timeout failures while preserving their existing error classes and messages.

--- a/packages/platform-bun/README.ko.md
+++ b/packages/platform-bun/README.ko.md
@@ -138,6 +138,20 @@ Native handoff가 붙은 뒤 app middleware가 framework request의 method 또�
 - **Realtime seam**: `getRealtimeCapability()`는 fetch-style version 1을 보존하면서 optional version 1 `bindingInstallation` contract를 노출합니다. Bun websocket binding은 서버를 시작하는 `listen()` 전에 구성해야 합니다. Capability installer는 protocol package를 위한 canonical configuration path이며 `fetch` 및 `websocket` host contract가 없는 값을 거부합니다. Startup 이후 live server의 binding은 고정되고 adapter `close()` boundary가 Bun 종료와 요청 drain이 끝난 후 retained binding state를 정리합니다. Adapter가 새 유입을 받는 동안 Upgrade 요청은 HTTP dispatch로 넘어가기 전에 구성된 binding에 먼저 전달되며, 비동기 binding 평가 도중 shutdown이 시작되어도 이미 수락된 요청에는 dispatcher가 유지되고, binding이 response를 반환하거나 요청 업그레이드에 성공한 경우에만 HTTP fallback을 억제합니다. Binding host는 `upgrade(...)`만 노출하므로 adapter가 소유하는 `stop()`과 raw `fetch()` 제어는 realtime seam 밖에 남습니다.
 - **Adapter instance helper**: `BunHttpApplicationAdapter`는 `getServer()`, `getListenTarget()`, `getRealtimeCapability()`, `configureRealtimeBinding()`, `configureWebSocketBinding()`, `listen()`, `close()`를 노출합니다.
 
+### 안정적인 진단 코드
+
+패키지가 생성하는 caller-visible failure는 기존 `Error` 또는 `TypeError` class와 message를 유지하면서 `error.code`에 안정적인 문자열을 노출합니다.
+
+| 코드 | Error class | 실패 조건 |
+| --- | --- | --- |
+| `BUN_ADAPTER_INVALID_OPTION` | `Error` | 숫자형 adapter 또는 shutdown option이 문서화된 범위를 벗어납니다. |
+| `BUN_ADAPTER_REALTIME_BINDING_INVALID` | `TypeError` | Realtime capability installer가 필수 `fetch` 및 `websocket` contract가 없는 값을 받습니다. |
+| `BUN_ADAPTER_REALTIME_BINDING_LOCKED` | `Error` | `listen()`이 Bun server를 시작한 뒤 caller가 realtime/websocket binding을 변경하려고 합니다. |
+| `BUN_ADAPTER_RUNTIME_UNAVAILABLE` | `Error` | `listen()`이 호출 가능한 `globalThis.Bun.serve()`를 찾지 못합니다. |
+| `BUN_ADAPTER_SHUTDOWN_TIMEOUT` | `Error` | Caller-facing `close()` 대기가 bounded shutdown timeout을 초과합니다. |
+
+Bun 또는 application code에서 전파된 error에는 package-owned code를 덧붙이지 않고 원래 class, message, metadata를 유지합니다.
+
 ## Conformance 커버리지
 
 `packages/platform-bun/src/adapter.test.ts`는 문서화된 계약을 검증하는 package-local regression 대상입니다. 이 파일은 conditional request, single-byte range 및 `If-Range`, custom `QUERY`/extension-method fallback, malformed cookie, byte-exact JSON/text raw-body 보존, managed/custom fetch handler의 multipart raw-body 제외, SSE framing, native-route param parity, same-path multi-method handoff, middleware가 request path 또는 method를 rewrite한 뒤의 stale native handoff rematch, versioning fallback, normalization-sensitive fallback, OPTIONS/CORS ownership, same-shape route fallback, TLS listen-target reporting을 검증하는 Bun fetch-style portability assertion과 startup logging, duplicate listen idempotency, shutdown listener cleanup, in-flight drain, 비동기 realtime binding 평가 중 close, binding 완료 후 HTTP fallback, timeout validation/reporting, shutdown 503 ingress rejection, signal-driven close rejection reporting, upgrade-only host를 통한 websocket binding delegation/short-circuit 동작을 검증하는 집중 테스트를 포함합니다.

--- a/packages/platform-bun/README.md
+++ b/packages/platform-bun/README.md
@@ -138,6 +138,20 @@ The adapter also exports the typed Bun integration seams used by realtime packag
 - **Realtime seam**: `getRealtimeCapability()` preserves fetch-style version 1 and exposes its optional version 1 `bindingInstallation` contract. Bun websocket bindings must be configured before `listen()` starts the server. The capability installer is the canonical configuration path for protocol packages and rejects values without `fetch` and `websocket` host contracts. After startup the binding remains frozen for the live server; the adapter `close()` boundary clears its retained binding state after Bun termination and request drain settle. Upgrade requests are offered to the configured binding before falling back to HTTP dispatch while the adapter is accepting new ingress; an accepted request keeps its dispatcher available if shutdown begins during asynchronous binding evaluation, and HTTP fallback is suppressed only after the binding returns a response or successfully upgrades the request. The binding host exposes only `upgrade(...)`, so adapter-owned `stop()` and raw `fetch()` control remain outside the realtime seam.
 - **Adapter instance helpers**: `BunHttpApplicationAdapter` exposes `getServer()`, `getListenTarget()`, `getRealtimeCapability()`, `configureRealtimeBinding()`, `configureWebSocketBinding()`, `listen()`, and `close()`.
 
+### Stable diagnostic codes
+
+Package-generated caller-visible failures retain their existing `Error` or `TypeError` class and message while exposing a stable string through `error.code`:
+
+| Code | Error class | Failure |
+| --- | --- | --- |
+| `BUN_ADAPTER_INVALID_OPTION` | `Error` | A numeric adapter or shutdown option is outside its documented range. |
+| `BUN_ADAPTER_REALTIME_BINDING_INVALID` | `TypeError` | The realtime capability installer receives a value without the required `fetch` and `websocket` contracts. |
+| `BUN_ADAPTER_REALTIME_BINDING_LOCKED` | `Error` | A caller attempts to change the realtime/websocket binding after `listen()` starts the Bun server. |
+| `BUN_ADAPTER_RUNTIME_UNAVAILABLE` | `Error` | `listen()` cannot find a callable `globalThis.Bun.serve()`. |
+| `BUN_ADAPTER_SHUTDOWN_TIMEOUT` | `Error` | The caller-facing `close()` wait exceeds its bounded shutdown timeout. |
+
+Errors propagated from Bun or application code keep their original class, message, and metadata instead of receiving a package-owned code.
+
 ## Conformance Coverage
 
 `packages/platform-bun/src/adapter.test.ts` is the package-local regression target for the documented contract. It includes Bun fetch-style portability assertions for conditional requests, single-byte ranges and `If-Range`, custom `QUERY`/extension-method fallback, malformed cookies, byte-exact JSON/text raw-body preservation, multipart raw-body exclusion for managed and custom fetch handlers, SSE framing, native-route param parity, same-path multi-method handoff, stale native handoff rematching after middleware rewrites the request path or method, versioning fallback, normalization-sensitive fallback, OPTIONS/CORS ownership, same-shape route fallback, and TLS listen-target reporting, plus focused tests for startup logging, duplicate listen idempotency, shutdown listener cleanup, in-flight drain behavior, close during asynchronous realtime binding evaluation, HTTP fallback after binding completion, timeout validation/reporting, shutdown 503 ingress rejection, signal-driven close rejection reporting, and websocket binding delegation/short-circuit behavior through an upgrade-only host.

--- a/packages/platform-bun/src/adapter.test.ts
+++ b/packages/platform-bun/src/adapter.test.ts
@@ -2835,7 +2835,7 @@ describe('@fluojs/platform-bun', () => {
       throw new TypeError('Expected realtime binding installation to throw an Error.');
     }
 
-    expect(thrown).toBeInstanceOf(TypeError);
+    expect(thrown.constructor).toBe(TypeError);
     expect(thrown).toMatchObject({
       code: 'BUN_ADAPTER_REALTIME_BINDING_INVALID',
     });

--- a/packages/platform-bun/src/adapter.test.ts
+++ b/packages/platform-bun/src/adapter.test.ts
@@ -68,6 +68,20 @@ function captureError(operation: () => unknown): Error {
   throw new TypeError('Expected the operation to throw.');
 }
 
+async function captureRejectedError(operation: Promise<unknown>): Promise<Error> {
+  try {
+    await operation;
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      return error;
+    }
+
+    throw new TypeError('Expected the operation to reject with an Error.');
+  }
+
+  throw new TypeError('Expected the operation to reject.');
+}
+
 async function waitForSettlement<T>(promise: Promise<T>, timeoutMs = 1_000): Promise<T> {
   let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<never>((_resolve, reject) => {
@@ -414,10 +428,10 @@ describe('@fluojs/platform-bun', () => {
     ];
 
     expect(failures.map((error) => error.message)).toEqual([
-      expect.stringMatching(/idleTimeout/i),
-      expect.stringMatching(/maxBodySize/i),
-      expect.stringMatching(/port/i),
-      expect.stringMatching(/maxBodySize/i),
+      'Invalid idleTimeout value: -1. Expected a non-negative integer.',
+      'Invalid maxBodySize value: 1.5. Expected a non-negative integer.',
+      'Invalid port value: 65536. Expected an integer between 0 and 65535.',
+      'Invalid maxBodySize value: NaN. Expected a non-negative integer.',
     ]);
     expect(failures).toEqual([
       expect.objectContaining({ code: 'BUN_ADAPTER_INVALID_OPTION' }),
@@ -434,15 +448,18 @@ describe('@fluojs/platform-bun', () => {
     class AppModule {}
     defineModule(AppModule, {});
 
-    const failure = runBunApplication(AppModule, {
+    const failure = await captureRejectedError(runBunApplication(AppModule, {
       forceExitTimeoutMs: Number.NaN,
       shutdownSignals: false,
-    });
+    }));
 
-    await expect(failure).rejects.toThrow(/forceExitTimeoutMs/i);
-    await expect(failure).rejects.toMatchObject({
+    expect(failure.constructor).toBe(Error);
+    expect(failure).toMatchObject({
       code: 'BUN_ADAPTER_INVALID_OPTION',
     });
+    expect(failure.message).toBe(
+      'Invalid forceExitTimeoutMs value: NaN. Expected a non-negative integer.',
+    );
   });
 
   it('keeps the Bun adapter runtime import path free of the Node runtime subpath', () => {
@@ -2282,16 +2299,20 @@ describe('@fluojs/platform-bun', () => {
         websocket: {},
       }));
 
+      expect(realtimeFailure.constructor).toBe(Error);
+      expect(websocketFailure.constructor).toBe(Error);
       expect(realtimeFailure).toMatchObject({
         code: 'BUN_ADAPTER_REALTIME_BINDING_LOCKED',
-        message: expect.stringMatching(/before Bun adapter listen\(\) starts/i),
       });
       expect(websocketFailure).toMatchObject({
         code: 'BUN_ADAPTER_REALTIME_BINDING_LOCKED',
-        message: expect.stringMatching(/before Bun adapter listen\(\) starts/i),
       });
-      expect(realtimeFailure.constructor).toBe(Error);
-      expect(websocketFailure.constructor).toBe(Error);
+      expect(realtimeFailure.message).toBe(
+        'Bun websocket binding must be configured before Bun adapter listen() starts the server.',
+      );
+      expect(websocketFailure.message).toBe(
+        'Bun websocket binding must be configured before Bun adapter listen() starts the server.',
+      );
     } finally {
       await adapter.close();
     }
@@ -2352,14 +2373,18 @@ describe('@fluojs/platform-bun', () => {
       await requestAccepted.promise;
       const closeResultPromise = adapter.close();
       void closeResultPromise.catch(() => {});
+      const closeFailurePromise = captureRejectedError(closeResultPromise);
       const closeSettlementPromise = Reflect.get(adapter, 'closeInFlight') as Promise<void>;
 
       await vi.advanceTimersByTimeAsync(10_001);
 
-      await expect(closeResultPromise).rejects.toThrow('Bun adapter shutdown timeout exceeded 10000ms.');
-      await expect(closeResultPromise).rejects.toMatchObject({
+      const closeFailure = await closeFailurePromise;
+
+      expect(closeFailure.constructor).toBe(Error);
+      expect(closeFailure).toMatchObject({
         code: 'BUN_ADAPTER_SHUTDOWN_TIMEOUT',
       });
+      expect(closeFailure.message).toBe('Bun adapter shutdown timeout exceeded 10000ms.');
       expect(adapter.getServer()).toBe(server);
       expect(Reflect.get(adapter, 'dispatcher')).toBe(dispatcher);
       expect(Reflect.get(adapter, 'closeInFlight')).toBe(closeSettlementPromise);
@@ -2756,15 +2781,17 @@ describe('@fluojs/platform-bun', () => {
 
     const adapter = createBunAdapter();
 
-    const failure = adapter.listen({ dispatch: async () => undefined });
+    const failure = await captureRejectedError(Promise.resolve(
+      adapter.listen({ dispatch: async () => undefined }),
+    ));
 
-    await expect(failure).rejects.toThrow(
-      'Bun adapter requires globalThis.Bun.serve()',
-    );
-    await expect(failure).rejects.toMatchObject({
+    expect(failure.constructor).toBe(Error);
+    expect(failure).toMatchObject({
       code: 'BUN_ADAPTER_RUNTIME_UNAVAILABLE',
     });
-    await expect(failure).rejects.not.toBeInstanceOf(TypeError);
+    expect(failure.message).toBe(
+      'Bun adapter requires globalThis.Bun.serve(). Run this package inside Bun or provide a Bun-compatible test double.',
+    );
   });
 
   it('reports supported fetch-style websocket hosting for the official Bun binding seam', () => {

--- a/packages/platform-bun/src/adapter.test.ts
+++ b/packages/platform-bun/src/adapter.test.ts
@@ -54,6 +54,20 @@ function createDeferred<T>() {
   return { promise, reject, resolve };
 }
 
+function captureError(operation: () => unknown): Error {
+  try {
+    operation();
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      return error;
+    }
+
+    throw new TypeError('Expected the operation to throw an Error.');
+  }
+
+  throw new TypeError('Expected the operation to throw.');
+}
+
 async function waitForSettlement<T>(promise: Promise<T>, timeoutMs = 1_000): Promise<T> {
   let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<never>((_resolve, reject) => {
@@ -389,13 +403,29 @@ describe('@fluojs/platform-bun', () => {
   registerBunWebRuntimePortabilitySuite();
 
   it('rejects invalid explicit numeric adapter options during setup', () => {
-    expect(() => createBunAdapter({ idleTimeout: -1 })).toThrow(/idleTimeout/i);
-    expect(() => createBunAdapter({ maxBodySize: 1.5 })).toThrow(/maxBodySize/i);
-    expect(() => createBunAdapter({ port: 65_536 })).toThrow(/port/i);
-    expect(() => createBunFetchHandler({
+    const failures = [
+      captureError(() => createBunAdapter({ idleTimeout: -1 })),
+      captureError(() => createBunAdapter({ maxBodySize: 1.5 })),
+      captureError(() => createBunAdapter({ port: 65_536 })),
+      captureError(() => createBunFetchHandler({
       dispatcher: { async dispatch() {} },
       maxBodySize: Number.NaN,
-    })).toThrow(/maxBodySize/i);
+      })),
+    ];
+
+    expect(failures.map((error) => error.message)).toEqual([
+      expect.stringMatching(/idleTimeout/i),
+      expect.stringMatching(/maxBodySize/i),
+      expect.stringMatching(/port/i),
+      expect.stringMatching(/maxBodySize/i),
+    ]);
+    expect(failures).toEqual([
+      expect.objectContaining({ code: 'BUN_ADAPTER_INVALID_OPTION' }),
+      expect.objectContaining({ code: 'BUN_ADAPTER_INVALID_OPTION' }),
+      expect.objectContaining({ code: 'BUN_ADAPTER_INVALID_OPTION' }),
+      expect.objectContaining({ code: 'BUN_ADAPTER_INVALID_OPTION' }),
+    ]);
+    expect(failures.every((error) => error.constructor === Error)).toBe(true);
   });
 
   it('rejects invalid signal shutdown timeout options before registering Bun signal handlers', async () => {
@@ -404,10 +434,15 @@ describe('@fluojs/platform-bun', () => {
     class AppModule {}
     defineModule(AppModule, {});
 
-    await expect(runBunApplication(AppModule, {
+    const failure = runBunApplication(AppModule, {
       forceExitTimeoutMs: Number.NaN,
       shutdownSignals: false,
-    })).rejects.toThrow(/forceExitTimeoutMs/i);
+    });
+
+    await expect(failure).rejects.toThrow(/forceExitTimeoutMs/i);
+    await expect(failure).rejects.toMatchObject({
+      code: 'BUN_ADAPTER_INVALID_OPTION',
+    });
   });
 
   it('keeps the Bun adapter runtime import path free of the Node runtime subpath', () => {
@@ -2241,11 +2276,22 @@ describe('@fluojs/platform-bun', () => {
     });
 
     try {
-      expect(() => adapter.configureRealtimeBinding(undefined)).toThrow(/before Bun adapter listen\(\) starts/i);
-      expect(() => adapter.configureWebSocketBinding({
+      const realtimeFailure = captureError(() => adapter.configureRealtimeBinding(undefined));
+      const websocketFailure = captureError(() => adapter.configureWebSocketBinding({
         fetch: async () => undefined,
         websocket: {},
-      })).toThrow(/before Bun adapter listen\(\) starts/i);
+      }));
+
+      expect(realtimeFailure).toMatchObject({
+        code: 'BUN_ADAPTER_REALTIME_BINDING_LOCKED',
+        message: expect.stringMatching(/before Bun adapter listen\(\) starts/i),
+      });
+      expect(websocketFailure).toMatchObject({
+        code: 'BUN_ADAPTER_REALTIME_BINDING_LOCKED',
+        message: expect.stringMatching(/before Bun adapter listen\(\) starts/i),
+      });
+      expect(realtimeFailure.constructor).toBe(Error);
+      expect(websocketFailure.constructor).toBe(Error);
     } finally {
       await adapter.close();
     }
@@ -2311,6 +2357,9 @@ describe('@fluojs/platform-bun', () => {
       await vi.advanceTimersByTimeAsync(10_001);
 
       await expect(closeResultPromise).rejects.toThrow('Bun adapter shutdown timeout exceeded 10000ms.');
+      await expect(closeResultPromise).rejects.toMatchObject({
+        code: 'BUN_ADAPTER_SHUTDOWN_TIMEOUT',
+      });
       expect(adapter.getServer()).toBe(server);
       expect(Reflect.get(adapter, 'dispatcher')).toBe(dispatcher);
       expect(Reflect.get(adapter, 'closeInFlight')).toBe(closeSettlementPromise);
@@ -2707,9 +2756,15 @@ describe('@fluojs/platform-bun', () => {
 
     const adapter = createBunAdapter();
 
-    await expect(adapter.listen({ dispatch: async () => undefined })).rejects.toThrow(
+    const failure = adapter.listen({ dispatch: async () => undefined });
+
+    await expect(failure).rejects.toThrow(
       'Bun adapter requires globalThis.Bun.serve()',
     );
+    await expect(failure).rejects.toMatchObject({
+      code: 'BUN_ADAPTER_RUNTIME_UNAVAILABLE',
+    });
+    await expect(failure).rejects.not.toBeInstanceOf(TypeError);
   });
 
   it('reports supported fetch-style websocket hosting for the official Bun binding seam', () => {
@@ -2754,6 +2809,9 @@ describe('@fluojs/platform-bun', () => {
     }
 
     expect(thrown).toBeInstanceOf(TypeError);
+    expect(thrown).toMatchObject({
+      code: 'BUN_ADAPTER_REALTIME_BINDING_INVALID',
+    });
     expect(thrown.message).toBe(
       'Bun realtime binding installation requires fetch and websocket host contracts.',
     );

--- a/packages/platform-bun/src/adapter.ts
+++ b/packages/platform-bun/src/adapter.ts
@@ -242,12 +242,33 @@ const DEFAULT_FORCE_EXIT_TIMEOUT_MS = 30_000;
 const MINIMUM_BUN_NATIVE_ROUTES_VERSION = '1.2.3';
 const EMPTY_NATIVE_ROUTE_PARAMS: Readonly<Record<string, string>> = Object.freeze({});
 const BUN_ADAPTER_CLOSE_TIMEOUT_MS = Symbol('fluo.bunAdapterCloseTimeoutMs');
+const BUN_ADAPTER_DIAGNOSTIC_CODES = {
+  invalidOption: 'BUN_ADAPTER_INVALID_OPTION',
+  realtimeBindingInvalid: 'BUN_ADAPTER_REALTIME_BINDING_INVALID',
+  realtimeBindingLocked: 'BUN_ADAPTER_REALTIME_BINDING_LOCKED',
+  runtimeUnavailable: 'BUN_ADAPTER_RUNTIME_UNAVAILABLE',
+  shutdownTimeout: 'BUN_ADAPTER_SHUTDOWN_TIMEOUT',
+} as const;
 const BUN_WEBSOCKET_SUPPORT_REASON =
   'Bun exposes Bun.serve() + server.upgrade() request-upgrade hosting. Use @fluojs/websockets/bun for the official raw websocket binding.';
+
+type BunAdapterDiagnosticCode = typeof BUN_ADAPTER_DIAGNOSTIC_CODES[keyof typeof BUN_ADAPTER_DIAGNOSTIC_CODES];
 
 type BunAdapterInternalOptions = BunAdapterOptions & {
   [BUN_ADAPTER_CLOSE_TIMEOUT_MS]?: number;
 };
+
+function attachBunAdapterDiagnosticCode<TError extends Error>(
+  error: TError,
+  code: BunAdapterDiagnosticCode,
+): TError {
+  Object.defineProperty(error, 'code', {
+    enumerable: true,
+    value: code,
+  });
+
+  return error;
+}
 
 function isBunWebSocketBinding(value: unknown): value is BunWebSocketBinding<unknown> {
   return typeof value === 'object'
@@ -325,7 +346,10 @@ export class BunHttpApplicationAdapter implements HttpApplicationAdapter, BunWeb
     }
 
     if (!isBunWebSocketBinding(binding)) {
-      throw new TypeError('Bun realtime binding installation requires fetch and websocket host contracts.');
+      throw attachBunAdapterDiagnosticCode(
+        new TypeError('Bun realtime binding installation requires fetch and websocket host contracts.'),
+        BUN_ADAPTER_DIAGNOSTIC_CODES.realtimeBindingInvalid,
+      );
     }
 
     this.configureRealtimeBinding(binding);
@@ -334,7 +358,10 @@ export class BunHttpApplicationAdapter implements HttpApplicationAdapter, BunWeb
   /** Configures the official realtime binding before the Bun server starts. */
   configureRealtimeBinding<TData>(binding: BunWebSocketBinding<TData> | undefined): void {
     if (this.server) {
-      throw new Error('Bun websocket binding must be configured before Bun adapter listen() starts the server.');
+      throw attachBunAdapterDiagnosticCode(
+        new Error('Bun websocket binding must be configured before Bun adapter listen() starts the server.'),
+        BUN_ADAPTER_DIAGNOSTIC_CODES.realtimeBindingLocked,
+      );
     }
 
     this.realtimeBinding = binding;
@@ -655,7 +682,10 @@ function requireBunGlobal(): BunGlobal {
   const bun = (globalThis as typeof globalThis & { Bun?: BunGlobal }).Bun;
 
   if (!bun || typeof bun.serve !== 'function') {
-    throw new Error('Bun adapter requires globalThis.Bun.serve(). Run this package inside Bun or provide a Bun-compatible test double.');
+    throw attachBunAdapterDiagnosticCode(
+      new Error('Bun adapter requires globalThis.Bun.serve(). Run this package inside Bun or provide a Bun-compatible test double.'),
+      BUN_ADAPTER_DIAGNOSTIC_CODES.runtimeUnavailable,
+    );
   }
 
   return bun;
@@ -669,7 +699,10 @@ function validatePortOption(port: number | undefined): number {
   const resolved = port ?? DEFAULT_PORT;
 
   if (!Number.isInteger(resolved) || resolved < 0 || resolved > 65535) {
-    throw new Error(`Invalid port value: ${String(resolved)}. Expected an integer between 0 and 65535.`);
+    throw attachBunAdapterDiagnosticCode(
+      new Error(`Invalid port value: ${String(resolved)}. Expected an integer between 0 and 65535.`),
+      BUN_ADAPTER_DIAGNOSTIC_CODES.invalidOption,
+    );
   }
 
   return resolved;
@@ -681,7 +714,10 @@ function validateNonNegativeIntegerOption(name: string, value: number | undefine
   }
 
   if (!Number.isInteger(value) || value < 0) {
-    throw new Error(`Invalid ${name} value: ${String(value)}. Expected a non-negative integer.`);
+    throw attachBunAdapterDiagnosticCode(
+      new Error(`Invalid ${name} value: ${String(value)}. Expected a non-negative integer.`),
+      BUN_ADAPTER_DIAGNOSTIC_CODES.invalidOption,
+    );
   }
 }
 
@@ -948,7 +984,10 @@ function createShutdownResponse(): Response {
 function waitForCloseWithTimeout(closePromise: Promise<void>, timeoutMs: number): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     const timeoutHandle = setTimeout(() => {
-      reject(new Error(`Bun adapter shutdown timeout exceeded ${String(timeoutMs)}ms.`));
+      reject(attachBunAdapterDiagnosticCode(
+        new Error(`Bun adapter shutdown timeout exceeded ${String(timeoutMs)}ms.`),
+        BUN_ADAPTER_DIAGNOSTIC_CODES.shutdownTimeout,
+      ));
     }, timeoutMs);
 
     void closePromise.then(


### PR DESCRIPTION
## Summary

Add stable machine-readable diagnostic codes to public Bun adapter failure families while preserving existing classes, messages, and throw conditions.

Linked context: Closes #3364

## Changes

- Add five stable `error.code` values.
- Preserve propagated Bun/application errors unchanged.
- Document EN/KO diagnostic contracts.
- Pin exact constructor, full message, and code in deterministic tests.
- Add a minor Changeset for the compatible public feature.

## Testing

- dependency closure build
- platform-bun typecheck and 80 tests
- reverse-dependent suites
- lint and governance
- stable Changeset gate
- built public package manual error inspection

## Release impact

- [x] Consumer-visible compatible feature with a minor Changeset.

## Behavioral contract

- [x] Existing throw conditions, classes and messages are unchanged.
- [x] External errors retain object identity.

## Platform consistency governance (SSOT)

- [x] EN/KO diagnostics are synchronized.