### PR TITLE
fix(cron): close distributed tick admission (#3155)

### DIFF
--- a/.changeset/close-distributed-tick-admission.md
+++ b/.changeset/close-distributed-tick-admission.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/cron': patch
+---
+
+Prevent delayed distributed lock acquisition from starting a cron task after shutdown closes tick admission.

--- a/packages/cron/src/lifecycle-race.test.ts
+++ b/packages/cron/src/lifecycle-race.test.ts
@@ -1,3 +1,4 @@
+import { REDIS_CLIENT } from '@fluojs/redis';
 import { bootstrapApplication, defineModule } from '@fluojs/runtime';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -50,6 +51,54 @@ function createRetainedCallbackScheduler(): {
   };
 
   return { callbacks, scheduler, stopStarted: stopStarted.promise, stops };
+}
+
+class DeferredAcquisitionRedisClient {
+  private readonly acquisitionStarted = createDeferred();
+  private readonly allowAcquisition = createDeferred();
+  private readonly locks = new Map<string, string>();
+
+  completeAcquisition(): void {
+    this.allowAcquisition.resolve();
+  }
+
+  hasLock(key: string): boolean {
+    return this.locks.has(key);
+  }
+
+  waitForAcquisition(): Promise<void> {
+    return this.acquisitionStarted.promise;
+  }
+
+  async set(key: string, token: string, _mode: 'PX', _ttl: number, _existence: 'NX'): Promise<'OK' | null> {
+    if (key.includes(':__probe:')) {
+      this.locks.set(key, token);
+      return 'OK';
+    }
+
+    this.acquisitionStarted.resolve();
+    await this.allowAcquisition.promise;
+
+    if (this.locks.has(key)) {
+      return null;
+    }
+
+    this.locks.set(key, token);
+    return 'OK';
+  }
+
+  async eval(script: string, _keysLength: number, key: string, token: string): Promise<number> {
+    if (script.includes('PEXPIRE')) {
+      return this.locks.get(key) === token ? 1 : 0;
+    }
+
+    if (!script.includes('DEL') || this.locks.get(key) !== token) {
+      return 0;
+    }
+
+    this.locks.delete(key);
+    return 1;
+  }
 }
 
 describe('Cron lifecycle race safety', () => {
@@ -158,5 +207,42 @@ describe('Cron lifecycle race safety', () => {
     } finally {
       await app.close();
     }
+  });
+
+  it('releases a lease acquired after shutdown starts without running the task body', async () => {
+    // Given
+    const redis = new DeferredAcquisitionRedisClient();
+    const scheduled = createRetainedCallbackScheduler();
+    let runs = 0;
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [
+        CronModule.forRoot({
+          distributed: { enabled: true, keyPrefix: 'shutdown-acquisition', lockTtlMs: 60_000 },
+          scheduler: scheduled.scheduler,
+        }),
+      ],
+    });
+
+    const app = await bootstrapApplication({
+      providers: [{ provide: REDIS_CLIENT, useValue: redis }],
+      rootModule: AppModule,
+    });
+    const registry = await app.container.resolve<SchedulingRegistry>(SCHEDULING_REGISTRY);
+    registry.addCron('acquired-after-shutdown', CronExpression.EVERY_SECOND, () => {
+      runs += 1;
+    });
+    const tick = requireValue(scheduled.callbacks[0], 'Expected a distributed cron callback.')();
+    await redis.waitForAcquisition();
+
+    // When
+    const closePromise = app.close();
+    await scheduled.stopStarted;
+    redis.completeAcquisition();
+    await Promise.all([tick, closePromise]);
+
+    // Then
+    expect(runs).toBe(0);
+    expect(redis.hasLock('shutdown-acquisition:acquired-after-shutdown')).toBe(false);
   });
 });

--- a/packages/cron/src/service.ts
+++ b/packages/cron/src/service.ts
@@ -758,11 +758,11 @@ export class CronLifecycleService
   private async handleTaskTick(taskName: string, token: object): Promise<void> {
     const taskState = this.tasks.get(taskName);
 
-    if (!this.started || !taskState?.enabled || taskState.running || taskState.activeScheduleToken !== token) {
+    if (!this.started || !this.isTaskTickCurrent(taskName, token, taskState) || taskState.running) {
       return;
     }
 
-    const task = this.runTaskTick(taskState.descriptor, taskState);
+    const task = this.runTaskTick(taskState.descriptor, taskState, token);
     taskState.running = true;
     this.activeTasks.add(task);
 
@@ -774,23 +774,53 @@ export class CronLifecycleService
     }
   }
 
-  private async runTaskTick(descriptor: CronTaskDescriptor, taskState: RuntimeTaskState): Promise<void> {
+  private isTaskTickCurrent(
+    taskName: string,
+    token: object,
+    taskState: RuntimeTaskState | undefined,
+  ): taskState is RuntimeTaskState {
+    return (
+      this.lifecycleState !== 'stopping' &&
+      this.lifecycleState !== 'stopped' &&
+      taskState?.enabled === true &&
+      this.tasks.get(taskName) === taskState &&
+      taskState.activeScheduleToken === token
+    );
+  }
+
+  private async runTaskTick(
+    descriptor: CronTaskDescriptor,
+    taskState: RuntimeTaskState,
+    token: object,
+  ): Promise<void> {
     if (!this.shouldUseDistributedExecution(descriptor)) {
       await this.executeTask(descriptor, taskState);
       return;
     }
 
-    await this.runDistributedTaskTick(descriptor, taskState);
+    await this.runDistributedTaskTick(descriptor, taskState, token);
   }
 
   private shouldUseDistributedExecution(descriptor: CronTaskDescriptor): boolean {
     return this.options.distributed.enabled && descriptor.distributed && this.distributedLocks.resolvedClient !== undefined;
   }
 
-  private async runDistributedTaskTick(descriptor: CronTaskDescriptor, taskState: RuntimeTaskState): Promise<void> {
+  private async runDistributedTaskTick(
+    descriptor: CronTaskDescriptor,
+    taskState: RuntimeTaskState,
+    token: object,
+  ): Promise<void> {
     const lease = await this.distributedLocks.tryAcquireLock(descriptor);
 
     if (!lease) {
+      return;
+    }
+
+    if (this.lifecycleState !== 'failed' && !this.isTaskTickCurrent(descriptor.taskName, token, taskState)) {
+      await this.distributedLocks.releaseLock(
+        lease,
+        this.shutdownPromise ? this.getRemainingShutdownTimeoutMs() : undefined,
+      );
       return;
     }
 


### PR DESCRIPTION
Closes #3155

## Summary
- revalidate distributed tick admission after Redis lease acquisition
- release late leases without running task bodies during shutdown
- add deterministic lifecycle race coverage and a patch changeset

## Verification
- cron closure build/typecheck/tests: 105 passed
- reverse-dependent tests, lint, platform governance
- exact-head full triad: PASS