### PR TITLE
test(platform-deno): verify published adapter under native Deno

### DIFF
--- a/.changeset/issue-3377-deno-native-adapter-journey.md
+++ b/.changeset/issue-3377-deno-native-adapter-journey.md
@@ -1,5 +1,5 @@
 ---
-'@fluojs/platform-deno': patch
+'@fluojs/platform-deno': minor
 ---
 
-Verify the published Deno adapter journey under native Deno 2, including request dispatch and managed server shutdown.
+Add the public host-owned `createDenoFetchHandler(...)` entrypoint and verify the published Deno adapter journey under native Deno 2, including request dispatch and managed server shutdown.

--- a/.changeset/issue-3377-deno-native-adapter-journey.md
+++ b/.changeset/issue-3377-deno-native-adapter-journey.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/platform-deno': patch
+---
+
+Verify the published Deno adapter journey under native Deno 2, including request dispatch and managed server shutdown.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -471,6 +471,7 @@ jobs:
       - build-and-typecheck
       - lint
       - test
+      - deno-platform
       - studio-browser
       - official-web-runtime-adapter-portability
       - native-response-cookie-conformance

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,6 +276,54 @@ jobs:
           path: .artifacts/vitest-shutdown-debug/**/*.json
           if-no-files-found: error
 
+  deno-platform:
+    name: Deno platform
+    runs-on: ubuntu-latest
+    needs:
+      - resolve-pr-verification-scope
+
+    steps:
+      - name: Checkout
+        if: github.event_name != 'pull_request' || needs.resolve-pr-verification-scope.outputs.mode != 'scoped' || contains(needs.resolve-pr-verification-scope.outputs.package_names, '@fluojs/platform-deno')
+        uses: actions/checkout@v5
+
+      - name: Install pnpm
+        if: github.event_name != 'pull_request' || needs.resolve-pr-verification-scope.outputs.mode != 'scoped' || contains(needs.resolve-pr-verification-scope.outputs.package_names, '@fluojs/platform-deno')
+        uses: pnpm/action-setup@v5
+
+      - name: Setup Node.js
+        if: github.event_name != 'pull_request' || needs.resolve-pr-verification-scope.outputs.mode != 'scoped' || contains(needs.resolve-pr-verification-scope.outputs.package_names, '@fluojs/platform-deno')
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+          cache: pnpm
+
+      - name: Setup Deno
+        if: github.event_name != 'pull_request' || needs.resolve-pr-verification-scope.outputs.mode != 'scoped' || contains(needs.resolve-pr-verification-scope.outputs.package_names, '@fluojs/platform-deno')
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.5.0
+
+      - name: Install dependencies
+        if: github.event_name != 'pull_request' || needs.resolve-pr-verification-scope.outputs.mode != 'scoped' || contains(needs.resolve-pr-verification-scope.outputs.package_names, '@fluojs/platform-deno')
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Deno adapter closure
+        if: github.event_name != 'pull_request' || needs.resolve-pr-verification-scope.outputs.mode != 'scoped' || contains(needs.resolve-pr-verification-scope.outputs.package_names, '@fluojs/platform-deno')
+        run: node tooling/scripts/run-workspace-build-closure.mjs @fluojs/platform-deno
+
+      - name: Check published Deno adapter root import
+        if: github.event_name != 'pull_request' || needs.resolve-pr-verification-scope.outputs.mode != 'scoped' || contains(needs.resolve-pr-verification-scope.outputs.package_names, '@fluojs/platform-deno')
+        run: deno check --no-lock --node-modules-dir=auto --config packages/platform-deno/deno/deno.json npm:@fluojs/platform-deno
+
+      - name: Test published Deno adapter journey
+        if: github.event_name != 'pull_request' || needs.resolve-pr-verification-scope.outputs.mode != 'scoped' || contains(needs.resolve-pr-verification-scope.outputs.package_names, '@fluojs/platform-deno')
+        run: deno test --no-lock --config packages/platform-deno/deno/deno.json --allow-net --allow-read packages/platform-deno/deno/native-adapter.test.ts
+
+      - name: Skip Deno platform verification outside scoped Deno changes
+        if: github.event_name == 'pull_request' && needs.resolve-pr-verification-scope.outputs.mode == 'scoped' && !contains(needs.resolve-pr-verification-scope.outputs.package_names, '@fluojs/platform-deno')
+        run: echo "Deno platform verification is outside the scoped package set."
+
   studio-browser:
     name: Studio browser
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,7 +318,7 @@ jobs:
 
       - name: Test published Deno adapter journey
         if: github.event_name != 'pull_request' || needs.resolve-pr-verification-scope.outputs.mode != 'scoped' || contains(needs.resolve-pr-verification-scope.outputs.package_names, '@fluojs/platform-deno')
