### PR TITLE
fix(notifications): isolate async options per application (#3227)

### DIFF
--- a/.changeset/isolate-notifications-async-options.md
+++ b/.changeset/isolate-notifications-async-options.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/notifications': patch
+---
+
+Isolate `NotificationsModule.forRootAsync` options, failures, and singleton resolution per application container.

--- a/packages/notifications/src/async-application-context.test.ts
+++ b/packages/notifications/src/async-application-context.test.ts
@@ -1,0 +1,195 @@
+import { Inject, type Token } from '@fluojs/core';
+import { bootstrapApplication, defineModule } from '@fluojs/runtime';
+import { describe, expect, it } from 'vitest';
+
+import { NotificationsModule } from './module.js';
+import { NotificationsService } from './service.js';
+import type { NotificationChannel, NotificationDispatchRequest, NotificationDispatchResult } from './types.js';
+
+interface ApplicationNotificationSettings {
+  readonly channel: NotificationChannel;
+  readonly label: string;
+  readonly shouldFail?: boolean;
+}
+
+const APPLICATION_NOTIFICATION_SETTINGS = Symbol(
+  'application-notification-settings',
+) as Token<ApplicationNotificationSettings>;
+
+@Inject(NotificationsService)
+class LocalNotificationsProbe {
+  constructor(private readonly notifications: NotificationsService) {}
+
+  dispatch(template: string): Promise<NotificationDispatchResult> {
+    return this.notifications.dispatch({
+      channel: 'email',
+      payload: { template },
+    });
+  }
+}
+
+describe('NotificationsModule.forRootAsync application contexts', () => {
+  it('isolates one async registration across concurrently bootstrapped application contexts', async () => {
+    const factoryCalls: string[] = [];
+    const firstDeliveries: string[] = [];
+    const secondDeliveries: string[] = [];
+    const registration = NotificationsModule.forRootAsync({
+      global: false,
+      inject: [APPLICATION_NOTIFICATION_SETTINGS],
+      useFactory: async (...dependencies: unknown[]) => {
+        const settings = dependencies[0] as ApplicationNotificationSettings;
+        factoryCalls.push(settings.label);
+
+        return { channels: [settings.channel] };
+      },
+    });
+
+    class NotificationsOwnerModule {}
+    defineModule(NotificationsOwnerModule, {
+      imports: [registration],
+      providers: [LocalNotificationsProbe],
+    });
+
+    class AppModule {}
+    defineModule(AppModule, { imports: [NotificationsOwnerModule] });
+
+    const [firstApp, secondApp] = await Promise.all([
+      bootstrapApplication({
+        providers: [
+          {
+            provide: APPLICATION_NOTIFICATION_SETTINGS,
+            useValue: {
+              channel: {
+                channel: 'email',
+                async send(notification: NotificationDispatchRequest) {
+                  firstDeliveries.push(String(notification.payload.template));
+
+                  return { externalId: 'first-application' };
+                },
+              },
+              label: 'first',
+            },
+          },
+        ],
+        rootModule: AppModule,
+      }),
+      bootstrapApplication({
+        providers: [
+          {
+            provide: APPLICATION_NOTIFICATION_SETTINGS,
+            useValue: {
+              channel: {
+                channel: 'email',
+                async send(notification: NotificationDispatchRequest) {
+                  secondDeliveries.push(String(notification.payload.template));
+
+                  return { externalId: 'second-application' };
+                },
+              },
+              label: 'second',
+            },
+          },
+        ],
+        rootModule: AppModule,
+      }),
+    ]);
+
+    try {
+      const [firstProbe, secondProbe] = await Promise.all([
+        firstApp.container.resolve(LocalNotificationsProbe),
+        secondApp.container.resolve(LocalNotificationsProbe),
+      ]);
+      const [firstResult, secondResult] = await Promise.all([
+        firstProbe.dispatch('first-template'),
+        secondProbe.dispatch('second-template'),
+      ]);
+
+      expect(factoryCalls).toHaveLength(2);
+      expect([...factoryCalls].sort()).toEqual(['first', 'second']);
+      expect(firstResult).toMatchObject({ deliveryId: 'first-application', status: 'delivered' });
+      expect(secondResult).toMatchObject({ deliveryId: 'second-application', status: 'delivered' });
+      expect(firstDeliveries).toEqual(['first-template']);
+      expect(secondDeliveries).toEqual(['second-template']);
+    } finally {
+      await Promise.all([firstApp.close(), secondApp.close()]);
+    }
+  });
+
+  it('retries a failed async registration in a later application context', async () => {
+    const factoryCalls: string[] = [];
+    const registration = NotificationsModule.forRootAsync({
+      global: false,
+      inject: [APPLICATION_NOTIFICATION_SETTINGS],
+      useFactory: async (...dependencies: unknown[]) => {
+        const settings = dependencies[0] as ApplicationNotificationSettings;
+        factoryCalls.push(settings.label);
+
+        if (settings.shouldFail) {
+          throw new Error(`notification settings failed:${settings.label}`);
+        }
+
+        return { channels: [settings.channel] };
+      },
+    });
+
+    class NotificationsOwnerModule {}
+    defineModule(NotificationsOwnerModule, {
+      imports: [registration],
+      providers: [LocalNotificationsProbe],
+    });
+
+    class AppModule {}
+    defineModule(AppModule, { imports: [NotificationsOwnerModule] });
+
+    await expect(
+      bootstrapApplication({
+        providers: [
+          {
+            provide: APPLICATION_NOTIFICATION_SETTINGS,
+            useValue: {
+              channel: {
+                channel: 'email',
+                async send() {
+                  return { externalId: 'unreachable' };
+                },
+              },
+              label: 'failed',
+              shouldFail: true,
+            },
+          },
+        ],
+        rootModule: AppModule,
+      }),
+    ).rejects.toThrow('notification settings failed:failed');
+
+    const app = await bootstrapApplication({
+      providers: [
+        {
+          provide: APPLICATION_NOTIFICATION_SETTINGS,
+          useValue: {
+            channel: {
+              channel: 'email',
+              async send() {
+                return { externalId: 'recovered-application' };
+              },
+            },
+            label: 'recovered',
+          },
+        },
+      ],
+      rootModule: AppModule,
+    });
+
+    try {
+      const probe = await app.container.resolve(LocalNotificationsProbe);
+
+      await expect(probe.dispatch('recovered-template')).resolves.toMatchObject({
+        deliveryId: 'recovered-application',
+        status: 'delivered',
+      });
+      expect(factoryCalls).toEqual(['failed', 'recovered']);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/packages/notifications/src/module.ts
+++ b/packages/notifications/src/module.ts
@@ -109,15 +109,6 @@ function buildNotificationsModuleAsync(options: NotificationsAsyncModuleOptions)
   class NotificationsAsyncModuleDefinition {}
 
   const factory = options.useFactory as (...args: unknown[]) => MaybePromise<NotificationsModuleOptions>;
-  let cachedResult: Promise<NormalizedNotificationsModuleOptions> | undefined;
-
-  const memoizedFactory = (...deps: unknown[]): Promise<NormalizedNotificationsModuleOptions> => {
-    if (!cachedResult) {
-      cachedResult = Promise.resolve(factory(...deps)).then((resolved) => normalizeNotificationsModuleOptions(resolved));
-    }
-
-    return cachedResult;
-  };
 
   return defineModule(NotificationsAsyncModuleDefinition, {
     exports: [NotificationsService, NOTIFICATIONS, NOTIFICATION_CHANNELS],
@@ -126,7 +117,8 @@ function buildNotificationsModuleAsync(options: NotificationsAsyncModuleOptions)
       inject: options.inject,
       provide: NOTIFICATIONS_OPTIONS,
       scope: 'singleton',
-      useFactory: (...deps: unknown[]) => memoizedFactory(...deps),
+      useFactory: (...deps: unknown[]) =>
+        Promise.resolve(factory(...deps)).then((resolved) => normalizeNotificationsModuleOptions(resolved)),
     }),
   });
 }
@@ -137,7 +129,7 @@ export class NotificationsModule {
    * Registers notifications providers using static options.
    *
    * @param options Static notifications module options including channels and optional queue/event integrations.
-   * @returns A global module definition that exports {@link NotificationsService}, `NOTIFICATIONS`, and `NOTIFICATION_CHANNELS`.
+   * @returns A module definition that exports {@link NotificationsService}, `NOTIFICATIONS`, and `NOTIFICATION_CHANNELS`; exports are global unless `global: false`.
    * @throws {NotificationsConfigurationError} When channel registrations are duplicated or `queue.bulkThreshold` is not a finite positive integer.
    *
    * @example
@@ -155,7 +147,7 @@ export class NotificationsModule {
    * Registers notifications providers from an async DI factory.
    *
    * @param options Async module options that resolve channels and optional integration seams.
-   * @returns A global module definition that memoizes async options resolution per module instance.
+   * @returns A module definition that resolves async options once per application container and exports {@link NotificationsService}, `NOTIFICATIONS`, and `NOTIFICATION_CHANNELS`; exports are global unless `global: false`.
    * @throws {NotificationsConfigurationError} During options resolution when channel registrations are duplicated or `queue.bulkThreshold` is not a finite positive integer.
    *
    * @example


### PR DESCRIPTION
## Summary

- remove module-definition closure caching from NotificationsModule.forRootAsync
- rely on per-application container singleton ownership
- isolate concurrent application factories and allow recovery after another app fails

## Verification

- dependency build then Notifications typecheck
- Notifications plus Email/Slack/Discord reverse tests
- async application contexts 2/2, governance 229/229, docs 88/88
- built concurrent a/b and failed bad then recovered c
- final exact-head triad: merge

Fixes #3227