### PR TITLE
fix(drizzle)!: guard Node engine support (#3150)

### DIFF
--- a/.changeset/align-drizzle-node-engine.md
+++ b/.changeset/align-drizzle-node-engine.md
@@ -1,0 +1,7 @@
+---
+"@fluojs/drizzle": major
+---
+
+**Breaking change:** `@fluojs/drizzle` supports Node.js `>=20.19.3 <21 || >=22.2.0 <27` to match its mandatory `@fluojs/runtime` dependency. Node 21 and Node 27+ are unsupported.
+
+Migration: Move Node 20 deployments to `>=20.19.3` or Node 22 deployments to `>=22.2.0` before updating. Run the application's driver-specific Drizzle query and migration tests after the runtime upgrade.

--- a/tooling/governance/runtime-matrix-docs-contract.test.ts
+++ b/tooling/governance/runtime-matrix-docs-contract.test.ts
@@ -218,6 +218,25 @@ describe('runtime matrix docs contract', () => {
     }
   });
 
+  it('keeps Drizzle runtime support aligned to its mandatory runtime dependency range', () => {
+    const runtimeNodeEngine = JSON.parse(read('packages/runtime/package.json')).engines.node;
+
+    expect(JSON.parse(read('packages/drizzle/package.json'))).toMatchObject({
+      engines: { node: runtimeNodeEngine },
+    });
+
+    for (const path of [
+      'packages/drizzle/README.md',
+      'packages/drizzle/README.ko.md',
+      'docs/reference/package-chooser.md',
+      'docs/reference/package-chooser.ko.md',
+      'docs/reference/package-surface.md',
+      'docs/reference/package-surface.ko.md',
+    ]) {
+      expect(read(path)).toContain(runtimeNodeEngine);
+    }
+  });
+
   it('keeps the openapi runtime boundary aligned to its mandatory runtime dependency range', () => {
     const nodeListenerEngine = '>=20.19.3 <21 || >=22.2.0 <27';
 

--- a/tooling/governance/runtime-matrix-docs-contract.test.ts
+++ b/tooling/governance/runtime-matrix-docs-contract.test.ts
@@ -5,6 +5,14 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const drizzleRuntimeDocumentationPaths = [
+  'packages/drizzle/README.md',
+  'packages/drizzle/README.ko.md',
+  'docs/reference/package-chooser.md',
+  'docs/reference/package-chooser.ko.md',
+  'docs/reference/package-surface.md',
+  'docs/reference/package-surface.ko.md',
+] as const;
 
 function read(relativePath: string) {
   return readFileSync(join(repoRoot, relativePath), 'utf8');
@@ -14,6 +22,14 @@ function expectAll(document: string, snippets: string[]) {
   for (const snippet of snippets) {
     expect(document).toContain(snippet);
   }
+}
+
+function expectDrizzleRuntimeClaim(document: string, runtimeNodeEngine: string) {
+  const drizzleLinesDeclaringTheRange = document
+    .split('\n')
+    .filter((line) => line.includes('@fluojs/drizzle') && line.includes(runtimeNodeEngine));
+
+  expect(drizzleLinesDeclaringTheRange).not.toHaveLength(0);
 }
 
 describe('runtime matrix docs contract', () => {
@@ -225,16 +241,26 @@ describe('runtime matrix docs contract', () => {
       engines: { node: runtimeNodeEngine },
     });
 
-    for (const path of [
-      'packages/drizzle/README.md',
-      'packages/drizzle/README.ko.md',
-      'docs/reference/package-chooser.md',
-      'docs/reference/package-chooser.ko.md',
-      'docs/reference/package-surface.md',
-      'docs/reference/package-surface.ko.md',
-    ]) {
-      expect(read(path)).toContain(runtimeNodeEngine);
+    for (const path of drizzleRuntimeDocumentationPaths) {
+      expectDrizzleRuntimeClaim(read(path), runtimeNodeEngine);
     }
+  });
+
+  it.each(drizzleRuntimeDocumentationPaths)('rejects a stale Drizzle runtime claim in %s', (path) => {
+    const runtimeNodeEngine = JSON.parse(read('packages/runtime/package.json')).engines.node;
+    const staleRuntimeNodeEngine = '>=0.0.0 <1';
+    const document = read(path);
+    const documentWithStaleDrizzleClaim = document
+      .split('\n')
+      .map((line) =>
+        line.includes('@fluojs/drizzle') && line.includes(runtimeNodeEngine)
+          ? line.replace(runtimeNodeEngine, staleRuntimeNodeEngine)
+          : line,
+      )
+      .join('\n');
+
+    expect(documentWithStaleDrizzleClaim).not.toBe(document);
+    expect(() => expectDrizzleRuntimeClaim(documentWithStaleDrizzleClaim, runtimeNodeEngine)).toThrow();
   });
 
   it('keeps the openapi runtime boundary aligned to its mandatory runtime dependency range', () => {


### PR DESCRIPTION
## Summary
- add a major changeset aligning @fluojs/drizzle Node support with mandatory @fluojs/runtime support
- lock exact manifest equality and every Drizzle-specific EN/KO documentation claim
- add per-document stale-claim mutation regressions

## Breaking change
@fluojs/drizzle supports Node.js >=20.19.3 <21 || >=22.2.0 <27. Upgrade Node 20 to >=20.19.3 or Node 22 to >=22.2.0 before updating, then run driver-specific query and migration tests.

## Verification
- pnpm vitest run tooling/governance/runtime-matrix-docs-contract.test.ts tooling/governance/verify-platform-consistency-governance.test.ts
- pnpm docs:sync-check
- pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main
- pnpm lint
- pnpm verify:platform-consistency-governance

Closes #3150