### PR TITLE
fix(cli): wait for install streams before failure logs

### DIFF
--- a/.changeset/wait-for-install-streams.md
+++ b/.changeset/wait-for-install-streams.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/cli": patch
+---
+
+Wait for captured dependency-install streams to close before reporting failures.

--- a/packages/cli/src/new/install.test.ts
+++ b/packages/cli/src/new/install.test.ts
@@ -87,6 +87,41 @@ describe('resolveInstallCommand', () => {
     });
   });
 
+  it('retains buffered subprocess output when a failed install child exits', async () => {
+    const targetDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-install-target-'));
+    createdDirectories.push(targetDirectory);
+    const { env } = createExecutableFixture(
+      'npm',
+      `#!/usr/bin/env node
+const { spawn } = require('node:child_process');
+const bufferedWriter = spawn(process.execPath, ['-e', "process.stdin.resume(); process.stdin.once('end', () => { process.stdout.write('npm notice buffered output\\\\n'); process.stderr.write('npm error buffered output\\\\n'); });"], {
+  stdio: ['pipe', 'inherit', 'inherit'],
+});
+bufferedWriter.unref();
+process.stderr.write('npm error install failed\\n');
+process.exit(2);
+`,
+    );
+
+    let thrownError: unknown;
+
+    try {
+      await installDependencies(targetDirectory, 'npm', {
+        env,
+        stdio: 'capture',
+      });
+    } catch (error: unknown) {
+      thrownError = error;
+    }
+
+    expect(thrownError).toMatchObject({
+      output: expect.stringContaining('npm notice buffered output\n'),
+    });
+    expect(thrownError).toMatchObject({
+      output: expect.stringContaining('npm error buffered output\n'),
+    });
+  });
+
   it('surfaces the yarn corepack fallback warning through the provided stderr stream', async () => {
     const targetDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-install-target-'));
     createdDirectories.push(targetDirectory);

--- a/packages/cli/src/new/install.test.ts
+++ b/packages/cli/src/new/install.test.ts
@@ -1,18 +1,53 @@
+import { ChildProcess } from 'node:child_process';
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { delimiter, join } from 'node:path';
+import { PassThrough } from 'node:stream';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { installDependencies, resolveInstallCommand } from './install.js';
 
 const createdDirectories: string[] = [];
 
+type SpawnOverride = () => ChildProcess;
+type SpawnParameters = Parameters<typeof import('node:child_process').spawn>;
+
+const spawnControl = vi.hoisted<{ override?: SpawnOverride }>(() => ({}));
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+
+  return {
+    ...actual,
+    spawn: (...parameters: SpawnParameters) => spawnControl.override?.() ?? actual.spawn(...parameters),
+  };
+});
+
 afterEach(() => {
+  spawnControl.override = undefined;
+
   for (const directory of createdDirectories.splice(0)) {
     rmSync(directory, { force: true, recursive: true });
   }
 });
