### PR TITLE
Resolve #3283: preserve Terminus health probe ownership

### DIFF
--- a/.changeset/quiet-terminus-health.md
+++ b/.changeset/quiet-terminus-health.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/terminus": patch
+---
+
+Keep lifecycle-aware dependency health probes serialized through raw probe settlement and normalize thrown health-check failures as unavailable.

--- a/packages/terminus/src/health-check.test.ts
+++ b/packages/terminus/src/health-check.test.ts
@@ -2,9 +2,24 @@ import { describe, expect, it } from 'vitest';
 
 import { HealthCheckError } from './errors.js';
 import { assertHealthCheck, runHealthCheck, TerminusHealthService } from './health-check.js';
+import { RedisHealthIndicator } from './indicators/redis.js';
 import type { HealthIndicator } from './types.js';
 
 type TestHealthIndicatorResult = Awaited<ReturnType<HealthIndicator['check']>>;
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve(value: T | PromiseLike<T>): void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: Deferred<T>['resolve'];
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+
+  return { promise, resolve };
+}
 
 function unsafeHealthIndicatorResult(result: unknown): TestHealthIndicatorResult {
   return result as TestHealthIndicatorResult;
@@ -103,6 +118,40 @@ describe('runHealthCheck', () => {
       latencyMs: 1_500,
       message: 'timeout',
       status: 'down',
+    });
+  });
+
+  it('normalizes every all-up HealthCheckError cause as down', async () => {
+    const report = await runHealthCheck([
+      {
+        key: 'database',
+        check: async () => {
+          throw new HealthCheckError('database failed', {
+            database: {
+              latencyMs: 1_500,
+              status: 'up',
+            },
+            replica: {
+              status: 'up',
+            },
+          });
+        },
+      },
+    ]);
+
+    expect(report.status).toBe('error');
+    expect(report.error).toEqual({
+      database: {
+        latencyMs: 1_500,
+        status: 'down',
+      },
+      replica: {
+        status: 'down',
+      },
+    });
+    expect(report.contributors).toEqual({
+      down: ['database', 'replica'],
+      up: [],
     });
   });
 
@@ -244,33 +293,36 @@ describe('runHealthCheck', () => {
     });
   });
 
