### PR TITLE
Resolve #3269: correct advanced logger guidance

### DIFF
--- a/book/advanced/ch09-app-context.ko.md
+++ b/book/advanced/ch09-app-context.ko.md
@@ -68,7 +68,7 @@ microservice branch는 또 다른 독립 bootstrap이 아닙니다. 먼저 conte
 
 `path:packages/runtime/src/bootstrap.ts:1168-1180`
 ```typescript
-    const logger = options.logger ?? createConsoleApplicationLogger();
+    const logger = options.logger ?? createDefaultApplicationLogger();
     const microserviceToken = options.microserviceToken ?? DEFAULT_MICROSERVICE_TOKEN;
     const context = await FluoFactory.createApplicationContext(rootModule, options);
 

--- a/book/advanced/ch09-app-context.ko.md
+++ b/book/advanced/ch09-app-context.ko.md
@@ -68,7 +68,7 @@ microservice branch는 또 다른 독립 bootstrap이 아닙니다. 먼저 conte
 
 `path:packages/runtime/src/bootstrap.ts:1168-1180`
 ```typescript
-    const logger = options.logger ?? createDefaultApplicationLogger();
+    const logger = createDefaultApplicationLogger();
     const microserviceToken = options.microserviceToken ?? DEFAULT_MICROSERVICE_TOKEN;
     const context = await FluoFactory.createApplicationContext(rootModule, options);
 

--- a/book/advanced/ch09-app-context.md
+++ b/book/advanced/ch09-app-context.md
@@ -68,7 +68,7 @@ The microservice branch is not another independent bootstrap. It first creates a
 
 `path:packages/runtime/src/bootstrap.ts:1168-1180`
 ```typescript
-    const logger = options.logger ?? createDefaultApplicationLogger();
+    const logger = createDefaultApplicationLogger();
     const microserviceToken = options.microserviceToken ?? DEFAULT_MICROSERVICE_TOKEN;
     const context = await FluoFactory.createApplicationContext(rootModule, options);
 

--- a/book/advanced/ch09-app-context.md
+++ b/book/advanced/ch09-app-context.md
@@ -68,7 +68,7 @@ The microservice branch is not another independent bootstrap. It first creates a
 
 `path:packages/runtime/src/bootstrap.ts:1168-1180`
 ```typescript
-    const logger = options.logger ?? createConsoleApplicationLogger();
+    const logger = options.logger ?? createDefaultApplicationLogger();
     const microserviceToken = options.microserviceToken ?? DEFAULT_MICROSERVICE_TOKEN;
     const context = await FluoFactory.createApplicationContext(rootModule, options);
 

--- a/book/advanced/ch10-runtime-branching.ko.md
+++ b/book/advanced/ch10-runtime-branching.ko.md
@@ -28,7 +28,7 @@ Chapter 10에서 가장 먼저 볼 사실은 Fluo의 runtime portability가 하�
 `path:packages/runtime/src/bootstrap.ts:920-938`
 ```typescript
 export async function bootstrapApplication(options: BootstrapApplicationOptions): Promise<Application> {
-  const logger = options.logger ?? createConsoleApplicationLogger();
+  const logger = options.logger ?? createDefaultApplicationLogger();
   let lifecycleInstances: unknown[] = [];
   let bootstrappedContainer: Container | undefined;
   const hasHttpAdapter = options.adapter !== undefined;
@@ -46,6 +46,8 @@ export async function bootstrapApplication(options: BootstrapApplicationOptions)
     logger.log('Starting fluo application...', 'FluoFactory');
     const runtimeProviders = createRuntimeProviders(options, logger);
 ```
+
+root 기본값은 shared bootstrap surface를 transport-neutral하게 유지하는 `createDefaultApplicationLogger()`입니다. `createConsoleApplicationLogger()`는 `@fluojs/runtime/node`에서 import하는 명시적인 Node 전용 구성에서만 선택하세요.
 
 이 발췌가 보여 주는 분기는 host 종류가 아니라 adapter 존재 여부입니다. 그래서 공통 bootstrap shell은 Node 서버 생성이나 Web Request 정규화 없이도 먼저 성립하고, 실제 host 차이는 adapter가 들어오는 가장자리로 밀려납니다.
 

--- a/book/advanced/ch10-runtime-branching.md
+++ b/book/advanced/ch10-runtime-branching.md
@@ -28,7 +28,7 @@ Instead of detecting the host name, that center assembles already prepared adapt
 `path:packages/runtime/src/bootstrap.ts:920-938`
 ```typescript
 export async function bootstrapApplication(options: BootstrapApplicationOptions): Promise<Application> {
-  const logger = options.logger ?? createConsoleApplicationLogger();
+  const logger = options.logger ?? createDefaultApplicationLogger();
   let lifecycleInstances: unknown[] = [];
   let bootstrappedContainer: Container | undefined;
   const hasHttpAdapter = options.adapter !== undefined;
@@ -46,6 +46,8 @@ export async function bootstrapApplication(options: BootstrapApplicationOptions)
     logger.log('Starting fluo application...', 'FluoFactory');
     const runtimeProviders = createRuntimeProviders(options, logger);
 ```
+
+The root default is `createDefaultApplicationLogger()`, which keeps the shared bootstrap surface transport-neutral. Choose `createConsoleApplicationLogger()` only for an explicit Node-only setup imported from `@fluojs/runtime/node`.
 
 The branch shown by this excerpt is about adapter presence, not host kind. Because of that, the shared Bootstrap shell can exist before any Node server creation or Web Request normalization happens. The real host differences are pushed out to the edge where the adapter enters.
 


### PR DESCRIPTION
## Summary

Correct the advanced-book logger guidance so the root runtime default remains transport-neutral and the Node console logger stays an explicit `@fluojs/runtime/node` choice.

Linked context: Closes #3269

## Changes

- use `createDefaultApplicationLogger()` in Chapter 9/10 EN/KO excerpts
- remove the nonexistent microservice `options.logger` override from the source excerpt
- document `createConsoleApplicationLogger()` as an explicit Node-only choice

## Testing

- `pnpm verify:docs`
- `pnpm lint`
- `pnpm verify:platform-consistency-governance`
- exact-head contract review: PASS

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

## Behavioral contract

- [x] Runtime behavior is unchanged; source excerpts now match it.
- [x] EN/KO parity is preserved.
