### PR TITLE
docs(email): align public TSDoc (#3164)

### DIFF
--- a/.changeset/align-email-public-tsdoc.md
+++ b/.changeset/align-email-public-tsdoc.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/email': patch
+---
+
+Correct EmailModule and EmailLifecycleError TSDoc to match existing provider visibility and lifecycle failure contracts.

--- a/packages/email/src/errors.ts
+++ b/packages/email/src/errors.ts
@@ -19,7 +19,7 @@ export class EmailMessageValidationError extends Error {
 }
 
 /**
- * Thrown when email delivery is requested after the service lifecycle has started shutting down.
+ * Thrown when email transport initialization or shutdown fails, or delivery is requested outside an active service lifecycle.
  */
 export class EmailLifecycleError extends Error {
   constructor(message: string, options?: ErrorOptions) {

--- a/packages/email/src/module.ts
+++ b/packages/email/src/module.ts
@@ -146,7 +146,7 @@ export class EmailModule {
    * Registers email providers using static options.
    *
    * @param options Static email module options including transport wiring and optional template rendering behavior.
-   * @returns A global module definition that exports {@link EmailService}, {@link EmailChannel}, and email facade tokens.
+   * @returns A module definition that exports {@link EmailService}, {@link EmailChannel}, and email facade tokens globally by default or only to explicit importers when `options.global` is `false`.
    *
    * @example
     * ```ts
@@ -167,7 +167,7 @@ export class EmailModule {
    * Registers email providers from an async DI factory.
    *
    * @param options Async module options that resolve email transport and renderer configuration through DI.
-   * @returns A global module definition that memoizes async option resolution per module instance.
+   * @returns A module definition that memoizes async option resolution per module instance and exports its providers globally by default or only to explicit importers when `options.global` is `false`.
    *
    * @example
     * ```ts


### PR DESCRIPTION
## Summary
- align `EmailModule` factory TSDoc with configurable provider visibility
- document every `EmailLifecycleError` lifecycle failure surface
- add a patch Changeset for `@fluojs/email`

## Verification
- `pnpm --filter '@fluojs/email...' build`
- `pnpm --filter '@fluojs/email' typecheck`
- `pnpm --filter '@fluojs/email' test`
- `pnpm --filter '...@fluojs/email' test`
- `pnpm lint`
- `pnpm verify:platform-consistency-governance`
- `node tooling/release/verify-changeset-release-lane.mjs --lane=stable --base-ref=origin/main`

Closes #3164