### PR TITLE
docs(drizzle): align Korean status scope (#3148)

### DIFF
--- a/book/intermediate/ch20-drizzle.ko.md
+++ b/book/intermediate/ch20-drizzle.ko.md
@@ -185,7 +185,7 @@ export const orders = pgTable('orders', {
 
 ## 20.7 Observability and Health
 
-주입된 `DrizzleDatabase` 래퍼는 진단 surface와 같은 공개 상태 계약을 따르는 스냅샷 메서드를 제공합니다. 데이터베이스 풀이 끊기거나 지연이 커지는 상황을 애플리케이션 상태와 함께 확인할 수 있어 운영 판단이 빨라집니다.
+주입된 `DrizzleDatabase` 래퍼는 진단 surface와 같은 공개 상태 계약을 따르는 스냅샷 메서드를 제공합니다. 이 스냅샷은 lifecycle state, transaction capability, 활성 request transaction, 종료 중 drain 상태를 설명합니다.
 종료 중에는 활성 request transaction을 abort하고 drain한 뒤 설정된 dispose hook을 실행합니다. 중첩 request transaction은 활성 Drizzle transaction handle을 재사용하며, 수동 transaction 안에서 열렸다면 `activeRequestTransactions`는 해당 중첩 request callback이 실행 중인 동안만 반영되고 callback이 settle되는 즉시 감소합니다.
 열린 수동 `transaction(...)` boundary도 종료 중 tracking되므로, dispose hook은 underlying Drizzle transaction runner가 commit, rollback, cleanup을 마칠 때까지 기다립니다. `strictTransactions`가 `false`이고 `database.transaction(...)` runner가 없다면 fail-open 직접 실행 callback도 같은 방식으로 tracking되어 dispose 전에 settle되어야 합니다. 종료가 시작된 뒤에는 새 수동 또는 요청 스코프 transaction boundary가 거부됩니다.
 


### PR DESCRIPTION
## Summary
- narrow the Korean Drizzle status description to lifecycle and transaction state
- remove the unsupported connectivity and latency diagnostic claim

## Verification
- pnpm docs:sync-check
- pnpm vitest run tooling/governance/verify-platform-consistency-governance.test.ts
- pnpm lint
- pnpm verify:platform-consistency-governance

Closes #3148