### PR TITLE
Resolve #3288: add health endpoint middleware

### DIFF
--- a/.changeset/soft-shrimps-sleep.md
+++ b/.changeset/soft-shrimps-sleep.md
@@ -1,0 +1,6 @@
+---
+'@fluojs/runtime': minor
+'@fluojs/terminus': minor
+---
+
+Add DI-backed route-scoped middleware options for generated health and readiness endpoints.

--- a/book/beginner/ch18-health.ko.md
+++ b/book/beginner/ch18-health.ko.md
@@ -90,7 +90,31 @@ import { MemoryHealthIndicator } from '@fluojs/terminus/node';
 export class AppModule {}
 ```
 
-### 18.3.1 The Response Format
+### 18.3.1 경로 범위 엔드포인트 미들웨어
+헬스와 준비성 probe에는 모든 애플리케이션 route에 동일한 정책을 추가하지 않고도 배포별 접근 정책이 필요한 경우가 많습니다. Class 기반 미들웨어를 `endpointMiddleware`로 전달하면 Terminus가 DI를 통해 해석하고 생성한 두 probe route에 선언 순서대로 적용합니다.
+
+```typescript
+import { ForbiddenException, type MiddlewareContext, type Next } from '@fluojs/http';
+
+class HealthProbeAuthMiddleware {
+  async handle(context: MiddlewareContext, next: Next): Promise<void> {
+    if (context.request.headers['x-health-token'] !== 'secret-token') {
+      throw new ForbiddenException('Health endpoints require x-health-token.');
+    }
+
+    await next();
+  }
+}
+
+TerminusModule.forRoot({
+  endpointMiddleware: [HealthProbeAuthMiddleware],
+  path: '/internal/',
+});
+```
+
+이 설정은 정규화된 `/internal/health`와 `/internal/ready`만 보호합니다. `endpointMiddleware`를 생략하면 기본 엔드포인트 동작은 변경되지 않습니다.
+
+### 18.3.2 The Response Format
 `/health` 엔드포인트에 요청을 보내면 Terminus는 표준화된 JSON 응답을 반환합니다. 모든 인디케이터가 통과하면 `200 OK` 상태를 반환합니다. 만약 하나라도 실패하면(예: 데이터베이스 연결 불가) `503 Service Unavailable` 상태와 함께 무엇이 잘못되었는지에 대한 상세 보고서를 반환합니다. 이 형식은 사람뿐만 아니라 Prometheus, Grafana, Datadog과 같은 자동화된 모니터링 도구도 쉽게 해석할 수 있습니다. 애플리케이션이 나머지 프로덕션 인프라와 같은 상태 언어로 소통하게 되는 셈입니다.
 
 NestJS Terminus에서 마이그레이션한다면 `@HealthCheck()`로 장식한 controller method가 `HealthCheckService.check([...])`를 호출하는 구조를 먼저 재현하지 마세요. Fluo의 기본 API는 위에서 본 module registration입니다. Indicator, indicator provider, readiness check, execution guardrail은 `TerminusModule.forRoot(...)`에 두어 runtime-owned `GET /health`와 `GET /ready` route가 platform diagnostics와 정렬되게 해야 합니다. `TerminusHealthService.check()`는 test나 custom application flow에서 여전히 유용하지만, 기본 route authoring pattern은 아닙니다.

--- a/book/beginner/ch18-health.md
+++ b/book/beginner/ch18-health.md
@@ -90,7 +90,31 @@ import { MemoryHealthIndicator } from '@fluojs/terminus/node';
 export class AppModule {}
 ```
 
