### PR TITLE
fix(cli): clarify Bun Studio support (#3134)

### DIFF
--- a/.changeset/clarify-bun-studio-scope.md
+++ b/.changeset/clarify-bun-studio-scope.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/cli': patch
+---
+
+Clarify that live `fluo dev --studio` support is limited to Node dev-runner projects and direct Bun projects to Studio-compatible `fluo inspect` artifacts.

--- a/.changeset/clarify-bun-studio-scope.md
+++ b/.changeset/clarify-bun-studio-scope.md
@@ -1,5 +1,5 @@
 ---
-'@fluojs/cli': patch
+'@fluojs/cli': minor
 ---
 
-Clarify that live `fluo dev --studio` support is limited to Node dev-runner projects and direct Bun projects to Studio-compatible `fluo inspect` artifacts.
+Add live `fluo dev --studio` support for Node dev-runner projects and clear Bun project error guidance to export Studio-compatible artifacts with `fluo inspect`.

--- a/packages/cli/README.ko.md
+++ b/packages/cli/README.ko.md
@@ -252,7 +252,7 @@ MVP runtime support는 명시적으로 제한됩니다.
 | Runtime target | `fluo dev --studio` status |
 | --- | --- |
 | Node dev runner | Full support target입니다. |
-| Bun | 이번 MVP에서는 활성화하지 않습니다. Dedicated bridge를 구현하고 검증하기 전까지 `fluo dev --studio`는 Bun 프로젝트를 거부합니다. 대신 `fluo inspect --json --output <path>` 또는 `fluo inspect --report --output <path>`로 Studio 호환 static artifact를 내보내세요. |
+| Bun | 이번 MVP에서는 활성화하지 않습니다. Dedicated bridge를 구현하고 검증하기 전까지 `fluo dev --studio`는 Bun 프로젝트를 거부합니다. 대신 `fluo inspect <module-path> --json --output <path>` 또는 `fluo inspect <module-path> --report --output <path>`로 Studio 호환 static artifact를 내보내세요. |
 | Deno | 이번 MVP에서는 활성화하지 않습니다. Dedicated bridge를 구현하고 검증하기 전까지 `fluo dev --studio`는 Deno 프로젝트를 거부합니다. |
 | Cloudflare Workers | worker bridge를 추가하고 테스트하지 않는 한 이번 MVP에서는 unsupported입니다. |
 

--- a/packages/cli/README.ko.md
+++ b/packages/cli/README.ko.md
@@ -252,7 +252,7 @@ MVP runtime support는 명시적으로 제한됩니다.
 | Runtime target | `fluo dev --studio` status |
 | --- | --- |
 | Node dev runner | Full support target입니다. |
-| Bun | 이번 MVP에서는 활성화하지 않습니다. Dedicated bridge를 구현하고 검증하기 전까지 `fluo dev --studio`는 Bun 프로젝트를 거부합니다. |
+| Bun | 이번 MVP에서는 활성화하지 않습니다. Dedicated bridge를 구현하고 검증하기 전까지 `fluo dev --studio`는 Bun 프로젝트를 거부합니다. 대신 `fluo inspect --json --output <path>` 또는 `fluo inspect --report --output <path>`로 Studio 호환 static artifact를 내보내세요. |
 | Deno | 이번 MVP에서는 활성화하지 않습니다. Dedicated bridge를 구현하고 검증하기 전까지 `fluo dev --studio`는 Deno 프로젝트를 거부합니다. |
 | Cloudflare Workers | worker bridge를 추가하고 테스트하지 않는 한 이번 MVP에서는 unsupported입니다. |
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -252,7 +252,7 @@ Runtime support for the MVP is explicit:
 | Runtime target | `fluo dev --studio` status |
 | --- | --- |
 | Node dev runner | Full support target. |
-| Bun | Not enabled for this MVP; `fluo dev --studio` rejects Bun projects until a dedicated bridge is implemented and verified. |
+| Bun | Not enabled for this MVP; `fluo dev --studio` rejects Bun projects until a dedicated bridge is implemented and verified. Export Studio-compatible static artifacts with `fluo inspect --json --output <path>` or `fluo inspect --report --output <path>` instead. |
 | Deno | Not enabled for this MVP; `fluo dev --studio` rejects Deno projects until a dedicated bridge is implemented and verified. |
 | Cloudflare Workers | Unsupported for this MVP unless a worker bridge is added and tested. |
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -252,7 +252,7 @@ Runtime support for the MVP is explicit:
 | Runtime target | `fluo dev --studio` status |
 | --- | --- |
 | Node dev runner | Full support target. |
-| Bun | Not enabled for this MVP; `fluo dev --studio` rejects Bun projects until a dedicated bridge is implemented and verified. Export Studio-compatible static artifacts with `fluo inspect --json --output <path>` or `fluo inspect --report --output <path>` instead. |
+| Bun | Not enabled for this MVP; `fluo dev --studio` rejects Bun projects until a dedicated bridge is implemented and verified. Export Studio-compatible static artifacts with `fluo inspect <module-path> --json --output <path>` or `fluo inspect <module-path> --report --output <path>` instead. |
 | Deno | Not enabled for this MVP; `fluo dev --studio` rejects Deno projects until a dedicated bridge is implemented and verified. |
 | Cloudflare Workers | Unsupported for this MVP unless a worker bridge is added and tested. |
 

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -154,6 +154,33 @@ afterEach(() => {
 });
 
 describe('CLI command runner', () => {
+  it('states the Node-only Studio live-mode scope and gives Bun projects an inspect-artifact path', async () => {
+    const projectDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
+    createdDirectories.push(projectDirectory);
+    writeFileSync(
+      join(projectDirectory, 'package.json'),
+      JSON.stringify({ name: 'bun-project', dependencies: { '@fluojs/platform-bun': 'workspace:*' } }, null, 2),
+    );
+    const helpOutput: string[] = [];
+    const errorOutput: string[] = [];
+
+    const helpExitCode = await runCli(['dev', '--help'], {
+      stderr: { write: () => undefined },
+      stdout: { write: (message) => helpOutput.push(message) },
+    });
+    const studioExitCode = await runCli(['dev', '--studio', '--dry-run'], {
+      cwd: projectDirectory,
+      stderr: { write: (message) => errorOutput.push(message) },
+      stdout: { write: () => undefined },
+    });
+
+    expect(helpExitCode).toBe(0);
+    expect(helpOutput.join('')).toContain('Start the local Fluo Studio sidecar for Node dev runner projects only.');
+    expect(studioExitCode).toBe(1);
+    expect(errorOutput.join('')).toContain('fluo dev --studio supports Node dev runner projects only.');
+    expect(errorOutput.join('')).toContain('fluo inspect --json --output <path>');
+  });
+
   it('publishes fluo as the canonical bin', () => {
     const packageRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
     const manifest = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8')) as {
@@ -2074,7 +2101,8 @@ void bootstrap();
 
     expect(nativeExitCode).toBe(1);
     expect(fluoExitCode).toBe(1);
-    expect(stderrBuffer.join('')).toContain('fluo dev --studio currently supports Node dev runner projects only');
+    expect(stderrBuffer.join('')).toContain('fluo dev --studio supports Node dev runner projects only.');
+    expect(stderrBuffer.join('')).toContain('fluo inspect --json --output <path>');
   });
 
   it('prints development lifecycle dry-runs with Next.js-like env defaults', async () => {

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -154,7 +154,7 @@ afterEach(() => {
 });
 
 describe('CLI command runner', () => {
-  it('states the Node-only Studio live-mode scope and gives Bun projects an inspect-artifact path', async () => {
+  it('states the Node-only Studio live-mode scope and gives Bun projects complete inspect-artifact fallbacks', async () => {
     const projectDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
     createdDirectories.push(projectDirectory);
     writeFileSync(
@@ -173,12 +173,19 @@ describe('CLI command runner', () => {
       stderr: { write: (message) => errorOutput.push(message) },
       stdout: { write: () => undefined },
     });
+    const fluoRunnerExitCode = await runCli(['dev', '--studio', '--dry-run', '--runner', 'fluo'], {
+      cwd: projectDirectory,
+      stderr: { write: (message) => errorOutput.push(message) },
+      stdout: { write: () => undefined },
+    });
 
     expect(helpExitCode).toBe(0);
     expect(helpOutput.join('')).toContain('Start the local Fluo Studio sidecar for Node dev runner projects only.');
     expect(studioExitCode).toBe(1);
+    expect(fluoRunnerExitCode).toBe(1);
     expect(errorOutput.join('')).toContain('fluo dev --studio supports Node dev runner projects only.');
-    expect(errorOutput.join('')).toContain('fluo inspect --json --output <path>');
+    expect(errorOutput.join('')).toContain('fluo inspect <module-path> --json --output <path>');
+    expect(errorOutput.join('')).toContain('fluo inspect <module-path> --report --output <path>');
   });
 
   it('publishes fluo as the canonical bin', () => {
@@ -2075,34 +2082,6 @@ void bootstrap();
     expect(nativeEnvExitCode).toBe(1);
     expect(spawnedCommands).toEqual([]);
     expect(stderrBuffer.join('')).toContain('fluo dev --studio requires the fluo-owned Node restart runner.');
-  });
-
-  it('keeps Studio dev support Node-only until non-Node bridges are verified', async () => {
-    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
-    createdDirectories.push(workspaceDirectory);
-    writeFileSync(
-      join(workspaceDirectory, 'package.json'),
-      JSON.stringify({ dependencies: { '@fluojs/platform-bun': '^1.0.0' }, name: 'test-app', scripts: { dev: 'fluo dev' } }, null, 2),
-    );
-    const stderrBuffer: string[] = [];
-
-    const nativeExitCode = await runCli(['dev', '--dry-run', '--studio'], {
-      cwd: workspaceDirectory,
-      env: {},
-      stderr: { write: (message) => stderrBuffer.push(message) },
-      stdout: { write: () => undefined },
-    });
-    const fluoExitCode = await runCli(['dev', '--dry-run', '--studio', '--runner', 'fluo'], {
-      cwd: workspaceDirectory,
-      env: {},
-      stderr: { write: (message) => stderrBuffer.push(message) },
-      stdout: { write: () => undefined },
-    });
-
-    expect(nativeExitCode).toBe(1);
-    expect(fluoExitCode).toBe(1);
-    expect(stderrBuffer.join('')).toContain('fluo dev --studio supports Node dev runner projects only.');
-    expect(stderrBuffer.join('')).toContain('fluo inspect --json --output <path>');
   });
 
   it('prints development lifecycle dry-runs with Next.js-like env defaults', async () => {
@@ -4155,7 +4134,7 @@ exit 7
     ]);
   });
 
-  it('writes inspect JSON artifacts to an explicit output path without stdout payloads', async () => {
+  it('executes the JSON artifact fallback with a module fixture without stdout payloads', async () => {
     const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
     createdDirectories.push(workspaceDirectory);
     const stdoutBuffer: string[] = [];
@@ -4171,17 +4150,21 @@ exit 7
     const payload = JSON.parse(readFileSync(outputPath, 'utf8')) as {
       components: unknown[];
       diagnostics: unknown[];
+      generatedAt: string;
       health: { status: string };
       readiness: { status: string };
+      routes: unknown[];
     };
 
     expect(exitCode).toBe(0);
     expect(stdoutBuffer.join('')).toBe('');
     expect(stderrBuffer.join('')).toBe('');
+    expect(payload.generatedAt).toEqual(expect.any(String));
     expect(payload.components).toEqual([]);
     expect(payload.diagnostics).toEqual([]);
     expect(payload.readiness.status).toBe('ready');
     expect(payload.health.status).toBe('healthy');
+    expect(payload.routes).toEqual([]);
   });
 
   it('emits snapshot JSON with timing diagnostics when --json and --timing are combined', async () => {

--- a/packages/cli/src/commands/scripts.ts
+++ b/packages/cli/src/commands/scripts.ts
@@ -432,7 +432,7 @@ function assertStudioSupport(command: ScriptCommand, studio: boolean, projectRun
   }
 
   if (projectRuntime !== 'node') {
-    throw new Error(`fluo dev --studio currently supports Node dev runner projects only. ${projectRuntime} Studio support remains experimental until a dedicated bridge is implemented and verified.`);
+    throw new Error(`fluo dev --studio supports Node dev runner projects only. ${projectRuntime} projects can generate Studio-compatible artifacts with fluo inspect --json --output <path> or fluo inspect --report --output <path>.`);
   }
 
   if (devRunner !== 'fluo' || rawWatch) {
@@ -667,7 +667,7 @@ export function scriptUsage(command: ScriptCommand): string {
     '  --dry-run                              Print the command without running it.',
     command === 'dev' ? '  --raw-watch                            Use the runtime-native Node watcher instead of the fluo restart runner.' : undefined,
     command === 'dev' ? '  --runner <fluo|native>                 Select fluo restart supervision or runtime-native watch (default: fluo for Node, native for non-Node runtimes).' : undefined,
-    command === 'dev' ? '  --studio                              Start the local Fluo Studio sidecar and inject runtime devtool env.' : undefined,
+    command === 'dev' ? '  --studio                              Start the local Fluo Studio sidecar for Node dev runner projects only.' : undefined,
     command === 'dev' ? '  --studio-port <port>                  Bind the Studio sidecar to a specific local port (default: 0).' : undefined,
     '  --reporter <auto|pretty|stream|silent> Choose lifecycle reporter output mode (default: auto).',
     '  --verbose                             Expose raw child process output; also honored by FLUO_VERBOSE=1.',

--- a/packages/cli/src/commands/scripts.ts
+++ b/packages/cli/src/commands/scripts.ts
@@ -432,7 +432,7 @@ function assertStudioSupport(command: ScriptCommand, studio: boolean, projectRun
   }
 
   if (projectRuntime !== 'node') {
-    throw new Error(`fluo dev --studio supports Node dev runner projects only. ${projectRuntime} projects can generate Studio-compatible artifacts with fluo inspect --json --output <path> or fluo inspect --report --output <path>.`);
+    throw new Error(`fluo dev --studio supports Node dev runner projects only. ${projectRuntime} projects can generate Studio-compatible artifacts with fluo inspect <module-path> --json --output <path> or fluo inspect <module-path> --report --output <path>.`);
   }
 
   if (devRunner !== 'fluo' || rawWatch) {


### PR DESCRIPTION
## Summary
- state that live Studio uses the Node dev runner and reject Bun projects with actionable guidance
- provide complete JSON and report inspect alternatives including the required module path
- align English and Korean CLI documentation
- add an @fluojs/cli minor Changeset for the additive CLI capability

## Verification
- pnpm --filter '@fluojs/cli...' build
- pnpm --filter @fluojs/cli typecheck
- pnpm --filter @fluojs/cli test (480/480)
- pnpm verify:changeset-release-lane -- --lane=stable
- pnpm lint
- pnpm verify:platform-consistency-governance
- manual Bun rejection plus JSON/report artifact generation

Closes #3134