+
+function createControlledChildProcess(): {
+  readonly child: ChildProcess;
+  readonly stderr: PassThrough;
+  readonly stdout: PassThrough;
+} {
+  const child = new ChildProcess();
+  const stderr = new PassThrough();
+  const stdout = new PassThrough();
+
+  Object.defineProperties(child, {
+    stderr: { value: stderr },
+    stdout: { value: stdout },
+  });
+
+  return { child, stderr, stdout };
+}
 
 function createExecutableFixture(commandName: string, script: string): { directory: string; env: NodeJS.ProcessEnv } {
   const directory = mkdtempSync(join(tmpdir(), `fluo-cli-install-${commandName}-`));
@@ -83,43 +118,62 @@ describe('resolveInstallCommand', () => {
     expect(thrownError).toBeInstanceOf(Error);
     expect((thrownError as Error).message).toBe('Dependency installation failed with exit code 2.');
     expect(thrownError).toMatchObject({
-      output: 'npm notice tarball contents\nnpm error install failed\n',
+      output: expect.stringContaining('npm notice tarball contents\n'),
+    });
+    expect(thrownError).toMatchObject({
+      output: expect.stringContaining('npm error install failed\n'),
     });
   });
 
-  it('retains buffered subprocess output when a failed install child exits', async () => {
+  it('waits for close after a failed install child exits before rejecting captured output', async () => {
     const targetDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-install-target-'));
     createdDirectories.push(targetDirectory);
-    const { env } = createExecutableFixture(
-      'npm',
-      `#!/usr/bin/env node
-const { spawn } = require('node:child_process');
-const bufferedWriter = spawn(process.execPath, ['-e', "process.stdin.resume(); process.stdin.once('end', () => { process.stdout.write('npm notice buffered output\\\\n'); process.stderr.write('npm error buffered output\\\\n'); });"], {
-  stdio: ['pipe', 'inherit', 'inherit'],
-});
-bufferedWriter.unref();
-process.stderr.write('npm error install failed\\n');
-process.exit(2);
-`,
+    const { child, stderr, stdout } = createControlledChildProcess();
+    spawnControl.override = () => child;
+
+    const installation = installDependencies(targetDirectory, 'npm', { stdio: 'capture' });
+    let settledBeforeClose = false;
+    void installation.then(
+      () => {
+        settledBeforeClose = true;
+      },
+      () => {
+        settledBeforeClose = true;
+      },
     );
 
-    let thrownError: unknown;
+    child.emit('exit', 2, null);
+    stdout.write('npm notice stream after exit\n');
+    stderr.write('npm error stream after exit\n');
 
-    try {
-      await installDependencies(targetDirectory, 'npm', {
-        env,
-        stdio: 'capture',
-      });
-    } catch (error: unknown) {
-      thrownError = error;
-    }
+    await Promise.resolve();
+    expect(settledBeforeClose).toBe(false);
 
-    expect(thrownError).toMatchObject({
-      output: expect.stringContaining('npm notice buffered output\n'),
+    child.emit('close', 2, null);
+    await expect(installation).rejects.toMatchObject({
+      output: 'npm notice stream after exit\nnpm error stream after exit\n',
     });
-    expect(thrownError).toMatchObject({
-      output: expect.stringContaining('npm error buffered output\n'),
-    });
+  });
+
+  it('rejects immediately and ignores later child events when spawning an install fails', async () => {
+    const targetDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-install-target-'));
+    createdDirectories.push(targetDirectory);
+    const { child, stderr, stdout } = createControlledChildProcess();
+    const spawnError = new Error('spawn ENOENT');
+    spawnControl.override = () => child;
+
+    const installation = installDependencies(targetDirectory, 'npm', { stdio: 'capture' });
+    const rejection = installation.then(
+      () => new Error('Expected installation to reject.'),
+      (error: unknown) => error,
+    );
+    child.emit('error', spawnError);
+    await expect(rejection).resolves.toBe(spawnError);
+
+    stdout.write('npm notice after spawn error\n');
+    stderr.write('npm error after spawn error\n');
+    child.emit('close', 1, null);
+    await expect(rejection).resolves.toBe(spawnError);
   });
 
   it('surfaces the yarn corepack fallback warning through the provided stderr stream', async () => {

--- a/packages/cli/src/new/install.test.ts
+++ b/packages/cli/src/new/install.test.ts
@@ -1,5 +1,6 @@
 import { ChildProcess } from 'node:child_process';
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer, type Server, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
 import { delimiter, join } from 'node:path';
 import { PassThrough } from 'node:stream';
@@ -9,23 +10,42 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { installDependencies, resolveInstallCommand } from './install.js';
 
 const createdDirectories: string[] = [];
+const openServers: Server[] = [];
+const openSockets: Socket[] = [];
 
 type SpawnOverride = () => ChildProcess;
+type SpawnObserver = (child: ChildProcess) => void;
 type SpawnParameters = Parameters<typeof import('node:child_process').spawn>;
 
-const spawnControl = vi.hoisted<{ override?: SpawnOverride }>(() => ({}));
+const spawnControl = vi.hoisted<{ observer?: SpawnObserver; override?: SpawnOverride }>(() => ({}));
 
 vi.mock('node:child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:child_process')>();
 
   return {
     ...actual,
-    spawn: (...parameters: SpawnParameters) => spawnControl.override?.() ?? actual.spawn(...parameters),
+    spawn: (...parameters: SpawnParameters) => {
+      const child = spawnControl.override?.() ?? actual.spawn(...parameters);
+      spawnControl.observer?.(child);
+      return child;
+    },
   };
 });
 
-afterEach(() => {
-  spawnControl.override = undefined;
+afterEach(async () => {
+  spawnControl.observer = undefined; spawnControl.override = undefined;
+
+  for (const socket of openSockets.splice(0)) {
+    socket.destroy();
+  }
+
+  await Promise.all(
+    openServers.splice(0).map(
+      (server) => new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      }),
+    ),
+  );
 
   for (const directory of createdDirectories.splice(0)) {
     rmSync(directory, { force: true, recursive: true });
@@ -152,6 +172,80 @@ describe('resolveInstallCommand', () => {
     child.emit('close', 2, null);
     await expect(installation).rejects.toMatchObject({
       output: 'npm notice stream after exit\nnpm error stream after exit\n',
+    });
+  });
+
+  it('retains real buffered output after an install parent exits until both streams close', async () => {
+    const targetDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-install-target-'));
+    const socketDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-install-socket-'));
+    const socketPath = join(socketDirectory, 'output.sock');
+    createdDirectories.push(targetDirectory, socketDirectory);
+
+    let markWriterReady: (socket: Socket) => void;
+    const writerReady = new Promise<Socket>((resolve) => {
+      markWriterReady = resolve;
+    });
+    const server = createServer((socket) => {
+      openSockets.push(socket);
+      socket.once('data', (message) => {
+        if (message.toString() === 'ready') {
+          markWriterReady(socket);
+        }
+      });
+    });
+    openServers.push(server);
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(socketPath, resolve);
+    });
+
+    const { env } = createExecutableFixture(
+      'npm',
+      `#!/usr/bin/env node
+const { spawn } = require('node:child_process');
+const childScript = ${JSON.stringify(`const { createConnection } = require('node:net');
+const socket = createConnection(${JSON.stringify(socketPath)});
+socket.once('connect', () => socket.write('ready'));
+socket.once('data', (command) => {
+  if (command.toString() === 'emit') { process.stdout.write('npm notice buffered output\\n'); process.stderr.write('npm error buffered output\\n'); socket.end(); }
+});
+socket.once('error', () => process.exit(0)); socket.once('close', () => process.exit(0));`)};
+spawn(process.execPath, ['--eval', childScript], { stdio: ['ignore', 'inherit', 'inherit'] });
+process.exit(2);
+`,
+    );
+
+    const parentExited = new Promise<void>((resolve) => {
+      spawnControl.observer = (child) => {
+        child.once('exit', resolve);
+      };
+    });
+    const installation = installDependencies(targetDirectory, 'npm', {
+      env,
+      stdio: 'capture',
+    });
+    let settlement = 'pending';
+    void installation.then(
+      () => {
+        settlement = 'resolved';
+      },
+      () => {
+        settlement = 'rejected';
+      },
+    );
+
+    await parentExited;
+    await new Promise<void>(queueMicrotask);
+    expect(settlement).toBe('pending');
+
+    const writer = await writerReady;
+    writer.write('emit');
+
+    await expect(installation).rejects.toMatchObject({
+      output: expect.stringContaining('npm notice buffered output\n'),
+    });
+    await expect(installation).rejects.toMatchObject({
+      output: expect.stringContaining('npm error buffered output\n'),
     });
   });
 

--- a/packages/cli/src/new/install.ts
+++ b/packages/cli/src/new/install.ts
@@ -63,7 +63,7 @@ function waitForChildProcess(
 ): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     child.on('error', reject);
-    child.on('exit', (code) => {
+    child.on('close', (code) => {
       if (code === 0) {
         resolve();
         return;


### PR DESCRIPTION
## Summary
- settle captured installs on child close after stdout and stderr drain
- preserve prompt spawn-error rejection
- add deterministic fake and real-subprocess regressions for post-exit output

## Verification
- CLI dependency build, typecheck, package and reverse-dependent tests
- focused install tests: 8 passed
- lint and platform consistency governance
- mutation to exit-based settlement fails
- real CLI install failure retains delayed stdout and stderr

Closes #3131