### PR TITLE
fix(release): clear stale Terminus changelog entry (#3286)

### DIFF
--- a/.changeset/clear-terminus-unreleased.md
+++ b/.changeset/clear-terminus-unreleased.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/terminus": patch
+---
+
+Remove stale pending changelog content that was already released in `1.0.5`.

--- a/packages/terminus/CHANGELOG.md
+++ b/packages/terminus/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## [Unreleased]
 
-### Patch Changes
-
-- Harden health/readiness diagnostics so timed-out indicator probes do not overlap later checks for the same indicator instance, platform diagnostic keys preserve runtime payloads on user-key collisions, and Terminus docs/tests align with the runtime-owned endpoint contract.
-
 ## 1.1.0
 
 ### Minor Changes

--- a/tooling/release/package-changelog.test.ts
+++ b/tooling/release/package-changelog.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import {
   normalizePackageChangelog,
@@ -165,5 +166,18 @@ describe('packageChangelogContractViolation', () => {
     ['the wrong heading level', '# @fluojs/prisma\n\n### [Unreleased]\n\n## 1.1.0\n'],
   ])('rejects %s', (_caseName, changelog) => {
     expect(packageChangelogContractViolation(changelog)).toBeTypeOf('string');
+  });
+});
+
+describe('Terminus package changelog', () => {
+  it('keeps the Unreleased placeholder empty after released notes', () => {
+    const changelog = readFileSync(
+      new URL('../../packages/terminus/CHANGELOG.md', import.meta.url),
+      'utf8',
+    );
+    const unreleasedSection = changelog.split(/^## \[Unreleased\]\s*$/mu)[1];
+    const unreleasedBody = unreleasedSection?.split(/^## /mu)[0];
+
+    expect(unreleasedBody?.trim()).toBe('');
   });
 });


### PR DESCRIPTION
## Summary

Remove the already released Terminus 1.0.5 body duplicated under `Unreleased` while preserving one canonical empty heading.

Linked context: Closes #3286

## Changes

- clear the stale `Unreleased` body
- retain released 1.0.5 history
- add deterministic changelog regression coverage
- add a patch Changeset for shipped Terminus release metadata

## Testing

- Terminus dependency closure build
- Terminus typecheck and reverse-dependent tests
- `pnpm verify:platform-consistency-governance`
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=<issue-base>`
- `pnpm exec vitest run tooling/release/package-changelog.test.ts --project tooling` (20 passed)
- direct normalizer/manual contract check

`pnpm lint` remains red only for identical pre-existing `packages/config` `useLiteralKeys` diagnostics confirmed on clean `main`.

## Release impact

- [x] This PR has consumer-visible release impact and includes a Changeset.
- [ ] This PR has no consumer-visible release impact.

Changeset: `.changeset/clear-terminus-unreleased.md` (`@fluojs/terminus`: patch)