### PR TITLE
fix(release): sync CLI dependency ranges after versioning

### DIFF
--- a/.changeset/sync-cli-release-dependencies.md
+++ b/.changeset/sync-cli-release-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/cli": patch
+---
+
+Refresh CLI starter dependency ranges after Changesets versioning so released scaffolds use the updated package versions.

--- a/tooling/release/cli-published-dependencies.test.ts
+++ b/tooling/release/cli-published-dependencies.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
+import { runVersionPackages } from './version-packages.mjs';
 
 const repositoryRoot = fileURLToPath(new URL('../../', import.meta.url));
 const releaseVersions: Readonly<Record<string, string>> = JSON.parse(readFileSync(
@@ -35,6 +36,57 @@ function createReleaseFixture() {
 }
 
 describe('CLI release metadata generation', () => {
+  it('refreshes metadata from manifests changed during versioning', () => {
+    const fixture = createReleaseFixture();
+    execFileSync(process.execPath, [fixture.script], { timeout: 10_000 });
+    const nextVersions = { ...releaseVersions, '@fluojs/config': '9.8.7', '@fluojs/react': '0.12.3' };
+
+    runVersionPackages({
+      workspacePackageManifests: () => [],
+      runChangesetsVersion: () => {
+        for (const [name, version] of Object.entries(nextVersions)) {
+          writeFileSync(
+            join(fixture.root, 'packages', name.slice('@fluojs/'.length), 'package.json'),
+            JSON.stringify({ name, version, type: 'module' }),
+          );
+        }
+      },
+      execFileSync: (command, args) => {
+        expect(command).toBe(process.execPath);
+        expect(args).toEqual([join(repositoryRoot, 'packages/cli/scripts/generate-published-internal-dependencies.mjs')]);
+        // Execute only the copied generator: its import.meta.url confines all writes to the fixture.
+        execFileSync(process.execPath, [fixture.script], { timeout: 10_000 });
+      },
+    });
+
+    const output = execFileSync(process.execPath, [
+      '--input-type=module', '--eval',
+      `import { PUBLISHED_INTERNAL_DEPENDENCIES } from ${JSON.stringify(pathToFileURL(fixture.output).href)}; console.log(JSON.stringify(PUBLISHED_INTERNAL_DEPENDENCIES));`,
+    ], { encoding: 'utf8', timeout: 10_000 });
+    expect(JSON.parse(output)).toEqual(Object.fromEntries(
+      Object.entries(nextVersions).filter(([name]) => name !== '@fluojs/cli')
+        .map(([name, version]) => [name, `^${version}`]),
+    ));
+  });
+
+  it('propagates generator failure after versioning without replacing metadata', () => {
+    const fixture = createReleaseFixture();
+    const previousOutput = readFileSync(fixture.output, 'utf8');
+
+    expect(() => runVersionPackages({
+      workspacePackageManifests: () => [],
+      runChangesetsVersion: () => {
+        writeFileSync(join(fixture.root, 'packages/config/package.json'), JSON.stringify({
+          name: '@fluojs/config', version: '',
+        }));
+      },
+      execFileSync: () => {
+        execFileSync(process.execPath, [fixture.script], { stdio: 'pipe', timeout: 10_000 });
+      },
+    })).toThrowError('Command failed:');
+    expect(readFileSync(fixture.output, 'utf8')).toBe(previousOutput);
+  });
+
   it('refreshes stale metadata using independent release manifest versions', () => {
     // Given: a fixture copies stale generated metadata before applying new release manifests.
     const fixture = createReleaseFixture();

--- a/tooling/release/version-packages.d.mts
+++ b/tooling/release/version-packages.d.mts
@@ -28,6 +28,11 @@ export type ChangesetsVersionDependencies = {
 };
 
 export type VersionPackagesDependencies = {
+  readonly execFileSync?: (
+    command: string,
+    args: readonly string[],
+    options: { readonly stdio: 'inherit' },
+  ) => unknown;
   readonly existsSync?: (targetPath: string) => boolean;
   readonly readFileSync?: (targetPath: string, encoding: 'utf8') => string;
   readonly runChangesetsVersion?: (dependencies?: ChangesetsVersionDependencies) => void;

--- a/tooling/release/version-packages.mjs
+++ b/tooling/release/version-packages.mjs
@@ -1,4 +1,4 @@
-import { spawnSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -90,6 +90,7 @@ export function runChangesetsVersion(dependencies = {}) {
 
 export function runVersionPackages(dependencies = {}) {
   const {
+    execFileSync: executeFile = execFileSync,
     existsSync: pathExists = existsSync,
     readFileSync: readFile = readFileSync,
     runChangesetsVersion: runVersion = runChangesetsVersion,
@@ -102,6 +103,9 @@ export function runVersionPackages(dependencies = {}) {
   );
 
   runVersion();
+  executeFile(process.execPath, [join(repoRoot, 'packages/cli/scripts/generate-published-internal-dependencies.mjs')], {
+    stdio: 'inherit',
+  });
 
   const normalizedChangelogPaths = [];
   const pendingWrites = [];

--- a/tooling/release/version-packages.test.ts
+++ b/tooling/release/version-packages.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { normalizePackageChangelog, runChangesetsVersion, runVersionPackages } from './version-packages.mjs';
 
 describe('runChangesetsVersion', () => {
@@ -130,6 +130,7 @@ describe('runVersionPackages', () => {
     const writes: string[] = [];
 
     const result = runVersionPackages({
+      execFileSync: () => {},
       existsSync: (targetPath) => changelogs.has(targetPath),
       readFileSync: (targetPath) => {
         const changelog = changelogs.get(targetPath);
@@ -187,6 +188,7 @@ describe('runVersionPackages', () => {
 
     expect(() =>
       runVersionPackages({
+        execFileSync: () => {},
         existsSync: (targetPath) => changelogs.has(targetPath),
         readFileSync: (targetPath) => {
           const changelog = changelogs.get(targetPath);
@@ -224,5 +226,17 @@ describe('runVersionPackages', () => {
       }),
     ).toThrowError('Package CHANGELOG.md must contain at most one `## [Unreleased]` section.');
     expect(writes).toEqual([]);
+  });
+
+  it('propagates versioning failure without running the CLI dependency generator', () => {
+    const failure = new Error('versioning failed');
+    const generate = vi.fn();
+
+    expect(() => runVersionPackages({
+      execFileSync: generate,
+      runChangesetsVersion: () => { throw failure; },
+      workspacePackageManifests: () => [],
+    })).toThrow(failure);
+    expect(generate).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Changesets 버전 갱신 직후 CLI starter 의존성 맵을 재생성해 release PR의 manifest와 생성 파일이 어긋나는 문제를 수정합니다.

Linked context: #2772의 CLI scaffold CI 실패 후속 수정이며, manifest 기반 의존성 맵을 도입한 #3702의 릴리스 연동을 보완합니다. 별도로 조사한 Socket.IO 실패는 이 PR의 수정 범위가 아닙니다.

## Changes

- `runVersionPackages`가 Changesets 버전 갱신 성공 후 기존 CLI 의존성 생성기를 실행합니다.
- 버전 갱신 실패 시 생성기를 실행하지 않고, 생성기 오류도 그대로 전파합니다.
- 변경된 manifest를 읽는 실제 생성기 통합 회귀 테스트와 오류 전파 검증을 추가했습니다.
- `@fluojs/cli` patch changeset을 포함했습니다.

## Testing

- RED: production 수정 전 회귀 테스트 2개 실패 확인.
- GREEN: 릴리스 테스트 176개, CLI starter 테스트 127개 통과.
- `pnpm exec tsc -p tsconfig.tools.json --noEmit`
- `pnpm --filter @fluojs/cli typecheck`
- `pnpm --filter @fluojs/cli build`
- 변경 파일 Biome lint exit 0; 기존 `outputChunks` 미사용 경고 1개는 유지.
- 실제 CLI `--help` exit 0, 잘못된 명령 exit 1, 표준/React starter 생성 및 manifest 의존성 범위 확인.
- LSP의 Node 타입 해석 오류는 별도 환경 제약이며 명시적 tsconfig 기반 타입검사는 통과했습니다.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

공개 패키지 export 변경 없음. 내부 릴리스 도구의 dependency 주입 타입만 추가했습니다.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

새 소비자 계약을 추가하지 않고 기존 manifest 기반 starter 의존성 계약의 릴리스 경로를 복구합니다.

## Platform consistency governance (SSOT)

플랫폼 계약과 EN/KO 문서 변경 없음.
