### PR TITLE
feat(terminus): allow differentiated readiness indicators (#3287)

### DIFF
--- a/.changeset/differentiated-terminus-readiness.md
+++ b/.changeset/differentiated-terminus-readiness.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/terminus': minor
+---
+
+Allow health indicators to opt out of `/ready` with `readiness: false` while preserving their `/health` diagnostics.

--- a/book/beginner/ch18-health.ko.md
+++ b/book/beginner/ch18-health.ko.md
@@ -123,6 +123,23 @@ return report;
 ### 18.4.1 Strategic Monitoring
 모든 의존성을 헬스 체크에 포함하지 않도록 주의하십시오. 만약 이메일 발송과 같은 부가적인 외부 서비스가 중단되더라도, 애플리케이션은 대부분의 사용자에게 정상적인 서비스를 제공할 수 있습니다. 이러한 서비스를 준비성(Readiness) 체크에 포함하면 앱 전체가 불필요하게 "오프라인" 상태가 될 수 있습니다. 애플리케이션이 제 기능을 하기 위해 엄격하게 요구되는 핵심 의존성에 집중하십시오. 이를 "차등 모니터링"이라고 하며 "치명적(Fatal)" 조건과 "경고(Warning)" 조건을 구분하는 것입니다.
 
+Terminus는 indicator의 `readiness` 설정으로 이 구분을 명시적으로 지원합니다. 기본적으로 모든 indicator는 계속 `/health`에 참여하고, `readiness: false`를 설정하면 비임계 의존성을 binary `/ready` gate에서 제외할 수 있습니다.
+
+```typescript
+TerminusModule.forRoot({
+  indicators: [
+    new HttpHealthIndicator({
+      key: 'search',
+      readiness: false,
+      url: 'https://search.example.com/health',
+    }),
+    new MemoryHealthIndicator({ key: 'memory', heapUsedThresholdRatio: 0.9 }),
+  ],
+});
+```
+
+`search`가 실패하면 `/health`는 `503`과 해당 diagnostic을 유지하지만, `memory`, custom readiness check, platform readiness가 성공하는 동안 `/ready`는 available 상태를 유지합니다. `readiness`를 생략하면 기존 기본 동작이 보존되어, indicator 하나의 실패가 `/health`와 `/ready`를 모두 unavailable 상태로 만듭니다.
+
 ### 18.4.2 Resource Monitoring: Memory and CPU
 외부 서비스 외에도 서버의 리소스 사용량을 모니터링해야 합니다. 메모리 누수는 최종적으로 크래시를 일으키기 전에 서서히 성능을 저하시킵니다. 내장된 메모리 헬스 인디케이터를 사용하면 RAM 사용량이 특정 임계값을 초과할 때 인스턴스를 "비정상"으로 표시할 수 있습니다. 이를 통해 오케스트레이터가 인스턴스가 임계 실패 상태에 도달하기 전에 우아하게 교체하도록 하여 전체 서비스가 안정적이고 응답성 있게 유지되도록 할 수 있습니다.
 

--- a/book/beginner/ch18-health.md
+++ b/book/beginner/ch18-health.md
@@ -123,6 +123,23 @@ return report;
 ### 18.4.1 Strategic Monitoring
 Be careful not to include every dependency in health checks. If an auxiliary external service such as email delivery goes down, the application may still serve most users normally. Including that service in the readiness check can unnecessarily make the entire app look "offline." Focus on the core dependencies that are strictly required for the application to do its job. This is called "differentiated monitoring," and it means separating "fatal" conditions from "warning" conditions.
 
+Terminus makes that distinction explicit with an indicator's `readiness` setting. Every indicator still participates in `/health` by default, while `readiness: false` keeps a non-critical dependency out of the binary `/ready` gate:
+
+```typescript
+TerminusModule.forRoot({
+  indicators: [
+    new HttpHealthIndicator({
+      key: 'search',
+      readiness: false,
+      url: 'https://search.example.com/health',
+    }),
+    new MemoryHealthIndicator({ key: 'memory', heapUsedThresholdRatio: 0.9 }),
+  ],
+});
+```
+
+If `search` fails, `/health` returns `503` and retains its diagnostic, but `/ready` remains available while `memory`, custom readiness checks, and platform readiness succeed. Omitting `readiness` preserves the existing default: a failing indicator makes both `/health` and `/ready` unavailable.
+
 ### 18.4.2 Resource Monitoring: Memory and CPU
 Beyond external services, you should monitor server resource usage. Memory leaks slowly degrade performance before they eventually cause a crash. With the built in memory health indicator, you can mark an instance as "unhealthy" when RAM usage crosses a specific threshold. This lets the orchestrator gracefully replace the instance before it reaches a critical failure state, keeping the overall service stable and responsive.
 

--- a/packages/terminus/README.ko.md
+++ b/packages/terminus/README.ko.md
@@ -107,6 +107,25 @@ Prisma의 경우 `createPrismaHealthIndicatorProvider()`는 `@fluojs/prisma`가 
 
 Provider factory는 반복 등록할 수 있습니다. 각 인스턴스가 서로 다른 indicator key나 dependency option을 사용한다면 같은 factory가 만든 provider 여러 개를 하나의 `indicatorProviders` 배열에 등록할 수 있으며, Terminus는 나중에 등록된 같은 타입 provider가 앞선 provider를 덮어쓰지 않도록 각 provider 인스턴스를 별도 DI token으로 보관합니다.
 
+### Readiness 참여
+
+기본적으로 모든 indicator는 `/health`와 `/ready` 양쪽에 참여합니다. 의존성 상태를 `/health`에는 계속 노출하되 그 외에는 준비된 인스턴스를 rotation에서 제외하지 않아야 한다면 `readiness: false`를 설정하세요.
+
+```typescript
+TerminusModule.forRoot({
+  indicators: [
+    new HttpHealthIndicator({
+      key: 'search',
+      readiness: false,
+      url: 'https://search.example.com/health',
+    }),
+    new MemoryHealthIndicator({ key: 'memory', heapUsedThresholdRatio: 0.9 }),
+  ],
+});
+```
+
+`search`가 `down`을 보고하면 `/health`는 해당 diagnostic과 함께 `503`을 반환하지만, `/ready`는 계속 `memory`, custom `readinessChecks`, platform readiness를 평가합니다. `readiness`를 생략하거나 `true`로 둔 indicator가 실패하면 이전과 같이 두 endpoint 모두 unavailable 상태가 됩니다.
+
 ### 실행 가드레일
 
 커스텀 인디케이터가 멈추거나 느린 하위 서비스에 의존할 수 있다면 `execution.indicatorTimeoutMs`를 사용하세요. probe가 설정된 시간을 넘기면 Terminus는 무기한 대기하지 않고 해당 인디케이터를 `down`으로 표시합니다.
@@ -131,7 +150,7 @@ TerminusModule.forRoot({
 인디케이터가 `down` 결과를 반환하거나 `HealthCheckError`를 던지면, `TerminusHealthService`는 이 실패들을 모아 보고서를 작성합니다.
 
 - 하나 이상의 인디케이터가 실패하면 `/health`는 HTTP `503`을 반환합니다.
-- 등록된 indicator가 실패하거나, custom readiness check가 `false`를 반환하거나, runtime shutdown이 시작되었거나, platform readiness가 `ready`가 아닌 경우 `/ready`는 HTTP `503`을 반환합니다. Platform `critical` metadata는 diagnostics에 보존되지만 HTTP readiness endpoint 자체는 binary ready/unavailable gate이며 warning severity bucket을 노출하지 않습니다.
+- `readiness`를 생략했거나 `true`인 indicator가 실패하거나, custom readiness check가 `false`를 반환하거나, runtime shutdown이 시작되었거나, platform readiness가 `ready`가 아닌 경우 `/ready`는 HTTP `503`을 반환합니다. `readiness: false`인 indicator는 `/health`에는 계속 기여하지만 `/ready`를 차단하지 않습니다. Platform `critical` metadata는 diagnostics에 보존되지만 HTTP readiness endpoint 자체는 binary ready/unavailable gate이며 warning severity bucket을 노출하지 않습니다.
 - 응답 본문은 `status`, `contributors`, `info`, `error`, `details`를 포함한 구조화된 JSON 객체입니다.
 - 하나의 인디케이터가 여러 keyed entry를 반환할 수도 있으며, 이 경우 `/health`는 모든 entry를 `details`와 `contributors.up` / `contributors.down` 요약에 그대로 반영합니다.
 - 지원하지 않는 status, 빈 결과, 객체가 아닌 인디케이터 결과는 조용히 버려지지 않고 `down` 진단으로 보고됩니다.
@@ -165,6 +184,13 @@ Runtime-specific indicator는 subpath별로 분리되어 있습니다. Node.js m
   - 현재 등록된 인디케이터를 실행해 집계된 보고서를 반환합니다.
 - `isHealthy(): Promise<boolean>`
   - 현재 집계 결과가 완전히 healthy 상태인지 반환합니다.
+- `isReady(): Promise<boolean>`
+  - readiness에 참여하는 모든 indicator가 현재 `up`을 보고하는지 반환합니다.
+
+### `HealthIndicator`
+
+- `readiness?: boolean`
+  - indicator의 `/ready` 참여 여부를 제어하며 기본값은 `true`입니다. 내장 indicator의 모든 option 객체가 이 설정을 지원합니다.
 
 ### 직접 helper와 token
 

--- a/packages/terminus/README.md
+++ b/packages/terminus/README.md
@@ -107,6 +107,25 @@ For Prisma, `createPrismaHealthIndicatorProvider()` prefers the lifecycle-aware 
 
 Provider factories are repeatable. You may register multiple providers created by the same factory in one `indicatorProviders` array when each instance uses a distinct indicator key or dependency option; Terminus keeps every provider instance under its own DI token instead of letting later same-type providers overwrite earlier ones.
 
+### Readiness Participation
+
+Every indicator participates in both `/health` and `/ready` by default. Set `readiness: false` when a dependency must remain visible in `/health` but must not remove an otherwise ready instance from rotation.
+
+```typescript
+TerminusModule.forRoot({
+  indicators: [
+    new HttpHealthIndicator({
+      key: 'search',
+      readiness: false,
+      url: 'https://search.example.com/health',
+    }),
+    new MemoryHealthIndicator({ key: 'memory', heapUsedThresholdRatio: 0.9 }),
+  ],
+});
+```
+
+If `search` reports `down`, `/health` returns `503` with its diagnostic while `/ready` continues to evaluate `memory`, custom `readinessChecks`, and platform readiness. A failing indicator whose `readiness` is omitted or `true` continues to make both endpoints unavailable.
+
 ### Execution Guardrails
 
 Use `execution.indicatorTimeoutMs` when custom indicators might hang or depend on slow downstreams. When a probe exceeds the configured timeout, Terminus marks that indicator as `down` instead of waiting forever.
@@ -131,7 +150,7 @@ Use `path` to mount the health endpoints under a custom path, and `readinessChec
 When an indicator returns a `down` result or throws a `HealthCheckError`, the `TerminusHealthService` aggregates the failure into a report:
 
 - `/health` returns HTTP `503` if any indicator fails.
-- `/ready` returns HTTP `503` when registered indicators fail, a custom readiness check returns `false`, runtime shutdown has begun, or platform readiness is anything other than `ready`. Platform `critical` metadata is preserved in diagnostics, but the HTTP readiness endpoint itself is a binary ready/unavailable gate and does not expose warning severity buckets.
+- `/ready` returns HTTP `503` when an indicator whose `readiness` is omitted or `true` fails, a custom readiness check returns `false`, runtime shutdown has begun, or platform readiness is anything other than `ready`. Indicators with `readiness: false` still contribute to `/health` but do not block `/ready`. Platform `critical` metadata is preserved in diagnostics, but the HTTP readiness endpoint itself is a binary ready/unavailable gate and does not expose warning severity buckets.
 - The response body contains a structured JSON object with `status`, `contributors`, `info`, `error`, and `details`.
 - Indicators may emit multiple keyed entries in a single check result; `/health` preserves every keyed entry in `details` and in the `contributors.up` / `contributors.down` summaries.
 - Unsupported, empty, or non-object indicator results are reported as `down` diagnostics instead of being silently discarded.
@@ -165,6 +184,13 @@ Runtime-specific indicators are split by subpath. Use `@fluojs/terminus/node` fo
   - Runs the currently registered indicators and returns the aggregated report.
 - `isHealthy(): Promise<boolean>`
   - Returns whether the current aggregated report is fully healthy.
+- `isReady(): Promise<boolean>`
+  - Returns whether every indicator participating in readiness currently reports `up`.
+
+### `HealthIndicator`
+
+- `readiness?: boolean`
+  - Controls whether an indicator participates in `/ready`; it defaults to `true`. All bundled indicator option objects accept this setting.
 
 ### Direct helpers and tokens
 

--- a/packages/terminus/src/health-check.ts
+++ b/packages/terminus/src/health-check.ts
@@ -408,4 +408,17 @@ export class TerminusHealthService {
   async isHealthy(): Promise<boolean> {
     return (await this.check()).status === 'ok';
   }
+
+  /**
+   * Return whether every indicator participating in readiness currently reports `up`.
+   *
+   * @returns `true` when all indicators whose `readiness` setting is not `false` report `up`.
+   */
+  async isReady(): Promise<boolean> {
+    const readinessIndicators = this.indicators.filter((indicator) => indicator.readiness !== false);
+
+    return (
+      await executeHealthCheck(readinessIndicators, this.executionOptions, this.runningIndicatorChecks)
+    ).status === 'ok';
+  }
 }

--- a/packages/terminus/src/indicators/disk.ts
+++ b/packages/terminus/src/indicators/disk.ts
@@ -9,6 +9,8 @@ export interface DiskHealthIndicatorOptions {
   minFreeBytes?: number;
   minFreeRatio?: number;
   path?: string;
+  /** Whether this indicator participates in `/ready`. Defaults to `true`. */
+  readiness?: boolean;
 }
 
 const DEFAULT_DISK_FREE_RATIO_THRESHOLD = 0.1;
@@ -51,9 +53,11 @@ export function createDiskHealthIndicatorProvider(options: DiskHealthIndicatorOp
 /** Health indicator that inspects free space for one filesystem path. */
 export class DiskHealthIndicator implements HealthIndicator {
   readonly key: string | undefined;
+  readonly readiness: boolean | undefined;
 
   constructor(private readonly options: DiskHealthIndicatorOptions = {}) {
     this.key = options.key;
+    this.readiness = options.readiness;
   }
 
   async check(key: string): Promise<HealthIndicatorResult> {

--- a/packages/terminus/src/indicators/drizzle.ts
+++ b/packages/terminus/src/indicators/drizzle.ts
@@ -34,6 +34,8 @@ export interface DrizzleHealthIndicatorOptions {
   key?: string;
   ping?: () => Promise<unknown> | unknown;
   query?: unknown;
+  /** Whether this indicator participates in `/ready`. Defaults to `true`. */
+  readiness?: boolean;
   timeoutMs?: number;
 }
 
@@ -136,9 +138,11 @@ export function createDrizzleHealthIndicatorProvider(options: Omit<DrizzleHealth
 /** Health indicator that maps Drizzle lifecycle state and probes connectivity with an execute-capable handle. */
 export class DrizzleHealthIndicator implements HealthIndicator {
   readonly key: string | undefined;
+  readonly readiness: boolean | undefined;
 
   constructor(private readonly options: DrizzleHealthIndicatorOptions = {}) {
     this.key = options.key;
+    this.readiness = options.readiness;
   }
 
   async check(key: string): Promise<HealthIndicatorResult> {

--- a/packages/terminus/src/indicators/http.ts
+++ b/packages/terminus/src/indicators/http.ts
@@ -10,6 +10,8 @@ export interface HttpHealthIndicatorOptions {
   headers?: Record<string, string>;
   key?: string;
   method?: string;
+  /** Whether this indicator participates in `/ready`. Defaults to `true`. */
+  readiness?: boolean;
   timeoutMs?: number;
   url: string;
 }
@@ -70,9 +72,11 @@ export function createHttpHealthIndicatorProvider(options: HttpHealthIndicatorOp
 /** Health indicator that probes an upstream HTTP endpoint with `fetch()`. */
 export class HttpHealthIndicator implements HealthIndicator {
   readonly key: string | undefined;
+  readonly readiness: boolean | undefined;
 
   constructor(private readonly options: HttpHealthIndicatorOptions) {
     this.key = options.key;
+    this.readiness = options.readiness;
   }
 
   async check(key: string): Promise<HealthIndicatorResult> {

--- a/packages/terminus/src/indicators/memory.ts
+++ b/packages/terminus/src/indicators/memory.ts
@@ -22,6 +22,8 @@ export interface MemoryHealthIndicatorOptions {
   heapUsedThresholdRatio?: number;
   key?: string;
   memoryUsage?: MemoryUsageSampler;
+  /** Whether this indicator participates in `/ready`. Defaults to `true`. */
+  readiness?: boolean;
   rssThresholdBytes?: number;
 }
 
@@ -63,9 +65,11 @@ export function createMemoryHealthIndicatorProvider(options: MemoryHealthIndicat
 /** Health indicator that checks local process heap and RSS usage. */
 export class MemoryHealthIndicator implements HealthIndicator {
   readonly key: string | undefined;
+  readonly readiness: boolean | undefined;
 
   constructor(private readonly options: MemoryHealthIndicatorOptions = {}) {
     this.key = options.key;
+    this.readiness = options.readiness;
   }
 
   async check(key: string): Promise<HealthIndicatorResult> {

--- a/packages/terminus/src/indicators/prisma.ts
+++ b/packages/terminus/src/indicators/prisma.ts
@@ -43,6 +43,8 @@ export interface PrismaHealthIndicatorOptions {
   name?: string;
   /** Custom ping callback for manual probes or tests. Lifecycle state is only mapped when `service` is available. */
   ping?: () => Promise<unknown> | unknown;
+  /** Whether this indicator participates in `/ready`. Defaults to `true`. */
+  readiness?: boolean;
   /** Lifecycle-aware Prisma service/facade handle, usually resolved from `getPrismaServiceToken(name)`. */
   service?: PrismaServiceLike;
   /** Explicit Prisma service token to resolve when using `createPrismaHealthIndicatorProvider(...)`. */
@@ -234,9 +236,11 @@ export function createPrismaHealthIndicatorProvider(
 /** Health indicator that maps Prisma lifecycle status and probes connectivity with a trivial query. */
 export class PrismaHealthIndicator implements HealthIndicator {
   readonly key: string | undefined;
+  readonly readiness: boolean | undefined;
 
   constructor(private readonly options: PrismaHealthIndicatorOptions = {}) {
     this.key = options.key;
+    this.readiness = options.readiness;
   }
 
   async check(key: string): Promise<HealthIndicatorResult> {

--- a/packages/terminus/src/indicators/redis.ts
+++ b/packages/terminus/src/indicators/redis.ts
@@ -26,6 +26,8 @@ export interface RedisHealthIndicatorOptions {
   key?: string;
   /** Custom ping callback for manual probes or tests. Lifecycle state is only mapped when `client.status` is available. */
   ping?: () => Promise<unknown> | unknown;
+  /** Whether this indicator participates in `/ready`. Defaults to `true`. */
+  readiness?: boolean;
   /** Maximum time to wait for the ping operation. Defaults to `2_000` ms. */
   timeoutMs?: number;
 }
@@ -129,9 +131,11 @@ export function createRedisHealthIndicatorProvider(options: Omit<RedisHealthIndi
 /** Health indicator that maps Redis lifecycle status and checks reachability with a ping-like operation. */
 export class RedisHealthIndicator implements HealthIndicator {
   readonly key: string | undefined;
+  readonly readiness: boolean | undefined;
 
   constructor(private readonly options: RedisHealthIndicatorOptions = {}) {
     this.key = options.key;
+    this.readiness = options.readiness;
   }
 
   async check(key: string): Promise<HealthIndicatorResult> {

--- a/packages/terminus/src/module.test.ts
+++ b/packages/terminus/src/module.test.ts
@@ -192,6 +192,104 @@ describe('TerminusModule.forRoot', () => {
     }
   });
 
+  it('keeps /ready available when only an indicator excluded from readiness fails', async () => {
+    const optionalDependencyCheck = vi.fn(async (key: string) => ({
+      [key]: {
+        message: 'search unavailable',
+        status: 'down' as const,
+      },
+    }));
+    const requiredDependencyCheck = vi.fn(async (key: string) => ({
+      [key]: {
+        status: 'up' as const,
+      },
+    }));
+    const indicators = [
+      {
+        key: 'search',
+        readiness: false,
+        check: optionalDependencyCheck,
+      },
+      {
+        key: 'database',
+        check: requiredDependencyCheck,
+      },
+    ];
+    const terminusModule = TerminusModule.forRoot({ indicators });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [terminusModule],
+    });
+
+    const app = await createTestApp({ rootModule: AppModule });
+
+    try {
+      const healthResponse = await app.request('GET', '/health').send();
+
+      expect(healthResponse.status).toBe(503);
+      expect(healthResponse.body).toMatchObject({
+        contributors: {
+          down: ['search'],
+          up: ['database'],
+        },
+        status: 'error',
+      });
+
+      const readyResponse = await app.request('GET', '/ready').send();
+
+      expect(readyResponse.status).toBe(200);
+      expect(readyResponse.body).toEqual({ status: 'ready' });
+      expect(optionalDependencyCheck).toHaveBeenCalledTimes(1);
+      expect(requiredDependencyCheck).toHaveBeenCalledTimes(2);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('keeps /ready available when a built-in indicator opts out of readiness', async () => {
+    const indicators: HealthIndicator[] = [
+      new RedisHealthIndicator({
+        key: 'search',
+        readiness: false,
+        ping: async () => {
+          throw new Error('search unavailable');
+        },
+      }),
+      new MemoryHealthIndicator({ key: 'memory' }),
+    ];
+    const terminusModule = TerminusModule.forRoot({ indicators });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [terminusModule],
+    });
+
+    const app = await createTestApp({ rootModule: AppModule });
+
+    try {
+      const healthResponse = await app.request('GET', '/health').send();
+
+      expect(healthResponse.status).toBe(503);
+      expect(healthResponse.body).toMatchObject({
+        contributors: {
+          down: ['search'],
+          up: ['memory'],
+        },
+        status: 'error',
+      });
+
+      const readyResponse = await app.request('GET', '/ready').send();
+
+      expect(readyResponse.status).toBe(200);
+      expect(readyResponse.body).toEqual({ status: 'ready' });
+    } finally {
+      await app.close();
+    }
+  });
+
   it('applies execution timeouts through request-facing /health and /ready endpoints', async () => {
     const indicators: HealthIndicator[] = [
       {

--- a/packages/terminus/src/module.ts
+++ b/packages/terminus/src/module.ts
@@ -276,7 +276,7 @@ function createTerminusRuntimeModule(options: TerminusModuleOptions = {}): Modul
         provide: TERMINUS_READINESS_REGISTRAR,
         useFactory: (resolvedHealthService: unknown) => {
           const healthService = resolvedHealthService as {
-            isHealthy(): Promise<boolean>;
+            isReady(): Promise<boolean>;
           };
 
           return {
@@ -284,7 +284,7 @@ function createTerminusRuntimeModule(options: TerminusModuleOptions = {}): Modul
               healthModule.addReadinessCheck(async (ctx: RequestContext) => {
                 const platformShell = await ctx.container.resolve<PlatformShell>(PLATFORM_SHELL);
                 const [indicatorHealthy, readiness] = await Promise.all([
-                  healthService.isHealthy(),
+                  healthService.isReady(),
                   platformShell.ready(),
                 ]);
 

--- a/packages/terminus/src/types.ts
+++ b/packages/terminus/src/types.ts
@@ -18,6 +18,8 @@ export type HealthIndicatorResult = {
 export interface HealthIndicator {
   check(key: string): Promise<HealthIndicatorResult>;
   key?: string;
+  /** Whether this indicator participates in `/ready`. Defaults to `true`. */
+  readiness?: boolean;
 }
 
 /** Structured health report returned by Terminus aggregation helpers. */


### PR DESCRIPTION
## Summary

Allow health indicators to remain visible in `/health` diagnostics without blocking `/ready`.

Linked context: Closes #3287

## Changes

- add the optional `HealthIndicator.readiness` contract
- propagate the option through Disk, Drizzle, HTTP, Memory, Prisma, and Redis indicators
- preserve current behavior when the option is omitted or true
- keep opted-out failures in `/health` while excluding them from readiness blocking
- synchronize EN/KO README and book guidance

## Testing

- Terminus dependency closure build
- Terminus typecheck and reverse-dependent tests
- platform consistency and Changeset release governance
- docs locale parity
- request-facing `/health` and `/ready` readiness opt-out verification

`pnpm lint` remains red only for identical pre-existing `packages/config` `useLiteralKeys` diagnostics confirmed on clean `main`.

## Release impact

- [x] This PR has consumer-visible release impact and includes a Changeset.
- [ ] This PR has no consumer-visible release impact.

Changeset: `.changeset/differentiated-terminus-readiness.md` (`@fluojs/terminus`: minor)