-### 18.3.1 The Response Format
+### 18.3.1 Route-Scoped Endpoint Middleware
+Health and readiness probes often need a deployment-specific access policy without adding that policy to every application route. Pass class-based middleware through `endpointMiddleware`; Terminus resolves it through DI and applies it in declaration order to both generated probe routes.
+
+```typescript
+import { ForbiddenException, type MiddlewareContext, type Next } from '@fluojs/http';
+
+class HealthProbeAuthMiddleware {
+  async handle(context: MiddlewareContext, next: Next): Promise<void> {
+    if (context.request.headers['x-health-token'] !== 'secret-token') {
+      throw new ForbiddenException('Health endpoints require x-health-token.');
+    }
+
+    await next();
+  }
+}
+
+TerminusModule.forRoot({
+  endpointMiddleware: [HealthProbeAuthMiddleware],
+  path: '/internal/',
+});
+```
+
+This protects normalized `/internal/health` and `/internal/ready` only. Leaving `endpointMiddleware` out keeps the default endpoint behavior unchanged.
+
+### 18.3.2 The Response Format
 When a request is sent to the `/health` endpoint, Terminus returns a standardized JSON response. If every indicator passes, it returns a `200 OK` status. If even one indicator fails, such as when the database connection is unavailable, it returns `503 Service Unavailable` with a detailed report about what went wrong. This format is easy for humans to read and easy for automated monitoring tools such as Prometheus, Grafana, and Datadog to interpret. The application is speaking the same state language as the rest of the production infrastructure.
 
 If you are migrating from NestJS Terminus, do not start by recreating a controller method decorated with `@HealthCheck()` that calls `HealthCheckService.check([...])`. In Fluo, the primary API is the module registration shown above: indicators, indicator providers, readiness checks, and execution guardrails belong in `TerminusModule.forRoot(...)` so the runtime-owned `GET /health` and `GET /ready` routes stay aligned with platform diagnostics. `TerminusHealthService.check()` is still useful in tests or custom application flows, but it is not the default route authoring pattern.

