### PR TITLE
fix(cli): make typegen watch lifecycle single-owner

### DIFF
--- a/.changeset/issue-3127-typegen-cancellation-ownership.md
+++ b/.changeset/issue-3127-typegen-cancellation-ownership.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/cli': patch
+---
+
+Ensure `fluo typegen --watch` cancels owned generation children before stale artifacts can be published.

--- a/.changeset/issue-3127-typegen-cancellation-ownership.md
+++ b/.changeset/issue-3127-typegen-cancellation-ownership.md
@@ -2,4 +2,5 @@
 '@fluojs/cli': patch
 ---
 
-Ensure `fluo typegen --watch` cancels owned generation children before stale artifacts can be published.
+Ensure `fluo typegen --watch` waits for caller-process generation bootstrap and application cleanup,
+as well as owned generation-child cancellation, before watch exit or stale artifact publication.

--- a/.changeset/reject-cli-output-module-aliases.md
+++ b/.changeset/reject-cli-output-module-aliases.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/cli": patch
+---
+
+Reject inspect and typegen artifact outputs that identify the input application module.

--- a/packages/cli/README.ko.md
+++ b/packages/cli/README.ko.md
@@ -389,7 +389,7 @@ burst는 100 ms 동안 coalesce되고 generation은 serialize되며 output과 �
 포함한 현재 application module graph를 평가합니다. Regeneration failure는 `ERROR <output>: <message>`를
 출력하고 마지막 valid artifact를 보존한 채 다음 change를 기다립니다. Watcher failure는 cleanup 뒤 code
 `1`로 종료됩니다. `SIGINT`와 `SIGTERM`은 watcher를 닫고 signal handler를 제거하며 active generation을
-기다린 뒤 code `0`으로 종료됩니다. Module directory 밖의 파일은 의도적으로 watch boundary 밖에
+child가 publish하기 전에 cancel하고 settle을 기다린 뒤 code `0`으로 종료됩니다. Module directory 밖의 파일은 의도적으로 watch boundary 밖에
 있습니다. Source scanner나 두 번째 route discovery system을 기대하지 말고 command를 다시 실행하거나
 의도한 source root의 module path를 선택하세요.
 

--- a/packages/cli/README.ko.md
+++ b/packages/cli/README.ko.md
@@ -399,7 +399,7 @@ burst는 100 ms 동안 coalesce되고 generation은 serialize되며 output과 �
 포함한 현재 application module graph를 평가합니다. Regeneration failure는 `ERROR <output>: <message>`를
 출력하고 마지막 valid artifact를 보존한 채 다음 change를 기다립니다. Watcher failure는 cleanup 뒤 code
 `1`로 종료됩니다. `SIGINT`와 `SIGTERM`은 watcher를 닫고 signal handler를 제거하며 active generation을
-기다린 뒤 code `0`으로 종료됩니다. Module directory 밖의 파일은 의도적으로 watch boundary 밖에
+child가 publish하기 전에 cancel하고 settle을 기다린 뒤 code `0`으로 종료됩니다. Module directory 밖의 파일은 의도적으로 watch boundary 밖에
 있습니다. Source scanner나 두 번째 route discovery system을 기대하지 말고 command를 다시 실행하거나
 의도한 source root의 module path를 선택하세요.
 

--- a/packages/cli/README.ko.md
+++ b/packages/cli/README.ko.md
@@ -398,8 +398,12 @@ burst는 100 ms 동안 coalesce되고 generation은 serialize되며 output과 �
 무시됩니다. 각 generation은 authoritative bootstrap 전에 변경된 native `.js`와 `.mjs` dependency를
 포함한 현재 application module graph를 평가합니다. Regeneration failure는 `ERROR <output>: <message>`를
 출력하고 마지막 valid artifact를 보존한 채 다음 change를 기다립니다. Watcher failure는 cleanup 뒤 code
-`1`로 종료됩니다. `SIGINT`와 `SIGTERM`은 watcher를 닫고 signal handler를 제거하며 active generation을
-child가 publish하기 전에 cancel하고 settle을 기다린 뒤 code `0`으로 종료됩니다. Module directory 밖의 파일은 의도적으로 watch boundary 밖에
+`1`로 종료됩니다. generation 또는 generation이 소유한 artifact commit이 active인 동안 수신한 모든 source
+event는 해당 작업을 무효화하므로 coalesce된 후속 generation이 끝나기 전에는 그 output이 publish될 수
+없습니다. `SIGINT`와 `SIGTERM`은 watcher를 닫고 signal handler를 제거하며 active owned generation child를
+cancel하고 owned artifact commit을 abort하여 둘 중 어느 것도 publish하지 못하게 한 뒤 settle을 기다리고
+code `0`으로 종료됩니다. `SIGTERM` 뒤에도 종료하지 않는 child는 제한된 grace period 뒤 force-kill됩니다.
+Module directory 밖의 파일은 의도적으로 watch boundary 밖에
 있습니다. Source scanner나 두 번째 route discovery system을 기대하지 말고 command를 다시 실행하거나
 의도한 source root의 module path를 선택하세요.
 

--- a/packages/cli/README.ko.md
+++ b/packages/cli/README.ko.md
@@ -390,9 +390,11 @@ burst는 100 ms 동안 coalesce되고 generation은 serialize되며 output과 �
 출력하고 마지막 valid artifact를 보존한 채 다음 change를 기다립니다. Watcher failure는 cleanup 뒤 code
 `1`로 종료됩니다. generation 또는 generation이 소유한 artifact commit이 active인 동안 수신한 모든 source
 event는 해당 작업을 무효화하므로 coalesce된 후속 generation이 끝나기 전에는 그 output이 publish될 수
-없습니다. `SIGINT`와 `SIGTERM`은 watcher를 닫고 signal handler를 제거하며 active owned generation child를
-cancel하고 owned artifact commit을 abort하여 둘 중 어느 것도 publish하지 못하게 한 뒤 settle을 기다리고
-code `0`으로 종료됩니다. `SIGTERM` 뒤에도 종료하지 않는 child는 제한된 grace period 뒤 force-kill됩니다.
+없습니다. `SIGINT`와 `SIGTERM`은 watcher를 닫고 signal handler를 제거하며 active owned generation(child
+process 또는 caller-process bootstrap)을 cancel하고 owned artifact commit을 abort하여 둘 중 어느 것도
+publish하지 못하게 합니다. Caller-process cancellation은 asynchronous bootstrap과 application close가
+settle될 때까지 기다린 뒤 code `0`으로 watch를 종료하며, `SIGTERM` 뒤에도 종료하지 않는 child는 제한된
+grace period 뒤 force-kill됩니다.
 Module directory 밖의 파일은 의도적으로 watch boundary 밖에
 있습니다. Source scanner나 두 번째 route discovery system을 기대하지 말고 command를 다시 실행하거나
 의도한 source root의 module path를 선택하세요.

--- a/packages/cli/README.ko.md
+++ b/packages/cli/README.ko.md
@@ -400,9 +400,11 @@ burst는 100 ms 동안 coalesce되고 generation은 serialize되며 output과 �
 출력하고 마지막 valid artifact를 보존한 채 다음 change를 기다립니다. Watcher failure는 cleanup 뒤 code
 `1`로 종료됩니다. generation 또는 generation이 소유한 artifact commit이 active인 동안 수신한 모든 source
 event는 해당 작업을 무효화하므로 coalesce된 후속 generation이 끝나기 전에는 그 output이 publish될 수
-없습니다. `SIGINT`와 `SIGTERM`은 watcher를 닫고 signal handler를 제거하며 active owned generation child를
-cancel하고 owned artifact commit을 abort하여 둘 중 어느 것도 publish하지 못하게 한 뒤 settle을 기다리고
-code `0`으로 종료됩니다. `SIGTERM` 뒤에도 종료하지 않는 child는 제한된 grace period 뒤 force-kill됩니다.
+없습니다. `SIGINT`와 `SIGTERM`은 watcher를 닫고 signal handler를 제거하며 active owned generation(child
+process 또는 caller-process bootstrap)을 cancel하고 owned artifact commit을 abort하여 둘 중 어느 것도
+publish하지 못하게 합니다. Caller-process cancellation은 asynchronous bootstrap과 application close가
+settle될 때까지 기다린 뒤 code `0`으로 watch를 종료하며, `SIGTERM` 뒤에도 종료하지 않는 child는 제한된
+grace period 뒤 force-kill됩니다.
 Module directory 밖의 파일은 의도적으로 watch boundary 밖에
 있습니다. Source scanner나 두 번째 route discovery system을 기대하지 말고 command를 다시 실행하거나
 의도한 source root의 module path를 선택하세요.

--- a/packages/cli/README.ko.md
+++ b/packages/cli/README.ko.md
@@ -388,8 +388,12 @@ burst는 100 ms 동안 coalesce되고 generation은 serialize되며 output과 �
 무시됩니다. 각 generation은 authoritative bootstrap 전에 변경된 native `.js`와 `.mjs` dependency를
 포함한 현재 application module graph를 평가합니다. Regeneration failure는 `ERROR <output>: <message>`를
 출력하고 마지막 valid artifact를 보존한 채 다음 change를 기다립니다. Watcher failure는 cleanup 뒤 code
-`1`로 종료됩니다. `SIGINT`와 `SIGTERM`은 watcher를 닫고 signal handler를 제거하며 active generation을
-child가 publish하기 전에 cancel하고 settle을 기다린 뒤 code `0`으로 종료됩니다. Module directory 밖의 파일은 의도적으로 watch boundary 밖에
+`1`로 종료됩니다. generation 또는 generation이 소유한 artifact commit이 active인 동안 수신한 모든 source
+event는 해당 작업을 무효화하므로 coalesce된 후속 generation이 끝나기 전에는 그 output이 publish될 수
+없습니다. `SIGINT`와 `SIGTERM`은 watcher를 닫고 signal handler를 제거하며 active owned generation child를
+cancel하고 owned artifact commit을 abort하여 둘 중 어느 것도 publish하지 못하게 한 뒤 settle을 기다리고
+code `0`으로 종료됩니다. `SIGTERM` 뒤에도 종료하지 않는 child는 제한된 grace period 뒤 force-kill됩니다.
+Module directory 밖의 파일은 의도적으로 watch boundary 밖에
 있습니다. Source scanner나 두 번째 route discovery system을 기대하지 말고 command를 다시 실행하거나
 의도한 source root의 module path를 선택하세요.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -390,7 +390,8 @@ output or its temporary files are ignored. Each generation evaluates a current a
 graph, including changed native `.js` and `.mjs` dependencies, before the authoritative bootstrap.
 A regeneration failure prints `ERROR <output>: <message>`, preserves the last valid artifact, and
 waits for a later change. A watcher failure exits with code `1` after cleanup. `SIGINT` and `SIGTERM`
-close the watcher, remove signal handlers, wait for an active generation, and exit with code `0`.
+close the watcher, remove signal handlers, cancel the active owned generation child before it can
+publish, wait for it to settle, and exit with code `0`.
 Files outside the module directory are intentionally outside this watch boundary; run the command
 again or choose a module path at the intended source root instead of expecting source scanning or a
 second route discovery system.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -392,9 +392,11 @@ A regeneration failure prints `ERROR <output>: <message>`, preserves the last va
 waits for a later change. A watcher failure exits with code `1` after cleanup. Every source event
 received while a generation or its owned artifact commit is active invalidates that work; its output
 cannot publish before the coalesced successor completes. `SIGINT` and `SIGTERM` close the watcher,
