### PR TITLE
fix(microservices): make shutdown terminal and drain inbound work (#3212)

### DIFF
--- a/.changeset/drain-microservice-inbound-close.md
+++ b/.changeset/drain-microservice-inbound-close.md
@@ -1,5 +1,6 @@
 ---
 '@fluojs/microservices': patch
+'@fluojs/runtime': patch
 ---
 
-Make microservice shutdown idempotent and wait for already-admitted inbound handlers before transport cleanup.
+Make microservice shutdown terminally idempotent, wait for already-admitted inbound handlers before transport cleanup, and preserve failed close results without retrying teardown.

--- a/.changeset/drain-microservice-inbound-close.md
+++ b/.changeset/drain-microservice-inbound-close.md
@@ -3,4 +3,4 @@
 '@fluojs/runtime': patch
 ---
 
-Make microservice shutdown terminally idempotent, wait for already-admitted inbound handlers before transport cleanup, and preserve failed close results without retrying teardown.
+Make microservice shutdown terminally idempotent, including synchronous shutdown-marker failures and reentry, wait for already-admitted inbound handlers before transport cleanup, and preserve failed close results without retrying teardown.

--- a/.changeset/drain-microservice-inbound-close.md
+++ b/.changeset/drain-microservice-inbound-close.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/microservices': patch
+---
+
+Make microservice shutdown idempotent and wait for already-admitted inbound handlers before transport cleanup.

--- a/packages/microservices/README.ko.md
+++ b/packages/microservices/README.ko.md
@@ -121,7 +121,7 @@ Redis Pub/Sub은 동일한 등록 경로를 사용하기 위해 공통 transport
 | --- | --- |
 | `await microservice.send(...)` | transport가 상관관계가 유지된 원격 응답을 반환할 때 settle하며, 원격 오류, abort, timeout, shutdown 시 reject합니다. |
 | `await microservice.emit(...)` | transport의 publish 연산이 outbound event를 accept/complete할 때 settle합니다. 원격 event handler를 기다리거나 collaborator의 publish 계약을 넘어선 delivery/redelivery 보장을 추가하지는 않습니다. |
-| `await microservice.close()` | transport-owned listener/subscription teardown과 pending-request cleanup을 기다립니다. Caller-owned NATS, Kafka, RabbitMQ collaborator의 경우 전달받은 broker resource를 close/disconnect하지 않습니다. |
+| `await microservice.close()` | 반복 호출은 하나의 shutdown 결과를 공유합니다. 이미 수락된 inbound handler가 settle할 때까지 기다린 뒤 transport-owned listener/subscription teardown과 pending-request cleanup을 수행합니다. Caller-owned NATS, Kafka, RabbitMQ collaborator의 경우 전달받은 broker resource를 close/disconnect하지 않습니다. |
 
 Kafka와 RabbitMQ는 일치한 handler와 request response publication이 settle할 때까지 각 inbound consumer callback을 pending 상태로 유지합니다. 이 consumer-side completion boundary를 통해 broker adapter가 delivery를 acknowledge할지 retry할지 결정할 수 있지만, producer-side `emit()` promise가 end-to-end handler completion signal로 바뀌는 것은 아닙니다. 애플리케이션 shutdown에서는 먼저 `Microservice` facade를 닫아 transport callback을 detach한 다음, caller-owned client, producer, consumer, publisher, channel, connection을 application bootstrap layer에서 close 또는 drain하세요.
 

--- a/packages/microservices/README.md
+++ b/packages/microservices/README.md
@@ -119,7 +119,7 @@ Keep application registration and programmatic calls on the root facade: registe
 | --- | --- |
 | `await microservice.send(...)` | Settles when the transport returns the correlated remote response, or rejects for a remote error, abort, timeout, or shutdown. |
 | `await microservice.emit(...)` | Settles when the transport's publish operation accepts/completes the outbound event. It does not wait for remote event handlers or add delivery/redelivery guarantees beyond the collaborator's publish contract. |
-| `await microservice.close()` | Waits for transport-owned listener/subscription teardown and pending-request cleanup. For caller-owned NATS, Kafka, and RabbitMQ collaborators, it does not close or disconnect the supplied broker resources. |
+| `await microservice.close()` | Repeated calls share one shutdown result. It waits for already-admitted inbound handlers to settle before transport-owned listener/subscription teardown and pending-request cleanup. For caller-owned NATS, Kafka, and RabbitMQ collaborators, it does not close or disconnect the supplied broker resources. |
 
 Kafka and RabbitMQ keep each inbound consumer callback pending until the matched handler and any request response publication settle. That consumer-side completion boundary lets a broker adapter decide whether to acknowledge or retry delivery, but it does not turn the producer-side `emit()` promise into an end-to-end handler completion signal. During application shutdown, close the `Microservice` facade first so it can detach transport callbacks, then close or drain caller-owned clients, producers, consumers, publishers, channels, and connections from the application bootstrap layer.
 

--- a/packages/microservices/src/lifecycle-regression.test.ts
+++ b/packages/microservices/src/lifecycle-regression.test.ts
@@ -3,9 +3,10 @@ import { defineModuleMetadata } from '@fluojs/core/internal';
 import { bootstrapApplication, FluoFactory } from '@fluojs/runtime';
 import { expect, it, vi } from 'vitest';
 
+import { MessagePattern } from './decorators.js';
 import { MicroservicesModule } from './module.js';
 import { MicroserviceLifecycleService } from './service.js';
-import type { MicroserviceTransport } from './types.js';
+import type { MicroserviceTransport, TransportHandler } from './types.js';
 
 function createDeferred(): { readonly promise: Promise<void>; readonly resolve: () => void } {
   let resolvePromise: () => void = () => undefined;
@@ -237,6 +238,50 @@ it('keeps facade send and emit rejected after a failed close attempt', async () 
   } catch {}
 });
 
