### PR TITLE
fix(cli): reject output aliases to source modules

### DIFF
--- a/.changeset/reject-cli-output-module-aliases.md
+++ b/.changeset/reject-cli-output-module-aliases.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/cli": patch
+---
+
+Reject inspect and typegen artifact outputs that identify the input application module.

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -4284,7 +4284,9 @@ exit 7
     expect(stdoutBuffer).toEqual([]);
     expect(stderrBuffer).toHaveLength(1);
     expect(readFileSync(modulePath, 'utf8')).toBe(source);
-  });
+    // The lazy `runCli` facade transforms the full CLI module graph on first use,
+    // which exceeds the default per-test budget on a cold Vitest cache.
+  }, 90000);
 
   it('delegates inspect --mermaid output to Studio when resolvable', async () => {
     const stdoutBuffer: string[] = [];

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1,6 +1,6 @@
 import { type ChildProcess, spawnSync } from 'node:child_process';
 import { EventEmitter } from 'node:events';
-import { chmodSync, existsSync, type FSWatcher, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, type FSWatcher, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { delimiter, dirname, join } from 'node:path';
 import { PassThrough } from 'node:stream';
@@ -4254,6 +4254,36 @@ exit 7
     expect(report.snapshot.diagnostics).toEqual([]);
     expect(report.summary.readinessStatus).toBe('ready');
     expect(report.summary.healthStatus).toBe('healthy');
+  });
+
+  it.each(['direct path', 'symlink'] as const)('rejects a %s output alias to the inspected application module', async (aliasKind) => {
+    // Given
+    const fixtureDirectory = mkdtempSync(join(dirname(inspectFixtureModulePath), 'inspect-output-alias-'));
+    createdDirectories.push(fixtureDirectory);
+    const modulePath = join(fixtureDirectory, 'app.module.mjs');
+    const source = readFileSync(inspectFixtureModulePath, 'utf8');
+    writeFileSync(modulePath, source, 'utf8');
+    const outputPath = aliasKind === 'direct path'
+      ? modulePath
+      : join(fixtureDirectory, 'inspect-output.json');
+    if (aliasKind === 'symlink') {
+      symlinkSync(modulePath, outputPath);
+    }
+    const stdoutBuffer: string[] = [];
+    const stderrBuffer: string[] = [];
+
+    // When
+    const exitCode = await runCli(['inspect', modulePath, '--output', outputPath], {
+      cwd: process.cwd(),
+      stderr: { write: (message) => stderrBuffer.push(message) },
+      stdout: { write: (message) => stdoutBuffer.push(message) },
+    });
+
+    // Then
+    expect(exitCode).toBe(1);
+    expect(stdoutBuffer).toEqual([]);
+    expect(stderrBuffer).toHaveLength(1);
+    expect(readFileSync(modulePath, 'utf8')).toBe(source);
   });
 
   it('delegates inspect --mermaid output to Studio when resolvable', async () => {

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -4353,7 +4353,9 @@ exit 7
     expect(stdoutBuffer).toEqual([]);
     expect(stderrBuffer).toHaveLength(1);
     expect(readFileSync(modulePath, 'utf8')).toBe(source);
-  });
+    // The lazy `runCli` facade transforms the full CLI module graph on first use,
+    // which exceeds the default per-test budget on a cold Vitest cache.
+  }, 90000);
 
   it('delegates inspect --mermaid output to Studio when resolvable', async () => {
     const stdoutBuffer: string[] = [];

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1,6 +1,6 @@
 import { type ChildProcess, spawnSync } from 'node:child_process';
 import { EventEmitter } from 'node:events';
-import { chmodSync, existsSync, type FSWatcher, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, type FSWatcher, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { delimiter, dirname, join } from 'node:path';
 import { PassThrough } from 'node:stream';
@@ -4323,6 +4323,36 @@ exit 7
     expect(report.snapshot.diagnostics).toEqual([]);
     expect(report.summary.readinessStatus).toBe('ready');
     expect(report.summary.healthStatus).toBe('healthy');
+  });
+
+  it.each(['direct path', 'symlink'] as const)('rejects a %s output alias to the inspected application module', async (aliasKind) => {
+    // Given
+    const fixtureDirectory = mkdtempSync(join(dirname(inspectFixtureModulePath), 'inspect-output-alias-'));
+    createdDirectories.push(fixtureDirectory);
+    const modulePath = join(fixtureDirectory, 'app.module.mjs');
+    const source = readFileSync(inspectFixtureModulePath, 'utf8');
+    writeFileSync(modulePath, source, 'utf8');
+    const outputPath = aliasKind === 'direct path'
+      ? modulePath
+      : join(fixtureDirectory, 'inspect-output.json');
+    if (aliasKind === 'symlink') {
+      symlinkSync(modulePath, outputPath);
+    }
+    const stdoutBuffer: string[] = [];
+    const stderrBuffer: string[] = [];
+
+    // When
+    const exitCode = await runCli(['inspect', modulePath, '--output', outputPath], {
+      cwd: process.cwd(),
+      stderr: { write: (message) => stderrBuffer.push(message) },
+      stdout: { write: (message) => stdoutBuffer.push(message) },
+    });
+
+    // Then
+    expect(exitCode).toBe(1);
+    expect(stdoutBuffer).toEqual([]);
+    expect(stderrBuffer).toHaveLength(1);
+    expect(readFileSync(modulePath, 'utf8')).toBe(source);
   });
 
   it('delegates inspect --mermaid output to Studio when resolvable', async () => {

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -20,6 +20,7 @@ import { tsImport } from 'tsx/esm/api';
 
 import { CliPromptCancelledError, isCliPromptCancelledError } from '../prompt-cancel.js';
 import { inspectUsage } from '../usage.js';
+import { assertOutputDoesNotAliasModule } from './output-path-safety.js';
 
 type CliStream = {
   write(message: string): unknown;
@@ -259,13 +260,12 @@ function stringifySnapshotWithTiming(snapshot: RuntimeInspectionSnapshot, timing
   }, null, 2);
 }
 
-async function emitInspectPayload(payload: string, parsed: ParsedInspectArgs, cwd: string, stdout: CliStream): Promise<void> {
-  if (!parsed.outputPath) {
+async function emitInspectPayload(payload: string, outputPath: string | undefined, stdout: CliStream): Promise<void> {
+  if (!outputPath) {
     stdout.write(`${payload}\n`);
     return;
   }
 
-  const outputPath = resolve(cwd, parsed.outputPath);
   await mkdir(dirname(outputPath), { recursive: true });
   await writeFile(outputPath, `${payload}\n`, 'utf8');
 }
@@ -375,6 +375,10 @@ export async function runInspectCommand(argv: string[], runtime: InspectCommandR
 
     const parsed = parseInspectArgs(argv);
     const modulePath = resolve(cwd, parsed.modulePath);
+    const outputPath = parsed.outputPath === undefined ? undefined : resolve(cwd, parsed.outputPath);
+    if (outputPath !== undefined) {
+      await assertOutputDoesNotAliasModule(modulePath, outputPath);
+    }
     const importedModule = await importInspectModule(modulePath);
     const rootModule = resolveRootModule(importedModule[parsed.exportName], parsed.exportName);
 
@@ -389,16 +393,16 @@ export async function runInspectCommand(argv: string[], runtime: InspectCommandR
       const snapshot = createRuntimeInspectionSnapshot(platformSnapshot, routes);
 
       if (parsed.json) {
-        await emitInspectPayload(parsed.timing ? stringifySnapshotWithTiming(snapshot, application.bootstrapTiming) : stringifySnapshot(snapshot), parsed, cwd, stdout);
+        await emitInspectPayload(parsed.timing ? stringifySnapshotWithTiming(snapshot, application.bootstrapTiming) : stringifySnapshot(snapshot), outputPath, stdout);
       }
 
       if (parsed.report) {
-        await emitInspectPayload(JSON.stringify(createInspectReport(snapshot, application.bootstrapTiming), null, 2), parsed, cwd, stdout);
+        await emitInspectPayload(JSON.stringify(createInspectReport(snapshot, application.bootstrapTiming), null, 2), outputPath, stdout);
       }
 
       if (parsed.mermaid) {
         const renderMermaid = await resolveStudioMermaidRenderer(cwd, runtime);
-        await emitInspectPayload(renderMermaid(snapshot), parsed, cwd, stdout);
+        await emitInspectPayload(renderMermaid(snapshot), outputPath, stdout);
       }
     } finally {
       await application.close();

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -21,6 +21,7 @@ import { tsImport } from 'tsx/esm/api';
 import { CliPromptCancelledError, isCliPromptCancelledError } from '../prompt-cancel.js';
 import { inspectUsage } from '../usage.js';
 import { createCliDiagnosticsLogger } from './diagnostics.js';
+import { assertOutputDoesNotAliasModule } from './output-path-safety.js';
 
 type CliStream = {
   write(message: string): unknown;
@@ -275,13 +276,12 @@ function stringifySnapshotWithTiming(snapshot: RuntimeInspectionSnapshot, timing
   }, null, 2);
 }
 
-async function emitInspectPayload(payload: string, parsed: ParsedInspectArgs, cwd: string, stdout: CliStream): Promise<void> {
-  if (!parsed.outputPath) {
+async function emitInspectPayload(payload: string, outputPath: string | undefined, stdout: CliStream): Promise<void> {
+  if (!outputPath) {
     stdout.write(`${payload}\n`);
     return;
   }
 
-  const outputPath = resolve(cwd, parsed.outputPath);
   await mkdir(dirname(outputPath), { recursive: true });
   await writeFile(outputPath, `${payload}\n`, 'utf8');
 }
@@ -391,6 +391,10 @@ export async function runInspectCommand(argv: string[], runtime: InspectCommandR
 
     const parsed = parseInspectArgs(argv);
     const modulePath = resolve(cwd, parsed.modulePath);
+    const outputPath = parsed.outputPath === undefined ? undefined : resolve(cwd, parsed.outputPath);
+    if (outputPath !== undefined) {
+      await assertOutputDoesNotAliasModule(modulePath, outputPath);
+    }
     const importedModule = await importInspectModule(modulePath);
     const rootModule = resolveRootModule(importedModule[parsed.exportName], parsed.exportName);
 
@@ -407,16 +411,16 @@ export async function runInspectCommand(argv: string[], runtime: InspectCommandR
       const snapshot = createRuntimeInspectionSnapshot(platformSnapshot, routes);
 
       if (parsed.json) {
-        await emitInspectPayload(parsed.timing ? stringifySnapshotWithTiming(snapshot, application.bootstrapTiming) : stringifySnapshot(snapshot), parsed, cwd, stdout);
+        await emitInspectPayload(parsed.timing ? stringifySnapshotWithTiming(snapshot, application.bootstrapTiming) : stringifySnapshot(snapshot), outputPath, stdout);
       }
 
       if (parsed.report) {
-        await emitInspectPayload(JSON.stringify(createInspectReport(snapshot, application.bootstrapTiming), null, 2), parsed, cwd, stdout);
+        await emitInspectPayload(JSON.stringify(createInspectReport(snapshot, application.bootstrapTiming), null, 2), outputPath, stdout);
       }
 
       if (parsed.mermaid) {
         const renderMermaid = await resolveStudioMermaidRenderer(cwd, runtime);
-        await emitInspectPayload(renderMermaid(snapshot), parsed, cwd, stdout);
+        await emitInspectPayload(renderMermaid(snapshot), outputPath, stdout);
       }
     } finally {
       await application.close();

--- a/packages/cli/src/commands/output-path-safety.ts
+++ b/packages/cli/src/commands/output-path-safety.ts
@@ -1,0 +1,38 @@
+import { realpath } from 'node:fs/promises';
+
+/** Raised when an artifact output resolves to its input application module. */
+export class OutputPathAliasesModuleError extends Error {
+  readonly name = 'OutputPathAliasesModuleError';
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT';
+}
+
+/**
+ * Rejects an artifact path that directly or through a symlink resolves to the input module.
+ *
+ * @param modulePath Absolute application module path.
+ * @param outputPath Absolute artifact output path.
+ * @throws {OutputPathAliasesModuleError} When the paths identify the same file.
+ */
+export async function assertOutputDoesNotAliasModule(
+  modulePath: string,
+  outputPath: string,
+): Promise<void> {
+  if (modulePath === outputPath) {
+    throw new OutputPathAliasesModuleError('Output path must not identify the input application module.');
+  }
+
+  const resolvedModulePath = await realpath(modulePath);
+  try {
+    const resolvedOutputPath = await realpath(outputPath);
+    if (resolvedModulePath === resolvedOutputPath) {
+      throw new OutputPathAliasesModuleError('Output path must not identify the input application module.');
+    }
+  } catch (error: unknown) {
+    if (error instanceof OutputPathAliasesModuleError || !isMissingPathError(error)) {
+      throw error;
+    }
+  }
+}

--- a/packages/cli/src/commands/output-path-safety.ts
+++ b/packages/cli/src/commands/output-path-safety.ts
@@ -14,6 +14,7 @@ function isMissingPathError(error: unknown): boolean {
  *
  * @param modulePath Absolute application module path.
  * @param outputPath Absolute artifact output path.
+ * @returns Resolves when the output path does not identify the input application module.
  * @throws {OutputPathAliasesModuleError} When the paths identify the same file.
  */
 export async function assertOutputDoesNotAliasModule(

--- a/packages/cli/src/commands/typegen.test.ts
+++ b/packages/cli/src/commands/typegen.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, stat, utimes, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, stat, symlink, utimes, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -68,6 +68,37 @@ afterEach(async () => {
 });
 
 describe('fluo typegen', () => {
+  it.each(['direct path', 'symlink'] as const)('rejects a %s output alias to the application module', async (aliasKind) => {
+    // Given
+    const fixture = await createFixture();
+    const sourceDirectory = await mkdtemp(join(dirname(fixtureModulePath), 'typegen-output-alias-'));
+    tempDirectories.push(sourceDirectory);
+    const modulePath = join(sourceDirectory, 'app.module.ts');
+    const source = await readFile(fixtureModulePath, 'utf8');
+    await writeFile(modulePath, source, 'utf8');
+    const outputPath = aliasKind === 'direct path'
+      ? modulePath
+      : join(sourceDirectory, 'react-pages.ts');
+    if (aliasKind === 'symlink') {
+      await symlink(modulePath, outputPath);
+    }
+    const loadReactTypegenModules = vi.fn(fixture.runtime.loadReactTypegenModules);
+
+    // When
+    const exitCode = await runTypegenCommand([
+      modulePath,
+      '--output',
+      outputPath,
+    ], { ...fixture.runtime, loadReactTypegenModules });
+
+    // Then
+    expect(exitCode).toBe(1);
+    expect(fixture.stdout).toEqual([]);
+    expect(fixture.stderr).toHaveLength(1);
+    expect(loadReactTypegenModules).not.toHaveBeenCalled();
+    expect(await readFile(modulePath, 'utf8')).toBe(source);
+  });
+
   it('creates a deterministic artifact from the compiled React page catalog', async () => {
     // Given
     const fixture = await createFixture();

--- a/packages/cli/src/commands/typegen.ts
+++ b/packages/cli/src/commands/typegen.ts
@@ -16,6 +16,7 @@ import {
   type ReactTypegenModules,
 } from './typegen-source.js';
 import { runTypegenWatch } from './typegen-watch.js';
+import { assertOutputDoesNotAliasModule } from './output-path-safety.js';
 
 type CliStream = {
   write(message: string): unknown;
@@ -88,8 +89,10 @@ export async function runTypegenCommand(
     }
 
     const parsed = parseTypegenArgs(argv);
-    const customModules = runtime.loadReactTypegenModules?.(cwd);
+    const modulePath = resolve(cwd, parsed.modulePath);
     const outputPath = resolve(cwd, parsed.outputPath);
+    await assertOutputDoesNotAliasModule(modulePath, outputPath);
+    const customModules = runtime.loadReactTypegenModules?.(cwd);
     const generateSource = async () => customModules === undefined
       ? runTypegenGenerationProcess({ cwd, exportName: parsed.exportName, modulePath: parsed.modulePath })
       : createTypegenSource({ cwd, modules: await customModules, parsed });
@@ -101,7 +104,7 @@ export async function runTypegenCommand(
     if (parsed.watch) {
       return await runTypegenWatch({
         generate: generateAndWrite,
-        modulePath: resolve(cwd, parsed.modulePath),
+        modulePath,
         onError(error) {
           stderr.write(`ERROR ${outputPath}: ${error instanceof Error ? error.message : String(error)}\n`);
         },


### PR DESCRIPTION
## Summary
- reject direct and symlink-resolved output aliases before inspect or typegen writes
- preserve source modules unchanged on rejected output paths
- retain normal separate artifact output behavior

## Verification
- CLI dependency build and typecheck
- full and reverse CLI tests: 238 passed each
- focused alias tests: 4 passed
- lint, platform governance, stable Changeset gate, TSDoc and LSP
- built inspect/typegen direct, symlink, normal, help, and bad-input scenarios

Closes #3129