### PR TITLE
Resolve #3284: harden Terminus regression boundaries

### DIFF
--- a/packages/terminus/src/health-check.test.ts
+++ b/packages/terminus/src/health-check.test.ts
@@ -297,7 +297,6 @@ describe('runHealthCheck', () => {
     const probeStarted = createDeferred<void>();
     let starts = 0;
     const releaseProbe = createDeferred<void>();
-    const probeSettled = createDeferred<void>();
     const indicator = new RedisHealthIndicator({
       key: 'database',
       ping: async () => {
@@ -309,7 +308,6 @@ describe('runHealthCheck', () => {
 
         probeStarted.resolve();
         await releaseProbe.promise;
-        probeSettled.resolve();
       },
       timeoutMs: 20,
     });
@@ -331,9 +329,7 @@ describe('runHealthCheck', () => {
     });
 
     releaseProbe.resolve();
-    await probeSettled.promise;
-    await new Promise<void>(queueMicrotask);
-    await new Promise<void>(queueMicrotask);
+    await indicator.getPendingHealthCheckSettlement();
     const recoveredReport = await service.check();
 
     expect(starts).toBe(2);

--- a/packages/terminus/src/public-subpaths.test.ts
+++ b/packages/terminus/src/public-subpaths.test.ts
@@ -1,4 +1,6 @@
+import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
@@ -25,5 +27,41 @@ describe('@fluojs/terminus subpath exports', () => {
         types: './dist/redis.d.ts',
       },
     });
+  });
+
+  it('imports emitted node and redis subpaths with their declarations', () => {
+    const packageRoot = fileURLToPath(new URL('../', import.meta.url));
+    const declarationFixture = fileURLToPath(new URL('../test-fixtures/public-subpaths-import.ts', import.meta.url));
+
+    expect(() => {
+      execFileSync(
+        process.execPath,
+        [
+          '--input-type=module',
+          '--eval',
+          "const [node, redis] = await Promise.all([import('@fluojs/terminus/node'), import('@fluojs/terminus/redis')]); const exports = [node.MemoryHealthIndicator, node.createMemoryHealthIndicator, node.createMemoryHealthIndicatorProvider, redis.RedisHealthIndicator, redis.createRedisHealthIndicator, redis.createRedisHealthIndicatorProvider]; if (!exports.every((value) => typeof value === 'function')) process.exitCode = 1;",
+        ],
+        { cwd: packageRoot },
+      );
+      execFileSync(
+        'pnpm',
+        [
+          'exec',
+          'tsc',
+          '--noEmit',
+          '--ignoreConfig',
+          '--module',
+          'NodeNext',
+          '--moduleResolution',
+          'NodeNext',
+          '--skipLibCheck',
+          '--strict',
+          '--target',
+          'ES2022',
+          declarationFixture,
+        ],
+        { cwd: packageRoot },
+      );
+    }).not.toThrow();
   });
 });