-        run: deno test --no-lock --config packages/platform-deno/deno/deno.json --allow-net --allow-read packages/platform-deno/deno/native-adapter.test.ts
+        run: deno test --no-lock --config packages/platform-deno/deno/deno.json --allow-net --allow-read packages/platform-deno/deno/native-adapter.test.js
 
       - name: Skip Deno platform verification outside scoped Deno changes
         if: github.event_name == 'pull_request' && needs.resolve-pr-verification-scope.outputs.mode == 'scoped' && !contains(needs.resolve-pr-verification-scope.outputs.package_names, '@fluojs/platform-deno')

--- a/book/intermediate/ch23-deno.ko.md
+++ b/book/intermediate/ch23-deno.ko.md
@@ -237,6 +237,8 @@ Deno.test("ProductService should return products", async () => {
 
 이 테스트는 process 내부에서 dispatch하므로 파일 시스템 권한이 필요하지 않습니다. `--allow-read` 없이 실행하세요. Import된 애플리케이션 그래프가 환경 변수를 읽거나 외부 서비스에 연결한다면 `deno test --allow-env=DATABASE_URL --allow-net=database.host:5432`처럼 필요한 key나 destination만 허용하세요. Fixture를 의도적으로 읽는 테스트라면 `--allow-read=./test/fixtures`처럼 fixture 경로에만 한정된 권한을 추가할 수 있습니다.
 
+저장소는 Deno 2 네이티브 adapter smoke lane도 실행합니다. Public `npm:@fluojs/platform-deno` import를 검사하고 listener를 열지 않는 host-owned handler를 dispatch한 뒤, port `0`과 `shutdownSignals: false`로 managed listener를 시작해 실제 route를 fetch하고 애플리케이션을 닫습니다. 이 managed-listener 경로에는 `--allow-net`만 필요하며, signal ownership은 의도적으로 package contract suite에서 별도로 검증합니다.
+
 ## 23.10 Summary: The Deno Advantage
 
 - **Security**: 명시적 동의 없는 예기치 않은 네트워크나 파일 접근이 없습니다.

--- a/book/intermediate/ch23-deno.md
+++ b/book/intermediate/ch23-deno.md
@@ -237,6 +237,8 @@ Deno.test("ProductService should return products", async () => {
 
 This test performs in-process dispatch and needs no filesystem permission. Run it without `--allow-read`; if the imported application graph reads environment variables or contacts an external service, grant only the required keys or destinations, for example `deno test --allow-env=DATABASE_URL --allow-net=database.host:5432`. Tests that intentionally load fixtures may add a fixture-only scope such as `--allow-read=./test/fixtures`.
 
+The repository also runs a Deno 2 native adapter smoke lane: it checks the public `npm:@fluojs/platform-deno` import, dispatches a host-owned handler without opening a listener, then starts a managed listener on port `0` with `shutdownSignals: false`, fetches a real route, and closes the application. That managed-listener path needs only `--allow-net`; signal ownership is intentionally tested by the package contract suite instead.
+
 ## 23.10 Summary: The Deno Advantage
 
 - **Security**: No unexpected network or file access without explicit consent.

--- a/packages/platform-deno/README.ko.md
+++ b/packages/platform-deno/README.ko.md
@@ -153,6 +153,8 @@ Advanced option에는 test 또는 non-hosted runtime을 위한 injectable `serve
 
 공유 edge portability suite인 `packages/testing/src/portability/web-runtime-adapter-portability.test.ts`는 Deno를 Bun 및 Cloudflare Workers와 함께 실행해 malformed cookie 보존, query decoding, JSON/text raw-body capture, 단일 byte-range status/header/body semantic, multipart raw-body 제외, SSE framing을 검증합니다. 패키지 테스트의 README parity assertion은 이 edge-runtime 커버리지 문서가 한국어 mirror와 계속 동기화되도록 확인합니다.
 
+Deno 2 smoke lane은 public `npm:@fluojs/platform-deno` root import를 검사하고 built adapter closure를 네이티브로 실행합니다. Listener 없이 host-owned `createDenoFetchHandler(...)` request를 dispatch한 뒤, port `0`과 `shutdownSignals: false`로 `runDenoApplication(...)`을 시작하고 실제 route를 fetch한 다음 애플리케이션을 닫습니다. 이 managed-listener test에서는 signal ownership을 의도적으로 비활성화하며, signal registration은 별도의 package-local contract suite에서 다룹니다.
+
 ## 공개 API 개요
 
 - `createDenoAdapter(options)`: Deno HTTP 어댑터를 위한 팩토리이며, 직접 생성과 같은 validation 및 normalization을 공유합니다.

--- a/packages/platform-deno/README.md
+++ b/packages/platform-deno/README.md
@@ -153,6 +153,8 @@ Advanced options include injectable `serve` and `upgradeWebSocket` seams for tes
 
 The shared edge portability suite in `packages/testing/src/portability/web-runtime-adapter-portability.test.ts` exercises Deno beside Bun and Cloudflare Workers for malformed cookie preservation, query decoding, JSON/text raw-body capture, single byte-range status/header/body semantics, multipart raw-body exclusion, and SSE framing. The README parity assertion in the package test keeps these documented edge-runtime coverage claims synchronized with the Korean mirror.
 
+The Deno 2 smoke lane checks the public `npm:@fluojs/platform-deno` root import and executes the built adapter closure natively. It dispatches a host-owned `createDenoFetchHandler(...)` request without a listener, then starts `runDenoApplication(...)` on port `0` with `shutdownSignals: false`, fetches a real route, and closes the application. Signal ownership remains disabled for that managed-listener test; signal registration is covered separately by the package-local contract suite.
+
 ## Public API Overview
 
 - `createDenoAdapter(options)`: Factory for the Deno HTTP adapter; it shares validation and normalization with direct construction.

--- a/packages/platform-deno/deno/deno.json
+++ b/packages/platform-deno/deno/deno.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true
+  },
+  "nodeModulesDir": "manual"
+}

--- a/packages/platform-deno/deno/native-adapter.test.js
+++ b/packages/platform-deno/deno/native-adapter.test.js
@@ -1,18 +1,27 @@
-import { Controller, Get } from 'npm:@fluojs/http';
-import { defineModule } from 'npm:@fluojs/runtime';
-import {
-  bootstrapDenoApplication,
-  createDenoFetchHandler,
-  runDenoApplication,
-} from 'npm:@fluojs/platform-deno';
+const resolvePublishedPackage = (name) => `npm:@fluojs/${name}`;
 
-@Controller('/health')
+const [
+  { Controller, Get },
+  { defineModule },
+  {
+    bootstrapDenoApplication,
+    createDenoFetchHandler,
+    runDenoApplication,
+  },
+] = await Promise.all([
+  import(resolvePublishedPackage('http')),
+  import(resolvePublishedPackage('runtime')),
+  import(resolvePublishedPackage('platform-deno')),
+]);
+
 class HealthController {
-  @Get('/status')
   status() {
     return { status: 'ok' };
   }
 }
+
+Get('/status')(HealthController.prototype, 'status');
+Controller('/health')(HealthController);
 
 class AppModule {}
 defineModule(AppModule, { controllers: [HealthController] });
@@ -38,7 +47,7 @@ Deno.test('createDenoFetchHandler dispatches a request through the published ada
 
 Deno.test('runDenoApplication serves and closes a native Deno listener', async () => {
   // Given: a Deno listener whose address is reported without signal registration.
-  const listening = Promise.withResolvers<{ hostname: string; port: number }>();
+  const listening = Promise.withResolvers();
   const app = await runDenoApplication(AppModule, {
     hostname: '127.0.0.1',
     onListen: listening.resolve,

--- a/packages/platform-deno/deno/native-adapter.test.ts
+++ b/packages/platform-deno/deno/native-adapter.test.ts
@@ -1,0 +1,62 @@
+import { Controller, Get } from 'npm:@fluojs/http';
+import { defineModule } from 'npm:@fluojs/runtime';
+import {
+  bootstrapDenoApplication,
+  createDenoFetchHandler,
+  runDenoApplication,
+} from 'npm:@fluojs/platform-deno';
+
+@Controller('/health')
+class HealthController {
+  @Get('/status')
+  status() {
+    return { status: 'ok' };
+  }
+}
+
+class AppModule {}
+defineModule(AppModule, { controllers: [HealthController] });
+
+Deno.test('createDenoFetchHandler dispatches a request through the published adapter', async () => {
+  // Given: a bootstrapped application and a handler that does not own a listener.
+  const app = await bootstrapDenoApplication(AppModule);
+
+  try {
+    // When: Deno invokes the handler with a native Request.
+    const response = await createDenoFetchHandler({
+      dispatcher: app.dispatcher,
+    })(new Request('http://fluo.test/health/status'));
+
+    // Then: the framework route returns its public response.
+    if (response.status !== 200 || await response.text() !== '{"status":"ok"}') {
+      throw new Error('The Deno fetch handler did not dispatch the health route.');
+    }
+  } finally {
+    await app.close();
+  }
+});
+
+Deno.test('runDenoApplication serves and closes a native Deno listener', async () => {
+  // Given: a Deno listener whose address is reported without signal registration.
+  const listening = Promise.withResolvers<{ hostname: string; port: number }>();
+  const app = await runDenoApplication(AppModule, {
+    hostname: '127.0.0.1',
+    onListen: listening.resolve,
+    port: 0,
+    shutdownSignals: false,
+  });
+
+  try {
+    const address = await listening.promise;
+
+    // When: a real native Deno fetch reaches the managed listener.
+    const response = await fetch(`http://${address.hostname}:${address.port}/health/status`);
+
+    // Then: the listener dispatches the route before application-owned shutdown.
+    if (response.status !== 200 || await response.text() !== '{"status":"ok"}') {
+      throw new Error('The managed Deno listener did not dispatch the health route.');
+    }
+  } finally {
+    await app.close();
+  }
+});

--- a/packages/platform-deno/deno/package.json
+++ b/packages/platform-deno/deno/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@fluojs/platform-deno-native-test",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@fluojs/http": "file:../../http",
+    "@fluojs/platform-deno": "file:..",
+    "@fluojs/runtime": "file:../../runtime"
+  }
+}