-remove signal handlers, cancel the active owned generation child and abort its owned artifact commit
-before either can publish, wait for them to settle, and exit with code `0`. A child that does not exit
-after `SIGTERM` is force-killed after the bounded grace period.
+remove signal handlers, cancel the active owned generation (a child process or caller-process
+bootstrap), and abort its owned artifact commit before either can publish. Caller-process
+cancellation waits for asynchronous bootstrap and application close to settle before watch exits
+with code `0`; a child that does not exit after `SIGTERM` is force-killed after the bounded grace
+period.
 Files outside the module directory are intentionally outside this watch boundary; run the command
 again or choose a module path at the intended source root instead of expecting source scanning or a
 second route discovery system.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -389,9 +389,12 @@ bursts after readiness are coalesced for 100 ms, generations are serialized, and
 output or its temporary files are ignored. Each generation evaluates a current application module
 graph, including changed native `.js` and `.mjs` dependencies, before the authoritative bootstrap.
 A regeneration failure prints `ERROR <output>: <message>`, preserves the last valid artifact, and
-waits for a later change. A watcher failure exits with code `1` after cleanup. `SIGINT` and `SIGTERM`
-close the watcher, remove signal handlers, cancel the active owned generation child before it can
-publish, wait for it to settle, and exit with code `0`.
+waits for a later change. A watcher failure exits with code `1` after cleanup. Every source event
+received while a generation or its owned artifact commit is active invalidates that work; its output
+cannot publish before the coalesced successor completes. `SIGINT` and `SIGTERM` close the watcher,
+remove signal handlers, cancel the active owned generation child and abort its owned artifact commit
+before either can publish, wait for them to settle, and exit with code `0`. A child that does not exit
+after `SIGTERM` is force-killed after the bounded grace period.
 Files outside the module directory are intentionally outside this watch boundary; run the command
 again or choose a module path at the intended source root instead of expecting source scanning or a
 second route discovery system.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -400,7 +400,8 @@ output or its temporary files are ignored. Each generation evaluates a current a
 graph, including changed native `.js` and `.mjs` dependencies, before the authoritative bootstrap.
 A regeneration failure prints `ERROR <output>: <message>`, preserves the last valid artifact, and
 waits for a later change. A watcher failure exits with code `1` after cleanup. `SIGINT` and `SIGTERM`
-close the watcher, remove signal handlers, wait for an active generation, and exit with code `0`.
+close the watcher, remove signal handlers, cancel the active owned generation child before it can
+publish, wait for it to settle, and exit with code `0`.
 Files outside the module directory are intentionally outside this watch boundary; run the command
 again or choose a module path at the intended source root instead of expecting source scanning or a
 second route discovery system.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -399,9 +399,12 @@ bursts after readiness are coalesced for 100 ms, generations are serialized, and
 output or its temporary files are ignored. Each generation evaluates a current application module
 graph, including changed native `.js` and `.mjs` dependencies, before the authoritative bootstrap.
 A regeneration failure prints `ERROR <output>: <message>`, preserves the last valid artifact, and
-waits for a later change. A watcher failure exits with code `1` after cleanup. `SIGINT` and `SIGTERM`
-close the watcher, remove signal handlers, cancel the active owned generation child before it can
-publish, wait for it to settle, and exit with code `0`.
+waits for a later change. A watcher failure exits with code `1` after cleanup. Every source event
+received while a generation or its owned artifact commit is active invalidates that work; its output
+cannot publish before the coalesced successor completes. `SIGINT` and `SIGTERM` close the watcher,
+remove signal handlers, cancel the active owned generation child and abort its owned artifact commit
+before either can publish, wait for them to settle, and exit with code `0`. A child that does not exit
+after `SIGTERM` is force-killed after the bounded grace period.
 Files outside the module directory are intentionally outside this watch boundary; run the command
 again or choose a module path at the intended source root instead of expecting source scanning or a
 second route discovery system.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -402,9 +402,11 @@ A regeneration failure prints `ERROR <output>: <message>`, preserves the last va
 waits for a later change. A watcher failure exits with code `1` after cleanup. Every source event
 received while a generation or its owned artifact commit is active invalidates that work; its output
 cannot publish before the coalesced successor completes. `SIGINT` and `SIGTERM` close the watcher,
-remove signal handlers, cancel the active owned generation child and abort its owned artifact commit
-before either can publish, wait for them to settle, and exit with code `0`. A child that does not exit
-after `SIGTERM` is force-killed after the bounded grace period.
+remove signal handlers, cancel the active owned generation (a child process or caller-process
+bootstrap), and abort its owned artifact commit before either can publish. Caller-process
+cancellation waits for asynchronous bootstrap and application close to settle before watch exits
+with code `0`; a child that does not exit after `SIGTERM` is force-killed after the bounded grace
+period.
 Files outside the module directory are intentionally outside this watch boundary; run the command
 again or choose a module path at the intended source root instead of expecting source scanning or a
 second route discovery system.

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1,6 +1,6 @@
 import { type ChildProcess, spawnSync } from 'node:child_process';
 import { EventEmitter } from 'node:events';
-import { chmodSync, existsSync, type FSWatcher, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, type FSWatcher, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { delimiter, dirname, join } from 'node:path';
 import { PassThrough } from 'node:stream';
@@ -4324,6 +4324,38 @@ exit 7
     expect(report.summary.readinessStatus).toBe('ready');
     expect(report.summary.healthStatus).toBe('healthy');
   });
