### PR TITLE
docs(drizzle): correct NestJS migration examples (#3151)

### DIFF
--- a/.changeset/correct-drizzle-nestjs-migration-docs.md
+++ b/.changeset/correct-drizzle-nestjs-migration-docs.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/drizzle': patch
+---
+
+Correct NestJS migration guidance for request cancellation and async factory provider visibility.

--- a/book/intermediate/ch20-drizzle.ko.md
+++ b/book/intermediate/ch20-drizzle.ko.md
@@ -53,6 +53,7 @@ import { Pool } from 'pg';
 @Module({
   imports: [
     ConfigModule.forRoot({
+      global: true,
       processEnv: {
         DATABASE_URL: process.env.DATABASE_URL,
       },
@@ -78,7 +79,7 @@ import { Pool } from 'pg';
 export class PersistenceModule {}
 ```
 
-`DrizzleModule.forRootAsync(...)`는 factory 의존성을 `inject`와 `useFactory`로만 해석하며 NestJS `imports`, `useClass`, `useExisting`, decorator metadata는 소비하지 않습니다. `ConfigModule.forRoot(...)` 등록은 기본적으로 `ConfigService`를 전역 export합니다. 애플리케이션이 module-local configuration provider를 쓴다면 해당 module이 token을 export하고 async Drizzle module을 등록하는 위치에서 import해야 합니다. Importing module에만 provider를 선언해도 async option provider에는 보이지 않습니다.
+`DrizzleModule.forRootAsync(...)`는 factory 의존성을 `inject`와 `useFactory`로만 해석하며 NestJS `imports`, `useClass`, `useExisting`, decorator metadata는 소비하지 않습니다. 생성되는 async module에는 `imports`가 없으므로 sibling module이 export하거나 parent module이 import한 token은 async option provider에 보이지 않습니다. 대신 factory 의존성을 global module로 등록하세요. `ConfigModule.forRoot(...)`는 기본적으로 `ConfigService`를 전역 export하며, 생성된 async Drizzle module이 이를 볼 수 있는 전역 export임을 명확히 하기 위해 이 예제에서는 `global: true`를 명시합니다. 다른 token은 importing module의 providers나 imports에 의존하지 말고, 해당 token을 소유하고 export하는 module을 bootstrap 전에 global로 만드세요.
 
 FluoShop production 주문 서비스에는 `strictTransactions: true`를 권장합니다. checkout에는 rollback 보장이 필요하기 때문입니다. 등록된 Drizzle handle이 `database.transaction(...)`을 노출하지 않고 `strictTransactions`를 기본값 `false`로 두면 fluo는 fail-open합니다. 즉 `transaction(...)`과 `requestTransaction(...)`이 callback을 root handle에서 직접 실행합니다. 이 동작은 local fake와 migration scaffold를 계속 사용할 수 있게 하지만 원자적이지 않으므로 실제 transaction으로 취급하면 안 됩니다. Fluo는 이 root handle을 fallback ALS context에도 바인딩하므로, 중첩 request helper는 실제 database transaction을 만들지 않으면서도 ambient abort signal과 소유 shutdown drain을 보존합니다.
 
@@ -167,9 +168,13 @@ await this.db.transaction(async () => {
 NestJS-style interceptor 대신 요청 전체 호환성에는 `requestTransaction(...)`을 사용하세요.
 
 ```typescript
+import { Inject } from '@fluojs/core';
+import { DrizzleDatabase } from '@fluojs/drizzle';
 import { Controller, Post, type RequestContext } from '@fluojs/http';
+import { CheckoutService } from './checkout.service';
 
 @Controller('/checkout')
+@Inject(DrizzleDatabase, CheckoutService)
 class CheckoutController {
   constructor(
     private readonly db: DrizzleDatabase<AppDatabase>,

--- a/book/intermediate/ch20-drizzle.ko.md
+++ b/book/intermediate/ch20-drizzle.ko.md
@@ -44,14 +44,19 @@ pnpm add -D drizzle-kit @types/pg
 `DrizzleModule`은 일반적으로 `ConfigService`를 사용해 비동기적으로 구성합니다. 이 방식은 커넥션 문자열과 풀 설정을 런타임 설정에 맞춰 주입하기 쉽습니다.
 
 ```typescript
+import { ConfigModule, ConfigService } from '@fluojs/config';
 import { Module } from '@fluojs/core';
 import { DrizzleModule } from '@fluojs/drizzle';
-import { ConfigService } from '@fluojs/config';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
 
 @Module({
   imports: [
+    ConfigModule.forRoot({
+      processEnv: {
+        DATABASE_URL: process.env.DATABASE_URL,
+      },
+    }),
     DrizzleModule.forRootAsync({
       inject: [ConfigService],
       useFactory: async (config: ConfigService) => {
@@ -72,6 +77,8 @@ import { Pool } from 'pg';
 })
 export class PersistenceModule {}
 ```
+
+`DrizzleModule.forRootAsync(...)`는 factory 의존성을 `inject`와 `useFactory`로만 해석하며 NestJS `imports`, `useClass`, `useExisting`, decorator metadata는 소비하지 않습니다. `ConfigModule.forRoot(...)` 등록은 기본적으로 `ConfigService`를 전역 export합니다. 애플리케이션이 module-local configuration provider를 쓴다면 해당 module이 token을 export하고 async Drizzle module을 등록하는 위치에서 import해야 합니다. Importing module에만 provider를 선언해도 async option provider에는 보이지 않습니다.
 
 FluoShop production 주문 서비스에는 `strictTransactions: true`를 권장합니다. checkout에는 rollback 보장이 필요하기 때문입니다. 등록된 Drizzle handle이 `database.transaction(...)`을 노출하지 않고 `strictTransactions`를 기본값 `false`로 두면 fluo는 fail-open합니다. 즉 `transaction(...)`과 `requestTransaction(...)`이 callback을 root handle에서 직접 실행합니다. 이 동작은 local fake와 migration scaffold를 계속 사용할 수 있게 하지만 원자적이지 않으므로 실제 transaction으로 취급하면 안 됩니다. Fluo는 이 root handle을 fallback ALS context에도 바인딩하므로, 중첩 request helper는 실제 database transaction을 만들지 않으면서도 ambient abort signal과 소유 shutdown drain을 보존합니다.
 
@@ -160,10 +167,23 @@ await this.db.transaction(async () => {
 NestJS-style interceptor 대신 요청 전체 호환성에는 `requestTransaction(...)`을 사용하세요.
 
 ```typescript
-return this.db.requestTransaction(
-  () => this.checkout.placeOrder(input),
-  request.signal,
-);
+import { Controller, Post, type RequestContext } from '@fluojs/http';
+
+@Controller('/checkout')
+class CheckoutController {
+  constructor(
+    private readonly db: DrizzleDatabase<AppDatabase>,
+    private readonly checkout: CheckoutService,
+  ) {}
+
+  @Post()
+  checkoutOrder(input: CheckoutInput, context: RequestContext) {
+    return this.db.requestTransaction(
+      () => this.checkout.placeOrder(input),
+      context.request.signal,
+    );
+  }
+}
 ```
 
 ## 20.6 FluoShop Context: Relational Schema

--- a/book/intermediate/ch20-drizzle.md
+++ b/book/intermediate/ch20-drizzle.md
@@ -53,6 +53,7 @@ import { Pool } from 'pg';
 @Module({
   imports: [
     ConfigModule.forRoot({
+      global: true,
       processEnv: {
         DATABASE_URL: process.env.DATABASE_URL,
       },
@@ -78,7 +79,7 @@ import { Pool } from 'pg';
 export class PersistenceModule {}
 ```
 
-`DrizzleModule.forRootAsync(...)` resolves factory dependencies only through `inject` and `useFactory`; it does not consume NestJS `imports`, `useClass`, `useExisting`, or decorator metadata. The `ConfigModule.forRoot(...)` registration exports `ConfigService` globally by default. If an application uses a module-local configuration provider instead, that module must export the token and be imported where the async Drizzle module is registered; declaring the provider only on the importing module does not make it visible to the async options provider.
+`DrizzleModule.forRootAsync(...)` resolves factory dependencies only through `inject` and `useFactory`; it does not consume NestJS `imports`, `useClass`, `useExisting`, or decorator metadata. Its generated async module has no `imports`, so a token exported only by a sibling module or by a parent module's import is not visible to the async options provider. Register factory dependencies through a global module instead. `ConfigModule.forRoot(...)` exports `ConfigService` globally by default; this example sets `global: true` explicitly because that global export makes it visible to the generated async Drizzle module. For another token, make the module that owns and exports it global before bootstrap rather than relying on the importing module's providers or imports.
 
 `strictTransactions: true` is recommended for FluoShop's production order service because checkout needs rollback guarantees. If the registered Drizzle handle does not expose `database.transaction(...)` and `strictTransactions` is left at its default `false`, fluo fails open: `transaction(...)` and `requestTransaction(...)` run the callback directly against the root handle. That keeps local fakes and migration scaffolds usable, but it is not atomic and should not be treated as a real transaction. Fluo still binds that root handle into the fallback ALS context, so nested request helpers preserve the ambient abort signal and the owning shutdown drain without creating a real database transaction.
 
@@ -167,9 +168,13 @@ await this.db.transaction(async () => {
 Use `requestTransaction(...)` for request-wide compatibility instead of a NestJS-style interceptor:
 
 ```typescript
+import { Inject } from '@fluojs/core';
+import { DrizzleDatabase } from '@fluojs/drizzle';
 import { Controller, Post, type RequestContext } from '@fluojs/http';
+import { CheckoutService } from './checkout.service';
 
 @Controller('/checkout')
+@Inject(DrizzleDatabase, CheckoutService)
 class CheckoutController {
   constructor(
     private readonly db: DrizzleDatabase<AppDatabase>,

--- a/book/intermediate/ch20-drizzle.md
+++ b/book/intermediate/ch20-drizzle.md
@@ -44,14 +44,19 @@ pnpm add -D drizzle-kit @types/pg
 `DrizzleModule` is usually configured asynchronously with `ConfigService`. This approach makes it easy to inject the connection string and pool settings from runtime configuration.
 
 ```typescript
+import { ConfigModule, ConfigService } from '@fluojs/config';
 import { Module } from '@fluojs/core';
 import { DrizzleModule } from '@fluojs/drizzle';
-import { ConfigService } from '@fluojs/config';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
 
 @Module({
   imports: [
+    ConfigModule.forRoot({
+      processEnv: {
+        DATABASE_URL: process.env.DATABASE_URL,
+      },
+    }),
     DrizzleModule.forRootAsync({
       inject: [ConfigService],
       useFactory: async (config: ConfigService) => {
@@ -72,6 +77,8 @@ import { Pool } from 'pg';
 })
 export class PersistenceModule {}
 ```
+
+`DrizzleModule.forRootAsync(...)` resolves factory dependencies only through `inject` and `useFactory`; it does not consume NestJS `imports`, `useClass`, `useExisting`, or decorator metadata. The `ConfigModule.forRoot(...)` registration exports `ConfigService` globally by default. If an application uses a module-local configuration provider instead, that module must export the token and be imported where the async Drizzle module is registered; declaring the provider only on the importing module does not make it visible to the async options provider.
 
 `strictTransactions: true` is recommended for FluoShop's production order service because checkout needs rollback guarantees. If the registered Drizzle handle does not expose `database.transaction(...)` and `strictTransactions` is left at its default `false`, fluo fails open: `transaction(...)` and `requestTransaction(...)` run the callback directly against the root handle. That keeps local fakes and migration scaffolds usable, but it is not atomic and should not be treated as a real transaction. Fluo still binds that root handle into the fallback ALS context, so nested request helpers preserve the ambient abort signal and the owning shutdown drain without creating a real database transaction.
 
@@ -160,10 +167,23 @@ await this.db.transaction(async () => {
 Use `requestTransaction(...)` for request-wide compatibility instead of a NestJS-style interceptor:
 
 ```typescript
-return this.db.requestTransaction(
-  () => this.checkout.placeOrder(input),
-  request.signal,
-);
+import { Controller, Post, type RequestContext } from '@fluojs/http';
+
+@Controller('/checkout')
+class CheckoutController {
+  constructor(
+    private readonly db: DrizzleDatabase<AppDatabase>,
+    private readonly checkout: CheckoutService,
+  ) {}
+
+  @Post()
+  checkoutOrder(input: CheckoutInput, context: RequestContext) {
+    return this.db.requestTransaction(
+      () => this.checkout.placeOrder(input),
+      context.request.signal,
+    );
+  }
+}
 ```
 
 ## 20.6 FluoShop Context: Relational Schema

--- a/packages/drizzle/README.ko.md
+++ b/packages/drizzle/README.ko.md
@@ -56,6 +56,7 @@ import { Pool } from 'pg';
 @Module({
   imports: [
     ConfigModule.forRoot({
+      global: true,
       processEnv: {
         DATABASE_URL: process.env.DATABASE_URL,
       },
@@ -80,7 +81,7 @@ import { Pool } from 'pg';
 export class AppModule {}
 ```
 
-`forRootAsync(...)`는 factory 의존성으로 `inject`와 `useFactory`만 받으며 NestJS `imports`, `useClass`, `useExisting`, decorator metadata를 탐색하지 않습니다. Async option provider가 resolve되기 전에 주입할 각 token을 등록하세요. 위의 `ConfigModule.forRoot(...)` 등록은 기본적으로 `ConfigService`를 전역 export합니다. Module-local configuration provider를 사용한다면 해당 token을 export하고 `DrizzleModule.forRootAsync(...)`를 등록하는 위치에서 그 module을 import해야 합니다. Importing application의 `providers`에만 provider를 추가해도 async Drizzle module에는 보이지 않습니다.
+`forRootAsync(...)`는 factory 의존성으로 `inject`와 `useFactory`만 받으며 NestJS `imports`, `useClass`, `useExisting`, decorator metadata를 탐색하지 않습니다. 생성되는 async module에는 `imports`가 없으므로 sibling module이 export하거나 parent module이 import한 token은 option provider에 보이지 않습니다. 대신 factory 의존성을 global module로 등록하세요. 위의 `ConfigModule.forRoot(...)` 등록은 기본적으로 `ConfigService`를 전역 export하며, 생성된 async Drizzle module이 `ConfigService`를 볼 수 있는 전역 export임을 명확히 하기 위해 `global: true`를 명시했습니다. 다른 token도 importing application의 `providers`나 imports에 의존하지 말고, 해당 token을 소유하고 export하는 module을 bootstrap 전에 global로 만드세요.
 
 ## 주요 패턴
 

--- a/packages/drizzle/README.ko.md
+++ b/packages/drizzle/README.ko.md
@@ -47,7 +47,7 @@ Drizzle ORM 자체는 Bun SQL이나 Cloudflare D1 같은 driver도 대상으로 
 ## 빠른 시작
 
 ```ts
-import { ConfigService } from '@fluojs/config';
+import { ConfigModule, ConfigService } from '@fluojs/config';
 import { Module } from '@fluojs/core';
 import { DrizzleModule } from '@fluojs/drizzle';
 import { drizzle } from 'drizzle-orm/node-postgres';
@@ -55,6 +55,11 @@ import { Pool } from 'pg';
 
 @Module({
   imports: [
+    ConfigModule.forRoot({
+      processEnv: {
+        DATABASE_URL: process.env.DATABASE_URL,
+      },
+    }),
     DrizzleModule.forRootAsync({
       inject: [ConfigService],
       useFactory: async (config: ConfigService) => {
@@ -74,6 +79,8 @@ import { Pool } from 'pg';
 })
 export class AppModule {}
 ```
+
+`forRootAsync(...)`는 factory 의존성으로 `inject`와 `useFactory`만 받으며 NestJS `imports`, `useClass`, `useExisting`, decorator metadata를 탐색하지 않습니다. Async option provider가 resolve되기 전에 주입할 각 token을 등록하세요. 위의 `ConfigModule.forRoot(...)` 등록은 기본적으로 `ConfigService`를 전역 export합니다. Module-local configuration provider를 사용한다면 해당 token을 export하고 `DrizzleModule.forRootAsync(...)`를 등록하는 위치에서 그 module을 import해야 합니다. Importing application의 `providers`에만 provider를 추가해도 async Drizzle module에는 보이지 않습니다.
 
 ## 주요 패턴
 
@@ -172,7 +179,7 @@ Transaction 안에서 생성된 async 작업은 소유 transaction이 commit, ro
 비즈니스 작업에는 서비스 레벨 `@Transaction()`을 우선 사용하세요. 전체 요청을 하나의 transaction으로 감싸던 NestJS controller/interceptor 패턴을 마이그레이션해야 한다면 controller, route adapter, request orchestration 경계에서 `requestTransaction(...)`을 명시적으로 호출하고 가능한 경우 request `AbortSignal`을 전달하세요.
 
 ```ts
-import { Controller, Post } from '@fluojs/http';
+import { Controller, Post, type RequestContext } from '@fluojs/http';
 import { DrizzleDatabase } from '@fluojs/drizzle';
 import { drizzle } from 'drizzle-orm/node-postgres';
 
@@ -186,10 +193,10 @@ export class CheckoutController {
   ) {}
 
   @Post()
-  create(input: CheckoutInput, requestSignal?: AbortSignal) {
+  create(input: CheckoutInput, context: RequestContext) {
     return this.db.requestTransaction(
       () => this.checkout.createOrder(input),
-      requestSignal,
+      context.request.signal,
     );
   }
 }

--- a/packages/drizzle/README.ko.md
+++ b/packages/drizzle/README.ko.md
@@ -180,13 +180,16 @@ Transaction 안에서 생성된 async 작업은 소유 transaction이 commit, ro
 비즈니스 작업에는 서비스 레벨 `@Transaction()`을 우선 사용하세요. 전체 요청을 하나의 transaction으로 감싸던 NestJS controller/interceptor 패턴을 마이그레이션해야 한다면 controller, route adapter, request orchestration 경계에서 `requestTransaction(...)`을 명시적으로 호출하고 가능한 경우 request `AbortSignal`을 전달하세요.
 
 ```ts
+import { Inject } from '@fluojs/core';
 import { Controller, Post, type RequestContext } from '@fluojs/http';
 import { DrizzleDatabase } from '@fluojs/drizzle';
 import { drizzle } from 'drizzle-orm/node-postgres';
+import { CheckoutService } from './checkout.service';
 
 type AppDatabase = ReturnType<typeof drizzle>;
 
 @Controller('/checkout')
+@Inject(DrizzleDatabase, CheckoutService)
 export class CheckoutController {
   constructor(
     private readonly db: DrizzleDatabase<AppDatabase>,

--- a/packages/drizzle/README.md
+++ b/packages/drizzle/README.md
@@ -180,13 +180,16 @@ Async work created inside a transaction can inherit its ALS context even when it
 Prefer service-level `@Transaction()` for business operations. If you are migrating a NestJS controller/interceptor pattern where an entire request must be transactional, call `requestTransaction(...)` explicitly at the controller, route adapter, or request orchestration boundary and pass the request `AbortSignal` when one is available:
 
 ```ts
+import { Inject } from '@fluojs/core';
 import { Controller, Post, type RequestContext } from '@fluojs/http';
 import { DrizzleDatabase } from '@fluojs/drizzle';
 import { drizzle } from 'drizzle-orm/node-postgres';
+import { CheckoutService } from './checkout.service';
 
 type AppDatabase = ReturnType<typeof drizzle>;
 
 @Controller('/checkout')
+@Inject(DrizzleDatabase, CheckoutService)
 export class CheckoutController {
   constructor(
     private readonly db: DrizzleDatabase<AppDatabase>,

--- a/packages/drizzle/README.md
+++ b/packages/drizzle/README.md
@@ -56,6 +56,7 @@ import { Pool } from 'pg';
 @Module({
   imports: [
     ConfigModule.forRoot({
+      global: true,
       processEnv: {
         DATABASE_URL: process.env.DATABASE_URL,
       },
@@ -80,7 +81,7 @@ import { Pool } from 'pg';
 export class AppModule {}
 ```
 
-`forRootAsync(...)` accepts only `inject` and `useFactory` for its factory dependencies; it does not discover NestJS `imports`, `useClass`, `useExisting`, or decorator metadata. Register each injected token before the async options provider resolves. The `ConfigModule.forRoot(...)` registration above exports `ConfigService` globally by default. For a module-local configuration provider, export its token and import that module where `DrizzleModule.forRootAsync(...)` is registered; adding the provider only to the importing application's `providers` does not make it visible to the async Drizzle module.
+`forRootAsync(...)` accepts only `inject` and `useFactory` for its factory dependencies; it does not discover NestJS `imports`, `useClass`, `useExisting`, or decorator metadata. Its generated async module has no `imports`, so a token exported only by a sibling module or by a parent module's import is not visible to the options provider. Register factory dependencies through a global module instead. The `ConfigModule.forRoot(...)` registration above exports `ConfigService` globally by default; `global: true` is shown explicitly because that global export makes `ConfigService` visible to the generated async Drizzle module. For another token, make the module that owns and exports it global before bootstrap rather than relying on the importing application's `providers` or imports.
 
 ## Common Patterns
 

--- a/packages/drizzle/README.md
+++ b/packages/drizzle/README.md
@@ -47,7 +47,7 @@ Non-Node runtimes should not import the root package. For Bun, Deno, Cloudflare 
 ## Quick Start
 
 ```ts
-import { ConfigService } from '@fluojs/config';
+import { ConfigModule, ConfigService } from '@fluojs/config';
 import { Module } from '@fluojs/core';
 import { DrizzleModule } from '@fluojs/drizzle';
 import { drizzle } from 'drizzle-orm/node-postgres';
@@ -55,6 +55,11 @@ import { Pool } from 'pg';
 
 @Module({
   imports: [
+    ConfigModule.forRoot({
+      processEnv: {
+        DATABASE_URL: process.env.DATABASE_URL,
+      },
+    }),
     DrizzleModule.forRootAsync({
       inject: [ConfigService],
       useFactory: async (config: ConfigService) => {
@@ -74,6 +79,8 @@ import { Pool } from 'pg';
 })
 export class AppModule {}
 ```
+
+`forRootAsync(...)` accepts only `inject` and `useFactory` for its factory dependencies; it does not discover NestJS `imports`, `useClass`, `useExisting`, or decorator metadata. Register each injected token before the async options provider resolves. The `ConfigModule.forRoot(...)` registration above exports `ConfigService` globally by default. For a module-local configuration provider, export its token and import that module where `DrizzleModule.forRootAsync(...)` is registered; adding the provider only to the importing application's `providers` does not make it visible to the async Drizzle module.
 
 ## Common Patterns
 
@@ -172,7 +179,7 @@ Async work created inside a transaction can inherit its ALS context even when it
 Prefer service-level `@Transaction()` for business operations. If you are migrating a NestJS controller/interceptor pattern where an entire request must be transactional, call `requestTransaction(...)` explicitly at the controller, route adapter, or request orchestration boundary and pass the request `AbortSignal` when one is available:
 
 ```ts
-import { Controller, Post } from '@fluojs/http';
+import { Controller, Post, type RequestContext } from '@fluojs/http';
 import { DrizzleDatabase } from '@fluojs/drizzle';
 import { drizzle } from 'drizzle-orm/node-postgres';
 
@@ -186,10 +193,10 @@ export class CheckoutController {
   ) {}
 
   @Post()
-  create(input: CheckoutInput, requestSignal?: AbortSignal) {
+  create(input: CheckoutInput, context: RequestContext) {
     return this.db.requestTransaction(
       () => this.checkout.createOrder(input),
-      requestSignal,
+      context.request.signal,
     );
   }
 }


### PR DESCRIPTION
## Summary
- use RequestContext.request.signal in request-wide Drizzle migration examples
- document the actual global provider visibility requirement for forRootAsync
- add executable @Inject metadata to EN/KO book and README controller examples

## Verification
- pnpm verify:docs
- pnpm --filter @fluojs/drizzle test
- pnpm vitest run tooling/governance/verify-platform-consistency-governance.test.ts
- pnpm lint
- pnpm verify:platform-consistency-governance
- minimal global ConfigModule + forRootAsync + controller injection bootstrap

Closes #3151