### PR TITLE
feat(queue): preserve notification deduplication keys (#3167)

### DIFF
--- a/.changeset/add-queue-enqueue-job-id.md
+++ b/.changeset/add-queue-enqueue-job-id.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/queue": minor
+---
+
+Add an optional caller-owned `deduplicationKey` to `enqueue(...)`, mapped to a BullMQ-safe job id so repeated producer attempts can use idempotency without inheriting BullMQ custom-id restrictions.

--- a/.changeset/preserve-email-notification-queue-id.md
+++ b/.changeset/preserve-email-notification-queue-id.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/email": patch
+---
+
+Preserve deterministic notification queue identities through the built-in email queue adapter and Queue's BullMQ-safe deduplication mapping.

--- a/book/intermediate/ch16-email.ko.md
+++ b/book/intermediate/ch16-email.ko.md
@@ -226,6 +226,8 @@ export class AppModule {}
 
 큐 어댑터는 대량 알림을 개별 백그라운드 작업으로 나누고, 내장 `EmailNotificationsQueueWorker`는 `DEFAULT_EMAIL_QUEUE_WORKER_OPTIONS`로 export되는 고정 기본값으로 이를 소비합니다. 기본값은 3회 시도, 1초부터 시작하는 exponential backoff, concurrency 5, 초당 50건 rate limiter, `fluo.email.notification` job name입니다. 큐에 쌓인 이메일 작업이 실제로 소비되도록 같은 애플리케이션 모듈의 provider에 `EmailNotificationsQueueWorker`를 등록해야 합니다. 내장 worker 대신 커스텀 queue adapter 또는 worker를 사용한다면 동일한 retry, backoff, concurrency, rate-limit, job-name 계약이 필요할 때 이 기본값을 명시적으로 미러링하세요.
 
+내장 adapter는 결정적인 notification queue identity를 Queue의 `deduplicationKey`로 전달합니다. Queue가 이를 BullMQ에 유효한 job id로 매핑하므로, 같은 notification dispatch를 반복해도 두 번째 email job을 만들지 않고 해당 backing queue identity를 재사용합니다.
+
 ## 16.7 Template Rendering
 
 `@fluojs/email`은 교체 가능한 템플릿 렌더러를 지원합니다. 핵심 패키지를 특정 엔진에 묶지 않으면서 Handlebars, EJS, React-email 같은 렌더링 방식을 선택할 수 있습니다.

--- a/book/intermediate/ch16-email.md
+++ b/book/intermediate/ch16-email.md
@@ -226,6 +226,8 @@ export class AppModule {}
 
 The queue adapter splits bulk notifications into individual background jobs, and the built-in `EmailNotificationsQueueWorker` consumes them with the fixed defaults exported as `DEFAULT_EMAIL_QUEUE_WORKER_OPTIONS`: 3 attempts, exponential backoff starting at 1 second, concurrency 5, a 50-per-second rate limiter, and the `fluo.email.notification` job name. Register `EmailNotificationsQueueWorker` as a provider in the same application module so those queued email jobs are actually consumed. If you replace the built-in worker with a custom queue adapter or worker, mirror those defaults explicitly when you need the same retry, backoff, concurrency, rate-limit, and job-name contract.
 
+The built-in adapter also carries the deterministic notification queue identity into Queue as its `deduplicationKey`. Queue maps it to a BullMQ-safe job id, so repeating one notification dispatch reuses that backing queue identity instead of creating a second email job.
+
 ## 16.7 Template Rendering
 
 `@fluojs/email` supports replaceable template rendering. You can choose rendering approaches such as Handlebars, EJS, or React-email without binding the core package to a specific engine.

--- a/docs/CONTEXT.ko.md
+++ b/docs/CONTEXT.ko.md
@@ -45,6 +45,8 @@ Structured HTTP access logging은 `@fluojs/http`의 `createAccessLogObserver(...
 
 NestJS 마이그레이션은 [NestJS migration map](./getting-started/migrate-from-nestjs.ko.md)에서 시작한다. i18n handoff는 각 custom resolver를 `HttpLocaleResolver`로 mapping하고, application-owned `Middleware` 하나를 `fluoFactory.create(AppModule, { middleware })`로 등록하며, 선택된 locale은 현재 `RequestContext`에만 저장한다. global locale fallback은 없다.
 
+Queue producer idempotency는 `packages/queue/README.md`와 `packages/queue/README.ko.md`에 문서화되어 있다. 공개 Queue facade는 호출자 소유 `deduplicationKey`를 받고 이를 BullMQ에 유효한 job id로 결정적으로 매핑하므로, 콜론을 포함하거나 숫자만으로 이루어진 notification identity도 deduplicate할 수 있다.
+
 NestJS HTTP pipeline migration에서 portable bootstrap `middleware`는 `handle(MiddlewareContext, next)`를 구현하며, Express `(req, res, next)` handler는 `createExpressAdapter({ nativeMiddleware: [...] })`를 사용하는 Express adapter boundary에 둔다.
 
 NestJS migration에서 `fluo migrate`는 `--platform express`를 명시하고 대응하는 `app.listen(...)`이 정확히 하나의 numeric literal port를 가질 때만 `NestFactory.create(AppModule)` bootstrap을 재작성한다. `--platform express` 없는 기본 호출과 그 밖의 지원하지 않는 모든 bootstrap form은 diagnostic과 함께 변경하지 않으며, 명시적으로 선택한 adapter-independent transform도 bootstrap을 변경하지 않는다.

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -45,6 +45,8 @@ For structured HTTP access logging, start at `@fluojs/http` with `createAccessLo
 
 For a NestJS migration, start with the [NestJS migration map](./getting-started/migrate-from-nestjs.md). Its i18n handoff maps every custom resolver to an `HttpLocaleResolver`, registers one application-owned `Middleware` through `fluoFactory.create(AppModule, { middleware })`, and stores the selected locale only on the current `RequestContext`; no global locale fallback exists.
 
+Queue producer idempotency is documented in `packages/queue/README.md` and `packages/queue/README.ko.md`: the public Queue facade accepts a caller-owned `deduplicationKey` and deterministically maps it to a BullMQ-safe job id, so notification identities containing colons or numeric-only values remain deduplicable.
+
 For NestJS HTTP pipeline migration, portable bootstrap `middleware` implements `handle(MiddlewareContext, next)`; keep Express `(req, res, next)` handlers at the Express adapter boundary with `createExpressAdapter({ nativeMiddleware: [...] })`.
 
 For NestJS migrations, `fluo migrate` rewrites `NestFactory.create(AppModule)` only when `--platform express` is explicit and its matching `app.listen(...)` has exactly one numeric literal port. Default invocation without `--platform express` and every other unsupported bootstrap form remain unchanged with a diagnostic; explicit adapter-independent transform selections also leave bootstrap unchanged.

--- a/packages/email/README.ko.md
+++ b/packages/email/README.ko.md
@@ -387,6 +387,7 @@ Behavioral contract 메모:
 
 - Queue 지원은 opt-in입니다. 루트 `@fluojs/email` 엔트리포인트와 `EmailModule`은 `@fluojs/queue`를 import하거나 `EmailNotificationsQueueWorker`를 등록하거나 queue peer 설치를 요구하지 않습니다.
 - `EmailNotificationsQueueWorker`는 `@fluojs/email/queue`에서 export되며, queue 기반 전달을 활성화하는 애플리케이션이 직접 등록해야 합니다.
+- 내장 adapter는 결정적인 `NotificationsQueueJob.id`를 queued email payload에 보존하고 Queue의 `deduplicationKey`로 전달합니다. Queue가 이를 BullMQ에 유효한 job id로 매핑하므로 BullMQ가 반복 notification dispatch 시도를 deduplicate할 수 있습니다.
 - worker는 transport handoff 전에 queued notification channel이 구성된 `EmailChannel.channel`과 정확히 일치하는지 확인합니다. 일치하지 않으면 `EmailMessageValidationError`로 실패하므로 non-email 작업이 email transport에 도달하지 않습니다.
 - worker는 `EmailChannel` 전달 semantics를 재사용하므로 transport가 수락된 수신자 0명 또는 `pending`/`rejected` 수신자를 보고하면 queued job이 실패합니다. 따라서 incomplete delivery는 성공한 job으로 승인되지 않고 `@fluojs/queue`의 retry/dead-letter 흐름으로 넘어갑니다.
 

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -387,6 +387,7 @@ Behavioral contract notes:
 
 - Queue support is opt-in. The root `@fluojs/email` entrypoint and `EmailModule` do not import `@fluojs/queue`, register `EmailNotificationsQueueWorker`, or require queue peer installation.
 - `EmailNotificationsQueueWorker` is exported from `@fluojs/email/queue` and must be registered by applications that enable queue-backed delivery.
+- The built-in adapter preserves each deterministic `NotificationsQueueJob.id` in the queued email payload and passes it to Queue as `deduplicationKey`; Queue maps it to a BullMQ-safe job id so BullMQ can deduplicate repeated notification dispatch attempts.
 - Before transport handoff, the worker requires the queued notification channel to exactly match the configured `EmailChannel.channel`. A mismatch fails with `EmailMessageValidationError`, so non-email work cannot reach the email transport.
 - The worker reuses `EmailChannel` delivery semantics, so a queued job fails when the underlying transport reports zero accepted recipients or any `pending`/`rejected` recipients. This lets `@fluojs/queue` retry and dead-letter incomplete deliveries instead of acknowledging them as successful jobs.
 

--- a/packages/email/src/queue.test.ts
+++ b/packages/email/src/queue.test.ts
@@ -2,9 +2,10 @@ import { describe, expect, it } from 'vitest';
 
 import { EmailChannel } from './channel.js';
 import { EmailMessageValidationError } from './errors.js';
-import { EmailNotificationQueueJob, EmailNotificationsQueueWorker } from './queue.js';
+import { createEmailNotificationsQueueAdapter, EmailNotificationQueueJob, EmailNotificationsQueueWorker } from './queue.js';
 import { EmailService } from './service.js';
 import type { EmailTransport, NormalizedEmailMessage, NormalizedEmailModuleOptions } from './types.js';
+import type { Queue } from '@fluojs/queue';
 
 function createQueueTestFixture(channel = 'email'): {
   readonly delivered: readonly NormalizedEmailMessage[];
@@ -42,6 +43,44 @@ function createQueueTestFixture(channel = 'email'): {
 }
 
 describe('EmailNotificationsQueueWorker', () => {
+  it('forwards the notification id through the public queue deduplication seam', async () => {
+    // Given
+    const queuedJobs: object[] = [];
+    const deduplicationKeys: string[] = [];
+    const queue = {
+      async enqueue<TJob extends object>(job: TJob, options?: { readonly deduplicationKey?: string }): Promise<string> {
+        queuedJobs.push(job);
+        if (options?.deduplicationKey) {
+          deduplicationKeys.push(options.deduplicationKey);
+        }
+        return options?.deduplicationKey ?? '';
+      },
+      async inspectDeadLetters() {
+        return { malformedRecordCount: 0, records: [] };
+      },
+    } satisfies Queue;
+    const adapter = createEmailNotificationsQueueAdapter(queue);
+    const notificationId = 'notification:email:payment-received';
+
+    // When
+    const queueId = await adapter.enqueue({
+      channel: 'email',
+      id: notificationId,
+      notification: {
+        channel: 'email',
+        payload: { text: 'Payment received.' },
+        recipients: ['user@example.com'],
+        subject: 'Payment received',
+      },
+      queuedAt: '2026-09-03T00:00:00.000Z',
+    });
+
+    // Then
+    expect(queueId).toBe(notificationId);
+    expect(deduplicationKeys).toEqual([notificationId]);
+    expect(queuedJobs).toMatchObject([{ id: notificationId }]);
+  });
+
   it('rejects another notification channel before email transport handoff', async () => {
     // Given
     const { delivered, worker } = createQueueTestFixture();

--- a/packages/email/src/queue.ts
+++ b/packages/email/src/queue.ts
@@ -1,6 +1,6 @@
 import { Inject } from '@fluojs/core';
 import type { NotificationsQueueAdapter, NotificationsQueueJob } from '@fluojs/notifications';
-import { QueueWorker, type QueueLifecycleService, type QueueWorkerOptions } from '@fluojs/queue';
+import { QueueWorker, type Queue, type QueueWorkerOptions } from '@fluojs/queue';
 
 import { DEFAULT_EMAIL_QUEUE_WORKER_OPTIONS } from './constants.js';
 import { EmailChannel } from './channel.js';
@@ -17,17 +17,19 @@ export class EmailNotificationQueueJob {
    *
    * @param notification Notification envelope that will be delivered by the email channel worker.
    * @param queuedAt ISO timestamp captured when the notifications foundation delegated the job.
+   * @param id Deterministic notification identity preserved for queue deduplication.
    */
   constructor(
     public readonly notification: EmailNotificationDispatchRequest,
     public readonly queuedAt: string,
+    public readonly id?: string,
   ) {}
 }
 
 /**
- * Creates a notifications queue adapter backed by {@link QueueLifecycleService}.
+ * Creates a notifications queue adapter backed by the public {@link Queue} facade.
  *
- * @param queue Queue lifecycle service used to enqueue email notification jobs.
+ * @param queue Queue facade used to enqueue email notification jobs.
  * @returns A queue adapter compatible with `NotificationsModule.forRoot(...)` queue wiring.
  *
  * @example
@@ -44,13 +46,21 @@ export class EmailNotificationQueueJob {
  * });
  * ```
  */
-export function createEmailNotificationsQueueAdapter(queue: QueueLifecycleService): NotificationsQueueAdapter {
+export function createEmailNotificationsQueueAdapter(queue: Queue): NotificationsQueueAdapter {
   return {
     enqueue(job: NotificationsQueueJob): Promise<string> {
-      return queue.enqueue(new EmailNotificationQueueJob(job.notification, job.queuedAt));
+      return queue.enqueue(new EmailNotificationQueueJob(job.notification, job.queuedAt, job.id), {
+        deduplicationKey: job.id,
+      });
     },
     enqueueMany(jobs: readonly NotificationsQueueJob[]): Promise<readonly string[]> {
-      return Promise.all(jobs.map((job) => queue.enqueue(new EmailNotificationQueueJob(job.notification, job.queuedAt))));
+      return Promise.all(
+        jobs.map((job) =>
+          queue.enqueue(new EmailNotificationQueueJob(job.notification, job.queuedAt, job.id), {
+            deduplicationKey: job.id,
+          }),
+        ),
+      );
     },
   };
 }

--- a/packages/queue/README.ko.md
+++ b/packages/queue/README.ko.md
@@ -234,6 +234,12 @@ Inspection은 read-only이며 유효한 record를 최신순으로 반환합니�
 
 `enqueue(job)`은 job의 정확한 constructor로 dispatch합니다. Queue는 `@QueueWorker(JobClass, options?)`로 discovery한 worker 집합에서 `job.constructor`를 조회하며, 그 constructor가 등록되지 않았으면 `No @QueueWorker() registered for job type <name>.`으로 호출을 거부합니다.
 
+불확실한 전달 또는 반복 dispatch에서도 호출자가 소유한 identity를 유지해야 한다면 두 번째 `enqueue` 인수로 선택적 `deduplicationKey`를 전달하세요. Queue는 이를 BullMQ에 유효한 backing job id로 결정적으로 매핑하므로, 호출자는 BullMQ의 콜론 또는 숫자 전용 custom-id 제한을 상속하지 않으면서 같은 worker queue에 대한 반복 enqueue 시도를 deduplicate할 수 있습니다.
+
+```typescript
+await queue.enqueue(new ProcessOrderJob(id), { deduplicationKey: `order:${id}` });
+```
+
 Plain payload object가 아니라 등록된 job class의 instance를 전달하세요.
 
 ```typescript
@@ -259,7 +265,7 @@ Queue는 `new ProcessOrderJob(id)` 같은 class instance를 포함한 job object
 ### 핵심 구성 요소
 - `QueueModule`: 큐 기능을 위한 기본 모듈입니다.
 - `QueueModule.forRoot(options)`: 애플리케이션 수준 큐 등록을 구성합니다.
-- `QueueLifecycleService`: 작업 enqueue, read-only dead-letter inspection, lifecycle/status snapshot 생성(`enqueue(job)`, `inspectDeadLetters(jobName, options?)`, `createPlatformStatusSnapshot()`)을 위한 기본 서비스입니다.
+- `QueueLifecycleService`: 작업 enqueue, read-only dead-letter inspection, lifecycle/status snapshot 생성(`enqueue(job, options?)`, `inspectDeadLetters(jobName, options?)`, `createPlatformStatusSnapshot()`)을 위한 기본 서비스입니다.
 - `@QueueWorker(JobClass, options?)`: 특정 작업을 처리할 핸들러를 지정하는 데코레이터입니다.
 - `QUEUE`: queue facade를 위한 호환성 주입 토큰입니다.
 - `getQueueToken(scope?)`: Queue facade token helper입니다. `scope`를 생략하면 기본 `QUEUE` token을 반환하고, 비어 있지 않은 scope는 해당 scoped registration의 facade token을 반환합니다.
@@ -268,7 +274,8 @@ Queue는 `new ProcessOrderJob(id)` 같은 class instance를 포함한 job object
 
 
 ### 타입
-- `Queue`: 애플리케이션 코드와 `QUEUE` 토큰에서 사용하는 `enqueue(job)` 및 read-only `inspectDeadLetters(jobName, options?)` facade입니다.
+- `Queue`: 애플리케이션 코드와 `QUEUE` 토큰에서 사용하는 `enqueue(job, options?)` 및 read-only `inspectDeadLetters(jobName, options?)` facade입니다.
+- `QueueEnqueueOptions`: idempotent enqueue 시도를 위해 Queue가 BullMQ에 유효한 job id로 매핑하는 호출자 소유 `deduplicationKey`를 포함하는 선택적 producer control입니다.
 - `QueueDeadLetterInspectionOptions`: Bounded dead-letter inspection 설정(`limit`) 타입입니다.
 - `QueueDeadLetterInspectionResult`: 최신순의 유효 record와 inspection window의 `malformedRecordCount`를 제공하는 결과 타입입니다.
 - `QueueDeadLetterRecord`: `unknown` 애플리케이션 payload를 포함하는 typed dead-letter metadata입니다.

--- a/packages/queue/README.md
+++ b/packages/queue/README.md
@@ -234,6 +234,12 @@ Inspection is read-only and returns valid records in newest-first order. It read
 
 `enqueue(job)` dispatches by the job's exact constructor. Queue looks up `job.constructor` in the workers discovered from `@QueueWorker(JobClass, options?)` and rejects the call with `No @QueueWorker() registered for job type <name>.` when that exact constructor is not registered.
 
+Pass an optional `deduplicationKey` as the second `enqueue` argument when one caller-owned identity must survive uncertain delivery or repeated dispatch. Queue deterministically maps it to a BullMQ-safe backing job id, so callers do not inherit BullMQ's colon or numeric-only custom-id restrictions and BullMQ can deduplicate repeated enqueue attempts for the same worker queue.
+
+```typescript
+await queue.enqueue(new ProcessOrderJob(id), { deduplicationKey: `order:${id}` });
+```
+
 Pass an instance of the registered job class, not a plain payload object:
 
 ```typescript
@@ -259,7 +265,7 @@ Treat low-level provider assembly as an internal implementation detail: low-leve
 ### Core
 - `QueueModule`: Main entry point for queue registration.
 - `QueueModule.forRoot(options)`: Registers queue support for an application module.
-- `QueueLifecycleService`: Primary service for enqueuing jobs, read-only dead-letter inspection, and lifecycle/status snapshots (`enqueue(job)`, `inspectDeadLetters(jobName, options?)`, `createPlatformStatusSnapshot()`).
+- `QueueLifecycleService`: Primary service for enqueuing jobs, read-only dead-letter inspection, and lifecycle/status snapshots (`enqueue(job, options?)`, `inspectDeadLetters(jobName, options?)`, `createPlatformStatusSnapshot()`).
 - `@QueueWorker(JobClass, options?)`: Decorator to mark a class as a job handler.
 - `QUEUE`: Compatibility injection token for the queue facade.
 - `getQueueToken(scope?)`: Queue facade token helper. Omitting `scope` returns the default `QUEUE` token; a non-empty scope returns that scoped registration's facade token.
@@ -268,7 +274,8 @@ Treat low-level provider assembly as an internal implementation detail: low-leve
 
 
 ### Types
-- `Queue`: Application facade with `enqueue(job)` and read-only `inspectDeadLetters(jobName, options?)` for application code and the `QUEUE` token.
+- `Queue`: Application facade with `enqueue(job, options?)` and read-only `inspectDeadLetters(jobName, options?)` for application code and the `QUEUE` token.
+- `QueueEnqueueOptions`: Optional producer controls, including a caller-owned `deduplicationKey` that Queue maps to a BullMQ-safe job id for idempotent enqueue attempts.
 - `QueueDeadLetterInspectionOptions`: Bounded dead-letter inspection settings (`limit`).
 - `QueueDeadLetterInspectionResult`: Newest-first valid records plus `malformedRecordCount` for the inspected window.
 - `QueueDeadLetterRecord`: Typed dead-letter metadata with an `unknown` application payload.

--- a/packages/queue/src/index.ts
+++ b/packages/queue/src/index.ts
@@ -10,6 +10,7 @@ export type {
   QueueDeadLetterInspectionOptions,
   QueueDeadLetterInspectionResult,
   QueueDeadLetterRecord,
+  QueueEnqueueOptions,
   QueueJobType,
   QueueModuleOptions,
   QueueOwnershipEnforcement,

--- a/packages/queue/src/module.test.ts
+++ b/packages/queue/src/module.test.ts
@@ -18,6 +18,7 @@ interface MockQueueJob {
   opts: {
     attempts?: number;
     backoff?: { delay?: number; type?: 'fixed' | 'exponential' };
+    jobId?: string;
   };
 }
 
@@ -264,10 +265,24 @@ vi.mock('bullmq', () => ({
     }
 
     async add(_jobName: string, data: Record<string, unknown>, opts: MockQueueJob['opts'] = {}): Promise<{ id: string }> {
+      if (opts.jobId !== undefined && `${parseInt(opts.jobId, 10)}` === opts.jobId) {
+        throw new Error('Custom Id cannot be integers');
+      }
+
+      if (opts.jobId?.includes(':')) {
+        throw new Error('Custom Id cannot contain :');
+      }
+
+      const existing = opts.jobId === undefined ? undefined : this.queue.jobs.find((job) => job.id === opts.jobId);
+
+      if (existing?.id) {
+        return { id: existing.id };
+      }
+
       const job: MockQueueJob = {
         attemptsMade: 0,
         data,
-        id: bullmqState.nextId(),
+        id: opts.jobId ?? bullmqState.nextId(),
         opts,
       };
 
@@ -726,6 +741,94 @@ describe('@fluojs/queue', () => {
       expect(jobId).toBe('1');
       expect(workerStore.isPrototypeRehydrated).toBe(true);
       expect(workerStore.subject).toBe('welcome:user-1');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('maps a colon-bearing deduplication key to a stable BullMQ-safe job id', async () => {
+    // Given
+    class SendReceiptJob {
+      constructor(public readonly receiptId: string) {}
+    }
+
+    @QueueWorker(SendReceiptJob)
+    class SendReceiptWorker {
+      async handle(_job: SendReceiptJob): Promise<void> {}
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [QueueModule.forRoot()],
+      providers: [SendReceiptWorker],
+    });
+
+    const redis = new MockRedisClient();
+    const app = await bootstrapApplication({
+      providers: [{ provide: REDIS_CLIENT, useValue: redis }],
+      rootModule: AppModule,
+    });
+
+    try {
+      const queue = await app.container.resolve<Queue>(QUEUE);
+      const deduplicationKey = 'notification:email:payment-received';
+      const expectedJobId = 'fluo-fe7e6f032c190d2e815ccd9f0afb2da5dc02548f90254460b1a00706a081818b';
+      await waitForApplicationQueueWorkers(app);
+
+      // When
+      const result = await Promise.all([
+        queue.enqueue(new SendReceiptJob('receipt-1'), { deduplicationKey }),
+        queue.enqueue(new SendReceiptJob('receipt-1'), { deduplicationKey }),
+      ]);
+
+      // Then
+      expect(result).toEqual([expectedJobId, expectedJobId]);
+      expect(bullmqState.queues.get('SendReceiptJob')?.jobs).toHaveLength(1);
+      expect(bullmqState.queues.get('SendReceiptJob')?.jobs).toMatchObject([{ opts: { jobId: expectedJobId } }]);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('maps a numeric-only deduplication key to a stable BullMQ-safe job id', async () => {
+    // Given
+    class SendReceiptJob {
+      constructor(public readonly receiptId: string) {}
+    }
+
+    @QueueWorker(SendReceiptJob)
+    class SendReceiptWorker {
+      async handle(_job: SendReceiptJob): Promise<void> {}
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [QueueModule.forRoot()],
+      providers: [SendReceiptWorker],
+    });
+
+    const redis = new MockRedisClient();
+    const app = await bootstrapApplication({
+      providers: [{ provide: REDIS_CLIENT, useValue: redis }],
+      rootModule: AppModule,
+    });
+
+    try {
+      const queue = await app.container.resolve<Queue>(QUEUE);
+      const deduplicationKey = '3167';
+      const expectedJobId = 'fluo-dcd0ea5b0fea71aa19678a266ac3620df54c68aef9e329a31f969a3862ba9168';
+      await waitForApplicationQueueWorkers(app);
+
+      // When
+      const result = await Promise.all([
+        queue.enqueue(new SendReceiptJob('receipt-1'), { deduplicationKey }),
+        queue.enqueue(new SendReceiptJob('receipt-1'), { deduplicationKey }),
+      ]);
+
+      // Then
+      expect(result).toEqual([expectedJobId, expectedJobId]);
+      expect(bullmqState.queues.get('SendReceiptJob')?.jobs).toHaveLength(1);
+      expect(bullmqState.queues.get('SendReceiptJob')?.jobs).toMatchObject([{ opts: { jobId: expectedJobId } }]);
     } finally {
       await app.close();
     }

--- a/packages/queue/src/module.ts
+++ b/packages/queue/src/module.ts
@@ -26,6 +26,7 @@ import {
 import type {
   NormalizedQueueModuleOptions,
   QueueDeadLetterInspectionOptions,
+  QueueEnqueueOptions,
   QueueModuleOptions,
 } from './types.js';
 import { assertUniqueQueueWorkerOwnership } from './worker-ownership.js';
@@ -213,7 +214,7 @@ function createQueueProviders(
       inject: [tokens.lifecycleServiceToken],
       provide: tokens.queueToken,
       useFactory: (service: unknown) => ({
-        enqueue: (job: object) => (service as QueueLifecycleService).enqueue(job),
+        enqueue: (job: object, options?: QueueEnqueueOptions) => (service as QueueLifecycleService).enqueue(job, options),
         inspectDeadLetters: (jobName: string, options?: QueueDeadLetterInspectionOptions) =>
           (service as QueueLifecycleService).inspectDeadLetters(jobName, options),
       }),

--- a/packages/queue/src/service.ts
+++ b/packages/queue/src/service.ts
@@ -1,6 +1,7 @@
 import { cloneWithFallback } from '@fluojs/core/internal';
 import type { Container } from '@fluojs/di';
 import { getRedisComponentId } from '@fluojs/redis';
+import { createHash } from 'node:crypto';
 import type {
   ApplicationLogger,
   CompiledModule,
@@ -27,6 +28,7 @@ import type {
   QueueBackoffOptions,
   QueueDeadLetterInspectionOptions,
   QueueDeadLetterInspectionResult,
+  QueueEnqueueOptions,
   QueueJobType,
   QueueWorkerDescriptor,
 } from './types.js';
@@ -100,6 +102,10 @@ interface ResolvedWorkerHandler {
 const IMMEDIATE_BOOTSTRAP_READY_SIGNAL: BootstrapReadySignal = {
   wait: () => Promise.resolve(),
 };
+
+function createBullMqJobId(deduplicationKey: string): string {
+  return `fluo-${createHash('sha256').update(deduplicationKey).digest('hex')}`;
+}
 
 function hasQueueRedisClient(value: unknown): value is QueueRedisClient {
   if (typeof value !== 'object' || value === null) {
@@ -212,11 +218,12 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
    * Enqueues one job instance using the worker metadata registered for its class.
    *
    * @param job Job instance whose constructor matches a discovered `@QueueWorker()` provider.
-   * @returns The queue-assigned job id, or an empty string when BullMQ does not provide one.
+   * @param options Optional producer controls, including a caller-owned deduplication key.
+   * @returns The backing BullMQ job id, or an empty string when BullMQ does not provide one.
    *
    * @throws {Error} When no worker is registered for the job type or the queue is not initialized.
    */
-  async enqueue<TJob extends object>(job: TJob): Promise<string> {
+  async enqueue<TJob extends object>(job: TJob, options?: QueueEnqueueOptions): Promise<string> {
     await this.ensureStarted();
 
     if (this.lifecycleState !== 'started') {
@@ -238,6 +245,7 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
     const queuedJob = await queue.add(descriptor.jobName, serializeJobPayload(job), {
       attempts: descriptor.attempts,
       backoff: toBullBackoff(descriptor.backoff),
+      ...(options?.deduplicationKey === undefined ? {} : { jobId: createBullMqJobId(options.deduplicationKey) }),
     });
 
     return queuedJob.id ?? '';

--- a/packages/queue/src/types.ts
+++ b/packages/queue/src/types.ts
@@ -119,15 +119,28 @@ export interface QueueDeadLetterInspectionResult {
   readonly records: readonly QueueDeadLetterRecord[];
 }
 
+/** Optional producer controls applied to one enqueue operation. */
+export interface QueueEnqueueOptions {
+  /**
+   * Caller-supplied identity used to deduplicate repeated enqueue attempts.
+   *
+   * Queue deterministically maps this value to a BullMQ-safe backing job id,
+   * so callers can use arbitrary identities without inheriting
+   * BullMQ's colon or numeric-only custom-id restrictions.
+   */
+  readonly deduplicationKey?: string;
+}
+
 /** Queue facade exposed to application code and compatibility tokens. */
 export interface Queue {
   /**
    * Enqueues one job instance for the worker registered against its class.
    *
    * @param job Job instance whose constructor identifies the target worker.
-   * @returns The BullMQ job id generated for the enqueued payload.
+   * @param options Optional producer controls, including a caller-owned deduplication key.
+   * @returns The backing BullMQ job id for the enqueued payload.
    */
-  enqueue<TJob extends object>(job: TJob): Promise<string>;
+  enqueue<TJob extends object>(job: TJob, options?: QueueEnqueueOptions): Promise<string>;
 
   /**
    * Reads a bounded snapshot of dead-letter records for one queue job name.

--- a/tooling/governance/verify-platform-consistency-governance.test.ts
+++ b/tooling/governance/verify-platform-consistency-governance.test.ts
@@ -273,6 +273,35 @@ describe('enforceContractCompanionUpdates', () => {
     );
   });
 
+  it('requires generic contract companions for Queue producer idempotency documentation', async () => {
+    // Given: paired Queue producer documentation that exposes a public deduplication contract.
+    const { enforceContractCompanionUpdates } = await loadGovernanceInternals();
+    const changedFiles = [
+      'packages/queue/README.md',
+      'packages/queue/README.ko.md',
+    ];
+
+    // When / Then: discoverability and tooling evidence remain mandatory.
+    expect(() => enforceContractCompanionUpdates(changedFiles)).toThrow(
+      /contract-governing doc updates must include docs\/CONTEXT\.md and docs\/CONTEXT\.ko\.md/u,
+    );
+    expect(() =>
+      enforceContractCompanionUpdates([
+        ...changedFiles,
+        'docs/CONTEXT.md',
+        'docs/CONTEXT.ko.md',
+      ]),
+    ).toThrow(/CI\/tooling enforcement updates/u);
+    expect(() =>
+      enforceContractCompanionUpdates([
+        ...changedFiles,
+        'docs/CONTEXT.md',
+        'docs/CONTEXT.ko.md',
+        'tooling/governance/verify-platform-consistency-governance.test.ts',
+      ]),
+    ).not.toThrow();
+  });
+
   it('requires Fastify raw-object regression coverage for its migration documentation', async () => {
     // Given: Fastify raw-object migration and package documentation updates with their discoverability and tooling companions.
     const { enforceContractCompanionUpdates } = await loadGovernanceInternals();


### PR DESCRIPTION
## Summary
- add an optional Queue `deduplicationKey` producer seam
- map arbitrary keys to BullMQ-safe SHA-256 job IDs
- preserve NotificationsQueueJob IDs through the email adapter

## Verification
- queue/email dependency closure build and typechecks
- queue, email and reverse-dependent tests
- lint, platform governance, targeted governance and docs parity
- built email adapter deduplication-key QA

Closes #3167