+
+  it.each(['direct path', 'symlink'] as const)('rejects a %s output alias to the inspected application module', async (aliasKind) => {
+    // Given
+    const fixtureDirectory = mkdtempSync(join(dirname(inspectFixtureModulePath), 'inspect-output-alias-'));
+    createdDirectories.push(fixtureDirectory);
+    const modulePath = join(fixtureDirectory, 'app.module.mjs');
+    const source = readFileSync(inspectFixtureModulePath, 'utf8');
+    writeFileSync(modulePath, source, 'utf8');
+    const outputPath = aliasKind === 'direct path'
+      ? modulePath
+      : join(fixtureDirectory, 'inspect-output.json');
+    if (aliasKind === 'symlink') {
+      symlinkSync(modulePath, outputPath);
+    }
+    const stdoutBuffer: string[] = [];
+    const stderrBuffer: string[] = [];
+
+    // When
+    const exitCode = await runCli(['inspect', modulePath, '--output', outputPath], {
+      cwd: process.cwd(),
+      stderr: { write: (message) => stderrBuffer.push(message) },
+      stdout: { write: (message) => stdoutBuffer.push(message) },
+    });
+
+    // Then
+    expect(exitCode).toBe(1);
+    expect(stdoutBuffer).toEqual([]);
+    expect(stderrBuffer).toHaveLength(1);
+    expect(readFileSync(modulePath, 'utf8')).toBe(source);
+    // The lazy `runCli` facade transforms the full CLI module graph on first use,
+    // which exceeds the default per-test budget on a cold Vitest cache.
+  }, 90000);
 
   it('delegates inspect --mermaid output to Studio when resolvable', async () => {
     const stdoutBuffer: string[] = [];

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -21,6 +21,7 @@ import { tsImport } from 'tsx/esm/api';
 import { CliPromptCancelledError, isCliPromptCancelledError } from '../prompt-cancel.js';
 import { inspectUsage } from '../usage.js';
 import { createCliDiagnosticsLogger } from './diagnostics.js';
+import { assertOutputDoesNotAliasModule } from './output-path-safety.js';
 
 type CliStream = {
   write(message: string): unknown;
@@ -275,13 +276,12 @@ function stringifySnapshotWithTiming(snapshot: RuntimeInspectionSnapshot, timing
   }, null, 2);
 }
 
-async function emitInspectPayload(payload: string, parsed: ParsedInspectArgs, cwd: string, stdout: CliStream): Promise<void> {
-  if (!parsed.outputPath) {
+async function emitInspectPayload(payload: string, outputPath: string | undefined, stdout: CliStream): Promise<void> {
+  if (!outputPath) {
     stdout.write(`${payload}\n`);
     return;
   }
 
-  const outputPath = resolve(cwd, parsed.outputPath);
   await mkdir(dirname(outputPath), { recursive: true });
   await writeFile(outputPath, `${payload}\n`, 'utf8');
 }
@@ -391,6 +391,10 @@ export async function runInspectCommand(argv: string[], runtime: InspectCommandR
 
     const parsed = parseInspectArgs(argv);
     const modulePath = resolve(cwd, parsed.modulePath);
+    const outputPath = parsed.outputPath === undefined ? undefined : resolve(cwd, parsed.outputPath);
+    if (outputPath !== undefined) {
+      await assertOutputDoesNotAliasModule(modulePath, outputPath);
+    }
     const importedModule = await importInspectModule(modulePath);
     const rootModule = resolveRootModule(importedModule[parsed.exportName], parsed.exportName);
 
@@ -407,16 +411,16 @@ export async function runInspectCommand(argv: string[], runtime: InspectCommandR
       const snapshot = createRuntimeInspectionSnapshot(platformSnapshot, routes);
 
       if (parsed.json) {
-        await emitInspectPayload(parsed.timing ? stringifySnapshotWithTiming(snapshot, application.bootstrapTiming) : stringifySnapshot(snapshot), parsed, cwd, stdout);
+        await emitInspectPayload(parsed.timing ? stringifySnapshotWithTiming(snapshot, application.bootstrapTiming) : stringifySnapshot(snapshot), outputPath, stdout);
       }
 
       if (parsed.report) {
-        await emitInspectPayload(JSON.stringify(createInspectReport(snapshot, application.bootstrapTiming), null, 2), parsed, cwd, stdout);
+        await emitInspectPayload(JSON.stringify(createInspectReport(snapshot, application.bootstrapTiming), null, 2), outputPath, stdout);
       }
 
       if (parsed.mermaid) {
         const renderMermaid = await resolveStudioMermaidRenderer(cwd, runtime);
-        await emitInspectPayload(renderMermaid(snapshot), parsed, cwd, stdout);
+        await emitInspectPayload(renderMermaid(snapshot), outputPath, stdout);
       }
     } finally {
       await application.close();

--- a/packages/cli/src/commands/output-path-safety.ts
+++ b/packages/cli/src/commands/output-path-safety.ts
@@ -1,0 +1,39 @@
+import { realpath } from 'node:fs/promises';
+
+/** Raised when an artifact output resolves to its input application module. */
+export class OutputPathAliasesModuleError extends Error {
+  readonly name = 'OutputPathAliasesModuleError';
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT';
+}
+
+/**
+ * Rejects an artifact path that directly or through a symlink resolves to the input module.
+ *
+ * @param modulePath Absolute application module path.
+ * @param outputPath Absolute artifact output path.
+ * @returns Resolves when the output path does not identify the input application module.
+ * @throws {OutputPathAliasesModuleError} When the paths identify the same file.
+ */
+export async function assertOutputDoesNotAliasModule(
+  modulePath: string,
+  outputPath: string,
+): Promise<void> {
+  if (modulePath === outputPath) {
+    throw new OutputPathAliasesModuleError('Output path must not identify the input application module.');
+  }
+
+  const resolvedModulePath = await realpath(modulePath);
+  try {
+    const resolvedOutputPath = await realpath(outputPath);
+    if (resolvedModulePath === resolvedOutputPath) {
+      throw new OutputPathAliasesModuleError('Output path must not identify the input application module.');
+    }
+  } catch (error: unknown) {
+    if (error instanceof OutputPathAliasesModuleError || !isMissingPathError(error)) {
+      throw error;
+    }
+  }
+}

--- a/packages/cli/src/commands/typegen-artifact.test.ts
+++ b/packages/cli/src/commands/typegen-artifact.test.ts
@@ -6,6 +6,52 @@ import {
 } from './typegen-artifact.js';
 
 describe('typegen artifact commits', () => {
+  it('publishes one complete replacement before a queued shutdown can run after synchronous rename begins', async () => {
+    // Given: one valid target and a shutdown event queued from the synchronous publication boundary.
+    const outputPath = '/project/src/generated/react-pages.ts';
+    const files = new Map<string, string>([[outputPath, 'last valid artifact\n']]);
+    const controller = new AbortController();
+    const fileSystem: TypegenArtifactFileSystem = {
+      mkdir: vi.fn(async () => undefined),
+      readFile: vi.fn(async (path) => {
+        const content = files.get(path);
+        if (content === undefined) {
+          throw Object.assign(new Error(`ENOENT: ${path}`), { code: 'ENOENT' });
+        }
+        return content;
+      }),
+      rename: vi.fn((source, destination) => {
+        const content = files.get(source);
+        if (content === undefined) {
+          throw new Error(`Missing temporary artifact ${source}`);
+        }
+        files.set(destination, content);
+        files.delete(source);
+        queueMicrotask(() => {
+          controller.abort();
+        });
+        return undefined;
+      }),
+      rm: vi.fn(async (path) => {
+        files.delete(path);
+      }),
+      writeFile: vi.fn(async (path, content) => {
+        files.set(path, content);
+      }),
+    };
+
+    // When: the final abort check succeeds and the synchronous rename begins before shutdown dispatches.
+    const action = await writeTypegenArtifact(outputPath, 'next complete artifact\n', fileSystem, controller.signal);
+
+    // Then: lifecycle dispatch cannot interrupt the atomic publication or leave a temporary artifact.
+    expect(action).toBe('UPDATE');
+    expect(controller.signal.aborted).toBe(true);
+    expect(files.get(outputPath)).toBe('next complete artifact\n');
+    expect([...files.keys()]).toEqual([outputPath]);
+    expect(fileSystem.rename).toHaveBeenCalledOnce();
+    expect(fileSystem.rm).not.toHaveBeenCalled();
+  });
+
   it('removes a prepared replacement when shutdown aborts before atomic publication', async () => {
     // Given: an existing valid artifact and a shutdown signal that begins during temporary-file preparation.
     const outputPath = '/project/src/generated/react-pages.ts';
@@ -20,13 +66,14 @@ describe('typegen artifact commits', () => {
         }
         return content;
       }),
-      rename: vi.fn(async (source, destination) => {
+      rename: vi.fn((source, destination) => {
         const content = files.get(source);
         if (content === undefined) {
           throw new Error(`Missing temporary artifact ${source}`);
         }
         files.set(destination, content);
         files.delete(source);
+        return undefined;
       }),
       rm: vi.fn(async (path) => {
         files.delete(path);
@@ -61,7 +108,7 @@ describe('typegen artifact commits', () => {
         }
         return content;
       }),
-      rename: vi.fn(async () => {
+      rename: vi.fn(() => {
         throw commitError;
       }),
       rm: vi.fn(async (path) => {

--- a/packages/cli/src/commands/typegen-artifact.test.ts
+++ b/packages/cli/src/commands/typegen-artifact.test.ts
@@ -5,7 +5,117 @@ import {
   writeTypegenArtifact,
 } from './typegen-artifact.js';
 
+const publication = vi.hoisted(() => {
+  const files = new Map<string, string>();
+  let invalidated = false;
+  let stalePublication = false;
+  let dispatchRename: () => void = () => undefined;
+  let releaseRename: () => void = () => undefined;
+  let renameDispatched = Promise.resolve();
+
+  return {
+    files,
+    get invalidated(): boolean {
+      return invalidated;
+    },
+    get stalePublication(): boolean {
+      return stalePublication;
+    },
+    beginRename(): void {
+      dispatchRename();
+    },
+    invalidateSource(): void {
+      invalidated = true;
+    },
+    publish(source: string, destination: string): void {
+      const content = files.get(source);
+      if (content === undefined) {
+        throw new Error(`Missing temporary artifact ${source}`);
+      }
+      if (invalidated) {
+        stalePublication = true;
+      }
+      files.set(destination, content);
+      files.delete(source);
+    },
+    releasePublication(): void {
+      releaseRename();
+    },
+    reset(): void {
+      files.clear();
+      invalidated = false;
+      stalePublication = false;
+      renameDispatched = new Promise<void>((resolve) => {
+        dispatchRename = resolve;
+      });
+      releaseRename = () => undefined;
+    },
+    waitForRenameDispatch(): Promise<void> {
+      return renameDispatched;
+    },
+    waitToPublish(): Promise<void> {
+      return new Promise<void>((resolve) => {
+        releaseRename = resolve;
+      });
+    },
+  };
+});
+
+vi.mock('node:fs', () => ({
+  renameSync(source: string, destination: string): void {
+    publication.publish(source, destination);
+    publication.beginRename();
+    publication.invalidateSource();
+  },
+}));
+
+vi.mock('node:fs/promises', () => ({
+  async mkdir(_path: string): Promise<void> {
+    return undefined;
+  },
+  async readFile(path: string): Promise<string> {
+    const content = publication.files.get(path);
+    if (content === undefined) {
+      throw Object.assign(new Error(`ENOENT: ${path}`), { code: 'ENOENT' });
+    }
+    return content;
+  },
+  rename(source: string, destination: string): Promise<void> {
+    publication.beginRename();
+    publication.invalidateSource();
+    return publication.waitToPublish().then(() => {
+      publication.publish(source, destination);
+    });
+  },
+  async rm(path: string): Promise<void> {
+    publication.files.delete(path);
+  },
+  async writeFile(path: string, content: string): Promise<void> {
+    publication.files.set(path, content);
+  },
+}));
+
 describe('typegen artifact commits', () => {
+  it('does not publish invalidated source after the rename dispatch boundary', async () => {
+    // Given: a replacement and an injected source invalidation at the filesystem rename boundary.
+    const outputPath = '/project/src/generated/react-pages.ts';
+    publication.reset();
+    publication.files.set(outputPath, 'last valid artifact\n');
+
+    // When: typegen commits through the production filesystem adapter.
+    const action = writeTypegenArtifact(outputPath, 'next complete artifact\n');
+    await publication.waitForRenameDispatch();
+    publication.releasePublication();
+    const result = await action;
+
+    // Then: publication completes before invalidation; an asynchronous rename would mark this stale.
+    expect(result).toBe('UPDATE');
+    expect(publication.invalidated).toBe(true);
+    expect(publication.stalePublication).toBe(false);
+    expect(publication.files.get(outputPath)).toBe('next complete artifact\n');
+    expect([...publication.files.keys()]).toEqual([outputPath]);
+  });
+
   it('publishes one complete replacement before a queued shutdown can run after synchronous rename begins', async () => {
     // Given: one valid target and a shutdown event queued from the synchronous publication boundary.
     const outputPath = '/project/src/generated/react-pages.ts';

--- a/packages/cli/src/commands/typegen-artifact.test.ts
+++ b/packages/cli/src/commands/typegen-artifact.test.ts
@@ -6,6 +6,47 @@ import {
 } from './typegen-artifact.js';
 
 describe('typegen artifact commits', () => {
+  it('removes a prepared replacement when shutdown aborts before atomic publication', async () => {
+    // Given: an existing valid artifact and a shutdown signal that begins during temporary-file preparation.
+    const outputPath = '/project/src/generated/react-pages.ts';
+    const files = new Map<string, string>([[outputPath, 'last valid artifact\n']]);
+    const controller = new AbortController();
+    const fileSystem: TypegenArtifactFileSystem = {
+      mkdir: vi.fn(async () => undefined),
+      readFile: vi.fn(async (path) => {
+        const content = files.get(path);
+        if (content === undefined) {
+          throw Object.assign(new Error(`ENOENT: ${path}`), { code: 'ENOENT' });
+        }
+        return content;
+      }),
+      rename: vi.fn(async (source, destination) => {
+        const content = files.get(source);
+        if (content === undefined) {
+          throw new Error(`Missing temporary artifact ${source}`);
+        }
+        files.set(destination, content);
+        files.delete(source);
+      }),
+      rm: vi.fn(async (path) => {
+        files.delete(path);
+      }),
+      writeFile: vi.fn(async (path, content) => {
+        files.set(path, content);
+        controller.abort();
+      }),
+    };
+
+    // When: shutdown aborts the owned write after its complete temporary body exists.
+    const action = writeTypegenArtifact(outputPath, 'next complete artifact\n', fileSystem, controller.signal);
+
+    // Then: atomic publication never starts, the temporary file is removed, and the last valid target remains.
+    await expect(action).rejects.toMatchObject({ name: 'AbortError' });
+    expect(files.get(outputPath)).toBe('last valid artifact\n');
+    expect(fileSystem.rename).not.toHaveBeenCalled();
+    expect([...files.keys()]).toEqual([outputPath]);
+  });
+
   it('preserves the last valid artifact when the atomic replacement fails', async () => {
     // Given: one valid target and a filesystem that fails only when committing its temporary replacement.
     const outputPath = '/project/src/generated/react-pages.ts';

--- a/packages/cli/src/commands/typegen-artifact.ts
+++ b/packages/cli/src/commands/typegen-artifact.ts
@@ -99,13 +99,16 @@ export async function checkTypegenArtifact(
  * @param outputPath Target artifact path.
  * @param source Complete generated source to publish.
  * @param fileSystem Filesystem boundary used for the atomic replacement.
+ * @param signal Optional owner cancellation signal checked before publication.
  * @returns The stable create, update, or unchanged action.
  */
 export async function writeTypegenArtifact(
   outputPath: string,
   source: string,
   fileSystem: TypegenArtifactFileSystem = NODE_FILE_SYSTEM,
+  signal?: AbortSignal,
 ): Promise<TypegenArtifactWriteAction> {
+  signal?.throwIfAborted();
   const existingSource = await readExistingArtifact(outputPath, fileSystem);
   if (existingSource === source) {
     return 'UNCHANGED';
@@ -120,6 +123,7 @@ export async function writeTypegenArtifact(
   let committed = false;
   try {
     await fileSystem.writeFile(temporaryPath, source);
+    signal?.throwIfAborted();
     await fileSystem.rename(temporaryPath, outputPath);
     committed = true;
   } finally {

--- a/packages/cli/src/commands/typegen-artifact.ts
+++ b/packages/cli/src/commands/typegen-artifact.ts
@@ -1,11 +1,12 @@
-import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { renameSync } from 'node:fs';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
 
 /** Filesystem boundary used by deterministic typegen artifact commits. */
 export type TypegenArtifactFileSystem = {
   readonly mkdir: (path: string) => Promise<void>;
   readonly readFile: (path: string) => Promise<string>;
-  readonly rename: (source: string, destination: string) => Promise<void>;
+  readonly rename: (source: string, destination: string) => undefined;
   readonly rm: (path: string) => Promise<void>;
   readonly writeFile: (path: string, content: string) => Promise<void>;
 };
@@ -31,7 +32,10 @@ const NODE_FILE_SYSTEM: TypegenArtifactFileSystem = {
     await mkdir(path, { recursive: true });
   },
   readFile: (path) => readFile(path, 'utf8'),
-  rename,
+  rename(source, destination) {
+    renameSync(source, destination);
+    return undefined;
+  },
   async rm(path) {
     await rm(path, { force: true });
   },
@@ -124,7 +128,7 @@ export async function writeTypegenArtifact(
   try {
     await fileSystem.writeFile(temporaryPath, source);
     signal?.throwIfAborted();
-    await fileSystem.rename(temporaryPath, outputPath);
+    fileSystem.rename(temporaryPath, outputPath);
     committed = true;
   } finally {
     if (!committed) {

--- a/packages/cli/src/commands/typegen-caller-process-cancellation.test.ts
+++ b/packages/cli/src/commands/typegen-caller-process-cancellation.test.ts
@@ -1,0 +1,143 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import type { TypegenCommandRuntimeOptions } from './typegen.js';
+import type {
+  TypegenWatcher,
+  TypegenWatchGeneration,
+  TypegenWatchOptions,
+  TypegenWatchSignalTarget,
+} from './typegen-watch.js';
+
+const fixtureModulePath = `${dirname(fileURLToPath(import.meta.url))}/../fixtures/typegen-react-app.module.ts`;
+
+function createDeferred<T>(): { readonly promise: Promise<T>; readonly resolve: (value: T) => void } {
+  let resolveResult: (value: T) => void = () => undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolveResult = resolve;
+  });
+  return { promise, resolve: resolveResult };
+}
+
+function createSignalTarget(): TypegenWatchSignalTarget & { emit(signal: 'SIGINT' | 'SIGTERM'): void } {
+  const listeners = new Map<'SIGINT' | 'SIGTERM', () => void>();
+  return {
+    emit(signal) {
+      listeners.get(signal)?.();
+    },
+    off(signal, listener) {
+      if (listeners.get(signal) === listener) {
+        listeners.delete(signal);
+      }
+    },
+    once(signal, listener) {
+      listeners.set(signal, listener);
+    },
+  };
+}
+
+describe('fluo typegen caller-process cancellation', () => {
+  it('waits for application cleanup before ending a cancelled watch', async () => {
+    // Given: caller-process generation is paused before bootstrap, then its application close is held.
+    const signalTarget = createSignalTarget();
+    const bootstrapStarted = createDeferred<void>();
+    const releaseBootstrap = createDeferred<void>();
+    const cleanupStarted = createDeferred<void>();
+    const releaseCleanup = createDeferred<void>();
+    const cancellationRequested = createDeferred<void>();
+    const generationStarted = createDeferred<void>();
+    const stderr: string[] = [];
+    const watcher: TypegenWatcher = { close: vi.fn(), on: vi.fn(() => watcher) };
+    let callerGeneration: TypegenWatchGeneration | undefined;
+    let cleanupFinished = false;
+    const close = vi.fn(async () => {
+      cleanupStarted.resolve();
+      await releaseCleanup.promise;
+      cleanupFinished = true;
+    });
+    vi.resetModules();
+    vi.doMock('./typegen-watch.js', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('./typegen-watch.js')>();
+      return {
+        ...actual,
+        runTypegenWatch(options: TypegenWatchOptions) {
+          return actual.runTypegenWatch({
+            ...options,
+            signalTarget,
+            startGeneration() {
+              const generation = options.startGeneration();
+              callerGeneration = generation;
+              generationStarted.resolve();
+              return {
+                cancel() {
+                  generation.cancel();
+                  cancellationRequested.resolve();
+                },
+                result: generation.result,
+              };
+            },
+            watchTarget: () => watcher,
+          });
+        },
+      };
+    });
+
+    try {
+      const { runTypegenCommand } = await import('./typegen.js');
+      const runtime: TypegenCommandRuntimeOptions = {
+        cwd: '/project',
+        loadReactTypegenModules: async () => ({
+          react: { createReactPageCatalog: () => [] },
+          runtime: {
+            FluoFactory: Object.assign(() => undefined, {
+              create: async () => {
+                bootstrapStarted.resolve();
+                await releaseBootstrap.promise;
+                return {
+                  close,
+                  dispatcher: { describeRoutes: () => [] },
+                };
+              },
+            }),
+          },
+          typegen: { generateReactPageTypes: () => 'source' },
+        }),
+        stderr: { write: (message) => stderr.push(message) },
+      };
+      const action = runTypegenCommand([
+        fixtureModulePath,
+        '--output',
+        '/project/generated/react-pages.ts',
+        '--watch',
+      ], runtime);
+      await generationStarted.promise;
+      if (callerGeneration === undefined) {
+        throw new Error('Caller-process generation did not start.');
+      }
+      let generationRejectedBeforeCleanup = false;
+      void callerGeneration.result.catch(() => {
+        generationRejectedBeforeCleanup = !cleanupFinished;
+      });
+      await bootstrapStarted.promise;
+
+      // When: shutdown reaches the active caller-process generation before it can finish bootstrap.
+      signalTarget.emit('SIGTERM');
+      await cancellationRequested.promise;
+      releaseBootstrap.resolve();
+      await cleanupStarted.promise;
+
+      // Then: watch ownership is retained until the application's asynchronous close completes.
+      releaseCleanup.resolve();
+      await expect(callerGeneration.result).rejects.toThrow('Typegen generation was cancelled.');
+      await expect(action).resolves.toBe(0);
+      expect(generationRejectedBeforeCleanup).toBe(false);
+      expect(close).toHaveBeenCalledOnce();
+      expect(stderr).toEqual([]);
+    } finally {
+      vi.doUnmock('./typegen-watch.js');
+      vi.resetModules();
+    }
+  });
+});

--- a/packages/cli/src/commands/typegen-caller-process-cancellation.test.ts
+++ b/packages/cli/src/commands/typegen-caller-process-cancellation.test.ts
@@ -21,6 +21,24 @@ function createDeferred<T>(): { readonly promise: Promise<T>; readonly resolve: 
   return { promise, resolve: resolveResult };
 }
 
+async function waitForSignal(signal: Promise<void>, description: string): Promise<void> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      signal,
+      new Promise<void>((_resolve, reject) => {
+        timeout = setTimeout(() => {
+          reject(new Error(`Timed out waiting for ${description}.`));
+        }, 1_000);
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
 function createSignalTarget(): TypegenWatchSignalTarget & { emit(signal: 'SIGINT' | 'SIGTERM'): void } {
   const listeners = new Map<'SIGINT' | 'SIGTERM', () => void>();
   return {
@@ -40,22 +58,21 @@ function createSignalTarget(): TypegenWatchSignalTarget & { emit(signal: 'SIGINT
 
 describe('fluo typegen caller-process cancellation', () => {
   it('waits for application cleanup before ending a cancelled watch', async () => {
-    // Given: caller-process generation is paused before bootstrap, then its application close is held.
+    // Given: caller-process generation has reached application close, which remains explicitly pending.
     const signalTarget = createSignalTarget();
-    const bootstrapStarted = createDeferred<void>();
-    const releaseBootstrap = createDeferred<void>();
-    const cleanupStarted = createDeferred<void>();
-    const releaseCleanup = createDeferred<void>();
+    const applicationCloseStarted = createDeferred<void>();
+    const releaseApplicationClose = createDeferred<void>();
     const cancellationRequested = createDeferred<void>();
     const generationStarted = createDeferred<void>();
     const stderr: string[] = [];
     const watcher: TypegenWatcher = { close: vi.fn(), on: vi.fn(() => watcher) };
     let callerGeneration: TypegenWatchGeneration | undefined;
-    let cleanupFinished = false;
+    let runTypegenWatchResult: Promise<number> | undefined;
+    let applicationClosed = false;
     const close = vi.fn(async () => {
-      cleanupStarted.resolve();
-      await releaseCleanup.promise;
-      cleanupFinished = true;
+      applicationCloseStarted.resolve();
+      await releaseApplicationClose.promise;
+      applicationClosed = true;
     });
     vi.resetModules();
     vi.doMock('./typegen-watch.js', async (importOriginal) => {
@@ -63,7 +80,7 @@ describe('fluo typegen caller-process cancellation', () => {
       return {
         ...actual,
         runTypegenWatch(options: TypegenWatchOptions) {
-          return actual.runTypegenWatch({
+          const result = actual.runTypegenWatch({
             ...options,
             signalTarget,
             startGeneration() {
@@ -80,6 +97,8 @@ describe('fluo typegen caller-process cancellation', () => {
             },
             watchTarget: () => watcher,
           });
+          runTypegenWatchResult = result;
+          return result;
         },
       };
     });
@@ -92,14 +111,10 @@ describe('fluo typegen caller-process cancellation', () => {
           react: { createReactPageCatalog: () => [] },
           runtime: {
             FluoFactory: Object.assign(() => undefined, {
-              create: async () => {
-                bootstrapStarted.resolve();
-                await releaseBootstrap.promise;
-                return {
-                  close,
-                  dispatcher: { describeRoutes: () => [] },
-                };
-              },
+              create: async () => ({
+                close,
+                dispatcher: { describeRoutes: () => [] },
+              }),
             }),
           },
           typegen: { generateReactPageTypes: () => 'source' },
@@ -112,28 +127,32 @@ describe('fluo typegen caller-process cancellation', () => {
         '/project/generated/react-pages.ts',
         '--watch',
       ], runtime);
-      await generationStarted.promise;
-      if (callerGeneration === undefined) {
+      await waitForSignal(generationStarted.promise, 'caller-process generation startup');
+      if (callerGeneration === undefined || runTypegenWatchResult === undefined) {
         throw new Error('Caller-process generation did not start.');
       }
-      let generationRejectedBeforeCleanup = false;
-      void callerGeneration.result.catch(() => {
-        generationRejectedBeforeCleanup = !cleanupFinished;
+      let watchSettled = false;
+      void runTypegenWatchResult.then(() => {
+        watchSettled = true;
       });
-      await bootstrapStarted.promise;
+      await waitForSignal(applicationCloseStarted.promise, 'application.close() to start');
 
-      // When: shutdown reaches the active caller-process generation before it can finish bootstrap.
+      // When: shutdown reaches the pending application close lifecycle.
       signalTarget.emit('SIGTERM');
-      await cancellationRequested.promise;
-      releaseBootstrap.resolve();
-      await cleanupStarted.promise;
+      await waitForSignal(cancellationRequested.promise, 'caller-process cancellation');
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
 
-      // Then: watch ownership is retained until the application's asynchronous close completes.
-      releaseCleanup.resolve();
+      // Then: cancellation cannot settle the watch before application close releases generation ownership.
+      expect(applicationClosed).toBe(false);
+      expect(watchSettled).toBe(false);
+      releaseApplicationClose.resolve();
       await expect(callerGeneration.result).rejects.toThrow('Typegen generation was cancelled.');
+      await expect(runTypegenWatchResult).resolves.toBe(0);
       await expect(action).resolves.toBe(0);
-      expect(generationRejectedBeforeCleanup).toBe(false);
       expect(close).toHaveBeenCalledOnce();
+      expect(watcher.close).toHaveBeenCalledOnce();
       expect(stderr).toEqual([]);
     } finally {
       vi.doUnmock('./typegen-watch.js');

--- a/packages/cli/src/commands/typegen-generation-lifecycle.test.ts
+++ b/packages/cli/src/commands/typegen-generation-lifecycle.test.ts
@@ -10,6 +10,10 @@ class FakeGenerationChild implements TypegenGenerationChild {
   readonly exitListeners = new Set<(code: number | null, signal: NodeJS.Signals | null) => void>();
   readonly messageListeners = new Set<(message: unknown) => void>();
 
+  kill(_signal: NodeJS.Signals): boolean {
+    return true;
+  }
+
   offError(listener: (error: Error) => void): void {
     this.errorListeners.delete(listener);
   }

--- a/packages/cli/src/commands/typegen-generation-lifecycle.test.ts
+++ b/packages/cli/src/commands/typegen-generation-lifecycle.test.ts
@@ -55,7 +55,7 @@ class FakeGenerationChild implements TypegenGenerationChild {
 }
 
 describe('fluo typegen generation child lifecycle', () => {
-  it('escalates an uncooperative cancellation from SIGTERM to SIGKILL', async () => {
+  it('sends one immediate SIGTERM and escalates only after the full cancellation grace period', async () => {
     // Given: a generation child that accepts SIGTERM but never exits.
     vi.useFakeTimers();
     try {
@@ -65,15 +65,45 @@ describe('fluo typegen generation child lifecycle', () => {
         () => child,
       );
 
-      // When: its owner cancels and the bounded grace period elapses without an exit event.
+      // When: its owner cancels repeatedly while the bounded grace period advances.
+      generation.cancel();
       generation.cancel();
       expect(child.signals).toEqual(['SIGTERM']);
-      vi.advanceTimersByTime(500);
+      vi.advanceTimersByTime(499);
+      expect(child.signals).toEqual(['SIGTERM']);
+      vi.advanceTimersByTime(1);
 
-      // Then: SIGKILL is sent without waiting for wall-clock time.
+      // Then: one SIGKILL is sent exactly at the deadline without wall-clock waiting.
       expect(child.signals).toEqual(['SIGTERM', 'SIGKILL']);
       child.emitExit(null, 'SIGKILL');
       await expect(generation.result).rejects.toThrow('signal SIGKILL');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('clears cancellation escalation and completion listeners when SIGTERM exits the child early', async () => {
+    // Given: a generation child with one pending SIGKILL escalation after cooperative cancellation.
+    vi.useFakeTimers();
+    try {
+      const child = new FakeGenerationChild();
+      const generation = startTypegenGenerationProcess(
+        { cwd: '/project', exportName: 'AppModule', modulePath: '/project/src/app.ts' },
+        () => child,
+      );
+      generation.cancel();
+
+      // When: the child exits before the bounded deadline.
+      child.emitExit(null, 'SIGTERM');
+      await expect(generation.result).rejects.toThrow('signal SIGTERM');
+
+      // Then: lifecycle listeners and the no-longer-owned escalation timer are both removed.
+      expect(child.errorListeners.size).toBe(0);
+      expect(child.exitListeners.size).toBe(0);
+      expect(child.messageListeners.size).toBe(0);
+      expect(vi.getTimerCount()).toBe(0);
+      vi.advanceTimersByTime(500);
+      expect(child.signals).toEqual(['SIGTERM']);
     } finally {
       vi.useRealTimers();
     }

--- a/packages/cli/src/commands/typegen-generation-lifecycle.test.ts
+++ b/packages/cli/src/commands/typegen-generation-lifecycle.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
+  startTypegenGenerationProcess,
   type TypegenGenerationChild,
   waitForTypegenGenerationChild,
 } from './typegen-generation-process.js';
@@ -9,8 +10,10 @@ class FakeGenerationChild implements TypegenGenerationChild {
   readonly errorListeners = new Set<(error: Error) => void>();
   readonly exitListeners = new Set<(code: number | null, signal: NodeJS.Signals | null) => void>();
   readonly messageListeners = new Set<(message: unknown) => void>();
+  readonly signals: NodeJS.Signals[] = [];
 
-  kill(_signal: NodeJS.Signals): boolean {
+  kill(signal: NodeJS.Signals): boolean {
+    this.signals.push(signal);
     return true;
   }
 
@@ -52,6 +55,30 @@ class FakeGenerationChild implements TypegenGenerationChild {
 }
 
 describe('fluo typegen generation child lifecycle', () => {
+  it('escalates an uncooperative cancellation from SIGTERM to SIGKILL', async () => {
+    // Given: a generation child that accepts SIGTERM but never exits.
+    vi.useFakeTimers();
+    try {
+      const child = new FakeGenerationChild();
+      const generation = startTypegenGenerationProcess(
+        { cwd: '/project', exportName: 'AppModule', modulePath: '/project/src/app.ts' },
+        () => child,
+      );
+
+      // When: its owner cancels and the bounded grace period elapses without an exit event.
+      generation.cancel();
+      expect(child.signals).toEqual(['SIGTERM']);
+      vi.advanceTimersByTime(500);
+
+      // Then: SIGKILL is sent without waiting for wall-clock time.
+      expect(child.signals).toEqual(['SIGTERM', 'SIGKILL']);
+      child.emitExit(null, 'SIGKILL');
+      await expect(generation.result).rejects.toThrow('signal SIGKILL');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('waits for process exit and removes every completion listener', async () => {
     // Given: a generation child that has sent source but has not exited.
     const child = new FakeGenerationChild();

--- a/packages/cli/src/commands/typegen-generation-process.ts
+++ b/packages/cli/src/commands/typegen-generation-process.ts
@@ -14,6 +14,7 @@ type TypegenGenerationRequest = {
 
 /** Listener boundary for one short-lived typegen generation child. */
 export type TypegenGenerationChild = {
+  readonly kill: (signal: NodeJS.Signals) => boolean;
   readonly offError: (listener: (error: Error) => void) => void;
   readonly offExit: (listener: (code: number | null, signal: NodeJS.Signals | null) => void) => void;
   readonly offMessage: (listener: (message: unknown) => void) => void;
@@ -37,6 +38,7 @@ function createGenerationChild(request: TypegenGenerationRequest): TypegenGenera
     stdio: ['ignore', 'ignore', 'ignore', 'ipc'],
   });
   return {
+    kill: (signal) => child.kill(signal),
     offError: (listener) => child.off('error', listener),
     offExit: (listener) => child.off('exit', listener),
     offMessage: (listener) => child.off('message', listener),
@@ -45,6 +47,12 @@ function createGenerationChild(request: TypegenGenerationRequest): TypegenGenera
     onMessage: (listener) => child.on('message', listener),
   };
 }
+
+/** One short-lived typegen generation process controlled by its watch coordinator. */
+export type TypegenGenerationProcess = {
+  cancel(): void;
+  readonly result: Promise<string>;
+};
 
 function describeExit(code: number | null, signal: NodeJS.Signals | null): string {
   if (signal !== null) {
@@ -100,6 +108,26 @@ export function waitForTypegenGenerationChild(child: TypegenGenerationChild): Pr
 }
 
 /**
+ * Starts one default typegen generation child for a coordinator to complete or cancel.
+ *
+ * @param request Consumer directory, application module path, and selected export.
+ * @param spawnGeneration Child-process factory used by the default runtime and lifecycle tests.
+ * @returns A cancellable child process whose result settles only after a clean process exit.
+ */
+export function startTypegenGenerationProcess(
+  request: TypegenGenerationRequest,
+  spawnGeneration: TypegenGenerationSpawner = createGenerationChild,
+): TypegenGenerationProcess {
+  const child = spawnGeneration(request);
+  return {
+    cancel() {
+      child.kill('SIGTERM');
+    },
+    result: waitForTypegenGenerationChild(child),
+  };
+}
+
+/**
  * Runs one default typegen generation in a short-lived child process.
  *
  * @param request Consumer directory, application module path, and selected export.
@@ -110,5 +138,5 @@ export async function runTypegenGenerationProcess(
   request: TypegenGenerationRequest,
   spawnGeneration: TypegenGenerationSpawner = createGenerationChild,
 ): Promise<string> {
-  return waitForTypegenGenerationChild(spawnGeneration(request));
+  return startTypegenGenerationProcess(request, spawnGeneration).result;
 }

--- a/packages/cli/src/commands/typegen-generation-process.ts
+++ b/packages/cli/src/commands/typegen-generation-process.ts
@@ -25,6 +25,8 @@ export type TypegenGenerationChild = {
 
 type TypegenGenerationSpawner = (request: TypegenGenerationRequest) => TypegenGenerationChild;
 
+const CHILD_TERMINATION_GRACE_MS = 500;
+
 function createGenerationChild(request: TypegenGenerationRequest): TypegenGenerationChild {
   const currentPath = fileURLToPath(import.meta.url);
   const extension = extname(currentPath);
@@ -119,11 +121,29 @@ export function startTypegenGenerationProcess(
   spawnGeneration: TypegenGenerationSpawner = createGenerationChild,
 ): TypegenGenerationProcess {
   const child = spawnGeneration(request);
+  let cancelled = false;
+  let forcedKillTimer: ReturnType<typeof setTimeout> | undefined;
+  const result = waitForTypegenGenerationChild(child).finally(() => {
+    if (forcedKillTimer !== undefined) {
+      clearTimeout(forcedKillTimer);
+      forcedKillTimer = undefined;
+    }
+  });
   return {
     cancel() {
-      child.kill('SIGTERM');
+      if (cancelled) {
+        return;
+      }
+      cancelled = true;
+      if (!child.kill('SIGTERM')) {
+        return;
+      }
+      forcedKillTimer = setTimeout(() => {
+        forcedKillTimer = undefined;
+        child.kill('SIGKILL');
+      }, CHILD_TERMINATION_GRACE_MS);
     },
-    result: waitForTypegenGenerationChild(child),
+    result,
   };
 }
 

--- a/packages/cli/src/commands/typegen-watch-cancellation.test.ts
+++ b/packages/cli/src/commands/typegen-watch-cancellation.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  runTypegenWatch,
+  type TypegenWatcher,
+  type TypegenWatchSignalTarget,
+} from './typegen-watch.js';
+
+function createSignalTarget(): TypegenWatchSignalTarget & { emit(signal: 'SIGINT' | 'SIGTERM'): void } {
+  const listeners = new Map<'SIGINT' | 'SIGTERM', () => void>();
+  return {
+    emit(signal) {
+      listeners.get(signal)?.();
+    },
+    off(signal, listener) {
+      if (listeners.get(signal) === listener) {
+        listeners.delete(signal);
+      }
+    },
+    once(signal, listener) {
+      listeners.set(signal, listener);
+    },
+  };
+}
+
+describe('fluo typegen watch cancellation', () => {
+  it('cancels a generation before child completion without committing stale source', async () => {
+    // Given: a coordinator-owned child generation that has not completed.
+    const signalTarget = createSignalTarget();
+    const cancel = vi.fn();
+    const commit = vi.fn(async () => undefined);
+    const watcher: TypegenWatcher = { close: vi.fn(), on: () => watcher };
+    let rejectGeneration: (error: Error) => void = () => undefined;
+    const result = runTypegenWatch({
+      commit,
+      modulePath: '/project/src/app.ts',
+      outputPath: '/project/src/generated/react-pages.ts',
+      signalTarget,
+      startGeneration() {
+        return {
+          cancel() {
+            cancel();
+            rejectGeneration(new Error('generation cancelled'));
+          },
+          result: new Promise<string>((_resolve, reject) => {
+            rejectGeneration = reject;
+          }),
+        };
+      },
+      watchTarget: () => watcher,
+    });
+
+    // When: terminal shutdown arrives before the child can complete.
+    signalTarget.emit('SIGTERM');
+
+    // Then: the coordinator cancels its child and never commits a stale artifact.
+    await expect(result).resolves.toBe(0);
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(commit).not.toHaveBeenCalled();
+  });
+
+  it('cancels during child completion without committing its reported source', async () => {
+    // Given: a child has reported source but remains incomplete until its process exit settles.
+    const signalTarget = createSignalTarget();
+    const cancel = vi.fn();
+    const commit = vi.fn(async () => undefined);
+    let rejectGeneration: (error: Error) => void = () => undefined;
+    let sourceReported = false;
+    const watcher: TypegenWatcher = { close: vi.fn(), on: () => watcher };
+    const result = runTypegenWatch({
+      commit,
+      modulePath: '/project/src/app.ts',
+      outputPath: '/project/src/generated/react-pages.ts',
+      signalTarget,
+      startGeneration() {
+        return {
+          cancel() {
+            cancel();
+            rejectGeneration(new Error('generation cancelled'));
+          },
+          result: new Promise<string>((_resolve, reject) => {
+            sourceReported = true;
+            rejectGeneration = reject;
+          }),
+        };
+      },
+      watchTarget: () => watcher,
+    });
+    await vi.waitFor(() => expect(sourceReported).toBe(true));
+
+    // When: shutdown races with the child process completion boundary.
+    signalTarget.emit('SIGTERM');
+
+    // Then: a reported-but-incomplete result cannot publish after cancellation.
+    await expect(result).resolves.toBe(0);
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(commit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/commands/typegen-watch-cancellation.test.ts
+++ b/packages/cli/src/commands/typegen-watch-cancellation.test.ts
@@ -23,6 +23,32 @@ function createSignalTarget(): TypegenWatchSignalTarget & { emit(signal: 'SIGINT
   };
 }
 
+function createDeferred<T>(): { readonly promise: Promise<T>; readonly resolve: (value: T) => void } {
+  let resolveResult: (value: T) => void = () => undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolveResult = resolve;
+  });
+  return { promise, resolve: resolveResult };
+}
+
+async function waitForSignal(signal: Promise<void>, description: string): Promise<void> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      signal,
+      new Promise<void>((_resolve, reject) => {
+        timeout = setTimeout(() => {
+          reject(new Error(`Timed out waiting for ${description}.`));
+        }, 1_000);
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
 describe('fluo typegen watch cancellation', () => {
   it('cancels a generation before child completion without committing stale source', async () => {
     // Given: a coordinator-owned child generation that has not completed.
@@ -30,6 +56,8 @@ describe('fluo typegen watch cancellation', () => {
     const cancel = vi.fn();
     const commit = vi.fn(async () => undefined);
     const watcher: TypegenWatcher = { close: vi.fn(), on: () => watcher };
+    const cancellationRequested = createDeferred<void>();
+    const generationStarted = createDeferred<void>();
     let rejectGeneration: (error: Error) => void = () => undefined;
     const result = runTypegenWatch({
       commit,
@@ -40,9 +68,10 @@ describe('fluo typegen watch cancellation', () => {
         return {
           cancel() {
             cancel();
-            rejectGeneration(new Error('generation cancelled'));
+            cancellationRequested.resolve();
           },
           result: new Promise<string>((_resolve, reject) => {
+            generationStarted.resolve();
             rejectGeneration = reject;
           }),
         };
@@ -51,7 +80,10 @@ describe('fluo typegen watch cancellation', () => {
     });
 
     // When: terminal shutdown arrives before the child can complete.
+    await waitForSignal(generationStarted.promise, 'the initial generation to start');
     signalTarget.emit('SIGTERM');
+    await waitForSignal(cancellationRequested.promise, 'generation cancellation');
+    rejectGeneration(new Error('generation cancelled'));
 
     // Then: the coordinator cancels its child and never commits a stale artifact.
     await expect(result).resolves.toBe(0);
@@ -64,8 +96,9 @@ describe('fluo typegen watch cancellation', () => {
     const signalTarget = createSignalTarget();
     const cancel = vi.fn();
     const commit = vi.fn(async () => undefined);
+    const cancellationRequested = createDeferred<void>();
+    const generationStarted = createDeferred<void>();
     let rejectGeneration: (error: Error) => void = () => undefined;
-    let sourceReported = false;
     const watcher: TypegenWatcher = { close: vi.fn(), on: () => watcher };
     const result = runTypegenWatch({
       commit,
@@ -76,20 +109,22 @@ describe('fluo typegen watch cancellation', () => {
         return {
           cancel() {
             cancel();
-            rejectGeneration(new Error('generation cancelled'));
+            cancellationRequested.resolve();
           },
           result: new Promise<string>((_resolve, reject) => {
-            sourceReported = true;
+            generationStarted.resolve();
             rejectGeneration = reject;
           }),
         };
       },
       watchTarget: () => watcher,
     });
-    await vi.waitFor(() => expect(sourceReported).toBe(true));
 
     // When: shutdown races with the child process completion boundary.
+    await waitForSignal(generationStarted.promise, 'the initial generation to start');
     signalTarget.emit('SIGTERM');
+    await waitForSignal(cancellationRequested.promise, 'generation cancellation');
+    rejectGeneration(new Error('generation cancelled'));
 
     // Then: a reported-but-incomplete result cannot publish after cancellation.
     await expect(result).resolves.toBe(0);

--- a/packages/cli/src/commands/typegen-watch-startup.test.ts
+++ b/packages/cli/src/commands/typegen-watch-startup.test.ts
@@ -44,16 +44,21 @@ describe('fluo typegen watch startup barrier', () => {
           releaseInitialGeneration = resolve;
         });
       }
-      publishedSources.push(capturedSource);
+      return capturedSource;
     });
     const runPromise = runTypegenWatch({
-      generate,
+      commit: async (source) => {
+        publishedSources.push(source);
+      },
       modulePath: '/project/src/app.ts',
       onReady() {
         readySources.push(publishedSources.at(-1) ?? 'missing');
       },
       outputPath: '/project/src/generated/react-pages.ts',
       signalTarget,
+      startGeneration() {
+        return { cancel: () => undefined, result: generate() };
+      },
       watchTarget,
     });
 
@@ -89,12 +94,16 @@ describe('fluo typegen watch startup barrier', () => {
 
     // When: watch mode performs its deterministic startup generation.
     const action = runTypegenWatch({
-      generate: async () => {
-        throw startupError;
-      },
+      commit: async () => undefined,
       modulePath: '/project/src/app.ts',
       outputPath: '/project/src/generated/react-pages.ts',
       signalTarget,
+      startGeneration() {
+        return {
+          cancel: () => undefined,
+          result: Promise.reject(startupError),
+        };
+      },
       watchTarget,
     });
 
@@ -117,13 +126,16 @@ describe('fluo typegen watch startup barrier', () => {
 
     // When: watch mode announces that its long-running lifecycle is ready.
     const action = runTypegenWatch({
-      generate: async () => undefined,
+      commit: async () => undefined,
       modulePath: '/project/src/app.ts',
       onReady() {
         throw readyError;
       },
       outputPath: '/project/src/generated/react-pages.ts',
       signalTarget,
+      startGeneration() {
+        return { cancel: () => undefined, result: Promise.resolve('source') };
+      },
       watchTarget: () => watcher,
     });
 

--- a/packages/cli/src/commands/typegen-watch-startup.test.ts
+++ b/packages/cli/src/commands/typegen-watch-startup.test.ts
@@ -24,7 +24,7 @@ function createSignalTarget(): TypegenWatchSignalTarget & { emit(signal: 'SIGINT
 }
 
 describe('fluo typegen watch startup barrier', () => {
-  it('publishes a change observed during initial generation before reporting ready', async () => {
+  it('withholds a change-invalidated initial generation before reporting ready', async () => {
     // Given: initial generation has captured stale source while the watcher can observe a newer save.
     const signalTarget = createSignalTarget();
     const publishedSources: string[] = [];
@@ -32,6 +32,18 @@ describe('fluo typegen watch startup barrier', () => {
     let currentSource = 'stale source';
     let listener: ((event: string, filename: string | Buffer | null) => void) | undefined;
     let releaseInitialGeneration: (() => void) | undefined;
+    let signalInitialGenerationStarted: (() => void) | undefined;
+    let signalCurrentSourcePublished: (() => void) | undefined;
+    let signalReady: (() => void) | undefined;
+    const initialGenerationStarted = new Promise<void>((resolve) => {
+      signalInitialGenerationStarted = resolve;
+    });
+    const currentSourcePublished = new Promise<void>((resolve) => {
+      signalCurrentSourcePublished = resolve;
+    });
+    const ready = new Promise<void>((resolve) => {
+      signalReady = resolve;
+    });
     const watcher: TypegenWatcher = { close: vi.fn(), on: vi.fn(() => watcher) };
     const watchTarget = vi.fn((_target, _options, nextListener) => {
       listener = nextListener;
@@ -40,6 +52,7 @@ describe('fluo typegen watch startup barrier', () => {
     const generate = vi.fn(async () => {
       const capturedSource = currentSource;
       if (generate.mock.calls.length === 1) {
+        signalInitialGenerationStarted?.();
         await new Promise<void>((resolve) => {
           releaseInitialGeneration = resolve;
         });
@@ -49,10 +62,14 @@ describe('fluo typegen watch startup barrier', () => {
     const runPromise = runTypegenWatch({
       commit: async (source) => {
         publishedSources.push(source);
+        if (source === 'current source') {
+          signalCurrentSourcePublished?.();
+        }
       },
       modulePath: '/project/src/app.ts',
       onReady() {
         readySources.push(publishedSources.at(-1) ?? 'missing');
+        signalReady?.();
       },
       outputPath: '/project/src/generated/react-pages.ts',
       signalTarget,
@@ -63,19 +80,24 @@ describe('fluo typegen watch startup barrier', () => {
     });
 
     try {
-      await vi.waitFor(() => expect(generate).toHaveBeenCalledOnce());
+      await initialGenerationStarted;
+      if (listener === undefined || releaseInitialGeneration === undefined) {
+        throw new Error('Typegen watch startup generation did not install its event boundary.');
+      }
 
       // When: source changes before the initial generation can publish its captured bytes.
       currentSource = 'current source';
-      listener?.('change', 'page.tsx');
-      releaseInitialGeneration?.();
+      listener('change', 'page.tsx');
+      releaseInitialGeneration();
 
       // Then: startup performs a buffered rerun and reports ready only after current bytes publish.
-      await vi.waitFor(() => expect(publishedSources).toEqual(['stale source', 'current source']));
+      await currentSourcePublished;
+      await ready;
+      expect(publishedSources).toEqual(['current source']);
       expect(readySources).toEqual(['current source']);
     } finally {
       releaseInitialGeneration?.();
-      await vi.waitFor(() => expect(watchTarget).toHaveBeenCalledOnce());
+      expect(watchTarget).toHaveBeenCalledOnce();
       signalTarget.emit('SIGTERM');
       await runPromise;
     }

--- a/packages/cli/src/commands/typegen-watch.test.ts
+++ b/packages/cli/src/commands/typegen-watch.test.ts
@@ -86,14 +86,18 @@ describe('fluo typegen watch lifecycle', () => {
         });
       }
       active -= 1;
+      return `source ${String(generationCount)}`;
     });
     const runPromise = runTypegenWatch({
-      generate,
+      commit: async () => undefined,
       modulePath: '/project/src/app.ts',
       onReady,
       outputPath: '/project/src/generated/react-pages.ts',
       scheduler,
       signalTarget,
+      startGeneration() {
+        return { cancel: () => undefined, result: generate() };
+      },
       watchTarget,
     });
     await vi.waitFor(() => expect(onReady).toHaveBeenCalledOnce());
@@ -140,16 +144,21 @@ describe('fluo typegen watch lifecycle', () => {
       if (generationCount === 2) {
         throw new Error('application bootstrap failed');
       }
-      await writeTypegenArtifact(outputPath, generationCount === 1 ? 'valid one\n' : 'valid two\n');
+      return generationCount === 1 ? 'valid one\n' : 'valid two\n';
     });
     const runPromise = runTypegenWatch({
-      generate,
+      commit: async (source) => {
+        await writeTypegenArtifact(outputPath, source);
+      },
       modulePath: join(cwd, 'src', 'app.ts'),
       onError,
       onReady,
       outputPath,
       scheduler,
       signalTarget,
+      startGeneration() {
+        return { cancel: () => undefined, result: generate() };
+      },
       watchTarget,
     });
     await vi.waitFor(() => expect(onReady).toHaveBeenCalledOnce());
@@ -185,15 +194,20 @@ describe('fluo typegen watch lifecycle', () => {
     });
     const onReady = vi.fn();
     const generate = vi.fn(async () => {
-      await writeTypegenArtifact(outputPath, 'stable artifact\n');
+      return 'stable artifact\n';
     });
     const runPromise = runTypegenWatch({
-      generate,
+      commit: async (source) => {
+        await writeTypegenArtifact(outputPath, source);
+      },
       modulePath: join(cwd, 'src', 'app.ts'),
       onReady,
       outputPath,
       scheduler,
       signalTarget,
+      startGeneration() {
+        return { cancel: () => undefined, result: generate() };
+      },
       watchTarget,
     });
     await vi.waitFor(() => expect(onReady).toHaveBeenCalledOnce());

--- a/packages/cli/src/commands/typegen-watch.test.ts
+++ b/packages/cli/src/commands/typegen-watch.test.ts
@@ -14,6 +14,14 @@ import {
 
 const tempDirectories: string[] = [];
 
+function createDeferred<T>(): { readonly promise: Promise<T>; readonly resolve: (value: T) => void } {
+  let resolveResult: (value: T) => void = () => undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolveResult = resolve;
+  });
+  return { promise, resolve: resolveResult };
+}
+
 function createScheduler(): TypegenWatchScheduler & { flush(): void } {
   let sequence = 0;
   const callbacks = new Map<number, () => void>();
@@ -60,6 +68,123 @@ afterEach(async () => {
 });
 
 describe('fluo typegen watch lifecycle', () => {
+  it('withholds an invalidated generation until its requested rerun publishes current source', async () => {
+    // Given: a ready watcher whose next generation holds a source snapshot while its inputs can change.
+    const scheduler = createScheduler();
+    const signalTarget = createSignalTarget();
+    const rerunStarted = createDeferred<void>();
+    const staleGeneration = createDeferred<string>();
+    const currentSourcePublished = createDeferred<void>();
+    const publishedSources: string[] = [];
+    let generationCount = 0;
+    let listener: ((event: string, filename: string | Buffer | null) => void) | undefined;
+    const watcher: TypegenWatcher = { close: vi.fn(), on: vi.fn(() => watcher) };
+    const runPromise = runTypegenWatch({
+      commit: async (source) => {
+        publishedSources.push(source);
+        if (source === 'current source') {
+          currentSourcePublished.resolve();
+        }
+      },
+      modulePath: '/project/src/app.ts',
+      onReady: () => undefined,
+      outputPath: '/project/src/generated/react-pages.ts',
+      scheduler,
+      signalTarget,
+      startGeneration() {
+        generationCount += 1;
+        switch (generationCount) {
+          case 1:
+            return { cancel: () => undefined, result: Promise.resolve('initial source') };
+          case 2:
+            rerunStarted.resolve();
+            return { cancel: () => undefined, result: staleGeneration.promise };
+          case 3:
+            return { cancel: () => undefined, result: Promise.resolve('current source') };
+          default:
+            throw new Error(`Unexpected generation ${String(generationCount)}`);
+        }
+      },
+      watchTarget: (_target, _options, nextListener) => {
+        listener = nextListener;
+        return watcher;
+      },
+    });
+    await Promise.resolve();
+    if (listener === undefined) {
+      throw new Error('Typegen watch listener was not installed.');
+    }
+
+    // When: another source event arrives after the active generation captured stale bytes.
+    listener('change', 'page.tsx');
+    scheduler.flush();
+    await rerunStarted.promise;
+    listener('change', 'page.tsx');
+    staleGeneration.resolve('stale source');
+    await currentSourcePublished.promise;
+    signalTarget.emit('SIGTERM');
+
+    // Then: only the successor generated from current inputs can replace the initial artifact.
+    await expect(runPromise).resolves.toBe(0);
+    expect(publishedSources).toEqual(['initial source', 'current source']);
+  });
+
+  it('aborts an owned asynchronous commit before it can publish during shutdown', async () => {
+    // Given: a ready watcher whose regeneration has entered an asynchronous artifact commit.
+    const scheduler = createScheduler();
+    const signalTarget = createSignalTarget();
+    const commitStarted = createDeferred<void>();
+    const releaseCommit = createDeferred<void>();
+    const publishedSources: string[] = [];
+    let generationCount = 0;
+    let listener: ((event: string, filename: string | Buffer | null) => void) | undefined;
+    const watcher: TypegenWatcher = { close: vi.fn(), on: vi.fn(() => watcher) };
+    const runPromise = runTypegenWatch({
+      async commit(source, signal?: AbortSignal) {
+        if (source === 'initial source') {
+          publishedSources.push(source);
+          return;
+        }
+        commitStarted.resolve();
+        await releaseCommit.promise;
+        if (signal?.aborted !== true) {
+          publishedSources.push(source);
+        }
+      },
+      modulePath: '/project/src/app.ts',
+      onReady: () => undefined,
+      outputPath: '/project/src/generated/react-pages.ts',
+      scheduler,
+      signalTarget,
+      startGeneration() {
+        generationCount += 1;
+        return {
+          cancel: () => undefined,
+          result: Promise.resolve(generationCount === 1 ? 'initial source' : 'next source'),
+        };
+      },
+      watchTarget: (_target, _options, nextListener) => {
+        listener = nextListener;
+        return watcher;
+      },
+    });
+    await Promise.resolve();
+    if (listener === undefined) {
+      throw new Error('Typegen watch listener was not installed.');
+    }
+
+    // When: shutdown begins after the commit has started but before its final publication boundary.
+    listener('change', 'page.tsx');
+    scheduler.flush();
+    await commitStarted.promise;
+    signalTarget.emit('SIGTERM');
+    releaseCommit.resolve();
+
+    // Then: shutdown owns the in-flight commit and the target remains at its last valid artifact.
+    await expect(runPromise).resolves.toBe(0);
+    expect(publishedSources).toEqual(['initial source']);
+  });
+
   it('coalesces rapid changes, serializes regeneration, and shuts down cleanly', async () => {
     // Given: a successful startup generation and an injectable watcher lifecycle.
     const scheduler = createScheduler();

--- a/packages/cli/src/commands/typegen-watch.ts
+++ b/packages/cli/src/commands/typegen-watch.ts
@@ -19,6 +19,12 @@ export type TypegenWatcher = {
   on(event: 'error', listener: (error: Error) => void): TypegenWatcher;
 };
 
+/** One child generation owned by a typegen watch coordinator. */
+export type TypegenWatchGeneration = {
+  cancel(): void;
+  readonly result: Promise<string>;
+};
+
 type TypegenWatchTarget = (
   target: string,
   options: { readonly persistent: boolean; readonly recursive: boolean },
@@ -27,14 +33,15 @@ type TypegenWatchTarget = (
 
 /** Dependencies and callbacks for one bounded typegen watch lifecycle. */
 export type TypegenWatchOptions = {
+  readonly commit: (source: string) => Promise<void>;
   readonly debounceMs?: number;
-  readonly generate: () => Promise<void>;
   readonly modulePath: string;
   readonly onError?: (error: unknown) => void;
   readonly onReady?: (watchRoot: string) => void;
   readonly outputPath: string;
   readonly scheduler?: TypegenWatchScheduler;
   readonly signalTarget?: TypegenWatchSignalTarget;
+  readonly startGeneration: () => TypegenWatchGeneration;
   readonly watchTarget?: TypegenWatchTarget;
 };
 
@@ -89,7 +96,7 @@ export async function runTypegenWatch(options: TypegenWatchOptions): Promise<num
   const signalTarget = options.signalTarget ?? process;
   const watchTarget = options.watchTarget ?? defaultWatchTarget;
   const watchRoot = dirname(options.modulePath);
-  let activeGeneration: Promise<void> | undefined;
+  let activeGeneration: TypegenWatchGeneration | undefined;
   let cleanedUp = false;
   let rerunRequested = false;
   let resolved = false;
@@ -131,6 +138,7 @@ export async function runTypegenWatch(options: TypegenWatchOptions): Promise<num
     if (!stopping) {
       stopping = true;
       cleanup();
+      activeGeneration?.cancel();
     }
     settleIfIdle();
   };
@@ -138,6 +146,32 @@ export async function runTypegenWatch(options: TypegenWatchOptions): Promise<num
   function stopForSignal(): void {
     stop(0);
   }
+
+  const runGeneration = async (reportError: boolean): Promise<void> => {
+    let generation: TypegenWatchGeneration | undefined;
+    try {
+      generation = options.startGeneration();
+      activeGeneration = generation;
+      const source = await generation.result;
+      if (!stopping) {
+        await options.commit(source);
+      }
+    } catch (error: unknown) {
+      if (stopping) {
+        return;
+      }
+      if (reportError) {
+        onError(error);
+        return;
+      }
+      throw error;
+    } finally {
+      if (activeGeneration === generation) {
+        activeGeneration = undefined;
+        settleIfIdle();
+      }
+    }
+  };
 
   const regenerate = () => {
     if (stopping) {
@@ -148,19 +182,12 @@ export async function runTypegenWatch(options: TypegenWatchOptions): Promise<num
       return;
     }
 
-    activeGeneration = (async () => {
+    void (async () => {
       do {
         rerunRequested = false;
-        try {
-          await options.generate();
-        } catch (error: unknown) {
-          onError(error);
-        }
+        await runGeneration(true);
       } while (rerunRequested && !stopping);
-    })().finally(() => {
-      activeGeneration = undefined;
-      settleIfIdle();
-    });
+    })();
   };
 
   const scheduleRegeneration = (changedPath: string) => {
@@ -201,16 +228,12 @@ export async function runTypegenWatch(options: TypegenWatchOptions): Promise<num
   try {
     signalTarget.once('SIGINT', stopForSignal);
     signalTarget.once('SIGTERM', stopForSignal);
-    activeGeneration = (async () => {
+    await (async () => {
       do {
         rerunRequested = false;
-        await options.generate();
+        await runGeneration(false);
       } while (rerunRequested && !stopping);
-    })().finally(() => {
-      activeGeneration = undefined;
-      settleIfIdle();
-    });
-    await activeGeneration;
+    })();
     startupComplete = true;
     if (stopping) {
       return result;

--- a/packages/cli/src/commands/typegen-watch.ts
+++ b/packages/cli/src/commands/typegen-watch.ts
@@ -33,7 +33,7 @@ type TypegenWatchTarget = (
 
 /** Dependencies and callbacks for one bounded typegen watch lifecycle. */
 export type TypegenWatchOptions = {
-  readonly commit: (source: string) => Promise<void>;
+  readonly commit: (source: string, signal: AbortSignal) => Promise<void>;
   readonly debounceMs?: number;
   readonly modulePath: string;
   readonly onError?: (error: unknown) => void;
@@ -96,6 +96,7 @@ export async function runTypegenWatch(options: TypegenWatchOptions): Promise<num
   const signalTarget = options.signalTarget ?? process;
   const watchTarget = options.watchTarget ?? defaultWatchTarget;
   const watchRoot = dirname(options.modulePath);
+  let activeCommit: AbortController | undefined;
   let activeGeneration: TypegenWatchGeneration | undefined;
   let cleanedUp = false;
   let rerunRequested = false;
@@ -138,6 +139,7 @@ export async function runTypegenWatch(options: TypegenWatchOptions): Promise<num
     if (!stopping) {
       stopping = true;
       cleanup();
+      activeCommit?.abort();
       activeGeneration?.cancel();
     }
     settleIfIdle();
@@ -153,11 +155,19 @@ export async function runTypegenWatch(options: TypegenWatchOptions): Promise<num
       generation = options.startGeneration();
       activeGeneration = generation;
       const source = await generation.result;
-      if (!stopping) {
-        await options.commit(source);
+      if (!stopping && !rerunRequested) {
+        const commit = new AbortController();
+        activeCommit = commit;
+        try {
+          await options.commit(source, commit.signal);
+        } finally {
+          if (activeCommit === commit) {
+            activeCommit = undefined;
+          }
+        }
       }
     } catch (error: unknown) {
-      if (stopping) {
+      if (stopping || rerunRequested) {
         return;
       }
       if (reportError) {
@@ -192,6 +202,11 @@ export async function runTypegenWatch(options: TypegenWatchOptions): Promise<num
 
   const scheduleRegeneration = (changedPath: string) => {
     if (stopping || isOwnArtifactEvent(changedPath, options.outputPath)) {
+      return;
+    }
+    if (activeGeneration !== undefined) {
+      rerunRequested = true;
+      activeCommit?.abort();
       return;
     }
     if (!startupComplete) {

--- a/packages/cli/src/commands/typegen.test.ts
+++ b/packages/cli/src/commands/typegen.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, stat, utimes, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, stat, symlink, utimes, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -68,6 +68,37 @@ afterEach(async () => {
 });
 
 describe('fluo typegen', () => {
+  it.each(['direct path', 'symlink'] as const)('rejects a %s output alias to the application module', async (aliasKind) => {
+    // Given
+    const fixture = await createFixture();
+    const sourceDirectory = await mkdtemp(join(dirname(fixtureModulePath), 'typegen-output-alias-'));
+    tempDirectories.push(sourceDirectory);
+    const modulePath = join(sourceDirectory, 'app.module.ts');
+    const source = await readFile(fixtureModulePath, 'utf8');
+    await writeFile(modulePath, source, 'utf8');
+    const outputPath = aliasKind === 'direct path'
+      ? modulePath
+      : join(sourceDirectory, 'react-pages.ts');
+    if (aliasKind === 'symlink') {
+      await symlink(modulePath, outputPath);
+    }
+    const loadReactTypegenModules = vi.fn(fixture.runtime.loadReactTypegenModules);
+
+    // When
+    const exitCode = await runTypegenCommand([
+      modulePath,
+      '--output',
+      outputPath,
+    ], { ...fixture.runtime, loadReactTypegenModules });
+
+    // Then
+    expect(exitCode).toBe(1);
+    expect(fixture.stdout).toEqual([]);
+    expect(fixture.stderr).toHaveLength(1);
+    expect(loadReactTypegenModules).not.toHaveBeenCalled();
+    expect(await readFile(modulePath, 'utf8')).toBe(source);
+  });
+
   it('creates a deterministic artifact from the compiled React page catalog', async () => {
     // Given
     const fixture = await createFixture();

--- a/packages/cli/src/commands/typegen.test.ts
+++ b/packages/cli/src/commands/typegen.test.ts
@@ -340,4 +340,5 @@ describe('fluo typegen', () => {
     expect(close).toHaveBeenCalledOnce();
     expect(fixture.stderr).toEqual([`${projectionError.message}\n`]);
   });
+
 });

--- a/packages/cli/src/commands/typegen.test.ts
+++ b/packages/cli/src/commands/typegen.test.ts
@@ -371,4 +371,5 @@ describe('fluo typegen', () => {
     expect(close).toHaveBeenCalledOnce();
     expect(fixture.stderr).toEqual([`${projectionError.message}\n`]);
   });
+
 });

--- a/packages/cli/src/commands/typegen.ts
+++ b/packages/cli/src/commands/typegen.ts
@@ -7,7 +7,10 @@ import {
   type TypegenArtifactCheck,
   writeTypegenArtifact,
 } from './typegen-artifact.js';
-import { runTypegenGenerationProcess } from './typegen-generation-process.js';
+import {
+  runTypegenGenerationProcess,
+  startTypegenGenerationProcess,
+} from './typegen-generation-process.js';
 import { parseTypegenArgs, TypegenCommandError } from './typegen-options.js';
 import {
   createTypegenSource,
@@ -93,14 +96,12 @@ export async function runTypegenCommand(
     const generateSource = async () => customModules === undefined
       ? runTypegenGenerationProcess({ cwd, exportName: parsed.exportName, modulePath: parsed.modulePath })
       : createTypegenSource({ cwd, modules: await customModules, parsed });
-    const generateAndWrite = async () => {
-      const source = await generateSource();
-      const action = await writeTypegenArtifact(outputPath, source);
-      stdout.write(`${action} ${outputPath}\n`);
-    };
     if (parsed.watch) {
       return await runTypegenWatch({
-        generate: generateAndWrite,
+        async commit(source) {
+          const action = await writeTypegenArtifact(outputPath, source);
+          stdout.write(`${action} ${outputPath}\n`);
+        },
         modulePath: resolve(cwd, parsed.modulePath),
         onError(error) {
           stderr.write(`ERROR ${outputPath}: ${error instanceof Error ? error.message : String(error)}\n`);
@@ -109,6 +110,37 @@ export async function runTypegenCommand(
           stdout.write(`WATCHING ${watchRoot}\n`);
         },
         outputPath,
+        startGeneration: customModules === undefined
+          ? () => startTypegenGenerationProcess({ cwd, exportName: parsed.exportName, modulePath: parsed.modulePath })
+          : () => {
+            let cancelled = false;
+            let rejectResult: (error: Error) => void = () => undefined;
+            const result = new Promise<string>((resolveResult, reject) => {
+              rejectResult = reject;
+              void generateSource().then(
+                (source) => {
+                  if (!cancelled) {
+                    resolveResult(source);
+                  }
+                },
+                (error: unknown) => {
+                  if (!cancelled) {
+                    reject(error);
+                  }
+                },
+              );
+            });
+            return {
+              cancel() {
+                if (cancelled) {
+                  return;
+                }
+                cancelled = true;
+                rejectResult(new TypegenCommandError('Typegen generation was cancelled.'));
+              },
+              result,
+            };
+          },
       });
     }
 

--- a/packages/cli/src/commands/typegen.ts
+++ b/packages/cli/src/commands/typegen.ts
@@ -16,6 +16,7 @@ import {
   type ReactTypegenModules,
 } from './typegen-source.js';
 import { runTypegenWatch } from './typegen-watch.js';
+import { assertOutputDoesNotAliasModule } from './output-path-safety.js';
 
 type CliStream = {
   write(message: string): unknown;
@@ -88,8 +89,10 @@ export async function runTypegenCommand(
     }
 
     const parsed = parseTypegenArgs(argv);
-    const customModules = runtime.loadReactTypegenModules?.(cwd);
+    const modulePath = resolve(cwd, parsed.modulePath);
     const outputPath = resolve(cwd, parsed.outputPath);
+    await assertOutputDoesNotAliasModule(modulePath, outputPath);
+    const customModules = runtime.loadReactTypegenModules?.(cwd);
     const generateSource = async () => customModules === undefined
       ? runTypegenGenerationProcess({ cwd, exportName: parsed.exportName, modulePath: parsed.modulePath })
       : createTypegenSource({ cwd, modules: await customModules, parsed });
@@ -101,7 +104,7 @@ export async function runTypegenCommand(
     if (parsed.watch) {
       return await runTypegenWatch({
         generate: generateAndWrite,
-        modulePath: resolve(cwd, parsed.modulePath),
+        modulePath,
         onError(error) {
           stderr.write(`ERROR ${outputPath}: ${error instanceof Error ? error.message : String(error)}\n`);
         },

--- a/packages/cli/src/commands/typegen.ts
+++ b/packages/cli/src/commands/typegen.ts
@@ -98,8 +98,8 @@ export async function runTypegenCommand(
       : createTypegenSource({ cwd, modules: await customModules, parsed });
     if (parsed.watch) {
       return await runTypegenWatch({
-        async commit(source) {
-          const action = await writeTypegenArtifact(outputPath, source);
+        async commit(source, signal) {
+          const action = await writeTypegenArtifact(outputPath, source, undefined, signal);
           stdout.write(`${action} ${outputPath}\n`);
         },
         modulePath: resolve(cwd, parsed.modulePath),

--- a/packages/cli/src/commands/typegen.ts
+++ b/packages/cli/src/commands/typegen.ts
@@ -7,7 +7,10 @@ import {
   type TypegenArtifactCheck,
   writeTypegenArtifact,
 } from './typegen-artifact.js';
-import { runTypegenGenerationProcess } from './typegen-generation-process.js';
+import {
+  runTypegenGenerationProcess,
+  startTypegenGenerationProcess,
+} from './typegen-generation-process.js';
 import { parseTypegenArgs, TypegenCommandError } from './typegen-options.js';
 import {
   createTypegenSource,
@@ -96,14 +99,12 @@ export async function runTypegenCommand(
     const generateSource = async () => customModules === undefined
       ? runTypegenGenerationProcess({ cwd, exportName: parsed.exportName, modulePath: parsed.modulePath })
       : createTypegenSource({ cwd, modules: await customModules, parsed });
-    const generateAndWrite = async () => {
-      const source = await generateSource();
-      const action = await writeTypegenArtifact(outputPath, source);
-      stdout.write(`${action} ${outputPath}\n`);
-    };
     if (parsed.watch) {
       return await runTypegenWatch({
-        generate: generateAndWrite,
+        async commit(source) {
+          const action = await writeTypegenArtifact(outputPath, source);
+          stdout.write(`${action} ${outputPath}\n`);
+        },
         modulePath,
         onError(error) {
           stderr.write(`ERROR ${outputPath}: ${error instanceof Error ? error.message : String(error)}\n`);
@@ -112,6 +113,37 @@ export async function runTypegenCommand(
           stdout.write(`WATCHING ${watchRoot}\n`);
         },
         outputPath,
+        startGeneration: customModules === undefined
+          ? () => startTypegenGenerationProcess({ cwd, exportName: parsed.exportName, modulePath: parsed.modulePath })
+          : () => {
+            let cancelled = false;
+            let rejectResult: (error: Error) => void = () => undefined;
+            const result = new Promise<string>((resolveResult, reject) => {
+              rejectResult = reject;
+              void generateSource().then(
+                (source) => {
+                  if (!cancelled) {
+                    resolveResult(source);
+                  }
+                },
+                (error: unknown) => {
+                  if (!cancelled) {
+                    reject(error);
+                  }
+                },
+              );
+            });
+            return {
+              cancel() {
+                if (cancelled) {
+                  return;
+                }
+                cancelled = true;
+                rejectResult(new TypegenCommandError('Typegen generation was cancelled.'));
+              },
+              result,
+            };
+          },
       });
     }
 

--- a/packages/cli/src/commands/typegen.ts
+++ b/packages/cli/src/commands/typegen.ts
@@ -101,8 +101,8 @@ export async function runTypegenCommand(
       : createTypegenSource({ cwd, modules: await customModules, parsed });
     if (parsed.watch) {
       return await runTypegenWatch({
-        async commit(source) {
-          const action = await writeTypegenArtifact(outputPath, source);
+        async commit(source, signal) {
+          const action = await writeTypegenArtifact(outputPath, source, undefined, signal);
           stdout.write(`${action} ${outputPath}\n`);
         },
         modulePath,

--- a/packages/cli/src/commands/typegen.ts
+++ b/packages/cli/src/commands/typegen.ts
@@ -114,21 +114,11 @@ export async function runTypegenCommand(
           ? () => startTypegenGenerationProcess({ cwd, exportName: parsed.exportName, modulePath: parsed.modulePath })
           : () => {
             let cancelled = false;
-            let rejectResult: (error: Error) => void = () => undefined;
-            const result = new Promise<string>((resolveResult, reject) => {
-              rejectResult = reject;
-              void generateSource().then(
-                (source) => {
-                  if (!cancelled) {
-                    resolveResult(source);
-                  }
-                },
-                (error: unknown) => {
-                  if (!cancelled) {
-                    reject(error);
-                  }
-                },
-              );
+            const result = generateSource().then((source) => {
+              if (cancelled) {
+                throw new TypegenCommandError('Typegen generation was cancelled.');
+              }
+              return source;
             });
             return {
               cancel() {
@@ -136,7 +126,6 @@ export async function runTypegenCommand(
                   return;
                 }
                 cancelled = true;
-                rejectResult(new TypegenCommandError('Typegen generation was cancelled.'));
               },
               result,
             };

--- a/packages/cli/src/commands/typegen.ts
+++ b/packages/cli/src/commands/typegen.ts
@@ -117,21 +117,11 @@ export async function runTypegenCommand(
           ? () => startTypegenGenerationProcess({ cwd, exportName: parsed.exportName, modulePath: parsed.modulePath })
           : () => {
             let cancelled = false;
-            let rejectResult: (error: Error) => void = () => undefined;
-            const result = new Promise<string>((resolveResult, reject) => {
-              rejectResult = reject;
-              void generateSource().then(
-                (source) => {
-                  if (!cancelled) {
-                    resolveResult(source);
-                  }
-                },
-                (error: unknown) => {
-                  if (!cancelled) {
-                    reject(error);
-                  }
-                },
-              );
+            const result = generateSource().then((source) => {
+              if (cancelled) {
+                throw new TypegenCommandError('Typegen generation was cancelled.');
+              }
+              return source;
             });
             return {
               cancel() {
@@ -139,7 +129,6 @@ export async function runTypegenCommand(
                   return;
                 }
                 cancelled = true;
-                rejectResult(new TypegenCommandError('Typegen generation was cancelled.'));
               },
               result,
             };


### PR DESCRIPTION
## Summary
- keep typegen watch generation, cancellation, completion, and artifact commit under one owner
- prevent invalidated or cancelled generations from publishing stale artifacts
- wait for caller-process bootstrap cleanup before cancellation settles
- bound child shutdown with TERM-to-KILL escalation
- publish artifacts through a synchronous atomic rename boundary

## Verification
- CLI dependency build and typecheck
- full and reverse CLI suites: 454 passed each
- focused typegen suites: 34 passed in both orders
- immediate-rejection and async-rename mutations killed
- direct TERM/KILL and real SIGTERM tests
- lint, platform/docs/Changeset governance and manual CLI paths

Closes #3127