+it('shares a failed close result without retrying transport teardown', async () => {
+  // Given
+  const closeError = new Error('transport close failed');
+  let closeCalls = 0;
+  const transport: MicroserviceTransport = {
+    async close() {
+      closeCalls += 1;
+      throw closeError;
+    },
+    async emit() {},
+    async listen() {},
+    async send() {
+      return 'sent';
+    },
+  };
+
+  class AppModule {}
+  defineModuleMetadata(AppModule, {
+    imports: [MicroservicesModule.forRoot({ transport })],
+  });
+
+  const app = await bootstrapApplication({ rootModule: AppModule });
+  const microservice = await app.container.resolve(MicroserviceLifecycleService);
+  await microservice.listen();
+  const firstClose = microservice.close();
+  const secondClose = microservice.close();
+
+  // When
+  await Promise.allSettled([firstClose, secondClose]);
+  const repeatedClose = microservice.close();
+
+  // Then
+  try {
+    expect(secondClose).toBe(firstClose);
+    expect(repeatedClose).toBe(firstClose);
+    await expect(repeatedClose).rejects.toThrow(closeError);
+    expect(closeCalls).toBe(1);
+  } finally {
+    try {
+      await app.close();
+    } catch {}
+  }
+});
+
   it('rejects resolved lifecycle facade send and emit while shell listen is still pending', async () => {
     // Given
     const events: string[] = [];
@@ -293,3 +338,75 @@ it('keeps facade send and emit rejected after a failed close attempt', async () 
       await closePromise;
     }
   });
+
+it('shares close and drains admitted inbound work before transport teardown', async () => {
+  // Given
+  const events: string[] = [];
+  const handlerMayFinish = createDeferred();
+  const handlerStarted = createDeferred();
+  let closeCalls = 0;
+  let transportHandler: TransportHandler | undefined;
+  const transport: MicroserviceTransport = {
+    async close() {
+      closeCalls += 1;
+      events.push('transport:close');
+    },
+    async emit() {},
+    async listen(handler) {
+      transportHandler = handler;
+    },
+    async send() {
+      return 'sent';
+    },
+  };
+
+  class OrdersHandler {
+    @MessagePattern('orders.fulfill')
+    async fulfill(): Promise<string> {
+      events.push('handler:start');
+      handlerStarted.resolve();
+      await handlerMayFinish.promise;
+      events.push('handler:end');
+      return 'fulfilled';
+    }
+  }
+
+  class AppModule {}
+  defineModuleMetadata(AppModule, {
+    imports: [MicroservicesModule.forRoot({ transport })],
+    providers: [OrdersHandler],
+  });
+
+  const app = await bootstrapApplication({ rootModule: AppModule });
+  const microservice = await app.container.resolve(MicroserviceLifecycleService);
+  await microservice.listen();
+
+  if (!transportHandler) {
+    throw new Error('Expected transport handler after listen().');
+  }
+
+  const inbound = transportHandler({
+    kind: 'message',
+    pattern: 'orders.fulfill',
+    payload: {},
+  });
+  await handlerStarted.promise;
+  const firstClose = microservice.close();
+  const secondClose = microservice.close();
+
+  // When
+  const closesBeforeInboundDrain = closeCalls;
+
+  // Then
+  try {
+    expect(secondClose).toBe(firstClose);
+    expect(closesBeforeInboundDrain).toBe(0);
+  } finally {
+    handlerMayFinish.resolve();
+    await expect(inbound).resolves.toBe('fulfilled');
+    await Promise.all([firstClose, secondClose]);
+    expect(events).toEqual(['handler:start', 'handler:end', 'transport:close']);
+    expect(closeCalls).toBe(1);
+    await app.close();
+  }
+});