--- a/packages/platform-deno/deno/package.json
+++ b/packages/platform-deno/deno/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@fluojs/platform-deno-native-test",
+  "version": "0.0.0",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/packages/platform-deno/src/adapter.test.ts
+++ b/packages/platform-deno/src/adapter.test.ts
@@ -507,7 +507,7 @@ describe('@fluojs/platform-deno', () => {
     }
 
     expect(server.shutdown).toHaveBeenCalledTimes(1);
-    expect(server.options?.signal?.aborted).toBe(true);
+    expect(server.options?.signal?.aborted).toBe(false);
   });
 
   it('dispatches successful requests through adapter.handle after listen binds the dispatcher', async () => {

--- a/packages/platform-deno/src/adapter.ts
+++ b/packages/platform-deno/src/adapter.ts
@@ -569,10 +569,10 @@ function closeDenoServerWithDrain(
       : await gracefulClose;
 
     if (closeResult.kind === 'graceful') {
-      abortController?.abort();
       const rejected = closeResult.results.find((result) => result.status === 'rejected');
 
       if (rejected?.status === 'rejected') {
+        abortController?.abort();
         closeFailure = { error: rejected.reason };
       }
     } else {

--- a/tooling/ci/vitest-project-boundaries.test.ts
+++ b/tooling/ci/vitest-project-boundaries.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+
+import config from '../../vitest.config.js';
+
+describe('root Vitest project boundaries', () => {
+  it('excludes Deno-native tests from the packages project', () => {
+    const packagesProject = config.test?.projects?.[0];
+
+    expect(packagesProject?.test?.name).toBe('packages');
+    expect(packagesProject?.test?.exclude).toContain('packages/**/deno/**');
+  });
+});

--- a/tooling/governance/native-response-cookie-ci.test.ts
+++ b/tooling/governance/native-response-cookie-ci.test.ts
@@ -32,3 +32,14 @@ it('runs scoped PR package scripts serially to prevent shared artifact build rac
     /run: pnpm --workspace-concurrency=1 -r --if-present \$\{\{ needs\.resolve-pr-verification-scope\.outputs\.test_filter_args \}\} run test/u,
   );
 });
+
+it('requires the Deno platform job before the Verify aggregate can pass', () => {
+  // Given
+  const workflow = readFileSync(resolve(import.meta.dirname, '../../.github/workflows/ci.yml'), 'utf8');
+
+  // When
+  const verifyJob = workflow.slice(workflow.indexOf('  verify:\n'));
+
+  // Then
+  expect(verifyJob).toMatch(/\n      - deno-platform\n/u);
+});

--- a/tooling/governance/verify-platform-consistency-governance.test.ts
+++ b/tooling/governance/verify-platform-consistency-governance.test.ts
@@ -2342,6 +2342,27 @@ describe('repository governance contracts', () => {
   it('keeps PR CI governance-gated', () => {
     const ciWorkflow = readFileSync(resolve(repoRoot, '.github/workflows/ci.yml'), 'utf8');
     const vitestConfig = readFileSync(resolve(repoRoot, 'vitest.config.ts'), 'utf8');
+    const workflowLines = ciWorkflow.split('\n');
+    const verifyJobStart = workflowLines.indexOf('  verify:');
+    const verifyJobEnd = workflowLines.findIndex(
+      (line, index) => index > verifyJobStart && /^ {2}\S.*:$/u.test(line),
+    );
+    const verifyJobLines = workflowLines.slice(
+      verifyJobStart,
+      verifyJobEnd === -1 ? undefined : verifyJobEnd,
+    );
+    const verifyNeedsStart = verifyJobLines.indexOf('    needs:');
+    const directNeeds = (jobLines: readonly string[]): string[] => {
+      const needsStart = jobLines.indexOf('    needs:');
+      const needsEnd = jobLines.findIndex(
+        (line, index) => index > needsStart && !line.startsWith('      - '),
+      );
+
+      return jobLines
+        .slice(needsStart + 1, needsEnd === -1 ? undefined : needsEnd)
+        .map((line) => line.slice('      - '.length));
+    };
+    const verifyNeeds = directNeeds(verifyJobLines);
 
     expect(ciWorkflow).toContain('resolve-pr-verification-scope:');
     expect(ciWorkflow).toContain('run: node tooling/ci/detect-pr-verification-scope.mjs');
@@ -2367,6 +2388,14 @@ describe('repository governance contracts', () => {
     expect(ciWorkflow).toContain('build-and-typecheck:');
     expect(ciWorkflow).toContain("if: github.event_name == 'pull_request'");
     expect(ciWorkflow).toContain('verify-platform-consistency-governance');
+    expect(verifyJobStart).toBeGreaterThanOrEqual(0);
+    expect(verifyNeedsStart).toBeGreaterThanOrEqual(0);
+    expect(verifyNeeds).toContain('deno-platform');
+    expect(() => {
+      expect(
+        directNeeds(verifyJobLines.filter((line) => line !== '      - deno-platform')),
+      ).toContain('deno-platform');
+    }).toThrow();
     expect(ciWorkflow).toMatch(
       /studio-browser:\n\s+name: Studio browser\n\s+runs-on: ubuntu-latest\n\s+needs:\n\s+- resolve-pr-verification-scope\n\n\s+steps:/u,
     );

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,7 +28,7 @@ export default mergeConfig(
           extends: true,
           test: {
             name: 'packages',
-            exclude: [...configDefaults.exclude, 'packages/cli/.sandbox/**'],
+            exclude: [...configDefaults.exclude, 'packages/**/deno/**', 'packages/cli/.sandbox/**'],
             include: ['packages/**/*.test.ts'],
           },
         },


### PR DESCRIPTION
## Summary
- add a native Deno 2 journey for the published platform adapter
- expose the host-owned createDenoFetchHandler entrypoint
- require the Deno job from the aggregate Verify gate with mutation coverage
- record the additive public API as a minor Changeset

## Verification
- native Deno 2.5 journey: 2 passed
- package/reverse-dependent suites passed
- governance mutation: removing deno-platform fails exactly one test
- tooling: 81 files / 1540 tests passed
- lint, platform governance and Changeset gate passed

Closes #3377