### PR TITLE
fix(drizzle): honor transaction target precedence (#3149)

### DIFF
--- a/.changeset/fix-drizzle-transaction-target-precedence.md
+++ b/.changeset/fix-drizzle-transaction-target-precedence.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/drizzle": patch
+---
+
+Honor direct transaction target precedence over nested `.db` targets.

--- a/packages/drizzle/src/transaction-target-precedence.test.ts
+++ b/packages/drizzle/src/transaction-target-precedence.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { Transaction } from './transaction.js';
+
+describe('Transaction decorator target precedence', () => {
+  it('selects every direct target before nested .db targets regardless of property creation order', async () => {
+    const events: string[] = [];
+    const nestedDatabase = {
+      async transaction<T>(callback: () => Promise<T>): Promise<T> {
+        events.push('nested:transaction:start');
+        const result = await callback();
+        events.push('nested:transaction:end');
+        return result;
+      },
+    };
+    const directDatabase = {
+      async transaction<T>(callback: () => Promise<T>): Promise<T> {
+        events.push('direct:transaction:start');
+        const result = await callback();
+        events.push('direct:transaction:end');
+        return result;
+      },
+    };
+
+    class DirectAfterNestedService {
+      readonly repository = { db: nestedDatabase };
+      readonly directDb = directDatabase;
+
+      @Transaction()
+      async run() {
+        events.push('work');
+      }
+    }
+
+    // Given: a nested target constructed before a direct Drizzle target.
+    const service = new DirectAfterNestedService();
+
+    // When: the default transaction decorator resolves its host target.
+    await service.run();
+
+    // Then: the later direct target still wins over every nested .db target.
+    expect(events).toEqual([
+      'direct:transaction:start',
+      'work',
+      'direct:transaction:end',
+    ]);
+  });
+});

--- a/packages/drizzle/src/transaction.ts
+++ b/packages/drizzle/src/transaction.ts
@@ -31,7 +31,9 @@ function findNestedTransactionTarget<TTransactionOptions>(value: unknown): Trans
     if (isTransactionCapableDrizzle<TTransactionOptions>(propertyValue)) {
       return propertyValue;
     }
+  }
 
+  for (const propertyValue of Object.values(value)) {
     const nestedDatabase = (propertyValue as { db?: unknown } | null)?.db;
     if (isTransactionCapableDrizzle<TTransactionOptions>(nestedDatabase)) {
       return nestedDatabase;


### PR DESCRIPTION
## Summary
- scan all direct transaction-capable properties before nested .db values
- add a regression test for direct-over-nested precedence independent of creation order

## Verification
- pnpm --filter @fluojs/drizzle... build
- pnpm --filter @fluojs/drizzle typecheck
- pnpm --filter @fluojs/drizzle test
- pnpm --filter ...@fluojs/drizzle test
- pnpm lint
- pnpm verify:platform-consistency-governance
- built decorator manual QA

Closes #3149