### PR TITLE
fix(runtime): await async cleanup callbacks

### DIFF
--- a/.changeset/await-runtime-cleanup-callbacks.md
+++ b/.changeset/await-runtime-cleanup-callbacks.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/runtime": patch
+---
+
+Wait for application-owned asynchronous runtime cleanup callbacks before `close()` or bootstrap-failure cleanup settles. Cleanup remains best-effort: later callbacks run after failures, close aggregates failures for explicit retry, and bootstrap preserves the original bootstrap error.

--- a/book/advanced/ch09-app-context.ko.md
+++ b/book/advanced/ch09-app-context.ko.md
@@ -118,7 +118,7 @@ class FluoApplicationContext implements ApplicationContext {
     readonly rootModule: ModuleType,
     readonly bootstrapTiming: ApplicationContext['bootstrapTiming'],
     private readonly lifecycleInstances: unknown[],
-    private readonly runtimeCleanup: Array<() => void>,
+    private readonly runtimeCleanup: Array<() => MaybePromise<void>>,
     private readonly contextCacheableTokens: ContextCacheableTokens,
   ) {
     installContextCacheInvalidation(this.container, this.contextResolutionCache, this.contextCacheableTokens);
@@ -427,6 +427,12 @@ class FluoApplication implements Application {
 이 구조 때문에 application shell은 context 기능을 포함하면서도 HTTP adapter와 dispatcher state를 관리합니다. context와 같은 baseline을 쓰지만, 같은 contract는 아닙니다.
 
 `ApplicationState`는 `path:packages/runtime/src/types.ts`에 선언되어 있습니다. 허용 값은 계속 `'bootstrapped'`, `'ready'`, `'closed'`입니다. `closeStarted`는 새 public state가 아니라 private admission gate입니다. Pending 또는 failed teardown은 이전 public state를 유지하지만 일반 application operation은 shutdown 시작부터 reject됩니다. Public state는 teardown이 성공적으로 완료된 뒤에만 `closed`가 됩니다.
+
+Runtime-owned cleanup callback은 `void` 또는 `Promise<void>`를 받을 수 있습니다. close와
+bootstrap-failure cleanup은 lifecycle hook, adapter, container disposal로 넘어가기 전에 registration을
+순서대로 await합니다. callback failure가 나도 이후 registration은 건너뛰지 않습니다. close는 failure를
+aggregate하여 완료되지 않은 phase를 명시적으로 retry하게 하고, bootstrap은 원래 error를 보존하며
+cleanup failure를 `ApplicationLogger`로 보고합니다.
 
 가장 먼저 볼 계약은 `path:packages/runtime/src/bootstrap.ts:437-443`의 `ready()`입니다. 이 메서드는 `adapter.listen()`을 호출하지 않습니다. application이 이미 닫혀 있지 않은지만 확인한 뒤, `platformShell.assertCriticalReadiness()`에 위임합니다.
 

--- a/book/advanced/ch09-app-context.md
+++ b/book/advanced/ch09-app-context.md
@@ -118,7 +118,7 @@ class FluoApplicationContext implements ApplicationContext {
     readonly rootModule: ModuleType,
     readonly bootstrapTiming: ApplicationContext['bootstrapTiming'],
     private readonly lifecycleInstances: unknown[],
-    private readonly runtimeCleanup: Array<() => void>,
+    private readonly runtimeCleanup: Array<() => MaybePromise<void>>,
     private readonly contextCacheableTokens: ContextCacheableTokens,
   ) {
     installContextCacheInvalidation(this.container, this.contextResolutionCache, this.contextCacheableTokens);
@@ -427,6 +427,12 @@ class FluoApplication implements Application {
 Because of this structure, the application shell includes context functionality while also managing HTTP adapter and dispatcher state. It uses the same baseline as a context, but it is not the same contract.
 
 `ApplicationState` is declared in `path:packages/runtime/src/types.ts`. The allowed values remain `'bootstrapped'`, `'ready'`, and `'closed'`. `closeStarted` is a private admission gate rather than a new public state: pending or failed teardown preserves the previous public state, while normal application operations reject from shutdown start. The public state becomes `closed` only after teardown completes successfully.
+
+Runtime-owned cleanup callbacks accept `void` or `Promise<void>`. Close and bootstrap-failure
+cleanup await registrations in order before moving to lifecycle hooks, adapters, or container
+disposal. A callback failure does not skip later registrations; close aggregates it for explicit
+retry of that incomplete phase, while bootstrap preserves its original error and reports cleanup
+failures through `ApplicationLogger`.
 
 The first contract to inspect is `ready()` in `path:packages/runtime/src/bootstrap.ts:437-443`. This method does not call `adapter.listen()`. It only checks that the application is not already closed, then delegates to `platformShell.assertCriticalReadiness()`.
 

--- a/docs/CONTEXT.ko.md
+++ b/docs/CONTEXT.ko.md
@@ -3,6 +3,14 @@
 
 이 문서는 fluo 저장소를 위한 최우선 AI 참조 진입점이다. 프레임워크 정체성, 위반 불가 규칙, 패키지 경계, 그리고 적절한 원본 문서로 이동하는 가장 짧은 경로를 요약한다.
 
+## Runtime cleanup settlement
+
+`RUNTIME_CLEANUP_REGISTRATION` callback은 동기 또는 비동기일 수 있습니다. Runtime close와
+bootstrap-failure cleanup은 각 registration을 순서대로 await하고 failure 뒤에도 계속 실행하며,
+cleanup failure를 보고하면서 원래 bootstrap failure를 보존합니다. 자세한 내용은
+[Lifecycle & Shutdown Guarantees](./architecture/lifecycle-and-shutdown.ko.md)와
+[`@fluojs/runtime` README](../packages/runtime/README.ko.md)를 참고하세요.
+
 ## Cloudflare Worker close 소유권
 
 `@fluojs/platform-cloudflare-workers` lifecycle contract는 package README, [NestJS migration map](./getting-started/migrate-from-nestjs.ko.md), [Cloudflare Workers Edge Deployment](../book/intermediate/ch24-cloudflare.ko.md)에 문서화합니다. Worker `fetch` handler에는 host가 호출하는 shutdown callback이 없으므로 애플리케이션이 close trigger를 소유합니다. `worker.fetch` 밖의 trigger는 `await worker.close()`를 직접 호출할 수 있지만, 그 fetch 안의 management route는 현재 response를 반환한 뒤 `executionContext.waitUntil(worker.close())` 또는 동등한 non-self-awaiting mechanism으로 close를 관찰해야 합니다. 성공한 lazy-entrypoint close는 재시작 가능합니다. 이후의 `fetch(...)`는 새 application을 bootstrap하고 bootstrap lifecycle hook을 다시 실행하며 application singleton provider를 다시 생성합니다.

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -3,6 +3,14 @@
 
 This document is the primary AI-reference entrypoint for the fluo repository. It summarizes framework identity, non-negotiable authoring rules, package boundaries, and the fastest path to the correct source document.
 
+## Runtime Cleanup Settlement
+
+`RUNTIME_CLEANUP_REGISTRATION` callbacks may be synchronous or asynchronous. Runtime close and
+bootstrap-failure cleanup await each registration in order, continue after failures, and preserve
+the original bootstrap failure while reporting cleanup failures. See the [Lifecycle & Shutdown
+Guarantees](./architecture/lifecycle-and-shutdown.md) and the
+[`@fluojs/runtime` README](../packages/runtime/README.md).
+
 ## Cloudflare Worker Close Ownership
 
 The `@fluojs/platform-cloudflare-workers` lifecycle contract is documented in its package README, the [NestJS migration map](./getting-started/migrate-from-nestjs.md), and [Cloudflare Workers Edge Deployment](../book/intermediate/ch24-cloudflare.md). A Worker `fetch` handler has no host-invoked shutdown callback. A trigger outside `worker.fetch` may call `await worker.close()` directly; a management route inside that fetch must return its current response, then use `executionContext.waitUntil(worker.close())` or an equivalent non-self-awaiting mechanism. A successful lazy-entrypoint close is restartable: a later `fetch(...)` bootstraps a fresh application, reruns bootstrap lifecycle hooks, and reconstructs application singleton providers.

--- a/docs/architecture/lifecycle-and-shutdown.ko.md
+++ b/docs/architecture/lifecycle-and-shutdown.ko.md
@@ -51,6 +51,14 @@
 
 런타임은 종료 훅을 명시적 계약으로만 제공합니다. 신호 등록은 범용 런타임 표면이 아니라 주변 호스트나 어댑터 헬퍼의 책임입니다.
 
+## Runtime cleanup settlement
+
+Runtime-owned cleanup registration은 동기 또는 비동기 callback을 받습니다. close와
+bootstrap-failure cleanup은 등록 순서대로 callback을 실행하고 다음 cleanup phase 전에 각각을
+await합니다. 실패해도 이후 registration은 건너뛰지 않습니다. close는 failure를 aggregate하고
+완료되지 않은 cleanup phase만 retry 가능하게 남기며, bootstrap은 원래 bootstrap error를 보존하고
+cleanup failure를 `ApplicationLogger`로 보고합니다.
+
 ## 관련 문서
 
 - [패키지 아키텍처 참조](./architecture-overview.ko.md)

--- a/docs/architecture/lifecycle-and-shutdown.md
+++ b/docs/architecture/lifecycle-and-shutdown.md
@@ -51,6 +51,14 @@ These guarantees separate bootstrap completion from listener binding. A compiled
 
 The runtime exposes shutdown hooks as explicit contracts only. Signal registration is owned by the surrounding host or adapter helper, not by the universal runtime surface.
 
+## Runtime Cleanup Settlement
+
+Runtime-owned cleanup registrations accept synchronous or asynchronous callbacks. Close and
+bootstrap-failure cleanup execute registrations in order and await every callback before the next
+cleanup phase. A failure does not skip later registrations: close aggregates failures and leaves
+only its incomplete cleanup phase retryable, while bootstrap keeps the original bootstrap error and
+reports cleanup failures through `ApplicationLogger`.
+
 ## Related Docs
 
 - [Package Architecture Reference](./architecture-overview.md)

--- a/packages/runtime/README.ko.md
+++ b/packages/runtime/README.ko.md
@@ -458,6 +458,15 @@ consumer는 rejection 또는 fallback을 명시적으로 처리하고 필요한 
 
 더 저수준의 Node compression internals는 공개 `@fluojs/runtime/node` 계약이 아니라 `@fluojs/runtime/internal-node` seam 뒤에 둡니다.
 
+### Runtime cleanup callback
+
+내부 `RUNTIME_CLEANUP_REGISTRATION` token을 받는 provider는 `void` 또는 `Promise<void>`를
+반환하는 cleanup callback을 등록할 수 있습니다. Runtime close와 bootstrap-failure cleanup은
+registration 순서대로 callback을 실행하고, 이후 cleanup phase로 넘어가기 전에 각각을 await합니다.
+실패해도 이후 callback은 계속 실행합니다. `close()`는 cleanup failure를 aggregate하고 완료되지 않은
+phase를 명시적 retry 대상으로 남기며, bootstrap은 원래 failure를 보존하고 cleanup failure를
+`ApplicationLogger`로 보고합니다.
+
 ## 관련 패키지
 
 - [@fluojs/core](../core): 핵심 데코레이터 및 메타데이터 시스템.

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -458,6 +458,15 @@ required application-owned header themselves.
 
 Lower-level Node compression internals stay behind the `@fluojs/runtime/internal-node` seam rather than the public `@fluojs/runtime/node` contract.
 
+### Runtime Cleanup Callbacks
+
+Providers that receive the internal `RUNTIME_CLEANUP_REGISTRATION` token may register cleanup
+callbacks that return `void` or `Promise<void>`. Runtime close and bootstrap-failure cleanup run
+the callbacks in registration order and await each one before entering later cleanup phases.
+Failures do not prevent later callbacks from running: `close()` aggregates cleanup failures and
+leaves that incomplete phase eligible for an explicit retry, while bootstrap preserves its original
+failure and reports cleanup failures through `ApplicationLogger`.
+
 ## Related Packages
 
 - [@fluojs/core](../core): Core decorators and metadata system.

--- a/packages/runtime/src/application.test.ts
+++ b/packages/runtime/src/application.test.ts
@@ -574,8 +574,18 @@ describe('bootstrapApplication', () => {
     ]);
   });
 
-  it('runs internally registered runtime cleanup callbacks on close', async () => {
+  it('awaits runtime cleanup callbacks before later shutdown phases and retries failed cleanup', async () => {
     const events: string[] = [];
+    const cleanupCanFinish = createDeferred<void>();
+    const cleanupStarted = createDeferred<void>();
+    const cleanupFailure = new Error('runtime cleanup failed');
+    let failCleanup = true;
+    const adapter: HttpApplicationAdapter = {
+      async close() {
+        events.push('adapter:close');
+      },
+      async listen() {},
+    };
 
     @Inject(RUNTIME_CLEANUP_REGISTRATION)
     class RuntimeCleanupProbe implements OnModuleInit {
@@ -583,23 +593,154 @@ describe('bootstrapApplication', () => {
 
       onModuleInit() {
         this.registerCleanup(() => {
-          events.push('runtime:cleanup');
+          events.push('runtime:waiting:start');
+          cleanupStarted.resolve();
+
+          return cleanupCanFinish.promise.then(() => {
+            events.push('runtime:waiting:end');
+          });
         });
+        this.registerCleanup(() => {
+          events.push('runtime:failing');
+
+          if (failCleanup) {
+            failCleanup = false;
+            throw cleanupFailure;
+          }
+        });
+        this.registerCleanup(() => {
+          events.push('runtime:after-failure');
+        });
+      }
+    }
+
+    class AppService {
+      onApplicationShutdown() {
+        events.push('application:shutdown');
+      }
+
+      onModuleDestroy() {
+        events.push('module:destroy');
       }
     }
 
     class AppModule {}
     defineModule(AppModule, {
-      providers: [RuntimeCleanupProbe],
+      providers: [RuntimeCleanupProbe, AppService],
     });
 
     const app = registerAppForCleanup(await bootstrapApplication({
+      adapter,
       rootModule: AppModule,
     }));
 
-    await app.close('SIGTERM');
+    const closePromise = app.close('SIGTERM');
 
-    expect(events).toEqual(['runtime:cleanup']);
+    try {
+      await cleanupStarted.promise;
+      expect(events).toEqual(['runtime:waiting:start']);
+
+      cleanupCanFinish.resolve();
+
+      await expect(closePromise).rejects.toBe(cleanupFailure);
+      expect(events).toEqual([
+        'runtime:waiting:start',
+        'runtime:waiting:end',
+        'runtime:failing',
+        'runtime:after-failure',
+        'module:destroy',
+        'application:shutdown',
+        'adapter:close',
+      ]);
+
+      await expect(app.close('SIGTERM')).resolves.toBeUndefined();
+      expect(events).toEqual([
+        'runtime:waiting:start',
+        'runtime:waiting:end',
+        'runtime:failing',
+        'runtime:after-failure',
+        'module:destroy',
+        'application:shutdown',
+        'adapter:close',
+        'runtime:waiting:start',
+        'runtime:waiting:end',
+        'runtime:failing',
+        'runtime:after-failure',
+      ]);
+    } finally {
+      cleanupCanFinish.resolve();
+      await closePromise.catch(() => undefined);
+    }
+  });
+
+  it('aggregates runtime cleanup failures while continuing later callbacks', async () => {
+    const events: string[] = [];
+    const firstFailure = new Error('first runtime cleanup failed');
+    const secondFailure = new Error('second runtime cleanup failed');
+    const secondFailurePromise = Promise.reject(secondFailure);
+    void secondFailurePromise.catch(() => undefined);
+    const adapter: HttpApplicationAdapter = {
+      async close() {
+        events.push('adapter:close');
+      },
+      async listen() {},
+    };
+
+    @Inject(RUNTIME_CLEANUP_REGISTRATION)
+    class RuntimeCleanupProbe implements OnModuleInit {
+      constructor(private readonly registerCleanup: RuntimeCleanupRegistration) {}
+
+      onModuleInit() {
+        this.registerCleanup(() => {
+          events.push('runtime:first-failure');
+          throw firstFailure;
+        });
+        this.registerCleanup(() => {
+          events.push('runtime:second-failure');
+          return secondFailurePromise;
+        });
+        this.registerCleanup(() => {
+          events.push('runtime:after-failures');
+        });
+      }
+    }
+
+    class AppService {
+      onApplicationShutdown() {
+        events.push('application:shutdown');
+      }
+
+      onModuleDestroy() {
+        events.push('module:destroy');
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      providers: [RuntimeCleanupProbe, AppService],
+    });
+
+    const app = registerAppForCleanup(await bootstrapApplication({
+      adapter,
+      rootModule: AppModule,
+    }));
+    const closeError = await app.close('SIGTERM').then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect(closeError).toBeInstanceOf(AggregateError);
+    if (closeError instanceof AggregateError) {
+      expect(closeError.errors).toEqual([firstFailure, secondFailure]);
+    }
+    expect(events).toEqual([
+      'runtime:first-failure',
+      'runtime:second-failure',
+      'runtime:after-failures',
+      'module:destroy',
+      'application:shutdown',
+      'adapter:close',
+    ]);
   });
 
   it('retries only a failed shutdown hook without repeating completed adapter cleanup', async () => {

--- a/packages/runtime/src/bootstrap.test.ts
+++ b/packages/runtime/src/bootstrap.test.ts
@@ -1068,9 +1068,15 @@ describe('FluoFactory.createApplicationContext', () => {
     ]);
   });
 
-  it('preserves the original application bootstrap error when a runtime cleanup callback fails', async () => {
+  it('awaits runtime cleanup failure before preserving the original application bootstrap error', async () => {
     const bootstrapFailure = new Error('application bootstrap failed');
     const cleanupFailure = new Error('application cleanup failed');
+    const cleanupCanFinish = createDeferred<void>();
+    const cleanupStarted = createDeferred<void>();
+    const cleanupFailurePromise = cleanupCanFinish.promise.then(() => {
+      throw cleanupFailure;
+    });
+    void cleanupFailurePromise.catch(() => undefined);
     const logger = { debug: vi.fn(), error: vi.fn(), log: vi.fn(), warn: vi.fn() };
 
     @Inject(RUNTIME_CLEANUP_REGISTRATION)
@@ -1079,7 +1085,8 @@ describe('FluoFactory.createApplicationContext', () => {
 
       onModuleInit() {
         this.registerCleanup(() => {
-          throw cleanupFailure;
+          cleanupStarted.resolve();
+          return cleanupFailurePromise;
         });
       }
     }
@@ -1095,7 +1102,31 @@ describe('FluoFactory.createApplicationContext', () => {
       providers: [CleanupRegistrant, FailingBootstrapHook],
     });
 
-    await expect(bootstrapApplication({ logger, rootModule: AppModule })).rejects.toBe(bootstrapFailure);
+    let bootstrapSettled = false;
+    const bootstrapResult = bootstrapApplication({ logger, rootModule: AppModule });
+    const observedBootstrapResult = bootstrapResult.then(
+      () => {
+        bootstrapSettled = true;
+        return undefined;
+      },
+      (error: unknown) => {
+        bootstrapSettled = true;
+        return error;
+      },
+    );
+
+    try {
+      await cleanupStarted.promise;
+      await Promise.resolve();
+      expect(bootstrapSettled).toBe(false);
+
+      cleanupCanFinish.resolve();
+      expect(await observedBootstrapResult).toBe(bootstrapFailure);
+    } finally {
+      cleanupCanFinish.resolve();
+      await observedBootstrapResult;
+    }
+
     expect(logger.error).toHaveBeenCalledWith(
       'Failed to clean up after application bootstrap failure.',
       cleanupFailure,

--- a/packages/runtime/src/bootstrap.ts
+++ b/packages/runtime/src/bootstrap.ts
@@ -79,6 +79,7 @@ type MutableBootstrapReadySignal = BootstrapReadySignal & {
 };
 
 type CacheInvalidatingContainer = Container & { override(...providers: Provider[]): Container };
+type RuntimeCleanupCallback = Parameters<RuntimeCleanupRegistration>[0];
 
 async function runExceptionFilters(
   filters: readonly ExceptionFilterHandler[],
@@ -126,12 +127,12 @@ async function disposeContainer(container: Container): Promise<void> {
   await container.dispose();
 }
 
-async function runCleanupCallbacks(cleanups: readonly (() => void)[]): Promise<unknown[]> {
+async function runCleanupCallbacks(cleanups: readonly RuntimeCleanupCallback[]): Promise<unknown[]> {
   const errors: unknown[] = [];
 
   for (const cleanup of cleanups) {
     try {
-      cleanup();
+      await cleanup();
     } catch (error) {
       errors.push(error);
     }
@@ -140,7 +141,7 @@ async function runCleanupCallbacks(cleanups: readonly (() => void)[]): Promise<u
   return errors;
 }
 
-function createRuntimeCleanupRegistration(cleanups: Array<() => void>): RuntimeCleanupRegistration {
+function createRuntimeCleanupRegistration(cleanups: RuntimeCleanupCallback[]): RuntimeCleanupRegistration {
   return (cleanup) => {
     cleanups.push(cleanup);
 
@@ -180,7 +181,7 @@ async function closeRuntimeResources(options: {
   container: Container;
   lifecycleInstances: readonly unknown[];
   modules: CompiledModule[];
-  runtimeCleanup: readonly (() => void)[];
+  runtimeCleanup: readonly RuntimeCleanupCallback[];
   shutdownState: RetryableShutdownState<RuntimeShutdownPhase>;
   signal?: string;
 }): Promise<void> {
@@ -238,7 +239,7 @@ async function runBootstrapFailureCleanup(options: {
   lifecycleInstances: readonly unknown[];
   logger: ApplicationLogger;
   modules: CompiledModule[];
-  runtimeCleanup: readonly (() => void)[];
+  runtimeCleanup: readonly RuntimeCleanupCallback[];
   scope: 'application' | 'application context';
 }): Promise<void> {
   const errors: unknown[] = [];
@@ -1403,7 +1404,7 @@ function registerRuntimeBootstrapTokens(
   bootstrapped: BootstrapResult,
   adapter: HttpApplicationAdapter,
   platformShell: RuntimePlatformShell,
-  runtimeCleanup: Array<() => void>,
+  runtimeCleanup: RuntimeCleanupCallback[],
   bootstrapReadySignal: BootstrapReadySignal,
 ): void {
   registerRuntimeContextTokens(bootstrapped, {
@@ -1438,7 +1439,7 @@ function registerRuntimeContextTokens(bootstrapped: BootstrapResult, ...provider
 function registerRuntimeApplicationContextTokens(
   bootstrapped: BootstrapResult,
   platformShell: RuntimePlatformShell,
-  runtimeCleanup: Array<() => void>,
+  runtimeCleanup: RuntimeCleanupCallback[],
   bootstrapReadySignal: BootstrapReadySignal,
 ): void {
   registerRuntimeContextTokens(bootstrapped, {
@@ -1585,7 +1586,7 @@ export async function bootstrapApplication(options: BootstrapApplicationOptions)
     async close() {},
     async listen() {},
   };
-  const runtimeCleanup: Array<() => void> = [];
+  const runtimeCleanup: RuntimeCleanupCallback[] = [];
   if (studioDevtools) {
     runtimeCleanup.push(() => studioDevtools.close());
   }
@@ -1757,7 +1758,7 @@ export class FluoFactory {
     let lifecycleInstances: unknown[] = [];
     let bootstrappedContainer: Container | undefined;
     let bootstrappedModules: CompiledModule[] = [];
-    const runtimeCleanup: Array<() => void> = [];
+    const runtimeCleanup: RuntimeCleanupCallback[] = [];
     if (studioDevtools) {
       runtimeCleanup.push(() => studioDevtools.close());
     }

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -1,14 +1,14 @@
 import type { Constructor, MaybePromise, Token } from '@fluojs/core';
 import type { Container, Provider } from '@fluojs/di';
 import type {
+  ConditionalRequestOptions,
   ContentNegotiationOptions,
   ConverterLike,
-  ConditionalRequestOptions,
   Dispatcher,
   FrameworkRequest,
   FrameworkResponse,
-  HttpErrorRepresentationOptions,
   HttpApplicationAdapter,
+  HttpErrorRepresentationOptions,
   InterceptorLike,
   MiddlewareLike,
   RequestObserverLike,
@@ -118,8 +118,8 @@ export interface ApplicationLogger {
   warn(message: string, context?: string): void;
 }
 
-/** Registers runtime-owned cleanup callbacks that must run during bootstrap failure or shutdown. */
-export type RuntimeCleanupRegistration = (cleanup: () => void) => () => void;
+/** Registers runtime-owned cleanup callbacks that must settle during bootstrap failure or shutdown. */
+export type RuntimeCleanupRegistration = (cleanup: () => MaybePromise<void>) => () => void;
 
 /** Runtime-visible application states for HTTP and microservice shells. */
 export type ApplicationState = 'bootstrapped' | 'ready' | 'closed';

--- a/tooling/governance/verify-platform-consistency-governance.test.ts
+++ b/tooling/governance/verify-platform-consistency-governance.test.ts
@@ -435,7 +435,7 @@ describe('enforceContractCompanionUpdates', () => {
     });
   });
 
-  describe('Lifecycle dispatch shutdown contract companions', () => {
+  describe('Lifecycle shutdown contract companions', () => {
     const lifecycleChangedFiles = [
       'book/advanced/ch09-app-context.md',
       'book/advanced/ch09-app-context.ko.md',
@@ -445,14 +445,17 @@ describe('enforceContractCompanionUpdates', () => {
       'packages/runtime/README.ko.md',
     ];
     const contextCompanions = ['docs/CONTEXT.md', 'docs/CONTEXT.ko.md'];
-    const regressionCompanion = 'packages/runtime/src/application.test.ts';
+    const regressionCompanions = [
+      'packages/runtime/src/application.test.ts',
+      'packages/runtime/src/bootstrap.test.ts',
+    ];
     const toolingCompanion = 'tooling/governance/verify-platform-consistency-governance.test.ts';
 
-    it('requires context, regression, and tooling companions for dispatch shutdown contract updates', async () => {
+    it('requires context, regression, and tooling companions for shutdown contract updates', async () => {
       const { enforceContractCompanionUpdates } = await loadGovernanceInternals();
       const changedFiles = [
         ...lifecycleChangedFiles,
-        regressionCompanion,
+        ...regressionCompanions,
       ];
 
       expect(() => enforceContractCompanionUpdates(changedFiles)).toThrow(


### PR DESCRIPTION
## Summary

- accept asynchronous runtime cleanup callbacks and await them before close settles
- continue cleanup best-effort after individual callback failures and aggregate cleanup errors
- preserve cleanup phase order, close retry semantics, and original bootstrap error ownership
- align EN/KO runtime, lifecycle, app-context, CONTEXT, governance, and Changeset contracts

## Verification

- runtime dependency closure build and typecheck
- targeted async cleanup regressions: 5
- runtime: 40 files / 475 tests
- platform governance: 229 tests
- `pnpm verify:platform-consistency-governance`
- docs parity/typecheck: 42 EN/KO pairs
- public-export TSDoc, stable Changeset lane, changed-file Biome, `git diff --check`
- full runtime reverse-dependent suite
- manual cleanup sequence: `cleanup:start,cleanup:end,cleanup:reject,cleanup:after-reject,adapter:close`
- exact-head contract/code/verification triad: PASS/PASS/PASS

## Release

Patch Changeset included for `@fluojs/runtime`. Publishing remains GitHub Actions + Changesets only.

Closes #3256