--- a/packages/terminus/src/request-regressions.test.ts
+++ b/packages/terminus/src/request-regressions.test.ts
@@ -1,0 +1,149 @@
+import { defineModule } from '@fluojs/runtime';
+import { createTestApp } from '@fluojs/testing';
+import { describe, expect, it } from 'vitest';
+
+import { TerminusModule } from './module.js';
+import type { HealthIndicator } from './types.js';
+
+describe('Terminus request regressions', () => {
+  it('reports malformed, empty, blank, duplicate, and multi-entry indicator results through /health', async () => {
+    const malformedIndicator = {
+      key: 'malformed',
+      check: async () => ({
+        malformed: {
+          status: 'degraded',
+        },
+      }),
+    } as unknown as HealthIndicator;
+    const indicators: HealthIndicator[] = [
+      {
+        key: 'dependencies',
+        check: async () => ({
+          database: {
+            status: 'up',
+          },
+          redis: {
+            message: 'redis unavailable',
+            status: 'down',
+          },
+        }),
+      },
+      {
+        key: 'empty',
+        check: async () => ({}),
+      },
+      {
+        key: 'blank',
+        check: async () => ({
+          blank: {
+            status: 'up',
+          },
+          ' ': {
+            status: 'up',
+          },
+        }),
+      },
+      malformedIndicator,
+      {
+        key: 'duplicate',
+        check: async () => ({
+          database: {
+            status: 'up',
+          },
+        }),
+      },
+    ];
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [TerminusModule.forRoot({ indicators })],
+    });
+
+    const app = await createTestApp({ rootModule: AppModule });
+
+    try {
+      const healthResponse = await app.request('GET', '/health').send();
+
+      expect(healthResponse.status).toBe(503);
+      expect(healthResponse.body).toMatchObject({
+        contributors: {
+          down: [
+            'redis',
+            'empty',
+            'blank-blank-key-error',
+            'malformed',
+            'duplicate-duplicate-key-error',
+          ],
+          up: ['database', 'blank'],
+        },
+        details: {
+          blank: {
+            status: 'up',
+          },
+          'blank-blank-key-error': {
+            message: 'Indicator returned a blank result key.',
+            status: 'down',
+          },
+          database: {
+            status: 'up',
+          },
+          'duplicate-duplicate-key-error': {
+            message: 'Indicator produced duplicate result key(s): database.',
+            status: 'down',
+          },
+          empty: {
+            message: 'Indicator returned no health result entries.',
+            status: 'down',
+          },
+          malformed: {
+            message: 'Indicator returned an unsupported status value for result key "malformed".',
+            status: 'down',
+          },
+          redis: {
+            message: 'redis unavailable',
+            status: 'down',
+          },
+        },
+        error: {
+          'blank-blank-key-error': {
+            message: 'Indicator returned a blank result key.',
+            status: 'down',
+          },
+          'duplicate-duplicate-key-error': {
+            message: 'Indicator produced duplicate result key(s): database.',
+            status: 'down',
+          },
+          empty: {
+            message: 'Indicator returned no health result entries.',
+            status: 'down',
+          },
+          malformed: {
+            message: 'Indicator returned an unsupported status value for result key "malformed".',
+            status: 'down',
+          },
+          redis: {
+            message: 'redis unavailable',
+            status: 'down',
+          },
+        },
+        info: {
+          blank: {
+            status: 'up',
+          },
+          database: {
+            status: 'up',
+          },
+        },
+        status: 'error',
+      });
+
+      const readyResponse = await app.request('GET', '/ready').send();
+
+      expect(readyResponse.status).toBe(503);
+      expect(readyResponse.body).toEqual({ status: 'unavailable' });
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/packages/terminus/test-fixtures/public-subpaths-import.ts
+++ b/packages/terminus/test-fixtures/public-subpaths-import.ts
@@ -1,0 +1,30 @@
+import {
+  createMemoryHealthIndicator,
+  createMemoryHealthIndicatorProvider,
+  MemoryHealthIndicator,
+  type MemoryHealthIndicatorOptions,
+} from '@fluojs/terminus/node';
+import {
+  createRedisHealthIndicator,
+  createRedisHealthIndicatorProvider,
+  RedisHealthIndicator,
+  type RedisHealthIndicatorOptions,
+} from '@fluojs/terminus/redis';
+
+const memoryOptions = {
+  heapUsedThresholdBytes: 1_024,
+  key: 'memory',
+  readiness: true,
+} satisfies MemoryHealthIndicatorOptions;
+const redisOptions = {
+  key: 'redis',
+  ping: async () => undefined,
+  timeoutMs: 10,
+} satisfies RedisHealthIndicatorOptions;
+
+new MemoryHealthIndicator(memoryOptions);
+createMemoryHealthIndicator(memoryOptions);
+createMemoryHealthIndicatorProvider(memoryOptions);
+new RedisHealthIndicator(redisOptions);
+createRedisHealthIndicator(redisOptions);
+createRedisHealthIndicatorProvider(redisOptions);


### PR DESCRIPTION
## Summary

Harden Terminus regression coverage at request and published-artifact boundaries.

Closes #3284

## Coverage added

- assert malformed, empty, blank-key, duplicate-key, and multi-entry health payloads through HTTP requests
- replace timing-dependent recovery waits with explicit deferred settlement
- import emitted `@fluojs/terminus/node` and `/redis` runtime subpaths
- compile strict consumers against emitted declarations

## Testing

- Terminus closure build
- Terminus typecheck
- Terminus tests: 99/99
- lint and platform governance
- emitted Node/Redis imports and strict declaration fixture QA
- exact-head code + verification review: PASS

## Release impact

Test/fixture-only change; no consumer-visible package artifact or Changeset.