--- a/packages/microservices/src/lifecycle-regression.test.ts
+++ b/packages/microservices/src/lifecycle-regression.test.ts
@@ -1,7 +1,7 @@
 import { InvariantError } from '@fluojs/core';
 import { defineModuleMetadata } from '@fluojs/core/internal';
 import { bootstrapApplication, FluoFactory } from '@fluojs/runtime';
-import { expect, it, vi } from 'vitest';
+import { expect, it } from 'vitest';
 
 import { MessagePattern } from './decorators.js';
 import { MicroservicesModule } from './module.js';
@@ -56,11 +56,13 @@ it('rejects facade listen re-entry after close completes', async () => {
 it('rejects facade listen re-entry after close starts', async () => {
   // Given
   const events: string[] = [];
+  const closeStarted = createDeferred();
   const closeCanFinish = createDeferred();
   let listenCalls = 0;
   const transport: MicroserviceTransport = {
     async close() {
       events.push('transport:close:start');
+      closeStarted.resolve();
       await closeCanFinish.promise;
       events.push('transport:close:end');
     },
@@ -82,9 +84,7 @@ it('rejects facade listen re-entry after close starts', async () => {
   const microservice = await app.container.resolve(MicroserviceLifecycleService);
   await microservice.listen();
   const closePromise = microservice.close();
-  await vi.waitFor(() => {
-    expect(events).toEqual(['transport:close:start']);
-  });
+  await closeStarted.promise;
 
   // When
   const listenReentry = microservice.listen();
@@ -103,6 +103,7 @@ it('rejects facade listen re-entry after close starts', async () => {
 it('rejects facade send before transport admission when close races with listen', async () => {
   // Given
   const events: string[] = [];
+  const listenStarted = createDeferred();
   const listenCanFinish = createDeferred();
   const transport: MicroserviceTransport = {
     async close() {
@@ -111,6 +112,7 @@ it('rejects facade send before transport admission when close races with listen'
     async emit() {},
     async listen() {
       events.push('transport:listen:start');
+      listenStarted.resolve();
       await listenCanFinish.promise;
       events.push('transport:listen:end');
     },
@@ -128,9 +130,7 @@ it('rejects facade send before transport admission when close races with listen'
   const app = await bootstrapApplication({ rootModule: AppModule });
   const microservice = await app.container.resolve(MicroserviceLifecycleService);
   const listenPromise = microservice.listen();
-  await vi.waitFor(() => {
-    expect(events).toEqual(['transport:listen:start']);
-  });
+  await listenStarted.promise;
 
   // When
   const closePromise = microservice.close();
@@ -152,6 +152,7 @@ it('rejects facade send before transport admission when close races with listen'
 it('rejects facade emit before transport admission when close races with listen', async () => {
   // Given
   const events: string[] = [];
+  const listenStarted = createDeferred();
   const listenCanFinish = createDeferred();
   const transport: MicroserviceTransport = {
     async close() {
@@ -162,6 +163,7 @@ it('rejects facade emit before transport admission when close races with listen'
     },
     async listen() {
       events.push('transport:listen:start');
+      listenStarted.resolve();
       await listenCanFinish.promise;
       events.push('transport:listen:end');
     },
@@ -178,9 +180,7 @@ it('rejects facade emit before transport admission when close races with listen'
   const app = await bootstrapApplication({ rootModule: AppModule });
   const microservice = await app.container.resolve(MicroserviceLifecycleService);
   const listenPromise = microservice.listen();
-  await vi.waitFor(() => {
-    expect(events).toEqual(['transport:listen:start']);
-  });
+  await listenStarted.promise;
 
   // When
   const closePromise = microservice.close();
@@ -238,7 +238,7 @@ it('keeps facade send and emit rejected after a failed close attempt', async () 
   } catch {}
 });
 
-it('shares a failed close result without retrying transport teardown', async () => {
+  it('shares a failed close result without retrying transport teardown', async () => {
   // Given
   const closeError = new Error('transport close failed');
   let closeCalls = 0;
@@ -280,11 +280,54 @@ it('shares a failed close result without retrying transport teardown', async () 
       await app.close();
     } catch {}
   }
+  });
+
+it('shares one close promise when transport close synchronously reenters', async () => {
+  // Given
+  let closeCalls = 0;
+  let reenteredClose: Promise<void> | undefined;
+  let microservice: MicroserviceLifecycleService;
+  const transport: MicroserviceTransport = {
+    async close() {
+      closeCalls += 1;
+
+      if (closeCalls === 1) {
+        reenteredClose = microservice.close();
+      }
+    },
+    async emit() {},
+    async listen() {},
+    async send() {
+      return 'sent';
+    },
+  };
+
+  class AppModule {}
+  defineModuleMetadata(AppModule, {
+    imports: [MicroservicesModule.forRoot({ transport })],
+  });
+
+  const app = await bootstrapApplication({ rootModule: AppModule });
+  microservice = await app.container.resolve(MicroserviceLifecycleService);
+  await microservice.listen();
+
+  // When
+  const firstClose = microservice.close();
+
+  // Then
+  try {
+    expect(reenteredClose).toBe(firstClose);
+    await firstClose;
+    expect(closeCalls).toBe(1);
+  } finally {
+    await app.close();
+  }
 });
 
   it('rejects resolved lifecycle facade send and emit while shell listen is still pending', async () => {
     // Given
     const events: string[] = [];
+    const listenStarted = createDeferred();
     const listenCanFinish = createDeferred();
     const closeCanFinish = createDeferred();
     const transport: MicroserviceTransport = {
@@ -298,6 +341,7 @@ it('shares a failed close result without retrying transport teardown', async () 
       },
       async listen() {
         events.push('transport:listen:start');
+        listenStarted.resolve();
         await listenCanFinish.promise;
         events.push('transport:listen:end');
       },
@@ -315,9 +359,7 @@ it('shares a failed close result without retrying transport teardown', async () 
     const shell = await FluoFactory.createMicroservice(AppModule);
     const lifecycle = await shell.container.resolve(MicroserviceLifecycleService);
     const listenPromise = shell.listen();
-    await vi.waitFor(() => {
-      expect(events).toEqual(['transport:listen:start']);
-    });
+    await listenStarted.promise;
 
     // When
     const closePromise = shell.close();
@@ -407,6 +449,126 @@ it('shares close and drains admitted inbound work before transport teardown', as
     await Promise.all([firstClose, secondClose]);
     expect(events).toEqual(['handler:start', 'handler:end', 'transport:close']);
     expect(closeCalls).toBe(1);
+    await app.close();
+  }
+});
+
+it('drains a rejected admitted handler before transport teardown', async () => {
+  // Given
+  const events: string[] = [];
+  const handlerMayReject = createDeferred();
+  const handlerStarted = createDeferred();
+  const handlerError = new Error('handler failed');
+  let closeCalls = 0;
+  let transportHandler: TransportHandler | undefined;
+  const transport: MicroserviceTransport = {
+    async close() {
+      closeCalls += 1;
+      events.push('transport:close');
+    },
+    async emit() {},
+    async listen(handler) {
+      transportHandler = handler;
+    },
+    async send() {
+      return 'sent';
+    },
+  };
+
+  class OrdersHandler {
+    @MessagePattern('orders.reject')
+    async reject(): Promise<void> {
+      events.push('handler:start');
+      handlerStarted.resolve();
+      await handlerMayReject.promise;
+      events.push('handler:reject');
+      throw handlerError;
+    }
+  }
+
+  class AppModule {}
+  defineModuleMetadata(AppModule, {
+    imports: [MicroservicesModule.forRoot({ transport })],
+    providers: [OrdersHandler],
+  });
+
+  const app = await bootstrapApplication({ rootModule: AppModule });
+  const microservice = await app.container.resolve(MicroserviceLifecycleService);
+  await microservice.listen();
+
+  if (!transportHandler) {
+    throw new Error('Expected transport handler after listen().');
+  }
+
+  const inbound = transportHandler({
+    kind: 'message',
+    pattern: 'orders.reject',
+    payload: {},
+  });
+  await handlerStarted.promise;
+  const closePromise = microservice.close();
+
+  // When
+  handlerMayReject.resolve();
+
+  // Then
+  try {
+    expect(closeCalls).toBe(0);
+    await expect(inbound).rejects.toThrow(handlerError);
+    await expect(closePromise).resolves.toBeUndefined();
+    expect(events).toEqual(['handler:start', 'handler:reject', 'transport:close']);
+    expect(closeCalls).toBe(1);
+  } finally {
+    await app.close();
+  }
+});
+
+it('rejects a transport callback invoked after shutdown admission closes', async () => {
+  // Given
+  let closeCalls = 0;
+  let transportHandler: TransportHandler | undefined;
+  const transport: MicroserviceTransport = {
+    async close() {
+      closeCalls += 1;
+    },
+    async emit() {},
+    async listen(handler) {
+      transportHandler = handler;
+    },
+    async send() {
+      return 'sent';
+    },
+  };
+
+  class AppModule {}
+  defineModuleMetadata(AppModule, {
+    imports: [MicroservicesModule.forRoot({ transport })],
+  });
+
+  const app = await bootstrapApplication({ rootModule: AppModule });
+  const microservice = await app.container.resolve(MicroserviceLifecycleService);
+  await microservice.listen();
+
+  if (!transportHandler) {
+    throw new Error('Expected transport handler after listen().');
+  }
+
+  await microservice.close();
+
+  // When
+  const callbackAfterClose = transportHandler({
+    kind: 'message',
+    pattern: 'orders.after-close',
+    payload: {},
+  });
+
+  // Then
+  try {
+    await expect(callbackAfterClose).rejects.toThrow(
+      'Microservice cannot accept inbound work after shutdown has started.',
+    );
+    expect(closeCalls).toBe(1);
+  } finally {
     await app.close();
   }
 });

--- a/packages/microservices/src/service.ts
+++ b/packages/microservices/src/service.ts
@@ -55,6 +55,8 @@ export class MicroserviceLifecycleService implements Microservice, MicroserviceR
   private readonly descriptors: HandlerDescriptor[] = [];
   private readonly handlerInstances = new Map<Token, Promise<unknown>>();
   private closeStarted = false;
+  private closePromise: Promise<void> | undefined;
+  private readonly inboundWork = new Set<Promise<unknown>>();
   private lifecycleState: 'created' | 'starting' | 'ready' | 'stopping' | 'stopped' | 'failed' = 'created';
   private lastListenError: string | undefined;
   private listening = false;
@@ -110,7 +112,7 @@ export class MicroserviceLifecycleService implements Microservice, MicroserviceR
     if (transport.listenServerStreaming) {
       transport.listenServerStreaming(
         async (pattern: string, payload: unknown, writer: ServerStreamWriter) => {
-          await this.dispatchServerStream(pattern, cloneWithFallback(payload), writer);
+          await this.trackInboundWork(() => this.dispatchServerStream(pattern, cloneWithFallback(payload), writer));
         },
       );
     }
@@ -118,7 +120,7 @@ export class MicroserviceLifecycleService implements Microservice, MicroserviceR
     if (transport.listenClientStreaming) {
       transport.listenClientStreaming(
         async (pattern: string, reader: AsyncIterable<unknown>) => {
-          return await this.dispatchClientStream(pattern, reader);
+          return await this.trackInboundWork(() => this.dispatchClientStream(pattern, reader));
         },
       );
     }
@@ -126,12 +128,12 @@ export class MicroserviceLifecycleService implements Microservice, MicroserviceR
     if (transport.listenBidiStreaming) {
       transport.listenBidiStreaming(
         async (pattern: string, reader: AsyncIterable<unknown>, writer: ServerStreamWriter) => {
-          await this.dispatchBidiStream(pattern, reader, writer);
+          await this.trackInboundWork(() => this.dispatchBidiStream(pattern, reader, writer));
         },
       );
     }
 
-    await transport.listen(async (packet) => this.dispatchPacket(packet));
+    await transport.listen(async (packet) => await this.trackInboundWork(() => this.dispatchPacket(packet)));
     this.listening = true;
     this.lifecycleState = 'ready';
   }
@@ -142,10 +144,20 @@ export class MicroserviceLifecycleService implements Microservice, MicroserviceR
    * @param signal Optional shutdown signal reported by the runtime lifecycle hook.
    * @returns A promise that resolves once shutdown completes.
    */
-  async close(signal?: string): Promise<void> {
+  close(signal?: string): Promise<void> {
     void signal;
     this.closeStarted = true;
 
+    if (this.closePromise) {
+      return this.closePromise;
+    }
+
+    this.closePromise = this.closeTransport();
+
+    return this.closePromise;
+  }
+
+  private async closeTransport(): Promise<void> {
     let listenError: unknown;
 
     if (this.listenPromise) {
@@ -159,6 +171,10 @@ export class MicroserviceLifecycleService implements Microservice, MicroserviceR
     this.lifecycleState = 'stopping';
 
     try {
+      if (this.inboundWork.size > 0) {
+        await this.drainInboundWork();
+      }
+
       await this.moduleOptions.transport.close();
       this.listening = false;
 
@@ -174,6 +190,27 @@ export class MicroserviceLifecycleService implements Microservice, MicroserviceR
       this.lastListenError = error instanceof Error ? error.message : String(error);
       throw error;
     }
+  }
+
+  private async drainInboundWork(): Promise<void> {
+    while (this.inboundWork.size > 0) {
+      await Promise.allSettled(this.inboundWork);
+    }
+  }
+
+  private trackInboundWork<T>(operation: () => Promise<T>): Promise<T> {
+    if (this.closeStarted) {
+      return Promise.reject(new InvariantError('Microservice cannot accept inbound work after shutdown has started.'));
+    }
+
+    const work = Promise.resolve().then(operation);
+    this.inboundWork.add(work);
+    void work.then(
+      () => this.inboundWork.delete(work),
+      () => this.inboundWork.delete(work),
+    );
+
+    return work;
   }
 
   markShutdownStarted(): void {

--- a/packages/microservices/src/service.ts
+++ b/packages/microservices/src/service.ts
@@ -152,7 +152,13 @@ export class MicroserviceLifecycleService implements Microservice, MicroserviceR
       return this.closePromise;
     }
 
-    this.closePromise = this.closeTransport();
+    let resolveClose!: () => void;
+    let rejectClose!: (reason?: unknown) => void;
+    this.closePromise = new Promise<void>((resolve, reject) => {
+      resolveClose = resolve;
+      rejectClose = reject;
+    });
+    void this.closeTransport().then(resolveClose, rejectClose);
 
     return this.closePromise;
   }

--- a/packages/runtime/src/bootstrap.ts
+++ b/packages/runtime/src/bootstrap.ts
@@ -1034,9 +1034,15 @@ class FluoMicroserviceApplication implements MicroserviceApplication {
     }
 
     this.closeStarted = true;
-    this.runtime.markShutdownStarted?.();
+    let resolveClose: () => void = () => undefined;
+    let rejectClose: (reason?: unknown) => void = () => undefined;
+    this.closingPromise = new Promise<void>((resolve, reject) => {
+      resolveClose = resolve;
+      rejectClose = reject;
+    });
+    void (async () => {
+      this.runtime.markShutdownStarted?.();
 
-    this.closingPromise = (async () => {
       if (this.listenPromise) {
         try {
           await this.listenPromise;
@@ -1067,7 +1073,7 @@ class FluoMicroserviceApplication implements MicroserviceApplication {
 
       this.closed = true;
       this.microserviceState = 'closed';
-    })();
+    })().then(resolveClose, rejectClose);
 
     await this.closingPromise;
   }

--- a/packages/runtime/src/bootstrap.ts
+++ b/packages/runtime/src/bootstrap.ts
@@ -1069,12 +1069,7 @@ class FluoMicroserviceApplication implements MicroserviceApplication {
       this.microserviceState = 'closed';
     })();
 
-    try {
-      await this.closingPromise;
-    } catch (error) {
-      this.closingPromise = undefined;
-      throw error;
-    }
+    await this.closingPromise;
   }
 
   private assertTransportIngressOpen(operation: 'emit' | 'send'): void {

--- a/packages/runtime/src/microservice-application.lifecycle.test.ts
+++ b/packages/runtime/src/microservice-application.lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { expect, it, vi } from 'vitest';
+import { expect, it } from 'vitest';
 
 import { FluoFactory } from './bootstrap.js';
 import { defineRuntimeModuleMetadata } from './internal/core-metadata.js';
@@ -24,6 +24,7 @@ function createDeferred(): { readonly promise: Promise<void>; readonly resolve: 
 it('rejects send before transport admission when close races with listen', async () => {
   // Given
   const events: string[] = [];
+  const listenStarted = createDeferred();
   const listenCanFinish = createDeferred();
   const microserviceToken = Symbol.for('fluo.microservices.service');
 
@@ -34,6 +35,7 @@ it('rejects send before transport admission when close races with listen', async
 
     async listen(): Promise<void> {
       events.push('runtime:listen:start');
+      listenStarted.resolve();
       await listenCanFinish.promise;
       events.push('runtime:listen:end');
     }
@@ -51,9 +53,7 @@ it('rejects send before transport admission when close races with listen', async
 
   const microservice = await FluoFactory.createMicroservice(AppModule);
   const listenPromise = microservice.listen();
-  await vi.waitFor(() => {
-    expect(events).toEqual(['runtime:listen:start']);
-  });
+  await listenStarted.promise;
 
   // When
   const closePromise = microservice.close();
@@ -74,6 +74,7 @@ it('rejects send before transport admission when close races with listen', async
 it('rejects emit before transport admission when close races with listen', async () => {
   // Given
   const events: string[] = [];
+  const listenStarted = createDeferred();
   const listenCanFinish = createDeferred();
   const microserviceToken = Symbol.for('fluo.microservices.service');
 
@@ -88,6 +89,7 @@ it('rejects emit before transport admission when close races with listen', async
 
     async listen(): Promise<void> {
       events.push('runtime:listen:start');
+      listenStarted.resolve();
       await listenCanFinish.promise;
       events.push('runtime:listen:end');
     }
@@ -100,9 +102,7 @@ it('rejects emit before transport admission when close races with listen', async
 
   const microservice = await FluoFactory.createMicroservice(AppModule);
   const listenPromise = microservice.listen();
-  await vi.waitFor(() => {
-    expect(events).toEqual(['runtime:listen:start']);
-  });
+  await listenStarted.promise;
 
   // When
   const closePromise = microservice.close();
@@ -123,12 +123,15 @@ it('rejects emit before transport admission when close races with listen', async
 it('notifies runtime facade of shutdown start before awaiting in-flight listen', async () => {
   // Given
   const events: string[] = [];
+  const listenStarted = createDeferred();
+  const shutdownStarted = createDeferred();
   const listenCanFinish = createDeferred();
   const microserviceToken = Symbol.for('fluo.microservices.service');
 
   class StubMicroserviceRuntime implements MicroserviceRuntime {
     markShutdownStarted(): void {
       events.push('runtime:mark-shutdown');
+      shutdownStarted.resolve();
     }
 
     async close(): Promise<void> {
@@ -137,6 +140,7 @@ it('notifies runtime facade of shutdown start before awaiting in-flight listen',
 
     async listen(): Promise<void> {
       events.push('runtime:listen:start');
+      listenStarted.resolve();
       await listenCanFinish.promise;
       events.push('runtime:listen:end');
     }
@@ -155,17 +159,13 @@ it('notifies runtime facade of shutdown start before awaiting in-flight listen',
       throw new Error('microservice not bootstrapped');
     }
     const listenPromise = app.listen();
-    await vi.waitFor(() => {
-      expect(events).toEqual(['runtime:listen:start']);
-    });
+    await listenStarted.promise;
 
     // When
     const closePromise = app.close();
 
     // Then
-    await vi.waitFor(() => {
-      expect(events).toContain('runtime:mark-shutdown');
-    });
+    await shutdownStarted.promise;
     await expect(app.send('orders.create', { id: 'order-1' })).rejects.toThrow(
       'Microservice cannot send after shutdown has started.',
     );
@@ -230,6 +230,49 @@ it('keeps send and emit rejected after a failed close attempt', async () => {
     );
     expect(events).not.toContain('runtime:send');
     expect(events).not.toContain('runtime:emit');
+  } finally {
+    await disposeApp(app);
+  }
+});
+
+it('caches a failed shell close without retrying terminal teardown', async () => {
+  // Given
+  const microserviceToken = Symbol.for('fluo.microservices.service');
+  const closeError = new Error('transport close failed');
+  let closeCalls = 0;
+
+  class StubMicroserviceRuntime implements MicroserviceRuntime {
+    async close(): Promise<void> {
+      closeCalls += 1;
+      throw closeError;
+    }
+
+    async listen(): Promise<void> {}
+  }
+
+  class AppModule {}
+  defineRuntimeModuleMetadata(AppModule, {
+    providers: [{ provide: microserviceToken, useClass: StubMicroserviceRuntime }],
+  });
+
+  let app: MicroserviceApplication | undefined;
+
+  try {
+    app = await FluoFactory.createMicroservice(AppModule);
+    if (!app) {
+      throw new Error('microservice not bootstrapped');
+    }
+    await app.listen();
+    const firstClose = app.close();
+    const secondClose = app.close();
+
+    // When
+    await expect(firstClose).rejects.toThrow(closeError);
+    await expect(secondClose).rejects.toThrow(closeError);
+    await expect(app.close()).rejects.toThrow(closeError);
+
+    // Then
+    expect(closeCalls).toBe(1);
   } finally {
     await disposeApp(app);
   }

--- a/packages/runtime/src/microservice-application.lifecycle.test.ts
+++ b/packages/runtime/src/microservice-application.lifecycle.test.ts
@@ -277,3 +277,104 @@ it('caches a failed shell close without retrying terminal teardown', async () =>
     await disposeApp(app);
   }
 });
+
+it('caches a synchronous shutdown-mark failure without retrying it', async () => {
+  // Given
+  const microserviceToken = Symbol.for('fluo.microservices.service');
+  const shutdownError = new Error('shutdown mark failed');
+  let closeCalls = 0;
+  let shutdownMarkCalls = 0;
+
+  class StubMicroserviceRuntime implements MicroserviceRuntime {
+    markShutdownStarted(): void {
+      shutdownMarkCalls += 1;
+      throw shutdownError;
+    }
+
+    async close(): Promise<void> {
+      closeCalls += 1;
+    }
+
+    async listen(): Promise<void> {}
+  }
+
+  class AppModule {}
+  defineRuntimeModuleMetadata(AppModule, {
+    providers: [{ provide: microserviceToken, useClass: StubMicroserviceRuntime }],
+  });
+
+  let app: MicroserviceApplication | undefined;
+
+  try {
+    app = await FluoFactory.createMicroservice(AppModule);
+    if (!app) {
+      throw new Error('microservice not bootstrapped');
+    }
+    const firstClose = app.close();
+    const secondClose = app.close();
+
+    // When
+    await expect(firstClose).rejects.toBe(shutdownError);
+    await expect(secondClose).rejects.toBe(shutdownError);
+    await expect(app.close()).rejects.toBe(shutdownError);
+
+    // Then
+    expect(shutdownMarkCalls).toBe(1);
+    expect(closeCalls).toBe(0);
+  } finally {
+    await disposeApp(app);
+  }
+});
+
+it('caches close before a synchronous shutdown-mark reentry', async () => {
+  // Given
+  const microserviceToken = Symbol.for('fluo.microservices.service');
+  let closeCalls = 0;
+  let reenteredClose: Promise<void> | undefined;
+  let shutdownMarkCalls = 0;
+  let app: MicroserviceApplication | undefined;
+
+  class StubMicroserviceRuntime implements MicroserviceRuntime {
+    markShutdownStarted(): void {
+      shutdownMarkCalls += 1;
+
+      if (!app) {
+        throw new Error('microservice not bootstrapped');
+      }
+
+      reenteredClose = app.close();
+    }
+
+    async close(): Promise<void> {
+      closeCalls += 1;
+    }
+
+    async listen(): Promise<void> {}
+  }
+
+  class AppModule {}
+  defineRuntimeModuleMetadata(AppModule, {
+    providers: [{ provide: microserviceToken, useClass: StubMicroserviceRuntime }],
+  });
+
+  try {
+    app = await FluoFactory.createMicroservice(AppModule);
+    if (!app) {
+      throw new Error('microservice not bootstrapped');
+    }
+
+    // When
+    const firstClose = app.close();
+
+    // Then
+    await expect(firstClose).resolves.toBeUndefined();
+    if (!reenteredClose) {
+      throw new Error('expected synchronous shutdown-mark reentry');
+    }
+    await expect(reenteredClose).resolves.toBeUndefined();
+    expect(shutdownMarkCalls).toBe(1);
+    expect(closeCalls).toBe(1);
+  } finally {
+    await disposeApp(app);
+  }
+});

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -239,6 +239,9 @@ export interface ApplicationContext {
   readonly modules: CompiledModule[];
   readonly rootModule: ModuleType;
 
+  /**
+   * Closes the shell once; later calls share the terminal success or failure result.
+   */
   close(signal?: string): Promise<void>;
   get<T>(token: Token<T>): Promise<T>;
 }

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -208,7 +208,12 @@ export interface CreateApplicationContextOptions
 
 /** Runtime transport contract used by microservice application shells. */
 export interface MicroserviceRuntime {
-  /** Release transport resources owned by the microservice runtime during shutdown. */
+  /**
+   * Releases transport resources owned by the microservice runtime during shutdown.
+   *
+   * The owning {@link MicroserviceApplication} invokes this collaborator at most
+   * once and preserves its terminal success or failure for every later shell close.
+   */
   close?(signal?: string): MaybePromise<void>;
   /** Emit a fire-and-forget message for the given transport pattern. */
   emit?(pattern: string, payload: unknown): MaybePromise<void>;
@@ -220,7 +225,8 @@ export interface MicroserviceRuntime {
    * Implementations that expose their own ingress admission gate must close it
    * before the first await in this call so that new send()/emit()/listen()
    * attempts are rejected while a racing listen() is still settling. The
-   * terminal gate must stay closed even if close() later rejects.
+   * owning shell caches its terminal close result before invoking this callback,
+   * and the terminal gate must stay closed even if close() later rejects.
    */
   markShutdownStarted?(): void;
   /** Send a request/response message for the given transport pattern. */
@@ -239,9 +245,7 @@ export interface ApplicationContext {
   readonly modules: CompiledModule[];
   readonly rootModule: ModuleType;
 
-  /**
-   * Closes the shell once; later calls share the terminal success or failure result.
-   */
+  /** Closes the shell and retries incomplete teardown after a failed close. */
   close(signal?: string): Promise<void>;
   get<T>(token: Token<T>): Promise<T>;
 }
@@ -268,6 +272,11 @@ export interface Application {
 export interface MicroserviceApplication extends ApplicationContext {
   readonly state: ApplicationState;
 
+  /**
+   * Closes the microservice shell once; later calls share its terminal success
+   * or failure result without re-invoking shutdown collaborators.
+   */
+  close(signal?: string): Promise<void>;
   emit(pattern: string, payload: unknown): Promise<void>;
   listen(): Promise<void>;
   send(pattern: string, payload: unknown, signal?: AbortSignal): Promise<unknown>;


### PR DESCRIPTION
Closes #3212

## Summary
- cache the terminal close promise before invoking any shutdown collaborator
- keep failed microservice close terminal instead of retrying teardown
- drain already-admitted inbound work and reject late transport callbacks
- document terminal semantics on the microservice shell while preserving retryable application contexts

## Verification
- dependency closure build
- runtime tests: 478 passed; microservices tests: 273 passed
- focused lifecycle suites: runtime 7 passed, microservices 11 passed
- lint, platform governance, stable release lane
- built-artifact QA: shared reentrant/repeated close promise, transport closed once
- exact-head full triad: PASS