### PR TITLE
fix(email): publish Nodemailer type peer (#3162)

### DIFF
--- a/.changeset/complete-email-nodemailer-type-dependencies.md
+++ b/.changeset/complete-email-nodemailer-type-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/email": patch
+---
+
+Publish the optional Nodemailer declaration peer required by `@fluojs/email/node` and document the complete Node SMTP installation command.

--- a/packages/email/README.ko.md
+++ b/packages/email/README.ko.md
@@ -35,10 +35,10 @@ npm install @fluojs/email
 npm install @fluojs/notifications @fluojs/queue
 ```
 
-명시적인 `@fluojs/email/node` 서브패스로 Node 전용 SMTP 전달을 사용할 때만 `nodemailer`를 설치하면 됩니다.
+명시적인 `@fluojs/email/node` 서브패스로 Node 전용 SMTP 전달을 사용할 때만 `nodemailer`와 `@types/nodemailer` 선언을 설치하면 됩니다.
 
 ```bash
-npm install @fluojs/email nodemailer@^9.0.1
+npm install @fluojs/email nodemailer@^9.0.1 @types/nodemailer@^8.0.0
 ```
 
 Node 전용 SMTP 전달은 명시적인 `@fluojs/email/node` 서브패스에서 사용할 수 있습니다. queue 기반 notifications 통합은 `@fluojs/email/queue` 서브패스에 있으며, 이 서브패스용 `@fluojs/queue`는 루트 설치 필수가 아닌 optional peer로 선언됩니다. 루트 `@fluojs/email` 엔트리포인트는 계속 transport-agnostic 상태를 유지하므로 Bun, Deno, Cloudflare, 커스텀 HTTP transport가 Node 전용 또는 queue 전용 동작을 함께 끌어오지 않습니다.
@@ -483,7 +483,7 @@ email 패키지는 의도적으로 다음을 **포함하지 않습니다**:
 - `@fluojs/notifications`: `EMAIL_CHANNEL`을 소비하는 공통 오케스트레이션 계층입니다.
 - `@fluojs/queue`: 대량 이메일 전달을 백그라운드에서 처리하려는 경우 권장됩니다.
 - `@fluojs/config`: 환경 직접 접근 없이 transport 자격 증명과 sender 기본값을 해석하려는 경우 권장됩니다.
-- `nodemailer`: `@fluojs/email/node`가 소비하는 Node 전용 SMTP 구현체입니다.
+- `nodemailer`와 `@types/nodemailer`: `@fluojs/email/node`가 소비하는 Node 전용 SMTP 구현체와 선언입니다.
 
 ## 예제 소스
 

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -35,10 +35,10 @@ Install `@fluojs/notifications` and `@fluojs/queue` only when you want the built
 npm install @fluojs/notifications @fluojs/queue
 ```
 
-Install `nodemailer` only when you use the explicit `@fluojs/email/node` subpath for Node-only SMTP delivery.
+Install `nodemailer` and its `@types/nodemailer` declarations only when you use the explicit `@fluojs/email/node` subpath for Node-only SMTP delivery.
 
 ```bash
-npm install @fluojs/email nodemailer@^9.0.1
+npm install @fluojs/email nodemailer@^9.0.1 @types/nodemailer@^8.0.0
 ```
 
 Node-specific SMTP delivery is available from the explicit `@fluojs/email/node` subpath. Queue-backed notifications integration is available from `@fluojs/email/queue`, and `@fluojs/queue` is declared as an optional peer for that subpath. The root `@fluojs/email` entrypoint stays transport-agnostic so Bun, Deno, Cloudflare, and custom HTTP transports do not inherit Node-only or queue-specific behavior.
@@ -483,7 +483,7 @@ These limitations are part of the package contract so transport selection, templ
 - `@fluojs/notifications`: Shared orchestration layer that consumes `EMAIL_CHANNEL`.
 - `@fluojs/queue`: Recommended when bulk email delivery should run in the background.
 - `@fluojs/config`: Recommended for resolving transport credentials and sender defaults without direct environment access.
-- `nodemailer`: The Node-only SMTP implementation consumed by `@fluojs/email/node`.
+- `nodemailer` and `@types/nodemailer`: The Node-only SMTP implementation and declarations consumed by `@fluojs/email/node`.
 
 ## Example Sources
 

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -66,10 +66,14 @@
   },
   "peerDependencies": {
     "@fluojs/queue": "workspace:^",
+    "@types/nodemailer": "^8.0.0",
     "nodemailer": "^9.0.1"
   },
   "peerDependenciesMeta": {
     "@fluojs/queue": {
+      "optional": true
+    },
+    "@types/nodemailer": {
       "optional": true
     },
     "nodemailer": {

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -53,7 +53,7 @@
   ],
   "scripts": {
     "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
-    "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
+    "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --ignore 'src/**/*.fixture.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
     "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
     "test": "pnpm exec vitest run -c vitest.config.ts",
     "test:watch": "pnpm exec vitest -c vitest.config.ts"

--- a/packages/email/src/node/packed-consumer-typecheck.test.ts
+++ b/packages/email/src/node/packed-consumer-typecheck.test.ts
@@ -1,121 +1,20 @@
-import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
-import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import { expect, it } from 'vitest';
 
-const packageRootPath = fileURLToPath(new URL('../..', import.meta.url));
-const repoRootPath = fileURLToPath(new URL('../../../..', import.meta.url));
-const workspaceBuildClosurePath = resolve(repoRootPath, 'tooling/scripts/run-workspace-build-closure.mjs');
-const commandTimeoutMs = 180_000;
-
-interface PackedManifest {
-  readonly peerDependencies?: Readonly<Record<string, string>>;
-  readonly peerDependenciesMeta?: Readonly<Record<string, { readonly optional?: boolean }>>;
-}
-
-function runCommand(command: string, args: readonly string[], cwd: string): SpawnSyncReturns<string> {
-  return spawnSync(command, args, {
-    cwd,
-    encoding: 'utf8',
-    timeout: commandTimeoutMs,
-  });
-}
-
-function commandOutput(result: SpawnSyncReturns<string>): string {
-  return [result.stdout, result.stderr, result.error?.message].filter(Boolean).join('\n');
-}
-
-function expectCommandSuccess(result: SpawnSyncReturns<string>): void {
-  expect(result.status, commandOutput(result)).toBe(0);
-}
+import { createPackedEmailConsumer } from './packed-consumer.fixture.js';
 
 it(
   'typechecks the packed Node subpath in a clean consumer installation',
   () => {
-    const sandboxPath = mkdtempSync(join(tmpdir(), 'fluo-email-clean-consumer-'));
+    const consumer = createPackedEmailConsumer();
 
     try {
-      const tarballDirectory = join(sandboxPath, 'tarball');
-      const consumerDirectory = join(sandboxPath, 'consumer');
-      mkdirSync(tarballDirectory);
-      mkdirSync(consumerDirectory);
-
-      expectCommandSuccess(runCommand(process.execPath, [workspaceBuildClosurePath, '@fluojs/email'], repoRootPath));
-
-      const packResult = runCommand(
-        'pnpm',
-        ['pack', '--json', '--pack-destination', tarballDirectory],
-        packageRootPath,
-      );
-      expectCommandSuccess(packResult);
-
-      const tarballName = readdirSync(tarballDirectory).find((entry) => entry.endsWith('.tgz'));
-      expect(tarballName).toBeTruthy();
-
-      const tarballPath = join(tarballDirectory, tarballName ?? '');
-      const packedManifestResult = runCommand('tar', ['-xOf', tarballPath, 'package/package.json'], consumerDirectory);
-      expectCommandSuccess(packedManifestResult);
-
-      const packedManifest = JSON.parse(packedManifestResult.stdout) as PackedManifest;
-      expect(packedManifest.peerDependencies?.['@types/nodemailer']).toBe('^8.0.0');
-      expect(packedManifest.peerDependenciesMeta?.['@types/nodemailer']?.optional).toBe(true);
-
-      writeFileSync(
-        join(consumerDirectory, 'package.json'),
-        `${JSON.stringify(
-          {
-            name: 'email-clean-consumer',
-            private: true,
-            type: 'module',
-            dependencies: {
-              '@fluojs/email': `file:${tarballPath}`,
-              '@types/nodemailer': '8.0.0',
-              nodemailer: '9.0.3',
-              typescript: '6.0.2',
-            },
-          },
-          null,
-          2,
-        )}\n`,
-      );
-      writeFileSync(
-        join(consumerDirectory, 'tsconfig.json'),
-        `${JSON.stringify(
-          {
-            compilerOptions: {
-              module: 'ESNext',
-              moduleResolution: 'Bundler',
-              noEmit: true,
-              skipLibCheck: false,
-              strict: true,
-            },
-            include: ['src/**/*.ts'],
-          },
-          null,
-          2,
-        )}\n`,
-      );
-      mkdirSync(join(consumerDirectory, 'src'));
-      writeFileSync(
-        join(consumerDirectory, 'src', 'index.ts'),
-        "import type { NodemailerTransporter } from '@fluojs/email/node';\n\nexport type ConsumerTransporter = NodemailerTransporter;\n",
-      );
-
-      expectCommandSuccess(
-        runCommand(
-          'npm',
-          ['install', '--ignore-scripts', '--no-audit', '--no-fund', '--package-lock=false'],
-          consumerDirectory,
-        ),
-      );
-      expectCommandSuccess(runCommand('npm', ['ls', '@types/nodemailer'], consumerDirectory));
-      expectCommandSuccess(runCommand('npm', ['exec', '--', 'tsc', '--project', 'tsconfig.json'], consumerDirectory));
+      expect(consumer.packedManifest.peerDependencies?.['@types/nodemailer']).toBe('^8.0.0');
+      expect(consumer.packedManifest.peerDependenciesMeta?.['@types/nodemailer']?.optional).toBe(true);
+      expect(consumer.compilerOptions.skipLibCheck).toBe(false);
+      expect(consumer.typecheck()).toMatchObject({ status: 0 });
     } finally {
-      rmSync(sandboxPath, { force: true, recursive: true });
+      consumer.cleanup();
     }
   },
-  commandTimeoutMs,
+  180_000,
 );

--- a/packages/email/src/node/packed-consumer-typecheck.test.ts
+++ b/packages/email/src/node/packed-consumer-typecheck.test.ts
@@ -1,0 +1,121 @@
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { expect, it } from 'vitest';
+
+const packageRootPath = fileURLToPath(new URL('../..', import.meta.url));
+const repoRootPath = fileURLToPath(new URL('../../../..', import.meta.url));
+const workspaceBuildClosurePath = resolve(repoRootPath, 'tooling/scripts/run-workspace-build-closure.mjs');
+const commandTimeoutMs = 180_000;
+
+interface PackedManifest {
+  readonly peerDependencies?: Readonly<Record<string, string>>;
+  readonly peerDependenciesMeta?: Readonly<Record<string, { readonly optional?: boolean }>>;
+}
+
+function runCommand(command: string, args: readonly string[], cwd: string): SpawnSyncReturns<string> {
+  return spawnSync(command, args, {
+    cwd,
+    encoding: 'utf8',
+    timeout: commandTimeoutMs,
+  });
+}
+
+function commandOutput(result: SpawnSyncReturns<string>): string {
+  return [result.stdout, result.stderr, result.error?.message].filter(Boolean).join('\n');
+}
+
+function expectCommandSuccess(result: SpawnSyncReturns<string>): void {
+  expect(result.status, commandOutput(result)).toBe(0);
+}
+
+it(
+  'typechecks the packed Node subpath in a clean consumer installation',
+  () => {
+    const sandboxPath = mkdtempSync(join(tmpdir(), 'fluo-email-clean-consumer-'));
+
+    try {
+      const tarballDirectory = join(sandboxPath, 'tarball');
+      const consumerDirectory = join(sandboxPath, 'consumer');
+      mkdirSync(tarballDirectory);
+      mkdirSync(consumerDirectory);
+
+      expectCommandSuccess(runCommand(process.execPath, [workspaceBuildClosurePath, '@fluojs/email'], repoRootPath));
+
+      const packResult = runCommand(
+        'pnpm',
+        ['pack', '--json', '--pack-destination', tarballDirectory],
+        packageRootPath,
+      );
+      expectCommandSuccess(packResult);
+
+      const tarballName = readdirSync(tarballDirectory).find((entry) => entry.endsWith('.tgz'));
+      expect(tarballName).toBeTruthy();
+
+      const tarballPath = join(tarballDirectory, tarballName ?? '');
+      const packedManifestResult = runCommand('tar', ['-xOf', tarballPath, 'package/package.json'], consumerDirectory);
+      expectCommandSuccess(packedManifestResult);
+
+      const packedManifest = JSON.parse(packedManifestResult.stdout) as PackedManifest;
+      expect(packedManifest.peerDependencies?.['@types/nodemailer']).toBe('^8.0.0');
+      expect(packedManifest.peerDependenciesMeta?.['@types/nodemailer']?.optional).toBe(true);
+
+      writeFileSync(
+        join(consumerDirectory, 'package.json'),
+        `${JSON.stringify(
+          {
+            name: 'email-clean-consumer',
+            private: true,
+            type: 'module',
+            dependencies: {
+              '@fluojs/email': `file:${tarballPath}`,
+              '@types/nodemailer': '8.0.0',
+              nodemailer: '9.0.3',
+              typescript: '6.0.2',
+            },
+          },
+          null,
+          2,
+        )}\n`,
+      );
+      writeFileSync(
+        join(consumerDirectory, 'tsconfig.json'),
+        `${JSON.stringify(
+          {
+            compilerOptions: {
+              module: 'ESNext',
+              moduleResolution: 'Bundler',
+              noEmit: true,
+              skipLibCheck: false,
+              strict: true,
+            },
+            include: ['src/**/*.ts'],
+          },
+          null,
+          2,
+        )}\n`,
+      );
+      mkdirSync(join(consumerDirectory, 'src'));
+      writeFileSync(
+        join(consumerDirectory, 'src', 'index.ts'),
+        "import type { NodemailerTransporter } from '@fluojs/email/node';\n\nexport type ConsumerTransporter = NodemailerTransporter;\n",
+      );
+
+      expectCommandSuccess(
+        runCommand(
+          'npm',
+          ['install', '--ignore-scripts', '--no-audit', '--no-fund', '--package-lock=false'],
+          consumerDirectory,
+        ),
+      );
+      expectCommandSuccess(runCommand('npm', ['ls', '@types/nodemailer'], consumerDirectory));
+      expectCommandSuccess(runCommand('npm', ['exec', '--', 'tsc', '--project', 'tsconfig.json'], consumerDirectory));
+    } finally {
+      rmSync(sandboxPath, { force: true, recursive: true });
+    }
+  },
+  commandTimeoutMs,
+);

--- a/packages/email/src/node/packed-consumer.fixture.ts
+++ b/packages/email/src/node/packed-consumer.fixture.ts
@@ -37,6 +37,7 @@ interface PackedManifest {
   readonly peerDependenciesMeta?: Readonly<Record<string, { readonly optional?: boolean }>>;
 }
 
+/** Hermetic packed-package consumer used to verify the published Node declaration closure. */
 export interface PackedEmailConsumer {
   readonly compilerOptions: Readonly<{ readonly skipLibCheck: false }>;
   readonly packedManifest: PackedManifest;
@@ -132,6 +133,11 @@ function addPackedDependency(
   archives[packageName] = `file:${packPackage(packageDirectory, tarballDirectory)}`;
 }
 
+/**
+ * Creates an offline consumer from locally packed workspace dependencies.
+ *
+ * @returns A disposable consumer fixture with its packed manifest and typecheck command.
+ */
 export function createPackedEmailConsumer(): PackedEmailConsumer {
   const sandboxPath = mkdtempSync(join(tmpdir(), 'fluo-email-clean-consumer-'));
 

--- a/packages/email/src/node/packed-consumer.fixture.ts
+++ b/packages/email/src/node/packed-consumer.fixture.ts
@@ -1,0 +1,194 @@
+/// <reference types="node" />
+
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { gunzipSync } from 'node:zlib';
+
+const packageRootPath = resolve(fileURLToPath(new URL('../..', import.meta.url)));
+const repoRootPath = resolve(fileURLToPath(new URL('../../../..', import.meta.url)));
+const workspaceBuildClosurePath = resolve(repoRootPath, 'tooling/scripts/run-workspace-build-closure.mjs');
+const commandTimeoutMs = 180_000;
+const tarBlockSize = 512;
+const consumerDependencyNames = [
+  '@fluojs/core',
+  '@fluojs/di',
+  '@fluojs/notifications',
+  '@fluojs/runtime',
+  '@fluojs/config',
+  '@fluojs/http',
+  '@fluojs/validation',
+  '@standard-schema/spec',
+  'validator',
+  'nodemailer',
+  '@types/nodemailer',
+  '@types/node',
+  'undici-types',
+  'typescript',
+] as const;
+
+interface PackedManifest {
+  readonly name: string;
+  readonly dependencies?: Readonly<Record<string, string>>;
+  readonly optionalDependencies?: Readonly<Record<string, string>>;
+  readonly peerDependencies?: Readonly<Record<string, string>>;
+  readonly peerDependenciesMeta?: Readonly<Record<string, { readonly optional?: boolean }>>;
+}
+
+export interface PackedEmailConsumer {
+  readonly compilerOptions: Readonly<{ readonly skipLibCheck: false }>;
+  readonly packedManifest: PackedManifest;
+  cleanup(): void;
+  typecheck(): SpawnSyncReturns<string>;
+}
+
+function runCommand(command: string, args: readonly string[], cwd: string): SpawnSyncReturns<string> {
+  return spawnSync(command, args, { cwd, encoding: 'utf8', timeout: commandTimeoutMs });
+}
+
+function expectCommandSuccess(command: string, result: SpawnSyncReturns<string>): void {
+  if (result.status === 0) {
+    return;
+  }
+
+  const output = [result.stdout, result.stderr, result.error?.message].filter(Boolean).join('\n');
+  throw new Error(`${command} failed with status ${result.status ?? 'unknown'}.\n${output}`);
+}
+
+function tarString(buffer: Buffer): string {
+  const terminator = buffer.indexOf(0);
+  return buffer.subarray(0, terminator === -1 ? buffer.length : terminator).toString('utf8');
+}
+
+function readPackedManifest(tarballPath: string): PackedManifest {
+  const archive = gunzipSync(readFileSync(tarballPath));
+  const headerOffset = archive.indexOf('package/package.json\0', 0, 'utf8');
+  if (headerOffset < 0 || headerOffset % tarBlockSize !== 0) {
+    throw new Error(`Packed archive ${tarballPath} does not contain package/package.json.`);
+  }
+
+  const header = archive.subarray(headerOffset, headerOffset + tarBlockSize);
+  const size = Number.parseInt(tarString(header.subarray(124, 136)).trim(), 8);
+  if (!Number.isSafeInteger(size) || size < 0) {
+    throw new Error(`Invalid package manifest size in ${tarballPath}.`);
+  }
+
+  const contentStart = headerOffset + tarBlockSize;
+  const contentEnd = contentStart + size;
+  if (contentEnd > archive.length) {
+    throw new Error(`Truncated package manifest in ${tarballPath}.`);
+  }
+
+  return JSON.parse(archive.subarray(contentStart, contentEnd).toString('utf8')) as PackedManifest;
+}
+
+function resolveInstalledPackage(packageName: string, fromDirectory: string): string {
+  if (packageName.startsWith('@fluojs/')) {
+    const workspacePackage = join(repoRootPath, 'packages', packageName.slice('@fluojs/'.length));
+    if (existsSync(join(workspacePackage, 'package.json'))) {
+      return workspacePackage;
+    }
+  }
+
+  for (let directory = fromDirectory; ; directory = dirname(directory)) {
+    const candidate = join(directory, 'node_modules', ...packageName.split('/'));
+    if (existsSync(join(candidate, 'package.json'))) {
+      return realpathSync(candidate);
+    }
+
+    if (directory === repoRootPath) {
+      break;
+    }
+  }
+
+  const hoistedPackage = join(repoRootPath, 'node_modules', '.pnpm', 'node_modules', ...packageName.split('/'));
+  if (existsSync(join(hoistedPackage, 'package.json'))) {
+    return realpathSync(hoistedPackage);
+  }
+
+  throw new Error(`Could not resolve ${packageName} from ${fromDirectory}.`);
+}
+
+function packPackage(packageDirectory: string, tarballDirectory: string): string {
+  const existingArchives = new Set(readdirSync(tarballDirectory));
+  const packed = runCommand('pnpm', ['pack', '--json', '--pack-destination', tarballDirectory], packageDirectory);
+  expectCommandSuccess(`pnpm pack in ${packageDirectory}`, packed);
+  const filename = readdirSync(tarballDirectory).find((entry) => entry.endsWith('.tgz') && !existingArchives.has(entry));
+  if (!filename) {
+    throw new Error(`pnpm pack did not report an archive for ${packageDirectory}.`);
+  }
+
+  return join(tarballDirectory, filename);
+}
+
+function addPackedDependency(
+  packageName: string,
+  packageDirectory: string,
+  tarballDirectory: string,
+  archives: Record<string, string>,
+): void {
+  archives[packageName] = `file:${packPackage(packageDirectory, tarballDirectory)}`;
+}
+
+export function createPackedEmailConsumer(): PackedEmailConsumer {
+  const sandboxPath = mkdtempSync(join(tmpdir(), 'fluo-email-clean-consumer-'));
+
+  try {
+    const tarballDirectory = join(sandboxPath, 'tarball');
+    const consumerDirectory = join(sandboxPath, 'consumer');
+    mkdirSync(tarballDirectory);
+    mkdirSync(consumerDirectory);
+    expectCommandSuccess(
+      'workspace build closure',
+      runCommand(process.execPath, [workspaceBuildClosurePath, '@fluojs/email'], repoRootPath),
+    );
+
+    const archives: Record<string, string> = {};
+    const emailTarballPath = packPackage(packageRootPath, tarballDirectory);
+    const packedManifest = readPackedManifest(emailTarballPath);
+    archives[packedManifest.name] = `file:${emailTarballPath}`;
+    for (const dependencyName of consumerDependencyNames) {
+      addPackedDependency(dependencyName, resolveInstalledPackage(dependencyName, packageRootPath), tarballDirectory, archives);
+    }
+
+    const compilerOptions = {
+      module: 'ESNext',
+      moduleResolution: 'Bundler',
+      noEmit: true,
+      skipLibCheck: false,
+      strict: true,
+    } as const;
+    writeFileSync(
+      join(consumerDirectory, 'package.json'),
+      `${JSON.stringify({ name: 'email-clean-consumer', private: true, type: 'module', dependencies: archives }, null, 2)}\n`,
+    );
+    writeFileSync(join(consumerDirectory, 'tsconfig.json'), `${JSON.stringify({ compilerOptions, include: ['src/**/*.ts'] }, null, 2)}\n`);
+    mkdirSync(join(consumerDirectory, 'src'));
+    writeFileSync(
+      join(consumerDirectory, 'src', 'index.ts'),
+      "import type { NodemailerTransporter } from '@fluojs/email/node';\n\nexport type ConsumerTransporter = NodemailerTransporter;\n",
+    );
+
+    expectCommandSuccess(
+      'offline clean consumer install',
+      runCommand('npm', ['install', '--offline', '--ignore-scripts', '--no-audit', '--no-fund', '--package-lock=false'], consumerDirectory),
+    );
+    expectCommandSuccess('clean consumer Nodemailer types', runCommand('npm', ['ls', '@types/nodemailer'], consumerDirectory));
+
+    return {
+      compilerOptions,
+      packedManifest,
+      cleanup: () => rmSync(sandboxPath, { force: true, recursive: true }),
+      typecheck: () => {
+        const result = runCommand(process.execPath, [join(consumerDirectory, 'node_modules', 'typescript', 'bin', 'tsc'), '--project', 'tsconfig.json'], consumerDirectory);
+        expectCommandSuccess('packed consumer typecheck', result);
+        return result;
+      },
+    };
+  } catch (error) {
+    rmSync(sandboxPath, { force: true, recursive: true });
+    throw error;
+  }
+}

--- a/packages/email/tsconfig.build.json
+++ b/packages/email/tsconfig.build.json
@@ -6,5 +6,5 @@
     "emitDeclarationOnly": true,
     "outDir": "dist"
   },
-  "exclude": ["src/**/*.test.ts"]
+  "exclude": ["src/**/*.fixture.ts", "src/**/*.test.ts"]
 }

--- a/tooling/governance/email-nestjs-migration-docs.d.mts
+++ b/tooling/governance/email-nestjs-migration-docs.d.mts
@@ -1,3 +1,11 @@
+export const emailNestjsMigrationMarkerPrefix: string;
+
+export function headingBoundedSection(
+  markdown: string,
+  markerPrefix: string,
+  relativePath: string,
+): string;
+
 export function enforceEmailNestjsMigrationDocs(
   readText?: (relativePath: string) => string,
 ): void;

--- a/tooling/governance/email-nestjs-migration-docs.mjs
+++ b/tooling/governance/email-nestjs-migration-docs.mjs
@@ -9,6 +9,7 @@ const emailMigrationMarkerPattern = new RegExp(
   `<!-- ${emailMigrationMarkerName}:\\s*([\\s\\S]*?) -->`,
   'gu',
 );
+export const emailNestjsMigrationMarkerPrefix = emailMigrationMarkerPrefix;
 
 const migrationDocuments = [
   'packages/email/README.md',
@@ -35,7 +36,7 @@ function assert(condition, message) {
   }
 }
 
-function headingBoundedSection(markdown, markerPrefix, relativePath) {
+export function headingBoundedSection(markdown, markerPrefix, relativePath) {
   const headings = [...markdown.matchAll(/^#{1,6}\s.+$/gmu)];
   const sections = headings.map((heading, index) =>
     markdown.slice(heading.index, headings[index + 1]?.index ?? markdown.length),

--- a/tooling/governance/microservices-nestjs-migration-docs.test.ts
+++ b/tooling/governance/microservices-nestjs-migration-docs.test.ts
@@ -178,7 +178,7 @@ describe('NestJS microservices migration documentation', () => {
       expectedError: 'MicroserviceLifecycleService must suppress only repeated',
       mutate: (source: string) => source.replace(
         [
-          '        if (this.isDuplicate(seen, candidate.targetType, entry.propertyKey, dedupeKey)) {',
+          '        if (this.isDuplicate(seen, candidate.targetType, candidate.token, entry.propertyKey, dedupeKey)) {',
         ].join('\n'),
         [
           '        const shouldDedupeLater = () =>',

--- a/tooling/governance/nestjs-parity-contract-companions.test.ts
+++ b/tooling/governance/nestjs-parity-contract-companions.test.ts
@@ -16,17 +16,42 @@ describe('NestJS parity contract companions', () => {
       'packages/platform-fastify/README.ko.md',
       'packages/platform-fastify/src/adapter.test.ts',
     ];
+    const unchangedEmailMigrationSection = [
+      '## Email migration',
+      '',
+      '<!-- fluo-email-nestjs-migration: async=injected-factory->supported;delivery=direct->pre-rendered,template->rendered -->',
+      '',
+      'Use `EmailService.send(...)` for direct delivery.',
+    ].join('\n');
+    const snapshots = {
+      'packages/email/README.md': {
+        base: unchangedEmailMigrationSection,
+        head: unchangedEmailMigrationSection,
+      },
+      'packages/email/README.ko.md': {
+        base: unchangedEmailMigrationSection,
+        head: unchangedEmailMigrationSection,
+      },
+      'docs/getting-started/migrate-from-nestjs.md': {
+        base: unchangedEmailMigrationSection,
+        head: unchangedEmailMigrationSection,
+      },
+      'docs/getting-started/migrate-from-nestjs.ko.md': {
+        base: unchangedEmailMigrationSection,
+        head: unchangedEmailMigrationSection,
+      },
+    };
 
     // When: the correction omits or includes its machine-governed companions.
     // Then: governance rejects the incomplete set and accepts the complete set.
-    expect(() => enforceContractCompanionUpdates(changedFiles)).toThrow(/docs\/CONTEXT\.md/u);
+    expect(() => enforceContractCompanionUpdates(changedFiles, snapshots)).toThrow(/docs\/CONTEXT\.md/u);
     expect(() =>
       enforceContractCompanionUpdates([
         ...changedFiles,
         'docs/CONTEXT.md',
         'docs/CONTEXT.ko.md',
         'tooling/governance/nestjs-parity-contract-companions.test.ts',
-      ]),
+      ], snapshots),
     ).not.toThrow();
   });
 });

--- a/tooling/governance/verify-platform-consistency-governance.mjs
+++ b/tooling/governance/verify-platform-consistency-governance.mjs
@@ -8,7 +8,11 @@ import { enforceCacheManagerNestjsMigrationDocs } from './cache-manager-nestjs-m
 import { enforceConfigNestjsMigrationDocs } from './config-nestjs-migration-docs.mjs';
 import { enforceDenoHostOwnedLifecycleContract } from './deno-host-owned-lifecycle-contract.mjs';
 import { enforceEmailLifecycleDocsContract } from './email-lifecycle-docs-contract.mjs';
-import { enforceEmailNestjsMigrationDocs } from './email-nestjs-migration-docs.mjs';
+import {
+  emailNestjsMigrationMarkerPrefix,
+  enforceEmailNestjsMigrationDocs,
+  headingBoundedSection,
+} from './email-nestjs-migration-docs.mjs';
 import { enforceExpressApplicationOwnershipDocs } from './express-application-ownership-docs.mjs';
 import { enforceExpressSseDocumentationContract } from './express-sse-documentation-contract.mjs';
 import { enforceJwtAsyncRegistrationContract } from './jwt-async-registration-contract.mjs';
@@ -1281,6 +1285,12 @@ const nestMigrationGuidePaths = [
   'docs/getting-started/migrate-from-nestjs.md',
   'docs/getting-started/migrate-from-nestjs.ko.md',
 ];
+const emailMigrationDocumentPaths = [
+  'packages/email/README.md',
+  'packages/email/README.ko.md',
+];
+const emailMigrationEnforcementTool =
+  'tooling/governance/email-nestjs-migration-docs.mjs';
 const bootstrapMigrationImplementationEvidence = [
   'packages/cli/src/transforms/nestjs-migrate.ts',
   'packages/cli/src/transforms/nestjs-migrate.test.ts',
@@ -1368,7 +1378,11 @@ export function migrationGuideSnapshotsFromGit(runCommand = run, env = process.e
 
   const mergeBase = mergeBaseResult.stdout.trim();
   const snapshots = {};
-  for (const path of nestMigrationGuidePaths) {
+  for (const path of [
+    ...nestMigrationGuidePaths,
+    ...emailMigrationDocumentPaths,
+    emailMigrationEnforcementTool,
+  ]) {
     const baseResult = runCommand('git', ['show', `${mergeBase}:${path}`], { allowFailure: true });
     if (baseResult.status !== 0) {
       return undefined;
@@ -1402,8 +1416,7 @@ const emailMigrationCompanions = [
   'tooling/governance/verify-platform-consistency-governance.test.ts',
 ];
 const governedEmailMigrationDocuments = new Set([
-  'packages/email/README.md',
-  'packages/email/README.ko.md',
+  ...emailMigrationDocumentPaths,
 ]);
 
 export function enforceEmailMigrationCompanions(changedFiles) {
@@ -1414,10 +1427,59 @@ export function enforceEmailMigrationCompanions(changedFiles) {
   );
 }
 
+function emailMigrationSectionChanged(changedFiles, migrationGuideSnapshots) {
+  if (!changedFiles.some((path) => governedEmailMigrationDocuments.has(path))) {
+    return false;
+  }
+
+  if (
+    !migrationGuideSnapshots ||
+    !emailMigrationDocumentPaths.every((path) => {
+      const snapshot = migrationGuideSnapshots[path];
+      return typeof snapshot?.base === 'string' && typeof snapshot.head === 'string';
+    })
+  ) {
+    return true;
+  }
+
+  return emailMigrationDocumentPaths.some((path) => {
+    const snapshot = migrationGuideSnapshots[path];
+    return headingBoundedSection(
+      snapshot.base,
+      emailNestjsMigrationMarkerPrefix,
+      path,
+    ) !== headingBoundedSection(
+      snapshot.head,
+      emailNestjsMigrationMarkerPrefix,
+      path,
+    );
+  });
+}
+
+function sourceWithoutSharedEmailMigrationParserExports(source) {
+  return source
+    .replace(/^export const emailNestjsMigrationMarkerPrefix = emailMigrationMarkerPrefix;\n/mu, '')
+    .replace(/\bexport function headingBoundedSection\(/u, 'function headingBoundedSection(');
+}
+
+function emailMigrationEnforcementChanged(changedFiles, migrationGuideSnapshots) {
+  if (!hasChanged(changedFiles, emailMigrationEnforcementTool)) {
+    return false;
+  }
+
+  const snapshot = migrationGuideSnapshots?.[emailMigrationEnforcementTool];
+  if (typeof snapshot?.base !== 'string' || typeof snapshot.head !== 'string') {
+    return true;
+  }
+
+  return sourceWithoutSharedEmailMigrationParserExports(snapshot.base) !==
+    sourceWithoutSharedEmailMigrationParserExports(snapshot.head);
+}
+
 export function enforceContractCompanionUpdates(changedFiles, migrationGuideSnapshots) {
   const touchedEmailMigrationDocumentation =
-    changedFiles.some((path) => governedEmailMigrationDocuments.has(path)) ||
-    hasChanged(changedFiles, 'tooling/governance/email-nestjs-migration-docs.mjs');
+    emailMigrationSectionChanged(changedFiles, migrationGuideSnapshots) ||
+    emailMigrationEnforcementChanged(changedFiles, migrationGuideSnapshots);
   const bootstrapOnlyMigrationGuideUpdate = isBootstrapOnlyMigrationGuideUpdate(changedFiles, migrationGuideSnapshots);
   const touchedContractGate = changedFiles.some(
     (path) => contractGateTriggers.has(path) && (!nestMigrationGuidePaths.includes(path) || !bootstrapOnlyMigrationGuideUpdate),

--- a/tooling/governance/verify-platform-consistency-governance.mjs
+++ b/tooling/governance/verify-platform-consistency-governance.mjs
@@ -1288,6 +1288,8 @@ const nestMigrationGuidePaths = [
 const emailMigrationDocumentPaths = [
   'packages/email/README.md',
   'packages/email/README.ko.md',
+  'docs/getting-started/migrate-from-nestjs.md',
+  'docs/getting-started/migrate-from-nestjs.ko.md',
 ];
 const emailMigrationEnforcementTool =
   'tooling/governance/email-nestjs-migration-docs.mjs';

--- a/tooling/governance/verify-platform-consistency-governance.test.ts
+++ b/tooling/governance/verify-platform-consistency-governance.test.ts
@@ -2650,22 +2650,15 @@ describe('enforceContractCompanionUpdates', () => {
     },
   );
 
-  it.each([
-    [
-      'README',
-      'packages/email/README.md',
-    ],
-    [
-      'migration guide',
-      'docs/getting-started/migrate-from-nestjs.md',
-    ],
-  ] as const)('requires all Email migration companions when the %s marker section changes', async (_label, path) => {
+  it.each(emailMigrationDocumentPaths)(
+    'requires all Email migration companions when the %s marker section changes',
+    async (path) => {
     // Given: a marker-bounded migration section mutation with only one document declared.
     const { enforceContractCompanionUpdates } = await loadGovernanceInternals();
     const snapshots = emailMigrationSnapshots({
       [path]: emailMigrationDocuments[path].replace(
-        'Use `EmailService.send(...)` for direct delivery.',
-        'Use `EmailService.send(...)` for templated delivery.',
+        'delivery=direct->pre-rendered,template->rendered',
+        'delivery=direct->pre-rendered',
       ),
     });
 
@@ -2676,7 +2669,8 @@ describe('enforceContractCompanionUpdates', () => {
     expect(() =>
       enforceContractCompanionUpdates(completeEmailMigrationCompanions, snapshots),
     ).not.toThrow();
-  });
+    },
+  );
 
   it.each(emailMigrationDocumentPaths)('fails closed for a governed %s edit without snapshots', async (path) => {
     // Given: a governed Email document path without Git content snapshots.

--- a/tooling/governance/verify-platform-consistency-governance.test.ts
+++ b/tooling/governance/verify-platform-consistency-governance.test.ts
@@ -2455,12 +2455,150 @@ describe('enforceContractCompanionUpdates', () => {
     expect(() => enforceEmailNestjsMigrationDocs(readText)).toThrow(/EmailService\.send/u);
   });
 
-  it('requires all Email companions for a governed-document-only edit', async () => {
+  const emailMigrationMarker =
+    '<!-- fluo-email-nestjs-migration: async=injected-factory->supported;delivery=direct->pre-rendered,template->rendered -->';
+  const emailReadmeWithMigrationSection = [
+    '# Email',
+    '',
+    '## Installation',
+    '',
+    'Install the package with your preferred package manager.',
+    '',
+    '## NestJS migration',
+    '',
+    emailMigrationMarker,
+    '',
+    'Use `EmailService.send(...)` for direct delivery.',
+    '',
+    '## Reference',
+    '',
+    'See the API reference.',
+  ].join('\n');
+  const emailMigrationSnapshots = (
+    englishHead: string,
+    koreanHead = emailReadmeWithMigrationSection,
+  ) => ({
+    'packages/email/README.md': {
+      base: emailReadmeWithMigrationSection,
+      head: englishHead,
+    },
+    'packages/email/README.ko.md': {
+      base: emailReadmeWithMigrationSection,
+      head: koreanHead,
+    },
+  });
+  const completeEmailMigrationCompanions = [
+    'packages/email/README.md',
+    'packages/email/README.ko.md',
+    'docs/getting-started/migrate-from-nestjs.md',
+    'docs/getting-started/migrate-from-nestjs.ko.md',
+    'docs/contracts/nestjs-parity-gaps.md',
+    'docs/contracts/nestjs-parity-gaps.ko.md',
+    'docs/CONTEXT.md',
+    'docs/CONTEXT.ko.md',
+    'book/intermediate/ch16-email.md',
+    'book/intermediate/ch16-email.ko.md',
+    'tooling/governance/verify-platform-consistency-governance.mjs',
+    'tooling/governance/verify-platform-consistency-governance.test.ts',
+  ];
+
+  it('does not require Email migration companions for an unrelated README section edit', async () => {
+    // Given: only the Email README installation section changes.
+    const { enforceContractCompanionUpdates } = await loadGovernanceInternals();
+    const snapshots = emailMigrationSnapshots(
+      emailReadmeWithMigrationSection.replace(
+        'Install the package with your preferred package manager.',
+        'Install Nodemailer before configuring the Email module.',
+      ),
+    );
+
+    // When / Then: the unchanged marker-bounded migration section does not trigger migration companions.
+    expect(() =>
+      enforceContractCompanionUpdates(['packages/email/README.md'], snapshots),
+    ).not.toThrow();
+  });
+
+  it.each([
+    [
+      'prose',
+      emailReadmeWithMigrationSection.replace(
+        'Use `EmailService.send(...)` for direct delivery.',
+        'Use `EmailService.send(...)` for templated delivery.',
+      ),
+    ],
+    [
+      'marker semantics',
+      emailReadmeWithMigrationSection.replace(
+        'delivery=direct->pre-rendered,template->rendered',
+        'delivery=direct->rendered,template->pre-rendered',
+      ),
+    ],
+  ])('requires all Email migration companions when marker-section %s changes', async (_label, head) => {
+    // Given: a marker-bounded migration section mutation with only the Email README declared.
+    const { enforceContractCompanionUpdates } = await loadGovernanceInternals();
+    const snapshots = emailMigrationSnapshots(head);
+
+    // When / Then: every migration companion remains mandatory, and the complete set is accepted.
+    expect(() =>
+      enforceContractCompanionUpdates(['packages/email/README.md'], snapshots),
+    ).toThrow(/Email NestJS migration documentation/u);
+    expect(() =>
+      enforceContractCompanionUpdates(completeEmailMigrationCompanions, snapshots),
+    ).not.toThrow();
+  });
+
+  it('fails closed for an Email README edit without snapshots', async () => {
+    // Given: a governed Email README path without Git content snapshots.
     const { enforceContractCompanionUpdates } = await loadGovernanceInternals();
 
+    // When / Then: governance cannot prove the migration section is unchanged.
     expect(() =>
       enforceContractCompanionUpdates(['packages/email/README.md']),
     ).toThrow(/Email NestJS migration documentation/u);
+  });
+
+  it('requires all Email migration companions when the enforcement tool changes', async () => {
+    // Given: a semantic change to the Email migration validator.
+    const { enforceContractCompanionUpdates } = await loadGovernanceInternals();
+    const snapshots = {
+      ...emailMigrationSnapshots(emailReadmeWithMigrationSection),
+      'tooling/governance/email-nestjs-migration-docs.mjs': {
+        base: 'function enforceEmailNestjsMigrationDocs() {}',
+        head: 'function enforceEmailNestjsMigrationDocs() { return undefined; }',
+      },
+    };
+
+    // When / Then: its companion set remains non-bypassable with complete snapshots.
+    expect(() =>
+      enforceContractCompanionUpdates(['tooling/governance/email-nestjs-migration-docs.mjs'], snapshots),
+    ).toThrow(/Email NestJS migration documentation/u);
+  });
+
+  it('does not treat a shared parser export as an Email migration semantic change', async () => {
+    // Given: the validator exports its existing parser without changing its implementation.
+    const { enforceContractCompanionUpdates } = await loadGovernanceInternals();
+    const snapshots = {
+      ...emailMigrationSnapshots(emailReadmeWithMigrationSection),
+      'tooling/governance/email-nestjs-migration-docs.mjs': {
+        base: [
+          "const emailMigrationMarkerPrefix = '<!-- fluo-email-nestjs-migration:';",
+          'function headingBoundedSection(markdown, markerPrefix, relativePath) {}',
+        ].join('\n'),
+        head: [
+          "const emailMigrationMarkerPrefix = '<!-- fluo-email-nestjs-migration:';",
+          'export const emailNestjsMigrationMarkerPrefix = emailMigrationMarkerPrefix;',
+          'export function headingBoundedSection(markdown, markerPrefix, relativePath) {}',
+        ].join('\n'),
+      },
+    };
+
+    // When / Then: sharing the parser cannot impose documentation companions by itself.
+    expect(() =>
+      enforceContractCompanionUpdates(
+        ['tooling/governance/email-nestjs-migration-docs.mjs'],
+        snapshots,
+      ),
+    ).not.toThrow();
   });
 
   it.each([

--- a/tooling/governance/verify-platform-consistency-governance.test.ts
+++ b/tooling/governance/verify-platform-consistency-governance.test.ts
@@ -18,7 +18,7 @@ import {
   collectNodeGlobalBufferViolations,
   enforceCliMigrationTransformDocs,
   enforceCloudflareWorkersLifecycleDocsSync,
-  enforceContractCompanionUpdates,
+  enforceContractCompanionUpdates as enforceContractCompanionUpdatesFromSources,
   enforceEmailMigrationCompanions,
   enforceExpressRuntimeMigrationDocsSync,
   enforceGraphqlRuntimeBoundaryDiscoverability,
@@ -64,6 +64,71 @@ const fastifyRawContextCompanions = [
   'packages/platform-fastify/README.ko.md',
   'packages/platform-fastify/src/adapter.test.ts',
 ];
+const unchangedEmailMigrationGuideSnapshots = {
+  'packages/email/README.md': {
+    base: readFileSync(join(repoRoot, 'packages/email/README.md'), 'utf8'),
+    head: readFileSync(join(repoRoot, 'packages/email/README.md'), 'utf8'),
+  },
+  'packages/email/README.ko.md': {
+    base: readFileSync(join(repoRoot, 'packages/email/README.ko.md'), 'utf8'),
+    head: readFileSync(join(repoRoot, 'packages/email/README.ko.md'), 'utf8'),
+  },
+  'docs/getting-started/migrate-from-nestjs.md': {
+    base: readFileSync(join(repoRoot, 'docs/getting-started/migrate-from-nestjs.md'), 'utf8'),
+    head: readFileSync(join(repoRoot, 'docs/getting-started/migrate-from-nestjs.md'), 'utf8'),
+  },
+  'docs/getting-started/migrate-from-nestjs.ko.md': {
+    base: readFileSync(join(repoRoot, 'docs/getting-started/migrate-from-nestjs.ko.md'), 'utf8'),
+    head: readFileSync(join(repoRoot, 'docs/getting-started/migrate-from-nestjs.ko.md'), 'utf8'),
+  },
+};
+const emailMigrationSectionFixture = [
+  '## Email migration',
+  '',
+  '<!-- fluo-email-nestjs-migration: async=injected-factory->supported;delivery=direct->pre-rendered,template->rendered -->',
+  '',
+  'Use `EmailService.send(...)` for direct delivery.',
+].join('\n');
+
+function withUnchangedEmailMigrationSections(
+  migrationGuideSnapshots: Readonly<Record<string, { base: string; head: string }>>,
+): Readonly<Record<string, { base: string; head: string }>> {
+  const snapshots: Record<string, { base: string; head: string }> = {
+    ...unchangedEmailMigrationGuideSnapshots,
+    ...migrationGuideSnapshots,
+  };
+
+  for (const path of [
+    'docs/getting-started/migrate-from-nestjs.md',
+    'docs/getting-started/migrate-from-nestjs.ko.md',
+  ]) {
+    const snapshot = snapshots[path];
+    if (
+      typeof snapshot.base === 'string'
+      && typeof snapshot.head === 'string'
+      && !snapshot.base.includes('fluo-email-nestjs-migration:')
+      && !snapshot.head.includes('fluo-email-nestjs-migration:')
+    ) {
+      snapshots[path] = {
+        base: `${snapshot.base}\n${emailMigrationSectionFixture}`,
+        head: `${snapshot.head}\n${emailMigrationSectionFixture}`,
+      };
+    }
+  }
+
+  return snapshots;
+}
+
+function enforceContractCompanionUpdates(
+  changedFiles: string[],
+  migrationGuideSnapshots: Readonly<Record<string, { base: string; head: string }>> =
+    unchangedEmailMigrationGuideSnapshots,
+): void {
+  enforceContractCompanionUpdatesFromSources(
+    changedFiles,
+    withUnchangedEmailMigrationSections(migrationGuideSnapshots),
+  );
+}
 
 describe('static asset contract companions', () => {
   it('requires focused portable, Node, and real-listener regressions', () => {
@@ -141,7 +206,7 @@ function requireWorkflowStepIndex(workflow: string, stepName: string): number {
 }
 
 async function loadGovernanceInternals() {
-  return (await import('./verify-platform-consistency-governance.mjs')) as unknown as {
+  const governance = (await import('./verify-platform-consistency-governance.mjs')) as unknown as {
     changedFilesFromGit: (runCommand?: RunCommand, env?: { GITHUB_BASE_REF?: string }) => string[];
     enforceAdvancedBookCoreBoundaryCompanions: (changedFiles: string[]) => void;
     enforceContractCompanionUpdates: (
@@ -156,6 +221,20 @@ async function loadGovernanceInternals() {
     enforceNotificationsStatusDocumentationContract: (readText?: (relativePath: string) => string) => void;
     enforceSocketIoNodeEngineAlignment: (readText?: (relativePath: string) => string) => void;
     enforceStudioRuntimeBridgeDiscoverability: (readText?: (relativePath: string) => string) => void;
+  };
+
+  return {
+    ...governance,
+    enforceContractCompanionUpdates(
+      changedFiles: string[],
+      migrationGuideSnapshots: Readonly<Record<string, { base: string; head: string }>> =
+        unchangedEmailMigrationGuideSnapshots,
+    ): void {
+      governance.enforceContractCompanionUpdates(
+        changedFiles,
+        withUnchangedEmailMigrationSections(migrationGuideSnapshots),
+      );
+    },
   };
 }
 
@@ -2462,7 +2541,7 @@ describe('enforceContractCompanionUpdates', () => {
     '',
     '## Installation',
     '',
-    'Install the package with your preferred package manager.',
+    'Unrelated prose.',
     '',
     '## NestJS migration',
     '',
@@ -2474,17 +2553,58 @@ describe('enforceContractCompanionUpdates', () => {
     '',
     'See the API reference.',
   ].join('\n');
+  const emailMigrationGuideWithMigrationSection = [
+    '# Migration map',
+    '',
+    '## General migration',
+    '',
+    'Unrelated prose.',
+    '',
+    '## Email migration',
+    '',
+    emailMigrationMarker,
+    '',
+    'Use `EmailService.send(...)` for direct delivery.',
+    '',
+    '## Reference',
+    '',
+    'See the API reference.',
+  ].join('\n');
+  const emailMigrationDocuments = {
+    'packages/email/README.md': emailReadmeWithMigrationSection,
+    'packages/email/README.ko.md': emailReadmeWithMigrationSection,
+    'docs/getting-started/migrate-from-nestjs.md': emailMigrationGuideWithMigrationSection,
+    'docs/getting-started/migrate-from-nestjs.ko.md': emailMigrationGuideWithMigrationSection,
+  };
+  type EmailMigrationDocumentPath = keyof typeof emailMigrationDocuments;
+  const emailMigrationDocumentPaths: EmailMigrationDocumentPath[] = [
+    'packages/email/README.md',
+    'packages/email/README.ko.md',
+    'docs/getting-started/migrate-from-nestjs.md',
+    'docs/getting-started/migrate-from-nestjs.ko.md',
+  ];
   const emailMigrationSnapshots = (
-    englishHead: string,
-    koreanHead = emailReadmeWithMigrationSection,
+    heads: Readonly<Partial<Record<EmailMigrationDocumentPath, string>>> = {},
   ) => ({
     'packages/email/README.md': {
       base: emailReadmeWithMigrationSection,
-      head: englishHead,
+      head: heads['packages/email/README.md'] ?? emailReadmeWithMigrationSection,
     },
     'packages/email/README.ko.md': {
       base: emailReadmeWithMigrationSection,
-      head: koreanHead,
+      head: heads['packages/email/README.ko.md'] ?? emailReadmeWithMigrationSection,
+    },
+    'docs/getting-started/migrate-from-nestjs.md': {
+      base: emailMigrationGuideWithMigrationSection,
+      head:
+        heads['docs/getting-started/migrate-from-nestjs.md'] ??
+        emailMigrationGuideWithMigrationSection,
+    },
+    'docs/getting-started/migrate-from-nestjs.ko.md': {
+      base: emailMigrationGuideWithMigrationSection,
+      head:
+        heads['docs/getting-started/migrate-from-nestjs.ko.md'] ??
+        emailMigrationGuideWithMigrationSection,
     },
   });
   const completeEmailMigrationCompanions = [
@@ -2501,59 +2621,81 @@ describe('enforceContractCompanionUpdates', () => {
     'tooling/governance/verify-platform-consistency-governance.mjs',
     'tooling/governance/verify-platform-consistency-governance.test.ts',
   ];
+  const changedFilesForUnrelatedEmailDocumentEdit = (path: EmailMigrationDocumentPath) =>
+    path.startsWith('docs/')
+      ? [
+          path,
+          'docs/CONTEXT.md',
+          'docs/CONTEXT.ko.md',
+          'tooling/governance/verify-platform-consistency-governance.test.ts',
+        ]
+      : [path];
 
-  it('does not require Email migration companions for an unrelated README section edit', async () => {
-    // Given: only the Email README installation section changes.
+  it.each(emailMigrationDocumentPaths)(
+    'does not require Email migration companions for an unrelated %s section edit',
+    async (path) => {
+    // Given: only an unrelated section in one governed Email document changes.
     const { enforceContractCompanionUpdates } = await loadGovernanceInternals();
-    const snapshots = emailMigrationSnapshots(
-      emailReadmeWithMigrationSection.replace(
-        'Install the package with your preferred package manager.',
+    const snapshots = emailMigrationSnapshots({
+      [path]: emailMigrationDocuments[path].replace(
+        'Unrelated prose.',
         'Install Nodemailer before configuring the Email module.',
       ),
-    );
+    });
 
     // When / Then: the unchanged marker-bounded migration section does not trigger migration companions.
     expect(() =>
-      enforceContractCompanionUpdates(['packages/email/README.md'], snapshots),
+      enforceContractCompanionUpdates(changedFilesForUnrelatedEmailDocumentEdit(path), snapshots),
     ).not.toThrow();
-  });
+    },
+  );
 
   it.each([
     [
-      'prose',
-      emailReadmeWithMigrationSection.replace(
+      'README',
+      'packages/email/README.md',
+    ],
+    [
+      'migration guide',
+      'docs/getting-started/migrate-from-nestjs.md',
+    ],
+  ] as const)('requires all Email migration companions when the %s marker section changes', async (_label, path) => {
+    // Given: a marker-bounded migration section mutation with only one document declared.
+    const { enforceContractCompanionUpdates } = await loadGovernanceInternals();
+    const snapshots = emailMigrationSnapshots({
+      [path]: emailMigrationDocuments[path].replace(
         'Use `EmailService.send(...)` for direct delivery.',
         'Use `EmailService.send(...)` for templated delivery.',
       ),
-    ],
-    [
-      'marker semantics',
-      emailReadmeWithMigrationSection.replace(
-        'delivery=direct->pre-rendered,template->rendered',
-        'delivery=direct->rendered,template->pre-rendered',
-      ),
-    ],
-  ])('requires all Email migration companions when marker-section %s changes', async (_label, head) => {
-    // Given: a marker-bounded migration section mutation with only the Email README declared.
-    const { enforceContractCompanionUpdates } = await loadGovernanceInternals();
-    const snapshots = emailMigrationSnapshots(head);
+    });
 
     // When / Then: every migration companion remains mandatory, and the complete set is accepted.
     expect(() =>
-      enforceContractCompanionUpdates(['packages/email/README.md'], snapshots),
+      enforceContractCompanionUpdates([path], snapshots),
     ).toThrow(/Email NestJS migration documentation/u);
     expect(() =>
       enforceContractCompanionUpdates(completeEmailMigrationCompanions, snapshots),
     ).not.toThrow();
   });
 
-  it('fails closed for an Email README edit without snapshots', async () => {
-    // Given: a governed Email README path without Git content snapshots.
-    const { enforceContractCompanionUpdates } = await loadGovernanceInternals();
+  it.each(emailMigrationDocumentPaths)('fails closed for a governed %s edit without snapshots', async (path) => {
+    // Given: a governed Email document path without Git content snapshots.
 
     // When / Then: governance cannot prove the migration section is unchanged.
     expect(() =>
-      enforceContractCompanionUpdates(['packages/email/README.md']),
+      enforceContractCompanionUpdatesFromSources([path]),
+    ).toThrow(/Email NestJS migration documentation/u);
+  });
+
+  it.each(emailMigrationDocumentPaths)('fails closed for malformed %s snapshots', async (path) => {
+    // Given: a changed governed Email document with a malformed sibling snapshot.
+    const { enforceContractCompanionUpdates } = await loadGovernanceInternals();
+    const snapshots = emailMigrationSnapshots();
+    Reflect.deleteProperty(snapshots[path], 'head');
+
+    // When / Then: governance cannot infer a section-safe edit from malformed evidence.
+    expect(() =>
+      enforceContractCompanionUpdates([path], snapshots),
     ).toThrow(/Email NestJS migration documentation/u);
   });
 
@@ -2561,7 +2703,7 @@ describe('enforceContractCompanionUpdates', () => {
     // Given: a semantic change to the Email migration validator.
     const { enforceContractCompanionUpdates } = await loadGovernanceInternals();
     const snapshots = {
-      ...emailMigrationSnapshots(emailReadmeWithMigrationSection),
+      ...emailMigrationSnapshots(),
       'tooling/governance/email-nestjs-migration-docs.mjs': {
         base: 'function enforceEmailNestjsMigrationDocs() {}',
         head: 'function enforceEmailNestjsMigrationDocs() { return undefined; }',
@@ -2578,7 +2720,7 @@ describe('enforceContractCompanionUpdates', () => {
     // Given: the validator exports its existing parser without changing its implementation.
     const { enforceContractCompanionUpdates } = await loadGovernanceInternals();
     const snapshots = {
-      ...emailMigrationSnapshots(emailReadmeWithMigrationSection),
+      ...emailMigrationSnapshots(),
       'tooling/governance/email-nestjs-migration-docs.mjs': {
         base: [
           "const emailMigrationMarkerPrefix = '<!-- fluo-email-nestjs-migration:';",


### PR DESCRIPTION
## Summary
- publish `@types/nodemailer` as an optional peer for `@fluojs/email/node`
- document complete EN/KO Node SMTP installation
- add hermetic packed-tarball offline consumer typecheck

## Verification
- clean-dist full build
- Email typecheck and 60 tests including offline packed consumer
- reverse-dependent tests, lint/TSDoc and governance

Closes #3162