### PR TITLE
fix(microservices): preserve provider-token handler discovery (#3216)

### DIFF
--- a/.changeset/fix-microservice-handler-tokens.md
+++ b/.changeset/fix-microservice-handler-tokens.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/microservices": patch
+---
+
+Preserve distinct provider-token registrations when discovering decorated handlers.

--- a/packages/microservices/src/handler-discovery-provider-token.test.ts
+++ b/packages/microservices/src/handler-discovery-provider-token.test.ts
@@ -1,0 +1,70 @@
+import { Inject } from '@fluojs/core';
+import { defineModuleMetadata } from '@fluojs/core/internal';
+import { FluoFactory } from '@fluojs/runtime';
+import { describe, expect, it } from 'vitest';
+
+import { EventPattern } from './decorators.js';
+import { MicroservicesModule } from './module.js';
+import type { MicroserviceTransport, TransportHandler } from './types.js';
+
+describe('provider-token handler discovery', () => {
+  it('discovers event handlers registered under distinct provider tokens', async () => {
+    // Given
+    let handler: TransportHandler | undefined;
+    const transport: MicroserviceTransport = {
+      async close() {},
+      async emit(pattern, payload) {
+        if (!handler) {
+          throw new Error('Transport handler is not listening.');
+        }
+
+        await handler({ kind: 'event', pattern, payload });
+      },
+      async listen(nextHandler) {
+        handler = nextHandler;
+      },
+      async send() {
+        return undefined;
+      },
+    };
+    const firstHandlerToken = Symbol('first-handler');
+    const secondHandlerToken = Symbol('second-handler');
+
+    class DeliveryTracker {
+      readonly instances: unknown[] = [];
+    }
+
+    @Inject(DeliveryTracker)
+    class MirroredEventHandler {
+      constructor(private readonly tracker: DeliveryTracker) {}
+
+      @EventPattern('audit.mirrored')
+      handle() {
+        this.tracker.instances.push(this);
+      }
+    }
+
+    class AppModule {}
+    defineModuleMetadata(AppModule, {
+      imports: [MicroservicesModule.forRoot({ transport })],
+      providers: [
+        DeliveryTracker,
+        { provide: firstHandlerToken, useClass: MirroredEventHandler },
+        { provide: secondHandlerToken, useClass: MirroredEventHandler },
+      ],
+    });
+
+    const microservice = await FluoFactory.createMicroservice(AppModule);
+    await microservice.listen();
+
+    // When
+    await microservice.emit('audit.mirrored', {});
+
+    // Then
+    const tracker = await microservice.get(DeliveryTracker);
+    expect(tracker.instances).toHaveLength(2);
+    expect(new Set(tracker.instances)).toHaveLength(2);
+
+    await microservice.close();
+  });
+});

--- a/packages/microservices/src/service.ts
+++ b/packages/microservices/src/service.ts
@@ -664,7 +664,7 @@ export class MicroserviceLifecycleService implements Microservice, MicroserviceR
   }
 
   private discoverHandlerDescriptors(): HandlerDescriptor[] {
-    const seen = new WeakMap<Function, Map<MetadataPropertyKey, Set<string>>>();
+    const seen = new WeakMap<Function, Map<Token, Map<MetadataPropertyKey, Set<string>>>>();
     const descriptors: HandlerDescriptor[] = [];
 
     for (const candidate of this.discoveryCandidates()) {
@@ -673,7 +673,7 @@ export class MicroserviceLifecycleService implements Microservice, MicroserviceR
       for (const entry of entries) {
         const dedupeKey = this.dedupeKey(entry.metadata.kind, entry.metadata.pattern);
 
-        if (this.isDuplicate(seen, candidate.targetType, entry.propertyKey, dedupeKey)) {
+        if (this.isDuplicate(seen, candidate.targetType, candidate.token, entry.propertyKey, dedupeKey)) {
           this.logger.warn(
             `Duplicate microservice handler registration for ${dedupeKey} on ${candidate.targetType.name}.${methodKeyToName(entry.propertyKey)} was ignored.`,
             'MicroserviceLifecycleService',
@@ -706,16 +706,24 @@ export class MicroserviceLifecycleService implements Microservice, MicroserviceR
   }
 
   private isDuplicate(
-    seen: WeakMap<Function, Map<MetadataPropertyKey, Set<string>>>,
+    seen: WeakMap<Function, Map<Token, Map<MetadataPropertyKey, Set<string>>>>,
     targetType: Function,
+    token: Token,
     methodKey: MetadataPropertyKey,
     dedupeKey: string,
   ): boolean {
-    let methodsByKey = seen.get(targetType);
+    let methodsByToken = seen.get(targetType);
+
+    if (!methodsByToken) {
+      methodsByToken = new Map<Token, Map<MetadataPropertyKey, Set<string>>>();
+      seen.set(targetType, methodsByToken);
+    }
+
+    let methodsByKey = methodsByToken.get(token);
 
     if (!methodsByKey) {
       methodsByKey = new Map<MetadataPropertyKey, Set<string>>();
-      seen.set(targetType, methodsByKey);
+      methodsByToken.set(token, methodsByKey);
     }
 
     let seenPatterns = methodsByKey.get(methodKey);


### PR DESCRIPTION
Closes #3216

## Summary
- include provider token identity in handler discovery deduplication
- preserve distinct singleton instances for separate provider tokens
- add deterministic regression coverage and a patch changeset

## Verification
- dependency closure build
- microservices typecheck
- microservices tests: 269 passed
- reverse-dependent tests
- lint and platform consistency governance
- exact-head code, contract, and verification reviews: PASS