### PR TITLE
feat(jwt): revoke presented refresh token (#3200)

### DIFF
--- a/.changeset/issue-3200-revoke-presented-refresh-token.md
+++ b/.changeset/issue-3200-revoke-presented-refresh-token.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/jwt': minor
+---
+
+Add `RefreshTokenService.revokePresentedRefreshToken(...)` for safe single-session logout with a verified compact refresh token.

--- a/book/beginner/ch14-jwt.ko.md
+++ b/book/beginner/ch14-jwt.ko.md
@@ -301,10 +301,16 @@ export class AuthService {
   async refresh(refreshToken: string) {
     return this.refreshTokens.rotateRefreshToken(refreshToken);
   }
+
+  async signOut(refreshToken: string): Promise<void> {
+    await this.refreshTokens.revokePresentedRefreshToken(refreshToken);
+  }
 }
 ```
 
 `JwtService.sign(...)`과 `JwtService.verify(...)`는 항상 Promise를 반환합니다. NestJS 코드를 마이그레이션할 때는 이 이름과 `await`를 사용하세요. fluo는 `signAsync()`나 `verifyAsync()` alias를 제공하지 않습니다. `JwtService.decode(...)`는 동기이지만 검증되지 않은 입력만 parse하므로 진단 용도로만 사용하고, claim을 신뢰하기 전에는 `await jwtService.verify(...)`를 호출하세요.
+
+단일 세션 로그아웃에서는 caller가 제시한 compact token을 `RefreshTokenService.revokePresentedRefreshToken(...)`에 전달하세요. 이 method는 durable record를 revoke하기 전에 signature, expiry, refresh-token `type`, `jti`, `family`, `sub`를 검증합니다. `revokeRefreshToken(tokenId)`는 신뢰할 수 있는 record ID에만 사용하세요. 이 API는 compact token을 받지 않습니다.
 
 ### Securing Refresh Tokens
 리프레시 토큰은 수명이 길기 때문에 각별히 주의해서 저장해야 합니다. 웹에서는 `httpOnly`, `secure`, `sameSite: 'strict'` 쿠키에 저장하는 것이 표준입니다. 이는 크로스 사이트 스크립팅(XSS) 공격을 통해 JavaScript로 토큰에 접근하는 것을 방지합니다. Fluo의 인증 패턴은 쿠키 기반과 헤더 기반 토큰 전달 방식 모두와 원활하게 작동하도록 설계되어, 브라우저, 네이티브 모바일 앱, 또는 다른 서버 등 특정 클라이언트 유형에 가장 적합한 보안 모델을 선택할 수 있는 유연성을 제공합니다. 또한 모바일 앱의 경우 보안 인클레이브(secure enclaves)나 키체인 저장소를 활용하여 이러한 영구적인 자격 증명을 무단 추출로부터 보호하는 것이 권장됩니다.

--- a/book/beginner/ch14-jwt.md
+++ b/book/beginner/ch14-jwt.md
@@ -301,10 +301,16 @@ export class AuthService {
   async refresh(refreshToken: string) {
     return this.refreshTokens.rotateRefreshToken(refreshToken);
   }
+
+  async signOut(refreshToken: string): Promise<void> {
+    await this.refreshTokens.revokePresentedRefreshToken(refreshToken);
+  }
 }
 ```
 
 `JwtService.sign(...)` and `JwtService.verify(...)` always return Promises. When migrating NestJS code, use those names with `await`; fluo does not provide `signAsync()` or `verifyAsync()` aliases. `JwtService.decode(...)` is synchronous but only parses unverified input, so use it for diagnostics at most and call `await jwtService.verify(...)` before trusting claims.
+
+For single-session logout, pass the compact token from the caller to `RefreshTokenService.revokePresentedRefreshToken(...)`. It verifies the signature, expiry, refresh-token `type`, `jti`, `family`, and `sub` before revoking the durable record. Keep `revokeRefreshToken(tokenId)` for trusted record IDs only; it does not accept a compact token.
 
 ### Securing Refresh Tokens
 Because refresh tokens are long lived, they must be stored with special care. On the web, the standard is to store them in `httpOnly`, `secure`, `sameSite: 'strict'` cookies. This prevents JavaScript from accessing the token through cross-site scripting (XSS) attacks. Fluo's Authentication patterns are designed to work smoothly with both cookie based and header based token delivery, giving you the flexibility to choose the security model that best fits the client type, whether that client is a browser, a native mobile app, or another server. For mobile apps, it is also recommended to use secure enclaves or keychain storage to protect these persistent credentials from unauthorized extraction.

--- a/packages/jwt/README.ko.md
+++ b/packages/jwt/README.ko.md
@@ -190,6 +190,14 @@ Rotation은 `RefreshTokenStore.rotate(...)`를 사용해 현재 토큰을 소비
 
 재사용을 감지하면 optional `revokeByFamily(family)` capability를 구현한 store는 침해된 token family만 revoke합니다. 기존 store는 source-compatible 상태를 유지합니다. `revokeByFamily(...)`가 없으면 `RefreshTokenService`는 보수적으로 `revokeBySubject(subject)`로 fallback하며, 이 경우 해당 subject의 독립적인 refresh-token family도 함께 revoke됩니다. 다른 family가 침해된 뒤에도 별도 device 또는 session family를 유지해야 하는 production store는 `revokeByFamily(...)`를 구현하세요.
 
+단일 세션 로그아웃에서는 caller가 제시한 compact token을 `revokePresentedRefreshToken(...)`에 전달하세요.
+
+```typescript
+await refreshTokens.revokePresentedRefreshToken(refreshToken);
+```
+
+이 method는 일치하는 record를 revoke하기 전에 signature, expiry, `type`, `jti`, `family`, `sub` claim을 검증합니다. `revokeRefreshToken(tokenId)`는 신뢰할 수 있는 record ID를 이미 가진 caller를 위한 API로 유지됩니다. raw compact token을 이 ID 기반 method에 전달하지 마세요.
+
 ## 설정 가드레일
 
 JWT 서명과 access-token 검증에는 `algorithms`에 지원되는 알고리즘이 하나 이상 필요합니다. Refresh-token 서명과 검증은 `refreshToken.algorithms`가 설정되어 있으면 이를 사용하고, 설정되지 않으면 backward compatibility를 위해 top-level HMAC algorithms를 사용합니다. 기본 signer는 `HS256`, `HS384`, `HS512`, `RS256`, `RS384`, `RS512`, `ES256`, `ES384`, `ES512`를 지원하며, 빈 알고리즘 목록은 모호한 토큰을 발행하거나 수락하지 않도록 즉시 실패합니다.
@@ -218,7 +226,7 @@ Lazy loading은 import-time 안전성 속성일 뿐입니다. 서명이나 검�
 - `DefaultJwtVerifier`: 토큰 검증 및 정규화를 담당하는 클래스입니다.
 - `JwtService`: 서명과 검증 기능을 결합한 편의용 파사드(facade)입니다.
 - `JwksClient`: 제한된 요청 시간 안에서 원격 JWKS 키를 가져오고 캐싱합니다.
-- `RefreshTokenService`: `refreshToken` 옵션이 구성된 경우 refresh token을 발행, 회전, 폐기합니다.
+- `RefreshTokenService`: `refreshToken` 옵션이 구성된 경우 refresh token을 발행, 회전, 폐기합니다. `revokePresentedRefreshToken(...)`은 compact refresh token을 검증한 뒤 record를 revoke하며, `revokeRefreshToken(tokenId)`는 신뢰된 ID를 받는 대안입니다.
 
 ### 타입
 - `JwtPrincipal`: 정규화된 사용자 식별 객체 (`subject`, `roles`, `scopes`, `claims`).

--- a/packages/jwt/README.md
+++ b/packages/jwt/README.md
@@ -190,6 +190,14 @@ Rotation can use `RefreshTokenStore.rotate(...)` to atomically mark the current 
 
 When reuse is detected, stores that implement the optional `revokeByFamily(family)` capability revoke only the compromised token family. Existing stores remain source-compatible: if `revokeByFamily(...)` is absent, `RefreshTokenService` conservatively falls back to `revokeBySubject(subject)`, which also revokes the subject's independent refresh-token families. Implement `revokeByFamily(...)` in production stores when separate device or session families must remain active after another family is compromised.
 
+For single-session logout, pass the compact token that the caller presented to `revokePresentedRefreshToken(...)`:
+
+```typescript
+await refreshTokens.revokePresentedRefreshToken(refreshToken);
+```
+
+This verifies the signature, expiry, `type`, `jti`, `family`, and `sub` claims before revoking the matching record. `revokeRefreshToken(tokenId)` remains available for callers that already hold a trusted record ID; do not pass a raw compact token to that ID-based method.
+
 ## Configuration Guardrails
 
 JWT signing and access-token verification require at least one supported algorithm in `algorithms`. Refresh-token signing and verification use `refreshToken.algorithms` when configured, or the top-level HMAC algorithms for backward compatibility. The built-in signer supports `HS256`, `HS384`, `HS512`, `RS256`, `RS384`, `RS512`, `ES256`, `ES384`, and `ES512`; configuration with an empty algorithm list fails fast instead of issuing or accepting ambiguous tokens.
@@ -218,7 +226,7 @@ Lazy loading is an import-time safety property only. It does **not** make signin
 - `DefaultJwtVerifier`: Handles token validation and normalization.
 - `JwtService`: A convenience facade combining signing and verification.
 - `JwksClient`: Fetches and caches remote JWKS keys with bounded request timeouts.
-- `RefreshTokenService`: Issues, rotates, and revokes refresh tokens when `refreshToken` options are configured.
+- `RefreshTokenService`: Issues, rotates, and revokes refresh tokens when `refreshToken` options are configured. `revokePresentedRefreshToken(...)` verifies a compact refresh token before revoking its record; `revokeRefreshToken(tokenId)` is the trusted-ID alternative.
 
 ### Types
 - `JwtPrincipal`: The normalized identity object (`subject`, `roles`, `scopes`, `claims`).

--- a/packages/jwt/src/refresh/refresh-token-claims.ts
+++ b/packages/jwt/src/refresh/refresh-token-claims.ts
@@ -1,0 +1,52 @@
+import { JwtInvalidTokenError } from '../errors.js';
+import type { DefaultJwtVerifier } from '../signing/verifier.js';
+import type { JwtClaims } from '../types.js';
+
+/**
+ * Describes the claims required for a verified refresh token.
+ */
+export interface RefreshTokenClaims extends JwtClaims {
+  family: string;
+  jti: string;
+  type: 'refresh';
+}
+
+/**
+ * Verifies a compact refresh token and returns its required claims.
+ *
+ * @param verifier Configured verifier for the refresh-token policy.
+ * @param token Compact refresh token to verify.
+ * @returns Verified refresh-token claims with non-empty required identifiers.
+ * @throws {JwtInvalidTokenError} When the token is not a refresh token or lacks required claims.
+ */
+export async function verifyRefreshTokenClaims(
+  verifier: DefaultJwtVerifier,
+  token: string,
+): Promise<RefreshTokenClaims & { sub: string }> {
+  const principal = await verifier.verifyRefreshToken(token);
+  const claims = principal.claims;
+
+  if (claims.type !== 'refresh') {
+    throw new JwtInvalidTokenError('JWT is not a refresh token.');
+  }
+
+  if (typeof claims.jti !== 'string' || claims.jti.length === 0) {
+    throw new JwtInvalidTokenError('Refresh token is missing jti.');
+  }
+
+  if (typeof claims.family !== 'string' || claims.family.length === 0) {
+    throw new JwtInvalidTokenError('Refresh token is missing family.');
+  }
+
+  if (typeof claims.sub !== 'string' || claims.sub.length === 0) {
+    throw new JwtInvalidTokenError('Refresh token is missing sub.');
+  }
+
+  return {
+    ...claims,
+    family: claims.family,
+    jti: claims.jti,
+    sub: claims.sub,
+    type: 'refresh',
+  };
+}

--- a/packages/jwt/src/refresh/refresh-token-presented-revoke.test.ts
+++ b/packages/jwt/src/refresh/refresh-token-presented-revoke.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import { JwtInvalidTokenError } from '../errors.js';
+import { DefaultJwtSigner } from '../signing/signer.js';
+import { DefaultJwtVerifier } from '../signing/verifier.js';
+import {
+  type RefreshTokenRecord,
+  RefreshTokenService,
+  type RefreshTokenStore,
+} from './refresh-token.js';
+
+class InMemoryRefreshTokenStore implements RefreshTokenStore {
+  private readonly records = new Map<string, RefreshTokenRecord>();
+
+  get size(): number {
+    return this.records.size;
+  }
+
+  async save(token: RefreshTokenRecord): Promise<void> {
+    this.records.set(token.id, token);
+  }
+
+  async find(tokenId: string): Promise<RefreshTokenRecord | undefined> {
+    return this.records.get(tokenId);
+  }
+
+  async revoke(tokenId: string): Promise<void> {
+    this.records.delete(tokenId);
+  }
+
+  async revokeBySubject(subject: string): Promise<void> {
+    for (const [tokenId, record] of this.records) {
+      if (record.subject === subject) {
+        this.records.delete(tokenId);
+      }
+    }
+  }
+}
+
+function createService(store: RefreshTokenStore): RefreshTokenService {
+  const refreshToken = {
+    expiresInSeconds: 3600,
+    rotation: false,
+    secret: 'refresh-secret',
+    store,
+  };
+  const signer = new DefaultJwtSigner({
+    algorithms: ['HS256'],
+    refreshToken,
+    secret: 'access-secret',
+  });
+  const verifier = new DefaultJwtVerifier({
+    algorithms: ['HS256'],
+    refreshToken,
+    secret: 'access-secret',
+  });
+
+  return new RefreshTokenService(refreshToken, signer, verifier);
+}
+
+describe('RefreshTokenService presented refresh-token revocation', () => {
+  it('revokes a record for a verified presented refresh token', async () => {
+    // Given
+    const store = new InMemoryRefreshTokenStore();
+    const service = createService(store);
+    const token = await service.issueRefreshToken('user-1');
+
+    // When
+    await expect(service.revokePresentedRefreshToken(token)).resolves.toBeUndefined();
+
+    // Then
+    expect(store.size).toBe(0);
+  });
+
+  it('does not revoke a record for a tampered presented refresh token', async () => {
+    // Given
+    const store = new InMemoryRefreshTokenStore();
+    const service = createService(store);
+    const token = await service.issueRefreshToken('user-1');
+
+    // When
+    await expect(service.revokePresentedRefreshToken(`${token}tampered`)).rejects.toBeInstanceOf(JwtInvalidTokenError);
+
+    // Then
+    expect(store.size).toBe(1);
+  });
+});

--- a/packages/jwt/src/refresh/refresh-token.ts
+++ b/packages/jwt/src/refresh/refresh-token.ts
@@ -2,7 +2,8 @@ import { JwtConfigurationError, JwtExpiredTokenError, JwtInvalidTokenError } fro
 import { SUPPORTED_HMAC_HASH } from '../signing/algorithm-policy.js';
 import type { DefaultJwtSigner } from '../signing/signer.js';
 import type { DefaultJwtVerifier } from '../signing/verifier.js';
-import type { JwtAlgorithm, JwtClaims } from '../types.js';
+import type { JwtAlgorithm } from '../types.js';
+import { type RefreshTokenClaims, verifyRefreshTokenClaims } from './refresh-token-claims.js';
 
 /**
  * Describes the refresh token store contract.
@@ -120,12 +121,6 @@ export function normalizeRefreshTokenOptions(options: RefreshTokenOptions | unde
   };
 }
 
-interface RefreshTokenClaims extends JwtClaims {
-  family: string;
-  jti: string;
-  type: 'refresh';
-}
-
 /**
  * Represents the refresh token service.
  */
@@ -148,7 +143,7 @@ export class RefreshTokenService {
   }
 
   async rotateRefreshToken(currentToken: string): Promise<{ accessToken: string; refreshToken: string }> {
-    const claims = await this.verifyRefreshClaims(currentToken);
+    const claims = await verifyRefreshTokenClaims(this.verifier, currentToken);
 
     if (this.options.rotation) {
       if (!this.options.store.rotate && !this.options.store.consume) {
@@ -225,6 +220,20 @@ export class RefreshTokenService {
     await this.options.store.revoke(tokenId);
   }
 
+  /**
+   * Revokes the record identified by a verified presented refresh token.
+   *
+   * @param token Compact refresh token to verify before its record is revoked.
+   * @returns A promise that resolves after the verified refresh-token record is revoked.
+   * @throws {JwtInvalidTokenError} When the token is malformed or lacks required refresh claims.
+   * @throws {JwtExpiredTokenError} When the refresh token has expired.
+   */
+  async revokePresentedRefreshToken(token: string): Promise<void> {
+    const claims = await verifyRefreshTokenClaims(this.verifier, token);
+
+    await this.options.store.revoke(claims.jti);
+  }
+
   async revokeAllForSubject(subject: string): Promise<void> {
     await this.options.store.revokeBySubject(subject);
   }
@@ -285,34 +294,5 @@ export class RefreshTokenService {
     const token = await this.signer.signRefreshToken(claims);
 
     return { record, token };
-  }
-
-  private async verifyRefreshClaims(token: string): Promise<RefreshTokenClaims & { sub: string }> {
-    const principal = await this.verifier.verifyRefreshToken(token);
-    const claims = principal.claims;
-
-    if (claims.type !== 'refresh') {
-      throw new JwtInvalidTokenError('JWT is not a refresh token.');
-    }
-
-    if (typeof claims.jti !== 'string' || claims.jti.length === 0) {
-      throw new JwtInvalidTokenError('Refresh token is missing jti.');
-    }
-
-    if (typeof claims.family !== 'string' || claims.family.length === 0) {
-      throw new JwtInvalidTokenError('Refresh token is missing family.');
-    }
-
-    if (typeof claims.sub !== 'string' || claims.sub.length === 0) {
-      throw new JwtInvalidTokenError('Refresh token is missing sub.');
-    }
-
-    return {
-      ...claims,
-      family: claims.family,
-      jti: claims.jti,
-      sub: claims.sub,
-      type: 'refresh',
-    };
   }
 }


### PR DESCRIPTION
## Summary

Add a safe explicit API for revoking a presented compact refresh token during single-session logout.

Linked context: Closes #3200

## Changes

- add `RefreshTokenService.revokePresentedRefreshToken(token)`
- reuse shared refresh-token verification for signature, expiry, type, `jti`, family, and subject
- revoke the verified `jti` while preserving the trusted-ID API
- add deterministic regressions and synchronized EN/KO README/book guidance

## Testing

- `pnpm --filter '@fluojs/jwt...' build`\n- `pnpm --filter '@fluojs/jwt' typecheck`\n- `pnpm --filter '...@fluojs/jwt' test`\n- `pnpm verify:platform-consistency-governance`\n- `pnpm verify:public-export-tsdoc`\n- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=main`\n- built-library driver verified `jti` revocation\n\n`pnpm lint` remains red only for identical pre-existing `packages/config/src/load-env-file-paths.test.ts` `useLiteralKeys` diagnostics confirmed on clean `main`.\n\n## Release impact\n\n- [x] This PR has consumer-visible release impact and includes a Changeset.\n- [ ] This PR has no consumer-visible release impact.\n\nChangeset: `.changeset/issue-3200-revoke-presented-refresh-token.md` (`@fluojs/jwt`: minor)