### PR TITLE
feat(discord): configure webhook retry policy (#3146)

### DIFF
--- a/.changeset/configure-discord-webhook-retries.md
+++ b/.changeset/configure-discord-webhook-retries.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/discord': minor
+---
+
+Add validated `retry.attempts` and `retry.baseDelayMs` controls to the built-in Discord webhook transport while preserving the three-attempt, 250ms default policy.

--- a/book/intermediate/ch17-slack-discord.ko.md
+++ b/book/intermediate/ch17-slack-discord.ko.md
@@ -354,6 +354,21 @@ async alertOps(event: OrderPlacedEvent) {
 - **취소 인식 backoff**: Discord retry wait는 signal이 이미 abort된 경우 전체 delay를 기다리지 않고 즉시 reject합니다.
 - **명시적 에러**: 영구적인 실패(404, 403 등)는 `SlackTransportError` 또는 `DiscordTransportError`로 드러내 애플리케이션 레벨에서 처리하게 합니다.
 
+Discord workload는 1st-party webhook transport를 교체하지 않고도 bounded in-process 재시도 정책을 구성할 수 있습니다. `retry`를 생략하면 총 세 번 시도하고 250ms를 base delay로 사용하는 기본값을 유지합니다. `attempts`는 `1`부터 `10`까지의 정수이고, `baseDelayMs`는 `0`부터 `60000`까지의 정수입니다.
+
+```typescript
+const transport = createDiscordWebhookTransport({
+  fetch: runtime.fetch,
+  retry: {
+    attempts: 5,
+    baseDelayMs: 500,
+  },
+  webhookUrl: config.discordWebhookUrl,
+});
+```
+
+각 재시도 대기 시간은 `baseDelayMs`를 기준으로 두 배씩 증가하며, attempts 횟수에는 최초 요청이 포함됩니다. 이는 latency가 제한된 in-process 정책이며 durable delivery가 아닙니다. 프로세스 재시작 뒤에도 notification을 보존해야 하거나, durable scheduling이 필요하거나, request latency와 독립적으로 실행해야 한다면 queue-backed `@fluojs/notifications` delivery로 route하세요.
+
 ## 17.8 Status Snapshots
 
 채팅 연동은 웹훅 URL 만료, 권한 변경, 외부 서비스 장애로 중단될 수 있습니다. 상태 스냅샷을 운영 지표와 알림에 연결해 조기에 감지합니다. 이 정보를 주기적으로 확인하면 알림이 필요한 순간에야 채널 장애를 발견하는 상황을 줄일 수 있습니다.

--- a/book/intermediate/ch17-slack-discord.md
+++ b/book/intermediate/ch17-slack-discord.md
@@ -356,6 +356,21 @@ The built-in webhook transports are designed around failure patterns seen in pro
 - **Cancellation-aware backoff**: Discord retry waits reject immediately when their signal is already aborted instead of sleeping through the full delay.
 - **Explicit errors**: Permanent failures, such as 404 or 403, are surfaced as `SlackTransportError` or `DiscordTransportError` so the application level can handle them.
 
+Discord workloads can configure the first-party webhook transport's bounded in-process retry policy without replacing it. Omitting `retry` preserves three total attempts and a 250ms base delay; `attempts` accepts integers from `1` through `10`, while `baseDelayMs` accepts integers from `0` through `60000`.
+
+```typescript
+const transport = createDiscordWebhookTransport({
+  fetch: runtime.fetch,
+  retry: {
+    attempts: 5,
+    baseDelayMs: 500,
+  },
+  webhookUrl: config.discordWebhookUrl,
+});
+```
+
+Each retry wait doubles from `baseDelayMs`, and the attempt count includes the initial request. This is a latency-bounded, in-process policy, not durable delivery. Route notifications through queue-backed `@fluojs/notifications` delivery when they must survive a process restart, be scheduled durably, or run independently of request latency.
+
 ## 17.8 Status Snapshots
 
 Chat integrations can stop working because webhook URLs expire, permissions change, or external services fail. Connect status snapshots to operational metrics and alerts so you can detect issues early.

--- a/packages/discord/README.ko.md
+++ b/packages/discord/README.ko.md
@@ -18,6 +18,7 @@ fluo를 위한 webhook-first, transport-agnostic Discord 전달 코어 패키지
   - [`@fluojs/notifications`와의 통합](#fluojs-notifications와의-통합)
   - [payload override를 사용하는 template rendering](#payload-override를-사용하는-template-rendering)
   - [명시적 fetch 주입을 사용하는 webhook-first 전달](#명시적-fetch-주입을-사용하는-webhook-first-전달)
+  - [구성 가능한 webhook 재시도 정책](#구성-가능한-webhook-재시도-정책)
   - [의도적인 제한 사항](#의도적인-제한-사항)
 - [공개 API 개요](#공개-api-개요)
 - [관련 패키지](#관련-패키지)
@@ -244,9 +245,26 @@ await discord.send({
 
 bot 기반 REST 전달처럼 더 풍부한 API 연동이 필요하다면 export된 `DiscordTransport` 계약을 구현해 `DiscordModule.forRoot(...)` 또는 `forRootAsync(...)`에 주입하면 됩니다.
 
+### 구성 가능한 webhook 재시도 정책
+
+내장 webhook transport는 일시적인 `408`, `429`, `5xx` 응답과 transport-level exception을 재시도합니다. `retry`를 생략하면 총 세 번 시도하고 250ms를 base로 지수 backoff하는 기존 기본값을 유지합니다. workload의 latency 또는 허용 가능한 재시도 수준이 다르다면 transport 생성 시 하나의 정책을 구성하세요.
+
+```typescript
+const transport = createDiscordWebhookTransport({
+  fetch: runtime.fetch,
+  retry: {
+    attempts: 5,
+    baseDelayMs: 500,
+  },
+  webhookUrl: config.discordWebhookUrl,
+});
+```
+
+`attempts`에는 최초 요청이 포함되며 `1`부터 `10`까지의 정수여야 합니다. `baseDelayMs`는 `0`부터 `60000`까지의 정수여야 하고 이후 대기 시간은 이 값을 기준으로 두 배씩 증가합니다. 이 정책은 이 프로세스 안에서 한 번 보내는 bounded webhook 재시도에만 적용됩니다. 프로세스 재시작 뒤에도 notification을 보존해야 하거나, durable scheduling이 필요하거나, request latency와 독립적으로 delivery를 관리해야 한다면 webhook attempts를 늘리는 대신 queue-backed delivery를 사용하는 `@fluojs/notifications`를 사용하세요.
+
 Behavioral contract 메모:
 
-- 내장 webhook transport는 `408`, `429`, `5xx` 같은 일시적 응답뿐 아니라 transport-level exception도 bounded exponential backoff로 재시도한 뒤 호출자에게 에러를 노출합니다. 영구적인 upstream 응답은 재시도하지 않습니다.
+- 내장 webhook transport는 `408`, `429`, `5xx` 같은 일시적 응답뿐 아니라 transport-level exception도 구성한 bounded exponential backoff로 재시도한 뒤 호출자에게 에러를 노출합니다. 영구적인 upstream 응답은 재시도하지 않습니다.
 - Retry backoff는 `DiscordSendOptions.signal`을 관찰합니다. 이미 abort된 signal은 다음 backoff timer를 기다리지 않고 즉시 reject됩니다.
 - 성공한 webhook 응답은 `DiscordSendResult.response`로 노출됩니다. rate-limit 재시도가 끝내 실패한 경우를 포함해, 호출자에게 보이는 `DiscordTransportError` 메시지는 기본적으로 raw upstream response body를 포함하지 않습니다.
 - 잘못되었거나 절대 URL이 아닌 `webhookUrl` 값은 전달 실패로 재시도하지 않고 즉시 `DiscordConfigurationError`로 거부됩니다.
@@ -288,6 +306,7 @@ Discord 패키지는 의도적으로 다음을 **포함하지 않습니다**:
 
 - `DiscordMessage`
 - `NormalizedDiscordMessage`
+- `DiscordWebhookRetryOptions`
 - `DiscordWebhookTransportOptions`
 - `DiscordFetchLike`
 - `DiscordFetchResponse`

--- a/packages/discord/README.md
+++ b/packages/discord/README.md
@@ -18,6 +18,7 @@ Migration boundary: the module API is intentionally Nest-like but not a NestJS d
   - [Integration with `@fluojs/notifications`](#integration-with-fluojs-notifications)
   - [Template rendering with payload overrides](#template-rendering-with-payload-overrides)
   - [Webhook-first delivery with explicit fetch injection](#webhook-first-delivery-with-explicit-fetch-injection)
+  - [Configurable webhook retry policy](#configurable-webhook-retry-policy)
   - [Intentional limitations](#intentional-limitations)
 - [Public API Overview](#public-api-overview)
 - [Related Packages](#related-packages)
@@ -244,9 +245,26 @@ await discord.send({
 
 For richer API integrations such as bot-backed REST delivery, implement the exported `DiscordTransport` contract and inject it through `DiscordModule.forRoot(...)` or `forRootAsync(...)`.
 
+### Configurable webhook retry policy
+
+The built-in webhook transport retries transient `408`, `429`, and `5xx` responses and transport-level exceptions. Omit `retry` to preserve the default of three total attempts with a 250ms exponential-backoff base delay. Configure one workload-specific policy at transport construction when its latency or tolerance differs:
+
+```typescript
+const transport = createDiscordWebhookTransport({
+  fetch: runtime.fetch,
+  retry: {
+    attempts: 5,
+    baseDelayMs: 500,
+  },
+  webhookUrl: config.discordWebhookUrl,
+});
+```
+
+`attempts` includes the initial request and must be an integer from `1` through `10`. `baseDelayMs` must be an integer from `0` through `60000`; later waits double from that base. The retry policy applies only to this bounded in-process webhook send. When a notification must survive process restarts, require durable scheduling, or need delivery managed independently of request latency, use `@fluojs/notifications` with queue-backed delivery instead of increasing webhook attempts.
+
 Behavioral contract notes:
 
-- The built-in webhook transport retries transient `408`, `429`, and `5xx` responses, and also retries transport-level exceptions, using bounded exponential backoff before surfacing an error. Permanent upstream responses are not retried.
+- The built-in webhook transport retries transient `408`, `429`, and `5xx` responses, and also retries transport-level exceptions, using the configured bounded exponential backoff before surfacing an error. Permanent upstream responses are not retried.
 - Retry backoff observes `DiscordSendOptions.signal`; an already-aborted signal rejects immediately instead of waiting for the next backoff timer.
 - Successful webhook responses are exposed through `DiscordSendResult.response`; caller-visible `DiscordTransportError` messages still omit raw upstream response bodies by default, including after rate-limit retries fail.
 - Malformed or non-absolute `webhookUrl` values are rejected immediately as `DiscordConfigurationError` instead of being retried as delivery failures.
@@ -288,6 +306,7 @@ The package intentionally keeps `createDiscordProviders(...)`, `DISCORD_OPTIONS`
 
 - `DiscordMessage`
 - `NormalizedDiscordMessage`
+- `DiscordWebhookRetryOptions`
 - `DiscordWebhookTransportOptions`
 - `DiscordFetchLike`
 - `DiscordFetchResponse`

--- a/packages/discord/src/index.ts
+++ b/packages/discord/src/index.ts
@@ -35,6 +35,7 @@ export type {
   DiscordTransportContext,
   DiscordTransportFactory,
   DiscordTransportReceipt,
+  DiscordWebhookRetryOptions,
   DiscordWebhookTransportOptions,
   NormalizedDiscordMessage,
 } from './types.js';

--- a/packages/discord/src/public-surface.test.ts
+++ b/packages/discord/src/public-surface.test.ts
@@ -9,6 +9,7 @@ import type {
   DiscordTemplateRenderer,
   DiscordTransport,
   DiscordTransportFactory,
+  DiscordWebhookRetryOptions,
   DiscordWebhookTransportOptions,
 } from './index.js';
 import * as discordPublicApi from './index.js';
@@ -39,6 +40,9 @@ describe('@fluojs/discord public API surface', () => {
     expectTypeOf<DiscordTransportFactory>().toHaveProperty('create');
     expectTypeOf<DiscordNotificationDispatchRequest>().toHaveProperty('channel');
     expectTypeOf<DiscordWebhookTransportOptions>().toHaveProperty('webhookUrl');
+    expectTypeOf<DiscordWebhookTransportOptions>().toHaveProperty('retry');
+    expectTypeOf<DiscordWebhookRetryOptions>().toHaveProperty('attempts');
+    expectTypeOf<DiscordWebhookRetryOptions>().toHaveProperty('baseDelayMs');
     expectTypeOf<DiscordFetchLike>().toBeFunction();
     expectTypeOf<DiscordTemplateRenderer>().toHaveProperty('render');
     expectTypeOf<DiscordStatusAdapterInput>().toHaveProperty('channelName');

--- a/packages/discord/src/types.ts
+++ b/packages/discord/src/types.ts
@@ -139,9 +139,19 @@ export type DiscordFetchLike = (input: string, init?: {
   signal?: AbortSignal;
 }) => MaybePromise<DiscordFetchResponse>;
 
+/** Bounded retry policy accepted by {@link createDiscordWebhookTransport}. */
+export interface DiscordWebhookRetryOptions {
+  /** Total delivery attempts, including the initial request. Defaults to `3` and accepts values from `1` through `10`. */
+  attempts?: number;
+
+  /** Initial exponential-backoff delay in milliseconds. Defaults to `250` and accepts values from `0` through `60000`. */
+  baseDelayMs?: number;
+}
+
 /** Options accepted by {@link createDiscordWebhookTransport}. */
 export interface DiscordWebhookTransportOptions {
   fetch?: DiscordFetchLike;
+  retry?: DiscordWebhookRetryOptions;
   wait?: boolean;
   webhookUrl: string;
 }

--- a/packages/discord/src/webhook-cancellation.test.ts
+++ b/packages/discord/src/webhook-cancellation.test.ts
@@ -4,6 +4,44 @@ import type { DiscordFetchLike } from './types.js';
 import { createDiscordWebhookTransport } from './webhook.js';
 
 describe('Discord webhook retry cancellation', () => {
+  it('does not make a zero-delay retry request after cancellation when fetch ignores the signal', async () => {
+    const controller = new AbortController();
+    const reason = new DOMException('zero-delay retry cancelled', 'AbortError');
+    const fetchLike = vi
+      .fn<DiscordFetchLike>()
+      .mockImplementationOnce(async () => {
+        controller.abort(reason);
+
+        return {
+          ok: false,
+          status: 429,
+          async text() {
+            return 'rate limited';
+          },
+        };
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        async text() {
+          return JSON.stringify({ id: 'should-not-send' });
+        },
+      });
+    const transport = createDiscordWebhookTransport({
+      fetch: fetchLike,
+      retry: { baseDelayMs: 0 },
+      webhookUrl: 'https://discord.com/api/webhooks/123/abc',
+    });
+
+    await expect(
+      transport.send(
+        { attachments: [], components: [], content: 'Zero-delay retry abort path', embeds: [] },
+        { signal: controller.signal },
+      ),
+    ).rejects.toBe(reason);
+    expect(fetchLike).toHaveBeenCalledOnce();
+  });
+
   it('does not start retry backoff when the signal is already aborted', async () => {
     vi.useFakeTimers();
 

--- a/packages/discord/src/webhook-retry.test.ts
+++ b/packages/discord/src/webhook-retry.test.ts
@@ -157,6 +157,134 @@ describe('Discord webhook retries', () => {
     }
   });
 
+  it('accepts the minimum retry attempt and delay boundaries', async () => {
+    const fetchLike = vi.fn<DiscordFetchLike>().mockResolvedValue({
+      ok: false,
+      status: 503,
+      statusText: 'Service Unavailable',
+      async text() {
+        return 'temporary provider response';
+      },
+    });
+    const transport = createDiscordWebhookTransport({
+      fetch: fetchLike,
+      retry: {
+        attempts: 1,
+        baseDelayMs: 0,
+      },
+      webhookUrl: 'https://discord.com/api/webhooks/123/abc',
+    });
+
+    await expect(
+      transport.send(
+        { attachments: [], components: [], content: 'Minimum retry boundaries', embeds: [] },
+        {},
+      ),
+    ).rejects.toThrowError(
+      new DiscordTransportError(
+        'Discord webhook delivery failed with status 503 Service Unavailable after 1 attempt(s). Upstream response body was omitted from the caller-visible error.',
+      ),
+    );
+    expect(fetchLike).toHaveBeenCalledOnce();
+  });
+
+  it('accepts the maximum retry attempt boundary', async () => {
+    let requestCount = 0;
+    const fetchLike = vi.fn<DiscordFetchLike>().mockImplementation(async () => {
+      requestCount += 1;
+
+      if (requestCount < 10) {
+        return {
+          ok: false,
+          status: 503,
+          statusText: 'Service Unavailable',
+          async text() {
+            return 'temporary provider response';
+          },
+        };
+      }
+
+      return {
+        ok: true,
+        status: 200,
+        async text() {
+          return JSON.stringify({ id: 'max-attempt-boundary' });
+        },
+      };
+    });
+    const transport = createDiscordWebhookTransport({
+      fetch: fetchLike,
+      retry: {
+        attempts: 10,
+        baseDelayMs: 0,
+      },
+      webhookUrl: 'https://discord.com/api/webhooks/123/abc',
+    });
+
+    await expect(
+      transport.send(
+        { attachments: [], components: [], content: 'Maximum retry attempt boundary', embeds: [] },
+        {},
+      ),
+    ).resolves.toMatchObject({
+      messageId: 'max-attempt-boundary',
+      ok: true,
+      statusCode: 200,
+    });
+    expect(fetchLike).toHaveBeenCalledTimes(10);
+  });
+
+  it('accepts the maximum retry delay boundary', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const fetchLike = vi
+        .fn<DiscordFetchLike>()
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 503,
+          async text() {
+            return 'temporary provider response';
+          },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          async text() {
+            return JSON.stringify({ id: 'max-delay-boundary' });
+          },
+        });
+      const transport = createDiscordWebhookTransport({
+        fetch: fetchLike,
+        retry: {
+          attempts: 2,
+          baseDelayMs: 60_000,
+        },
+        webhookUrl: 'https://discord.com/api/webhooks/123/abc',
+      });
+
+      const pending = transport.send(
+        { attachments: [], components: [], content: 'Maximum retry delay boundary', embeds: [] },
+        {},
+      );
+      await vi.advanceTimersByTimeAsync(59_999);
+
+      expect(fetchLike).toHaveBeenCalledOnce();
+
+      const expectation = expect(pending).resolves.toMatchObject({
+        messageId: 'max-delay-boundary',
+        ok: true,
+        statusCode: 200,
+      });
+      await vi.advanceTimersByTimeAsync(1);
+
+      await expectation;
+      expect(fetchLike).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it.each([
     {
       retry: { attempts: 0 },
@@ -167,11 +295,19 @@ describe('Discord webhook retries', () => {
       message: 'Discord webhook transport `retry.attempts` must be an integer between 1 and 10.',
     },
     {
+      retry: { attempts: 1.5 },
+      message: 'Discord webhook transport `retry.attempts` must be an integer between 1 and 10.',
+    },
+    {
       retry: { baseDelayMs: -1 },
       message: 'Discord webhook transport `retry.baseDelayMs` must be an integer between 0 and 60000.',
     },
     {
       retry: { baseDelayMs: 60_001 },
+      message: 'Discord webhook transport `retry.baseDelayMs` must be an integer between 0 and 60000.',
+    },
+    {
+      retry: { baseDelayMs: 0.5 },
       message: 'Discord webhook transport `retry.baseDelayMs` must be an integer between 0 and 60000.',
     },
   ])('rejects an out-of-bounds retry configuration', ({ retry, message }) => {

--- a/packages/discord/src/webhook-retry.test.ts
+++ b/packages/discord/src/webhook-retry.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { DiscordTransportError } from './errors.js';
+import { DiscordConfigurationError, DiscordTransportError } from './errors.js';
 import type { DiscordFetchLike } from './types.js';
 import { createDiscordWebhookTransport } from './webhook.js';
 
@@ -62,6 +62,166 @@ describe('Discord webhook retries', () => {
         statusCode: 200,
       });
       expect(fetchLike).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('preserves the default three-attempt policy with a 250ms initial backoff', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const fetchLike = vi
+        .fn<DiscordFetchLike>()
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 429,
+          async text() {
+            return 'rate limited';
+          },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          async text() {
+            return JSON.stringify({ id: 'msg-default-backoff' });
+          },
+        });
+      const transport = createDiscordWebhookTransport({
+        fetch: fetchLike,
+        webhookUrl: 'https://discord.com/api/webhooks/123/abc',
+      });
+
+      const pending = transport.send(
+        { attachments: [], components: [], content: 'Default retry policy', embeds: [] },
+        {},
+      );
+      await vi.advanceTimersByTimeAsync(249);
+
+      expect(fetchLike).toHaveBeenCalledOnce();
+
+      const expectation = expect(pending).resolves.toMatchObject({
+        messageId: 'msg-default-backoff',
+        ok: true,
+        statusCode: 200,
+      });
+      await vi.advanceTimersByTimeAsync(1);
+
+      await expectation;
+      expect(fetchLike).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('uses the configured attempt budget and initial backoff delay', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const fetchLike = vi.fn<DiscordFetchLike>().mockResolvedValue({
+        ok: false,
+        status: 503,
+        statusText: 'Service Unavailable',
+        async text() {
+          return 'temporary provider response';
+        },
+      });
+      const transport = createDiscordWebhookTransport({
+        fetch: fetchLike,
+        retry: {
+          attempts: 2,
+          baseDelayMs: 75,
+        },
+        webhookUrl: 'https://discord.com/api/webhooks/123/abc',
+      });
+
+      const pending = transport.send(
+        { attachments: [], components: [], content: 'Configured retry policy', embeds: [] },
+        {},
+      );
+      const expectation = expect(pending).rejects.toThrowError(
+        new DiscordTransportError(
+          'Discord webhook delivery failed with status 503 Service Unavailable after 2 attempt(s). Upstream response body was omitted from the caller-visible error.',
+        ),
+      );
+      await vi.advanceTimersByTimeAsync(74);
+
+      expect(fetchLike).toHaveBeenCalledOnce();
+
+      await vi.advanceTimersByTimeAsync(1);
+
+      await expectation;
+      expect(fetchLike).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it.each([
+    {
+      retry: { attempts: 0 },
+      message: 'Discord webhook transport `retry.attempts` must be an integer between 1 and 10.',
+    },
+    {
+      retry: { attempts: 11 },
+      message: 'Discord webhook transport `retry.attempts` must be an integer between 1 and 10.',
+    },
+    {
+      retry: { baseDelayMs: -1 },
+      message: 'Discord webhook transport `retry.baseDelayMs` must be an integer between 0 and 60000.',
+    },
+    {
+      retry: { baseDelayMs: 60_001 },
+      message: 'Discord webhook transport `retry.baseDelayMs` must be an integer between 0 and 60000.',
+    },
+  ])('rejects an out-of-bounds retry configuration', ({ retry, message }) => {
+    expect(() =>
+      createDiscordWebhookTransport({
+        fetch: vi.fn<DiscordFetchLike>(),
+        retry,
+        webhookUrl: 'https://discord.com/api/webhooks/123/abc',
+      }),
+    ).toThrowError(new DiscordConfigurationError(message));
+  });
+
+  it.each([408, 429, 502])('retries transient HTTP %s responses before succeeding', async (status) => {
+    vi.useFakeTimers();
+
+    try {
+      const fetchLike = vi
+        .fn<DiscordFetchLike>()
+        .mockResolvedValueOnce({
+          ok: false,
+          status,
+          async text() {
+            return 'temporary provider response';
+          },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          async text() {
+            return JSON.stringify({ id: `msg-${String(status)}` });
+          },
+        });
+      const transport = createDiscordWebhookTransport({
+        fetch: fetchLike,
+        webhookUrl: 'https://discord.com/api/webhooks/123/abc',
+      });
+
+      const pending = transport.send(
+        { attachments: [], components: [], content: `Retry HTTP ${String(status)}`, embeds: [] },
+        {},
+      );
+      const expectation = expect(pending).resolves.toMatchObject({
+        messageId: `msg-${String(status)}`,
+        ok: true,
+        statusCode: 200,
+      });
+      await vi.runAllTimersAsync();
+
+      await expectation;
+      expect(fetchLike).toHaveBeenCalledTimes(2);
     } finally {
       vi.useRealTimers();
     }

--- a/packages/discord/src/webhook.ts
+++ b/packages/discord/src/webhook.ts
@@ -124,12 +124,12 @@ function resolveRetryPolicy(retry: DiscordWebhookTransportOptions['retry']): {
 }
 
 async function waitForRetry(delayMs: number, signal: AbortSignal | undefined): Promise<void> {
-  if (delayMs <= 0) {
-    return;
-  }
-
   if (signal?.aborted) {
     throw signal.reason ?? new DOMException('The operation was aborted.', 'AbortError');
+  }
+
+  if (delayMs <= 0) {
+    return;
   }
 
   await new Promise<void>((resolve, reject) => {

--- a/packages/discord/src/webhook.ts
+++ b/packages/discord/src/webhook.ts
@@ -10,6 +10,8 @@ import type {
 
 const DEFAULT_RETRY_ATTEMPTS = 3;
 const DEFAULT_RETRY_DELAY_MS = 250;
+const MAX_RETRY_ATTEMPTS = 10;
+const MAX_RETRY_DELAY_MS = 60_000;
 
 function normalizeOptionalString(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
@@ -98,6 +100,29 @@ function isTransientStatus(status: number): boolean {
   return status === 408 || status === 429 || (status >= 500 && status <= 599);
 }
 
+function resolveRetryPolicy(retry: DiscordWebhookTransportOptions['retry']): {
+  attempts: number;
+  baseDelayMs: number;
+} {
+  const attempts = retry?.attempts ?? DEFAULT_RETRY_ATTEMPTS;
+
+  if (!Number.isInteger(attempts) || attempts < 1 || attempts > MAX_RETRY_ATTEMPTS) {
+    throw new DiscordConfigurationError(
+      `Discord webhook transport \`retry.attempts\` must be an integer between 1 and ${String(MAX_RETRY_ATTEMPTS)}.`,
+    );
+  }
+
+  const baseDelayMs = retry?.baseDelayMs ?? DEFAULT_RETRY_DELAY_MS;
+
+  if (!Number.isInteger(baseDelayMs) || baseDelayMs < 0 || baseDelayMs > MAX_RETRY_DELAY_MS) {
+    throw new DiscordConfigurationError(
+      `Discord webhook transport \`retry.baseDelayMs\` must be an integer between 0 and ${String(MAX_RETRY_DELAY_MS)}.`,
+    );
+  }
+
+  return { attempts, baseDelayMs };
+}
+
 async function waitForRetry(delayMs: number, signal: AbortSignal | undefined): Promise<void> {
   if (delayMs <= 0) {
     return;
@@ -164,11 +189,12 @@ export function createDiscordWebhookTransport(options: DiscordWebhookTransportOp
 
   const parsedWebhookUrl = parseWebhookUrl(webhookUrl);
   const fetchLike = resolveFetch(options.fetch);
+  const retry = resolveRetryPolicy(options.retry);
   const wait = options.wait ?? true;
 
   return {
     async send(message: NormalizedDiscordMessage, context: DiscordTransportContext) {
-      for (let attempt = 1; attempt <= DEFAULT_RETRY_ATTEMPTS; attempt += 1) {
+      for (let attempt = 1; attempt <= retry.attempts; attempt += 1) {
         let response: DiscordFetchResponse;
 
         try {
@@ -185,8 +211,8 @@ export function createDiscordWebhookTransport(options: DiscordWebhookTransportOp
             throw error;
           }
 
-          if (attempt < DEFAULT_RETRY_ATTEMPTS) {
-            await waitForRetry(DEFAULT_RETRY_DELAY_MS * 2 ** (attempt - 1), context.signal);
+          if (attempt < retry.attempts) {
+            await waitForRetry(retry.baseDelayMs * 2 ** (attempt - 1), context.signal);
             continue;
           }
 
@@ -196,8 +222,8 @@ export function createDiscordWebhookTransport(options: DiscordWebhookTransportOp
         const body = await readResponseBody(response);
 
         if (!response.ok) {
-          if (attempt < DEFAULT_RETRY_ATTEMPTS && isTransientStatus(response.status)) {
-            await waitForRetry(DEFAULT_RETRY_DELAY_MS * 2 ** (attempt - 1), context.signal);
+          if (attempt < retry.attempts && isTransientStatus(response.status)) {
+            await waitForRetry(retry.baseDelayMs * 2 ** (attempt - 1), context.signal);
             continue;
           }
 
@@ -223,7 +249,7 @@ export function createDiscordWebhookTransport(options: DiscordWebhookTransportOp
         };
       }
 
-      throw new DiscordTransportError(createTransportFailureMessage(DEFAULT_RETRY_ATTEMPTS));
+      throw new DiscordTransportError(createTransportFailureMessage(retry.attempts));
     },
   };
 }


### PR DESCRIPTION
## Summary
- expose configurable webhook retry attempts and exponential base delay
- preserve existing defaults and cancellation semantics, including zero-delay retries
- document EN/KO behavior and add a minor Changeset

## Verification
- discord dependency closure build
- discord typecheck and 67 tests
- reverse-dependent tests
- lint, platform governance, docs parity/build, release-lane check
- built-package happy/cancel/bad-input QA

Closes #3146