### PR TITLE
fix(email): preserve Nodemailer receipt addresses (#3166)

### DIFF
--- a/.changeset/issue-3166-nodemailer-receipts.md
+++ b/.changeset/issue-3166-nodemailer-receipts.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/email': patch
+---
+
+Preserve structured Nodemailer recipient identities in accepted, pending, and rejected delivery receipts.

--- a/packages/email/src/node/node.test.ts
+++ b/packages/email/src/node/node.test.ts
@@ -108,6 +108,27 @@ describe('@fluojs/email/node', () => {
     expect(close).toHaveBeenCalledTimes(1);
   });
 
+  it('preserves string and structured Nodemailer receipt recipient identities', async () => {
+    const sendMail = vi.fn().mockResolvedValue({
+      accepted: ['accepted-string@example.com', { address: 'accepted-structured@example.com', name: 'Accepted' }],
+      pending: ['pending-string@example.com', { address: 'pending-structured@example.com', name: 'Pending' }],
+      rejected: ['rejected-string@example.com', { address: 'rejected-structured@example.com', name: 'Rejected' }],
+    });
+    const transport = createNodemailerEmailTransport({
+      transporter: {
+        sendMail,
+      } as never,
+    });
+
+    const result = await transport.send(createMessage(), {});
+
+    expect(result).toMatchObject({
+      accepted: ['accepted-string@example.com', 'accepted-structured@example.com'],
+      pending: ['pending-string@example.com', 'pending-structured@example.com'],
+      rejected: ['rejected-string@example.com', 'rejected-structured@example.com'],
+    });
+  });
+
   it('creates and owns the Nodemailer transporter only through the node subpath factory helper', async () => {
     const sendMail = vi.fn().mockResolvedValue({
       accepted: ['user@example.com'],

--- a/packages/email/src/node/nodemailer.ts
+++ b/packages/email/src/node/nodemailer.ts
@@ -101,12 +101,8 @@ function createSendMailOptions(message: NormalizedEmailMessage): Mail.Options {
   };
 }
 
-function normalizeAddressList(value: unknown): string[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-
-  return value.map((entry) => String(entry));
+function normalizeAddressList(value: readonly (string | Mail.Address)[] | undefined): string[] {
+  return value?.map((entry) => (typeof entry === 'string' ? entry : entry.address)) ?? [];
 }
 
 /**


### PR DESCRIPTION
## Summary
- preserve structured Nodemailer receipt addresses instead of `[object Object]`
- normalize accepted, pending, and rejected entries consistently
- add deterministic regression coverage and a patch Changeset

## Verification
- `pnpm --filter '@fluojs/email...' build`
- `pnpm --filter '@fluojs/email' typecheck`
- `pnpm --filter '@fluojs/email' test` (60 passed)
- `pnpm --filter '...@fluojs/email' test` (60 passed)
- `pnpm lint`
- `pnpm verify:platform-consistency-governance`

Closes #3166