--- a/examples/ops-metrics-terminus/src/app.test.ts
+++ b/examples/ops-metrics-terminus/src/app.test.ts
@@ -22,11 +22,14 @@ describe('AppModule e2e', () => {
     const app = await createTestApp({ rootModule: AppModule });
 
     try {
-      await expect(app.request('GET', '/health').send()).resolves.toMatchObject({
+      const forbiddenHealthResult = await app.request('GET', '/health').send();
+      expect(forbiddenHealthResult.status).toBe(403);
+
+      await expect(app.request('GET', '/health').header('x-health-token', 'secret-token').send()).resolves.toMatchObject({
         status: 200,
       });
 
-      await expect(app.request('GET', '/ready').send()).resolves.toMatchObject({
+      await expect(app.request('GET', '/ready').header('x-health-token', 'secret-token').send()).resolves.toMatchObject({
         status: 200,
       });
 

--- a/examples/ops-metrics-terminus/src/app.ts
+++ b/examples/ops-metrics-terminus/src/app.ts
@@ -3,12 +3,13 @@ import { TerminusModule } from '@fluojs/terminus';
 import { MemoryHealthIndicator } from '@fluojs/terminus/node';
 
 import { OpsModule } from './ops/ops.module';
-import { opsMetricsModule } from './ops/metrics-registry';
+import { HealthEndpointMiddleware, opsMetricsModule } from './ops/metrics-registry';
 
 @Module({
   imports: [
     opsMetricsModule,
     TerminusModule.forRoot({
+      endpointMiddleware: [HealthEndpointMiddleware],
       indicators: [new MemoryHealthIndicator({ key: 'memory', rssThresholdBytes: Number.MAX_SAFE_INTEGER })],
     }),
     OpsModule,

--- a/examples/ops-metrics-terminus/src/ops/metrics-registry.ts
+++ b/examples/ops-metrics-terminus/src/ops/metrics-registry.ts
@@ -11,6 +11,16 @@ class MetricsTokenMiddleware {
   }
 }
 
+export class HealthEndpointMiddleware {
+  async handle(context: MiddlewareContext, next: Next): Promise<void> {
+    if (context.request.headers['x-health-token'] !== 'secret-token') {
+      throw new ForbiddenException('Health endpoints require x-health-token.');
+    }
+
+    await next();
+  }
+}
+
 export const sharedRegistry = new Registry();
 
 export const opsMetricsModule = MetricsModule.forRoot({

--- a/packages/runtime/README.ko.md
+++ b/packages/runtime/README.ko.md
@@ -73,6 +73,19 @@ await app.listen();
 
 ## 주요 패턴
 
+### 헬스 엔드포인트 미들웨어
+
+`HealthModule.forRoot()`는 생성된 health와 readiness route용 class 기반 `endpointMiddleware`를 받습니다. 미들웨어는 DI를 통해 해석되고 선언 순서대로 실행되며, 선택적 custom `path` 아래의 정규화된 두 엔드포인트 모두에 적용됩니다. 이 설정을 생략하면 기존 기본 동작이 유지됩니다.
+
+```typescript
+HealthModule.forRoot({
+  endpointMiddleware: [HealthProbeAuthMiddleware],
+  path: '/internal/',
+});
+```
+
+이 구성은 `HealthProbeAuthMiddleware`를 `/internal/health`와 `/internal/ready`에 적용하며, 관련 없는 애플리케이션 route에는 적용하지 않습니다.
+
 ### 스트리밍 멀티파트 소비
 
 큰 업로드 파일을 `Uint8Array`로 실체화하지 않고 standalone raw `Request` 또는 request-like body에서

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -73,6 +73,19 @@ await app.listen();
 
 ## Common Patterns
 
+### Health endpoint middleware
+
+`HealthModule.forRoot()` accepts class-based `endpointMiddleware` for its generated health and readiness routes. Middleware resolves through DI, runs in declaration order, and applies to both normalized endpoints under an optional custom `path`; omitting it preserves the default behavior.
+
+```typescript
+HealthModule.forRoot({
+  endpointMiddleware: [HealthProbeAuthMiddleware],
+  path: '/internal/',
+});
+```
+
+This configuration applies `HealthProbeAuthMiddleware` to `/internal/health` and `/internal/ready`, not to unrelated application routes.
+
 ### Streaming multipart consumption
 
 Use `parseMultipartStream(...)` from `@fluojs/runtime/web` for a standalone raw `Request` or

--- a/packages/runtime/src/health/health.test.ts
+++ b/packages/runtime/src/health/health.test.ts
@@ -1,8 +1,8 @@
 import {
   Controller,
-  Get,
   type FrameworkRequest,
   type FrameworkResponse,
+  Get,
   type Middleware,
   type MiddlewareContext,
   type Next,

--- a/packages/runtime/src/health/health.test.ts
+++ b/packages/runtime/src/health/health.test.ts
@@ -1,4 +1,13 @@
-import type { FrameworkRequest, FrameworkResponse, RequestContext } from '@fluojs/http';
+import {
+  Controller,
+  Get,
+  type FrameworkRequest,
+  type FrameworkResponse,
+  type Middleware,
+  type MiddlewareContext,
+  type Next,
+  type RequestContext,
+} from '@fluojs/http';
 import { describe, expect, it } from 'vitest';
 
 import { bootstrapApplication, defineModule } from '../bootstrap.js';
@@ -91,6 +100,73 @@ describe('createHealthModule', () => {
     expect(readyResponse.body).toEqual({ status: 'ready' });
 
     await app.close();
+  });
+
+  it('applies declared endpoint middleware to default health routes only', async () => {
+    const calls: string[] = [];
+
+    class FirstEndpointMiddleware implements Middleware {
+      async handle(context: MiddlewareContext, next: Next): Promise<void> {
+        calls.push(`first:${context.request.path}`);
+        await next();
+      }
+    }
+
+    class SecondEndpointMiddleware implements Middleware {
+      async handle(context: MiddlewareContext, next: Next): Promise<void> {
+        calls.push(`second:${context.request.path}`);
+        await next();
+      }
+    }
+
+    @Controller('/unrelated')
+    class UnrelatedController {
+      @Get('/')
+      getUnrelated() {
+        return { status: 'unrelated' };
+      }
+    }
+
+    const healthModule: RuntimeHealthModule = HealthModule.forRoot({
+      endpointMiddleware: [FirstEndpointMiddleware, SecondEndpointMiddleware],
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      controllers: [UnrelatedController],
+      imports: [healthModule],
+    });
+
+    const app = await bootstrapApplication({
+      rootModule: AppModule,
+    });
+
+    try {
+      const healthResponse = createResponse();
+      await app.dispatch(createRequest('/health'), healthResponse);
+      expect(healthResponse.statusCode).toBe(200);
+      expect(healthResponse.body).toEqual({ status: 'ok' });
+
+      const readyResponse = createResponse();
+      await app.dispatch(createRequest('/ready'), readyResponse);
+      expect(readyResponse.statusCode).toBe(200);
+      expect(readyResponse.body).toEqual({ status: 'ready' });
+
+      const unrelatedResponse = createResponse();
+      await app.dispatch(createRequest('/unrelated'), unrelatedResponse);
+      expect(unrelatedResponse.statusCode).toBe(200);
+      expect(unrelatedResponse.body).toEqual({ status: 'unrelated' });
+
+      expect(calls).toEqual([
+        'first:/health',
+        'second:/health',
+        'first:/ready',
+        'second:/ready',
+      ]);
+    } finally {
+      await app.close();
+    }
   });
 
   it('returns a starting readiness status until the runtime marks the module ready', async () => {

--- a/packages/runtime/src/health/health.ts
+++ b/packages/runtime/src/health/health.ts
@@ -1,4 +1,5 @@
-import { Controller, Get } from '@fluojs/http';
+import type { Constructor } from '@fluojs/core';
+import { Controller, forRoutes, Get, type Middleware } from '@fluojs/http';
 
 import { defineModule } from '../bootstrap.js';
 import type { ModuleType } from '../types.js';
@@ -29,6 +30,8 @@ export interface ReadinessStatus {
  * Describes the health module options contract.
  */
 export interface HealthModuleOptions {
+  /** Class-based middleware applied only to the generated `/health` and `/ready` endpoints. */
+  endpointMiddleware?: readonly Constructor<Middleware>[];
   healthCheck?: (ctx: import('@fluojs/http').RequestContext) =>
     | HealthStatus
     | HealthCheckResponse
@@ -127,6 +130,9 @@ function createRuntimeHealthModule(options: HealthModuleOptions = {}): RuntimeHe
 
   defineModule(RuntimeHealthModule, {
     controllers: [HealthController],
+    middleware: (options.endpointMiddleware ?? []).map((middlewareClass) =>
+      forRoutes(middlewareClass, `${basePath}/health`, `${basePath}/ready`),
+    ),
   });
 
   return RuntimeHealthModule;

--- a/packages/terminus/README.ko.md
+++ b/packages/terminus/README.ko.md
@@ -12,6 +12,7 @@ fluo 애플리케이션을 위한 헬스 인디케이터(Health Indicator) 툴�
 - [공통 패턴](#공통-패턴)
   - [내장 인디케이터](#내장-인디케이터)
   - [DI 기반 인디케이터](#di-기반-인디케이터)
+  - [엔드포인트 미들웨어](#엔드포인트-미들웨어)
   - [실행 가드레일](#실행-가드레일)
   - [실패 시맨틱](#실패-시맨틱)
 - [NestJS 마이그레이션 경계](#nestjs-마이그레이션-경계)
@@ -150,6 +151,31 @@ TerminusModule.forRoot({
 ```
 
 named Redis indicator 의존성은 필수입니다. import된 module이나 global module 어디에서도 해당 token을 공급하지 않으면 bootstrap 중 module graph 검증이 누락된 token을 명시하는 `MODULE_VISIBILITY_ERROR`로 실패합니다. Prisma와 Drizzle indicator 의존성은 해당 token이 bootstrap graph 전체에 없을 때만 선택 사항입니다. 이 경우 owner module을 생략해도 애플리케이션은 bootstrap되지만 해당 indicator는 요청 시점의 `/health`에서 `down`을 보고합니다. Prisma 또는 Drizzle owner module이 애플리케이션의 다른 위치에 존재하지만 Terminus `imports`에서 생략된 경우에는 bootstrap이 `MODULE_VISIBILITY_ERROR`로 실패합니다. optional injection은 module visibility를 우회하지 않습니다. global module이 공급하는 의존성 — 예를 들어 `name` 없이 등록해 기본적으로 global인 `RedisModule.forRoot(...)` — 은 별도의 `imports` 항목 없이도 계속 보입니다.
+
+### 엔드포인트 미들웨어
+
+class 기반 `endpointMiddleware`로 Terminus가 생성한 엔드포인트에만 접근 정책을 적용하세요. 클래스는 DI를 통해 해석되고 선언 순서대로 `/health`와 `/ready` 모두에서 실행됩니다. 이 옵션을 생략하면 기존의 제한 없는 기본 동작이 유지됩니다. Custom `path` 값은 미들웨어 route match 전에 정규화됩니다.
+
+```typescript
+import { ForbiddenException, type MiddlewareContext, type Next } from '@fluojs/http';
+
+class HealthProbeAuthMiddleware {
+  async handle(context: MiddlewareContext, next: Next): Promise<void> {
+    if (context.request.headers['x-health-token'] !== 'secret-token') {
+      throw new ForbiddenException('Health endpoints require x-health-token.');
+    }
+
+    await next();
+  }
+}
+
+TerminusModule.forRoot({
+  endpointMiddleware: [HealthProbeAuthMiddleware],
+  path: '/internal/',
+});
+```
+
+위 미들웨어는 정규화된 `/internal/health` 및 `/internal/ready` route에서 실행되며, 관련 없는 애플리케이션 route에는 적용되지 않습니다.
 
 ### Readiness 참여
 

--- a/packages/terminus/README.md
+++ b/packages/terminus/README.md
@@ -12,6 +12,7 @@ Health indicator toolkit for fluo applications. `@fluojs/terminus` layers on top
 - [Common Patterns](#common-patterns)
   - [Built-in Indicators](#built-in-indicators)
   - [DI-Backed Indicators](#di-backed-indicators)
+  - [Endpoint Middleware](#endpoint-middleware)
   - [Execution Guardrails](#execution-guardrails)
   - [Failure Semantics](#failure-semantics)
 - [NestJS Migration Boundaries](#nestjs-migration-boundaries)
@@ -150,6 +151,31 @@ TerminusModule.forRoot({
 ```
 
 A named Redis indicator dependency is required. If no imported or global module supplies its token, module-graph validation fails during bootstrap with a `MODULE_VISIBILITY_ERROR` naming the missing token. Prisma and Drizzle indicator dependencies are optional only when their tokens are absent from the bootstrap graph: omitting their owner modules then allows the application to bootstrap and the corresponding indicator reports `down` in `/health` at request time. If a Prisma or Drizzle owner module exists elsewhere in the application but is omitted from Terminus `imports`, bootstrap instead fails with `MODULE_VISIBILITY_ERROR`; optional injection never bypasses module visibility. Dependencies published by a global module — for example `RedisModule.forRoot(...)` without a `name`, which is global by default — remain visible without an explicit `imports` entry.
+
+### Endpoint Middleware
+
+Use class-based `endpointMiddleware` to protect only Terminus-generated endpoints. Classes resolve through DI and run in declaration order for both `/health` and `/ready`; omitting the option preserves the default unprotected behavior. Custom `path` values are normalized before the middleware route match.
+
+```typescript
+import { ForbiddenException, type MiddlewareContext, type Next } from '@fluojs/http';
+
+class HealthProbeAuthMiddleware {
+  async handle(context: MiddlewareContext, next: Next): Promise<void> {
+    if (context.request.headers['x-health-token'] !== 'secret-token') {
+      throw new ForbiddenException('Health endpoints require x-health-token.');
+    }
+
+    await next();
+  }
+}
+
+TerminusModule.forRoot({
+  endpointMiddleware: [HealthProbeAuthMiddleware],
+  path: '/internal/',
+});
+```
+
+The middleware above runs for normalized `/internal/health` and `/internal/ready` routes, not for unrelated application routes.
 
 ### Readiness Participation
 

--- a/packages/terminus/src/module.test.ts
+++ b/packages/terminus/src/module.test.ts
@@ -1,4 +1,5 @@
 import { Inject } from '@fluojs/core';
+import type { MiddlewareContext, Next } from '@fluojs/http';
 import { getPrismaClientToken, getPrismaServiceToken } from '@fluojs/prisma';
 import { getRedisClientToken, REDIS_CLIENT } from '@fluojs/redis';
 import { defineModule, type PlatformComponent } from '@fluojs/runtime';
@@ -125,6 +126,65 @@ describe('TerminusModule.forRoot', () => {
       const defaultReadyResponse = await app.request('GET', '/ready').send();
 
       expect(defaultReadyResponse.status).toBe(404);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('applies DI-backed endpoint middleware to normalized custom health and readiness routes in declaration order', async () => {
+    const calls: string[] = [];
+
+    @Inject(TerminusHealthService)
+    class FirstEndpointMiddleware {
+      constructor(private readonly healthService: TerminusHealthService) {}
+
+      async handle(_context: MiddlewareContext, next: Next): Promise<void> {
+        calls.push(this.healthService instanceof TerminusHealthService ? 'first:before' : 'first:missing-service');
+        await next();
+        calls.push('first:after');
+      }
+    }
+
+    class SecondEndpointMiddleware {
+      async handle(_context: MiddlewareContext, next: Next): Promise<void> {
+        calls.push('second:before');
+        await next();
+        calls.push('second:after');
+      }
+    }
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [
+        TerminusModule.forRoot({
+          endpointMiddleware: [FirstEndpointMiddleware, SecondEndpointMiddleware],
+          indicators: [new MemoryHealthIndicator({ key: 'database' })],
+          path: '/internal/',
+        }),
+      ],
+    });
+
+    const app = await createTestApp({ rootModule: AppModule });
+
+    try {
+      await expect(app.request('GET', '/internal/health').send()).resolves.toMatchObject({
+        status: 200,
+      });
+      await expect(app.request('GET', '/internal/ready').send()).resolves.toMatchObject({
+        status: 200,
+      });
+
+      expect(calls).toEqual([
+        'first:before',
+        'second:before',
+        'second:after',
+        'first:after',
+        'first:before',
+        'second:before',
+        'second:after',
+        'first:after',
+      ]);
     } finally {
       await app.close();
     }

--- a/packages/terminus/src/module.ts
+++ b/packages/terminus/src/module.ts
@@ -236,6 +236,7 @@ function createTerminusRuntimeModule(options: TerminusModuleOptions = {}): Modul
   const readinessChecks = [...(options.readinessChecks ?? [])];
   const terminusImports = [...(options.imports ?? [])];
   const healthModule = HealthModule.forRoot({
+    endpointMiddleware: options.endpointMiddleware,
     healthCheck: async (ctx: RequestContext) => {
       const healthService = await ctx.container.resolve<TerminusHealthService>(TerminusHealthService);
       const platformShell = await ctx.container.resolve<PlatformShell>(PLATFORM_SHELL);
@@ -268,6 +269,7 @@ function createTerminusRuntimeModule(options: TerminusModuleOptions = {}): Modul
     providers: [
       ...createTerminusProviders({
         execution: options.execution,
+        endpointMiddleware: options.endpointMiddleware,
         imports: terminusImports,
         indicatorProviders: options.indicatorProviders,
         indicators: options.indicators,

--- a/packages/terminus/src/types.ts
+++ b/packages/terminus/src/types.ts
@@ -1,4 +1,6 @@
+import type { Constructor } from '@fluojs/core';
 import type { Provider } from '@fluojs/di';
+import type { Middleware } from '@fluojs/http';
 import type { ModuleType, PlatformHealthReport, PlatformReadinessReport, ReadinessCheck } from '@fluojs/runtime';
 
 /** Status values returned by one health indicator execution. */
@@ -53,6 +55,8 @@ export interface HealthCheckExecutionOptions {
  */
 export interface TerminusModuleOptions {
   execution?: HealthCheckExecutionOptions;
+  /** Class-based middleware applied only to the generated `/health` and `/ready` endpoints. */
+  endpointMiddleware?: readonly Constructor<Middleware>[];
   /**
    * Modules whose exported tokens must be visible to `indicatorProviders`.
    *


### PR DESCRIPTION
## Summary

Add DI-backed, route-scoped middleware options for generated Runtime and Terminus health/readiness endpoints.

Closes #3288

## Changes

- add optional `endpointMiddleware` to Runtime and Terminus public options
- scope middleware to normalized `/health` and `/ready` routes only
- preserve DI resolution and declaration order
- document EN/KO package and book usage
- update the operations example with protected health endpoints

## Testing

- Runtime 488 tests and Terminus 98 tests
- Runtime/Terminus builds and typechecks
- Runtime reverse dependents
- docs sync/typecheck/build
- ops example e2e 3/3
- lint, governance, Changeset release lane
- exact-head code/contract/verification triad: PASS

## Release impact

- [x] `@fluojs/runtime` minor
- [x] `@fluojs/terminus` minor