-  it('does not start overlapping probes for the same indicator after a timeout', async () => {
+  it('retains probe ownership after an indicator timeout until the raw probe settles', async () => {
+    const probeStarted = createDeferred<void>();
     let starts = 0;
-    let releaseProbe: (() => void) | undefined;
-    const indicator: HealthIndicator = {
+    const releaseProbe = createDeferred<void>();
+    const probeSettled = createDeferred<void>();
+    const indicator = new RedisHealthIndicator({
       key: 'database',
-      check: async (key: string) => {
+      ping: async () => {
         starts += 1;
 
         if (starts > 1) {
-          return { [key]: { status: 'up' } };
+          return;
         }
 
-        return new Promise<TestHealthIndicatorResult>((resolve) => {
-          releaseProbe = () => {
-            resolve({ [key]: { status: 'up' } });
-          };
-        });
+        probeStarted.resolve();
+        await releaseProbe.promise;
+        probeSettled.resolve();
       },
-    };
+      timeoutMs: 20,
+    });
 
-    const service = new TerminusHealthService([indicator], { indicatorTimeoutMs: 5 });
-    const timedOutReport = await service.check();
+    const service = new TerminusHealthService([indicator]);
+    const timedOutReportPromise = service.check();
+    await probeStarted.promise;
+    const timedOutReport = await timedOutReportPromise;
     const overlappingReport = await service.check();
 
     expect(starts).toBe(1);
     expect(timedOutReport.error.database).toEqual({
-      message: 'Health indicator timed out after 5ms.',
+      message: 'database health indicator timed out after 20ms.',
       status: 'down',
     });
     expect(overlappingReport.error.database).toEqual({
@@ -278,8 +330,10 @@ describe('runHealthCheck', () => {
       status: 'down',
     });
 
-    releaseProbe?.();
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    releaseProbe.resolve();
+    await probeSettled.promise;
+    await new Promise<void>(queueMicrotask);
+    await new Promise<void>(queueMicrotask);
     const recoveredReport = await service.check();
 
     expect(starts).toBe(2);

--- a/packages/terminus/src/health-check.ts
+++ b/packages/terminus/src/health-check.ts
@@ -16,6 +16,10 @@ type ExecutedIndicatorResult = {
 
 type RunningIndicatorChecks = WeakMap<HealthIndicator, Promise<HealthIndicatorResult>>;
 
+type SettlementAwareHealthIndicator = {
+  getPendingHealthCheckSettlement?: () => Promise<void> | undefined;
+};
+
 function normalizeIndicatorTimeoutMs(value: number | undefined): number | undefined {
   if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
     return undefined;
@@ -50,20 +54,49 @@ function startSerializedIndicatorCheck(
 
   const check = Promise.resolve().then(() => indicator.check(key));
   runningIndicatorChecks.set(indicator, check);
+
+  const releaseIndicatorOwnership = () => {
+    const settlement = (indicator as SettlementAwareHealthIndicator).getPendingHealthCheckSettlement?.();
+
+    if (settlement) {
+      void settlement.then(
+        () => {
+          if (runningIndicatorChecks.get(indicator) === check) {
+            runningIndicatorChecks.delete(indicator);
+          }
+        },
+        () => {
+          if (runningIndicatorChecks.get(indicator) === check) {
+            runningIndicatorChecks.delete(indicator);
+          }
+        },
+      );
+      return;
+    }
+
+    if (runningIndicatorChecks.get(indicator) === check) {
+      runningIndicatorChecks.delete(indicator);
+    }
+  };
+
   check.then(
-    () => {
-      if (runningIndicatorChecks.get(indicator) === check) {
-        runningIndicatorChecks.delete(indicator);
-      }
-    },
-    () => {
-      if (runningIndicatorChecks.get(indicator) === check) {
-        runningIndicatorChecks.delete(indicator);
-      }
-    },
+    releaseIndicatorOwnership,
+    releaseIndicatorOwnership,
   );
 
   return check;
+}
+
+function normalizeHealthCheckErrorCauses(key: string, causes: HealthIndicatorResult): HealthCheckEntry[] {
+  return normalizeIndicatorResult(key, causes).map(
+    ([entryKey, state]): HealthCheckEntry => [
+      entryKey,
+      {
+        ...state,
+        status: 'down',
+      },
+    ],
+  );
 }
 
 async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
@@ -278,7 +311,7 @@ async function runIndicator(
   } catch (error: unknown) {
     if (error instanceof HealthCheckError) {
       return {
-        entries: normalizeIndicatorResult(key, error.causes),
+        entries: normalizeHealthCheckErrorCauses(key, error.causes),
         indicatorKey: key,
       };
     }
@@ -372,7 +405,7 @@ export async function runHealthCheck(
  * @param report Health report returned by `runHealthCheck(...)` or `TerminusHealthService.check()`.
  * @param message Error message used when one or more indicators are down.
  * @returns The same health report when every indicator is healthy.
- * @throws {HealthCheckError} When the report contains at least one down indicator.
+ * @throws {HealthCheckError} When one or more indicators are down.
  */
 export function assertHealthCheck(report: HealthCheckReport, message = 'Health check failed.'): HealthCheckReport {
   if (report.status === 'error') {

--- a/packages/terminus/src/indicators/drizzle.test.ts
+++ b/packages/terminus/src/indicators/drizzle.test.ts
@@ -110,7 +110,10 @@ describe('DrizzleHealthIndicator', () => {
   });
 
   it('provider factory prefers lifecycle-aware Drizzle handles over raw pings', async () => {
-    const execute = vi.fn(async (_query: unknown) => undefined);
+    const wrapperExecute = vi.fn(async (_query: unknown) => undefined);
+    const rawExecute = vi.fn(async (_query: unknown) => {
+      throw new Error('The raw Drizzle handle must not win over the lifecycle wrapper.');
+    });
     const provider = createDrizzleHealthIndicatorProvider();
 
     if (typeof provider === 'function' || !('useFactory' in provider)) {
@@ -120,11 +123,11 @@ describe('DrizzleHealthIndicator', () => {
     const indicator = provider.useFactory({
       createPlatformStatusSnapshot: () => ({
         details: { lifecycleState: 'stopped' },
-        health: { reason: 'Drizzle integration has been disposed.', status: 'unhealthy' },
-        readiness: { reason: 'Drizzle integration is stopped.', status: 'not-ready' },
+      health: { reason: 'Drizzle integration has been disposed.', status: 'unhealthy' },
+      readiness: { reason: 'Drizzle integration is stopped.', status: 'not-ready' },
       }),
-      current: () => ({ execute }),
-    }, { execute }) as DrizzleHealthIndicator;
+      current: () => ({ execute: wrapperExecute }),
+    }, { execute: rawExecute }) as DrizzleHealthIndicator;
 
     await expect(indicator.check('drizzle')).rejects.toMatchObject({
       causes: {
@@ -137,7 +140,38 @@ describe('DrizzleHealthIndicator', () => {
       },
       name: 'HealthCheckError',
     } satisfies Partial<HealthCheckError>);
-    expect(execute).not.toHaveBeenCalled();
+    expect(wrapperExecute).not.toHaveBeenCalled();
+    expect(rawExecute).not.toHaveBeenCalled();
+  });
+
+  it('probes the lifecycle-aware Drizzle handle before the raw fallback', async () => {
+    const wrapperExecute = vi.fn(async (_query: unknown) => undefined);
+    const rawExecute = vi.fn(async (_query: unknown) => {
+      throw new Error('The raw Drizzle handle must not win over the lifecycle wrapper.');
+    });
+    const provider = createDrizzleHealthIndicatorProvider();
+
+    if (typeof provider === 'function' || !('useFactory' in provider)) {
+      throw new Error('Expected Drizzle health indicator provider factory.');
+    }
+
+    const indicator = provider.useFactory({
+      createPlatformStatusSnapshot: () => ({
+        health: { status: 'healthy' },
+        readiness: { status: 'ready' },
+      }),
+      current: () => ({ execute: wrapperExecute }),
+    }, { execute: rawExecute }) as DrizzleHealthIndicator;
+
+    await expect(indicator.check('drizzle')).resolves.toEqual({
+      drizzle: {
+        healthStatus: 'healthy',
+        readinessStatus: 'ready',
+        status: 'up',
+      },
+    });
+    expect(wrapperExecute).toHaveBeenCalledWith('select 1');
+    expect(rawExecute).not.toHaveBeenCalled();
   });
 
   it('provider factory falls back to the raw Drizzle database token when no lifecycle wrapper is registered', async () => {

--- a/packages/terminus/src/indicators/drizzle.ts
+++ b/packages/terminus/src/indicators/drizzle.ts
@@ -1,7 +1,7 @@
 import { optional, type Provider } from '@fluojs/di';
 
-import { createDownResult, createUpResult, resolveIndicatorKey, resolveIndicatorTimeoutMs, throwHealthCheckError, withIndicatorTimeout } from './utils.js';
 import type { HealthIndicator, HealthIndicatorResult } from '../types.js';
+import { createDownResult, createUpResult, resolveIndicatorKey, resolveIndicatorTimeoutMs, throwHealthCheckError, waitForIndicatorProbeSettlement, withIndicatorTimeout } from './utils.js';
 
 const DRIZZLE_DATABASE = Symbol.for('fluo.drizzle.database');
 const DRIZZLE_HANDLE_PROVIDER = Symbol.for('fluo.drizzle.handle-provider');
@@ -48,7 +48,7 @@ async function runDrizzlePing(options: DrizzleHealthIndicatorOptions): Promise<v
     return;
   }
 
-  const database = options.database ?? resolveCurrentDatabase(options.handleProvider);
+  const database = resolveCurrentDatabase(options.handleProvider) ?? options.database;
 
   if (!database || typeof database.execute !== 'function') {
     throw new Error(
@@ -139,6 +139,7 @@ export function createDrizzleHealthIndicatorProvider(options: Omit<DrizzleHealth
 export class DrizzleHealthIndicator implements HealthIndicator {
   readonly key: string | undefined;
   readonly readiness: boolean | undefined;
+  private pendingProbeSettlement: Promise<void> | undefined;
 
   constructor(private readonly options: DrizzleHealthIndicatorOptions = {}) {
     this.key = options.key;
@@ -159,7 +160,9 @@ export class DrizzleHealthIndicator implements HealthIndicator {
         throwHealthCheckError('Drizzle health check failed.', lifecycleDownResult);
       }
 
-      await withIndicatorTimeout(runDrizzlePing(this.options), timeoutMs, indicatorKey);
+      const probe = runDrizzlePing(this.options);
+      this.pendingProbeSettlement = waitForIndicatorProbeSettlement(probe);
+      await withIndicatorTimeout(probe, timeoutMs, indicatorKey);
       return createUpResult(indicatorKey, snapshot
         ? {
             details: snapshot.details,
@@ -177,5 +180,9 @@ export class DrizzleHealthIndicator implements HealthIndicator {
         error instanceof Error ? error.message : 'Drizzle health check failed.',
       ));
     }
+  }
+
+  getPendingHealthCheckSettlement(): Promise<void> | undefined {
+    return this.pendingProbeSettlement;
   }
 }

--- a/packages/terminus/src/indicators/prisma.ts
+++ b/packages/terminus/src/indicators/prisma.ts
@@ -1,8 +1,8 @@
 import type { Token } from '@fluojs/core';
 import { optional, type Provider } from '@fluojs/di';
 
-import { createDownResult, createUpResult, resolveIndicatorKey, resolveIndicatorTimeoutMs, throwHealthCheckError, withIndicatorTimeout } from './utils.js';
 import type { HealthIndicator, HealthIndicatorResult } from '../types.js';
+import { createDownResult, createUpResult, resolveIndicatorKey, resolveIndicatorTimeoutMs, throwHealthCheckError, waitForIndicatorProbeSettlement, withIndicatorTimeout } from './utils.js';
 
 const PRISMA_CLIENT = Symbol.for('fluo.prisma.client');
 const PRISMA_SERVICE = Symbol.for('fluo.prisma.service');
@@ -237,6 +237,7 @@ export function createPrismaHealthIndicatorProvider(
 export class PrismaHealthIndicator implements HealthIndicator {
   readonly key: string | undefined;
   readonly readiness: boolean | undefined;
+  private pendingProbeSettlement: Promise<void> | undefined;
 
   constructor(private readonly options: PrismaHealthIndicatorOptions = {}) {
     this.key = options.key;
@@ -257,7 +258,9 @@ export class PrismaHealthIndicator implements HealthIndicator {
         throwHealthCheckError('Prisma health check failed.', lifecycleDownResult);
       }
 
-      await withIndicatorTimeout(runPrismaPing(this.options), timeoutMs, indicatorKey);
+      const probe = runPrismaPing(this.options);
+      this.pendingProbeSettlement = waitForIndicatorProbeSettlement(probe);
+      await withIndicatorTimeout(probe, timeoutMs, indicatorKey);
       return createUpResult(indicatorKey, createPrismaLifecycleUpDetails(snapshot));
     } catch (error: unknown) {
       if (error instanceof Error && error.name === 'HealthCheckError') {
@@ -269,5 +272,9 @@ export class PrismaHealthIndicator implements HealthIndicator {
         error instanceof Error ? error.message : 'Prisma health check failed.',
       ));
     }
+  }
+
+  getPendingHealthCheckSettlement(): Promise<void> | undefined {
+    return this.pendingProbeSettlement;
   }
 }

--- a/packages/terminus/src/indicators/redis.ts
+++ b/packages/terminus/src/indicators/redis.ts
@@ -1,8 +1,8 @@
 import type { Provider } from '@fluojs/di';
 import { createRedisPlatformStatusSnapshot, getRedisClientToken, getRedisComponentId, type RedisStatusAdapterInput } from '@fluojs/redis';
 
-import { createDownResult, createUpResult, resolveIndicatorKey, resolveIndicatorTimeoutMs, throwHealthCheckError, withIndicatorTimeout } from './utils.js';
 import type { HealthIndicator, HealthIndicatorResult } from '../types.js';
+import { createDownResult, createUpResult, resolveIndicatorKey, resolveIndicatorTimeoutMs, throwHealthCheckError, waitForIndicatorProbeSettlement, withIndicatorTimeout } from './utils.js';
 
 interface RedisClientLike {
   ping?: () => Promise<unknown>;
@@ -136,6 +136,7 @@ export function createRedisHealthIndicatorProvider(options: Omit<RedisHealthIndi
 export class RedisHealthIndicator implements HealthIndicator {
   readonly key: string | undefined;
   readonly readiness: boolean | undefined;
+  private pendingProbeSettlement: Promise<void> | undefined;
 
   constructor(private readonly options: RedisHealthIndicatorOptions = {}) {
     this.key = options.key;
@@ -153,7 +154,9 @@ export class RedisHealthIndicator implements HealthIndicator {
         throwHealthCheckError('Redis health check failed.', lifecycleDownResult);
       }
 
-      await withIndicatorTimeout(runRedisPing(this.options), timeoutMs, indicatorKey);
+      const probe = runRedisPing(this.options);
+      this.pendingProbeSettlement = waitForIndicatorProbeSettlement(probe);
+      await withIndicatorTimeout(probe, timeoutMs, indicatorKey);
       return createUpResult(indicatorKey, createRedisLifecycleUpDetails(this.options));
     } catch (error: unknown) {
       if (error instanceof Error && error.name === 'HealthCheckError') {
@@ -165,5 +168,9 @@ export class RedisHealthIndicator implements HealthIndicator {
         error instanceof Error ? error.message : 'Redis health check failed.',
       ));
     }
+  }
+
+  getPendingHealthCheckSettlement(): Promise<void> | undefined {
+    return this.pendingProbeSettlement;
   }
 }

--- a/packages/terminus/src/indicators/utils.ts
+++ b/packages/terminus/src/indicators/utils.ts
@@ -109,6 +109,19 @@ export function withIndicatorTimeout<T>(
 }
 
 /**
+ * Convert a probe promise into a settlement signal that never rejects.
+ *
+ * @param promise Probe promise whose completion releases its execution ownership.
+ * @returns A promise that resolves after the probe either fulfills or rejects.
+ */
+export function waitForIndicatorProbeSettlement(promise: Promise<unknown>): Promise<void> {
+  return promise.then(
+    () => undefined,
+    () => undefined,
+  );
+}
+
+/**
  * Resolve the effective key used in reports for one indicator execution.
  *
  * @param fallbackKey Built-in fallback key for the indicator type.

--- a/packages/terminus/src/module.test.ts
+++ b/packages/terminus/src/module.test.ts
@@ -5,6 +5,7 @@ import { defineModule, type PlatformComponent } from '@fluojs/runtime';
 import { createTestApp, createTestingModule } from '@fluojs/testing';
 import { describe, expect, it, vi } from 'vitest';
 
+import { HealthCheckError } from './errors.js';
 import { TerminusHealthService } from './health-check.js';
 import { createDiskHealthIndicatorProvider } from './indicators/disk.js';
 import { createHttpHealthIndicatorProvider } from './indicators/http.js';
@@ -178,6 +179,63 @@ describe('TerminusModule.forRoot', () => {
           readiness: {
             critical: false,
             status: 'ready',
+          },
+        },
+        status: 'error',
+      });
+
+      const readyResponse = await app.request('GET', '/ready').send();
+
+      expect(readyResponse.status).toBe(503);
+      expect(readyResponse.body).toEqual({ status: 'unavailable' });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('returns 503 on /health and /ready when HealthCheckError causes are all up', async () => {
+    const indicators: HealthIndicator[] = [
+      {
+        key: 'database',
+        check: async () => {
+          throw new HealthCheckError('database failed', {
+            database: {
+              latencyMs: 1_500,
+              status: 'up',
+            },
+            replica: {
+              status: 'up',
+            },
+          });
+        },
+      },
+    ];
+    const terminusModule = TerminusModule.forRoot({ indicators });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [terminusModule],
+    });
+
+    const app = await createTestApp({ rootModule: AppModule });
+
+    try {
+      const healthResponse = await app.request('GET', '/health').send();
+
+      expect(healthResponse.status).toBe(503);
+      expect(healthResponse.body).toMatchObject({
+        contributors: {
+          down: ['database', 'replica'],
+          up: [],
+        },
+        error: {
+          database: {
+            latencyMs: 1_500,
+            status: 'down',
+          },
+          replica: {
+            status: 'down',
           },
         },
         status: 'error',


### PR DESCRIPTION
## Summary

Correct Terminus health execution across lifecycle-wrapper precedence, timeout ownership, and thrown failure normalization.

Linked context: Closes #3283

## Changes

- prefer lifecycle-aware Drizzle handles over raw fallback handles
- retain Redis/Prisma/Drizzle probe ownership until raw settlement after timeout
- normalize every thrown HealthCheckError cause as down while preserving metadata
- add deterministic request-facing and recovery regressions

## Testing

- Terminus dependency closure build and typecheck
- Terminus tests: 97/97
- Terminus reverse dependents
- repository lint and platform governance
- Changeset release-lane verification
- exact-head code/contract/verification triad: PASS

## Release impact

- [x] `@fluojs/terminus` patch Changeset included.

## Behavioral contract

- [x] Raw probes stay serialized after timeout until settlement.
- [x] Thrown health errors cannot report all-up causes.
- [x] Async tests use explicit signals instead of sleeps or polling.
