### PR TITLE
fix(email): serialize owned transport cleanup (#3163)

### DIFF
--- a/.changeset/serialize-email-transport-cleanup.md
+++ b/.changeset/serialize-email-transport-cleanup.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/email': patch
+---
+
+Serialize factory-owned email transport cleanup across bootstrap verification failure and application shutdown so each transport closes at most once.

--- a/packages/email/src/module.test.ts
+++ b/packages/email/src/module.test.ts
@@ -1325,6 +1325,55 @@ describe('EmailModule', () => {
     expect(transport.close).toHaveBeenCalledOnce();
   });
 
+  it('closes each factory-owned transport after a verification retry', async () => {
+    const failedTransport = new FailingLifecycleTransport('verify');
+    let retryCloseCalls = 0;
+    const retryTransport: EmailTransport = {
+      async close() {
+        retryCloseCalls += 1;
+      },
+      async send() {
+        return {
+          accepted: ['user@example.com'],
+          messageId: 'retry-cleanup-1',
+          pending: [],
+          rejected: [],
+        };
+      },
+      async verify() {
+        return undefined;
+      },
+    };
+    let createCalls = 0;
+    const container = new Container();
+    const moduleType = EmailModule.forRoot({
+      defaultFrom: 'noreply@example.com',
+      transport: {
+        async create() {
+          createCalls += 1;
+          return createCalls === 1 ? failedTransport : retryTransport;
+        },
+        ownsResources: true,
+      },
+      verifyOnModuleInit: true,
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(EmailService);
+
+    await expect(service.onModuleInit()).rejects.toMatchObject({
+      cause: expect.objectContaining({ message: 'provider verify failed' }),
+      message: 'Email transport failed to initialize.',
+    });
+    expect(failedTransport.closeCalls).toBe(1);
+
+    await service.onModuleInit();
+    expect(createCalls).toBe(2);
+
+    await service.onApplicationShutdown();
+    expect(retryCloseCalls).toBe(1);
+  });
+
   it('leaves caller-owned direct transport instances open during shutdown', async () => {
     const transport = new RecordingTransport('caller-owned-instance');
     const container = new Container();

--- a/packages/email/src/module.test.ts
+++ b/packages/email/src/module.test.ts
@@ -1273,6 +1273,58 @@ describe('EmailModule', () => {
     expect(closeTransport.closeCalls).toBe(1);
   });
 
+  it('closes a factory-owned transport once when verification failure overlaps shutdown', async () => {
+    let resolveClose!: () => void;
+    let signalCloseStarted!: () => void;
+    const closeCompletion = new Promise<void>((resolve) => {
+      resolveClose = resolve;
+    });
+    const closeStarted = new Promise<void>((resolve) => {
+      signalCloseStarted = resolve;
+    });
+    const transport: EmailTransport = {
+      close: vi.fn(async () => {
+        signalCloseStarted();
+        await closeCompletion;
+      }),
+      async send() {
+        return {
+          accepted: ['user@example.com'],
+          messageId: 'concurrent-cleanup-1',
+          pending: [],
+          rejected: [],
+        };
+      },
+      async verify() {
+        throw new Error('provider verify failed');
+      },
+    };
+    const container = new Container();
+    const moduleType = EmailModule.forRoot({
+      defaultFrom: 'noreply@example.com',
+      transport: {
+        create: async () => transport,
+        ownsResources: true,
+      },
+      verifyOnModuleInit: true,
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(EmailService);
+    const initialization = service.onModuleInit();
+
+    await closeStarted;
+    const shutdown = service.onApplicationShutdown();
+    resolveClose();
+
+    await expect(initialization).rejects.toMatchObject({
+      cause: expect.objectContaining({ message: 'provider verify failed' }),
+      message: 'Email transport failed to initialize.',
+    });
+    await expect(shutdown).resolves.toBeUndefined();
+    expect(transport.close).toHaveBeenCalledOnce();
+  });
+
   it('leaves caller-owned direct transport instances open during shutdown', async () => {
     const transport = new RecordingTransport('caller-owned-instance');
     const container = new Container();

--- a/packages/email/src/service.ts
+++ b/packages/email/src/service.ts
@@ -113,7 +113,7 @@ export class EmailService implements Email, OnModuleInit, OnApplicationShutdown 
   private lifecycleState: EmailServiceLifecycleState = 'created';
   private bootstrapPromise: Promise<void> | undefined;
   private shutdownPromise: Promise<void> | undefined;
-  private ownedTransportCleanupPromise: Promise<void> | undefined;
+  private readonly ownedTransportCleanupPromises = new WeakMap<EmailTransport, Promise<void>>();
   private readonly inFlightOperations = new Set<Promise<unknown>>();
   private resolvedTransport: EmailTransport | undefined;
   private transportPromise: Promise<EmailTransport> | undefined;
@@ -383,10 +383,17 @@ export class EmailService implements Email, OnModuleInit, OnApplicationShutdown 
       return Promise.resolve();
     }
 
-    const close = transport.close;
-    this.ownedTransportCleanupPromise ??= Promise.resolve().then(() => close.call(transport));
+    const existingCleanup = this.ownedTransportCleanupPromises.get(transport);
 
-    return this.ownedTransportCleanupPromise;
+    if (existingCleanup) {
+      return existingCleanup;
+    }
+
+    const close = transport.close;
+    const cleanup = Promise.resolve().then(() => close.call(transport));
+    this.ownedTransportCleanupPromises.set(transport, cleanup);
+
+    return cleanup;
   }
 
   private async handleTransportInitializationFailure(

--- a/packages/email/src/service.ts
+++ b/packages/email/src/service.ts
@@ -113,6 +113,7 @@ export class EmailService implements Email, OnModuleInit, OnApplicationShutdown 
   private lifecycleState: EmailServiceLifecycleState = 'created';
   private bootstrapPromise: Promise<void> | undefined;
   private shutdownPromise: Promise<void> | undefined;
+  private ownedTransportCleanupPromise: Promise<void> | undefined;
   private readonly inFlightOperations = new Set<Promise<unknown>>();
   private resolvedTransport: EmailTransport | undefined;
   private transportPromise: Promise<EmailTransport> | undefined;
@@ -138,8 +139,8 @@ export class EmailService implements Email, OnModuleInit, OnApplicationShutdown 
     try {
       await this.drainInFlightOperations();
 
-      if (transport && this.options.transport.ownsResources && transport.close) {
-        await transport.close();
+      if (transport) {
+        await this.closeOwnedTransport(transport);
       }
 
       this.lifecycleState = 'stopped';
@@ -377,6 +378,17 @@ export class EmailService implements Email, OnModuleInit, OnApplicationShutdown 
     this.transportPromise = undefined;
   }
 
+  private closeOwnedTransport(transport: EmailTransport): Promise<void> {
+    if (!this.options.transport.ownsResources || !transport.close) {
+      return Promise.resolve();
+    }
+
+    const close = transport.close;
+    this.ownedTransportCleanupPromise ??= Promise.resolve().then(() => close.call(transport));
+
+    return this.ownedTransportCleanupPromise;
+  }
+
   private async handleTransportInitializationFailure(
     error: unknown,
     options: { preserveShutdownState?: boolean } = {},
@@ -394,9 +406,9 @@ export class EmailService implements Email, OnModuleInit, OnApplicationShutdown 
     let cause: unknown = error;
     const transport = this.resolvedTransport;
 
-    if (transport && this.options.transport.ownsResources && transport.close) {
+    if (transport) {
       try {
-        await transport.close();
+        await this.closeOwnedTransport(transport);
       } catch (cleanupError) {
         cause = createCleanupFailureCause(error, cleanupError);
       }


### PR DESCRIPTION
## Summary
- serialize cleanup per factory-owned transport
- preserve retries after verification failure without leaking replacement transports
- add deterministic overlap and retry regression coverage

## Verification
- email dependency closure build
- email typecheck and 61 tests
- reverse-dependent tests
- `pnpm lint`
- `pnpm verify:platform-consistency-governance`
- built-package retry/cleanup manual QA

Closes #3163