### PR TITLE
Resolve #3705: patch brace-expansion build dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "overrides": {
       "@babel/core": "7.29.7",
       "body-parser": "2.3.0",
-      "brace-expansion@1.1.12": "1.1.16",
+      "brace-expansion@1.1.12": "1.1.18",
       "brace-expansion@2.0.2": "2.1.4",
       "engine.io": "6.6.9",
       "fast-uri@3": "3.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   '@babel/core': 7.29.7
   body-parser: 2.3.0
-  brace-expansion@1.1.12: 1.1.16
+  brace-expansion@1.1.12: 1.1.18
   brace-expansion@2.0.2: 2.1.4
   engine.io: 6.6.9
   fast-uri@3: 3.1.7
@@ -3102,8 +3102,8 @@ packages:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
   brace-expansion@2.1.4:
     resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
@@ -7222,7 +7222,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -8774,7 +8774,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimatch@5.1.9:
     dependencies:


### PR DESCRIPTION
## Summary

빌드 도구 의존성에 남아 있던 HIGH 보안 권고 2건을 해소합니다.

Linked context: Closes #3705

## Changes

- root `brace-expansion@1.1.12` override의 target을 `1.1.16`에서 `1.1.18`로 갱신했습니다.
- pnpm 10.4.1로 root lockfile의 관련 resolution/integrity와 minimatch 참조만 재생성했습니다.
- `brace-expansion` 2.x override와 다른 의존성은 유지했습니다.
- 수정 범위는 `package.json`, `pnpm-lock.yaml` 두 파일, 6 insertions / 6 deletions입니다.

## Testing

검증 head: `542f17b4355a8a3d422d5d4b3a129296713790e7` (Node 24.20.0, pnpm 10.4.1)

- `pnpm install --frozen-lockfile`: PASS.
- `pnpm audit --json`: HIGH 2 → 0, 모든 severity 0. GHSA-mh99-v99m-4gvg 및 GHSA-rgw5-rvv9-x895 제거.
- `pnpm why brace-expansion`: Babel CLI → glob → minimatch 경로가 `1.1.18`을 사용함을 확인했습니다.
- 실제 Babel CLI에 `packages/core/src/{errors,utils}.ts` brace glob을 전달해 컴파일하고 출력 JavaScript 구문을 검증했습니다. 설치된 brace-expansion의 중첩 대안/숫자 범위와 표준 decorator 실행도 확인했습니다.
- `pnpm verify`: build/typecheck/lint/test:verify PASS, **629 test files / 7943 tests**.
- `pnpm verify:platform-consistency-governance`: PASS.
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`: PASS.
- `git diff --check`: PASS.
- package.json LSP diagnostics 없음. YAML language server는 미설치이며 lockfile의 pnpm 생성 및 frozen install로 파싱/정합성을 검증했습니다.

기존 lint 41 warnings / 135 infos는 그대로 보고하며 수정하거나 숨기지 않았습니다. dependency-only 갱신이므로 버전 문자열을 고정하는 새 테스트 대신 audit와 실제 빌드 도구 실행을 검증했습니다.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

private root의 개발/빌드 의존성 override 및 lockfile만 변경합니다. 공개 `@fluojs/*` package manifest, API, runtime 코드, 생성 프로젝트 또는 release metadata는 변경하지 않으므로 Changeset과 버전 갱신은 없습니다.

## Public export documentation

해당 없음: 공개 export 및 source TSDoc 변경이 없습니다. `pnpm lint`의 public export TSDoc 검증은 통과했습니다.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- runtime 기본값, 오류, lifecycle, adapter 동작 및 의도된 제한을 변경하지 않습니다.
- 기존 Babel source glob과 표준 decorator 변환 동작을 실제 실행으로 확인했습니다.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- governance 문서/공개 README/플랫폼 conformance 계약 변경이 없어 추가 companion은 해당 없습니다.
- `pnpm verify:platform-consistency-governance`가 통과했습니다.

