### PR TITLE
Resolve #3713: scope Next backend compilation and preserve module paths

### DIFF
--- a/.changeset/next-backend-compiler-scope.md
+++ b/.changeset/next-backend-compiler-scope.md
@@ -1,0 +1,10 @@
+---
+"@fluojs/platform-nextjs": minor
+---
+
+Add optional `include` and `exclude` Turbopack path conditions to
+`withFluoNextBackend`, plus `preserveModulePaths` to retain original TypeScript
+module paths instead of renaming loader output to JavaScript paths. These
+independent opt-ins prevent unrelated client SSR stores from being transformed
+and avoid the reproduced Next 16.3 SSR import identity failure. Existing helper
+defaults and user rule order remain unchanged.

--- a/apps/docs/content/docs/packages/http-platform.ko.mdx
+++ b/apps/docs/content/docs/packages/http-platform.ko.mdx
@@ -14,6 +14,14 @@ description: HTTP 의미론, platform adapter, OpenAPI publication을 다룹니�
 | `@fluojs/platform-bun` | Bun-native HTTP/WebSocket behavior | `packages/platform-bun/README.ko.md` |
 | `@fluojs/platform-deno` | Deno-native request dispatch | `packages/platform-deno/README.ko.md` |
 | `@fluojs/platform-cloudflare-workers` | Edge Workers request/response APIs | `packages/platform-cloudflare-workers/README.ko.md` |
+| `@fluojs/platform-nextjs` | Next.js 16.x 호스팅과 opt-in backend compiler 범위 | `packages/platform-nextjs/README.ko.md` |
 | `@fluojs/openapi` | OpenAPI 3.1과 Swagger UI | `packages/openapi/README.ko.md` |
 
 작업 중심 안내는 [HTTP API](../guides/http-api)와 [런타임 어댑터](../guides/runtime-adapters)를 읽으세요.
+
+Next 앱은 `@fluojs/platform-nextjs/next-config`의
+`withFluoNextBackend(config, { include, exclude, preserveModulePaths: true })`로
+backend 변환 범위를 선언하고 SSR import의 원래 모듈 경로를 보존할 수 있습니다.
+옵션을 생략하면 기존 동작을 유지합니다. 정확한 path 조건과 Turbopack 전용
+제약은 package README, 실제 dev/build/start 회귀는
+`packages/platform-nextjs/e2e/README.ko.md`를 참조하세요.

--- a/apps/docs/content/docs/packages/http-platform.mdx
+++ b/apps/docs/content/docs/packages/http-platform.mdx
@@ -14,6 +14,15 @@ description: HTTP semantics, platform adapters, and OpenAPI publication.
 | `@fluojs/platform-bun` | Bun-native HTTP/WebSocket behavior | `packages/platform-bun/README.md` |
 | `@fluojs/platform-deno` | Deno-native request dispatch | `packages/platform-deno/README.md` |
 | `@fluojs/platform-cloudflare-workers` | Edge Workers request/response APIs | `packages/platform-cloudflare-workers/README.md` |
+| `@fluojs/platform-nextjs` | Next.js 16.x hosting and opt-in backend compiler scope | `packages/platform-nextjs/README.md` |
 | `@fluojs/openapi` | OpenAPI 3.1 and Swagger UI | `packages/openapi/README.md` |
 
 Read [HTTP API](../guides/http-api) and [Runtime Adapters](../guides/runtime-adapters) for task-oriented guidance.
+
+Next applications can declare backend compilation scope and preserve original
+SSR import paths with
+`withFluoNextBackend(config, { include, exclude, preserveModulePaths: true })`
+from `@fluojs/platform-nextjs/next-config`. Omitting options keeps existing
+behavior. The package README owns exact path conditions and Turbopack-only
+limitations; `packages/platform-nextjs/e2e/README.md` describes the real
+dev/build/start regressions.

--- a/book/03-internals/ch15-nextjs-hosting.ko.md
+++ b/book/03-internals/ch15-nextjs-hosting.ko.md
@@ -25,10 +25,25 @@ Next는 파일 하나를 발견하고 Fluo는 그 파일 뒤에서 자신의 rou
 ```typescript
 import { withFluoNextBackend } from '@fluojs/platform-nextjs/next-config';
 
-export default withFluoNextBackend({});
+export default withFluoNextBackend({}, {
+  include: 'src/**',
+  exclude: 'src/client/**',
+  preserveModulePaths: true,
+});
 ```
 
 helper는 서버 애플리케이션의 `*.ts` 파일에 packaged Turbopack decorator loader를 추가한다. browser와 dependency 파일은 대상에서 제외한다. 같은 TC39 `2023-11` 변환 recipe를 사용하지만 Vite plugin을 Next에 꽂는 방식은 아니다. 별도의 Babel loader를 임의로 추가하거나 legacy decorator 플래그를 켜지 않는다. 기존 `*.ts` rule이 있으면 rule 구성을 보존하면서 Fluo rule을 추가하므로 설정 객체를 직접 파괴하지도 않는다.
+
+이 장에서는 backend 선언을 `src/`에 두고 client store는 `src/client/`로 분리한다.
+`include`와 `exclude`는 Turbopack root 기준 path glob이며 `RegExp`도 받을 수 있다.
+아래의 `src/app.ts`와 `src/posts/`에 있는 decorated 선언은 모두 포함해야 한다.
+Client component의 SSR 처리는 browser 조건만으로 제외되지 않는다. 주석이나 import의
+`@`도 기존 content 조건에 일치할 수 있으므로 명시적인 경계가 필요하다.
+`preserveModulePaths: true`는 Babel 결과의 경로를 `.js`로 바꾸지 않는다.
+Next 16.3.4에서 재현한 `store.ts.js` SSR import 실패는
+[실제 fixture](../../packages/platform-nextjs/e2e/README.ko.md)로 비교할 수 있다.
+두 번째 인자를 생략하면 기존의 넓은 선택 범위와 `.js` 출력 규칙을 유지하며,
+이 opt-in은 webpack이나 `.tsx` decorator 지원을 추가하지 않는다.
 
 decorated class는 `.ts`에 둔다. 화면용 JSX 파일인 `.tsx`를 변환해 줄 것이라고 기대하면 빌드 경계가 달라진다. 다음 예제에서 React 페이지를 `createElement()`로 작성하는 것은 바로 이 제약을 명시적으로 지키기 위해서다. 실제 화면 컴포넌트는 decorator가 없는 별도 `.tsx`로 옮기고 `.ts` router에서 호출해도 된다.
 

--- a/book/03-internals/ch15-nextjs-hosting.md
+++ b/book/03-internals/ch15-nextjs-hosting.md
@@ -25,10 +25,26 @@ First, the following is the complete `next.config.ts`. If you have an existing N
 ```typescript
 import { withFluoNextBackend } from '@fluojs/platform-nextjs/next-config';
 
-export default withFluoNextBackend({});
+export default withFluoNextBackend({}, {
+  include: 'src/**',
+  exclude: 'src/client/**',
+  preserveModulePaths: true,
+});
 ```
 
 The helper adds a packaged Turbopack decorator loader for the server application's `*.ts` files. Browser and dependency files are excluded. It uses the same TC39 `2023-11` transformation recipe, but does not plug a Vite plugin into Next. Do not arbitrarily add another Babel loader or enable legacy decorator flags. If a `*.ts` rule already exists, the helper adds the Fluo rule while preserving the rule configuration, rather than destructively modifying the configuration object.
+
+This chapter keeps backend declarations under `src/` and client stores under
+`src/client/`. `include` and `exclude` accept path globs relative to the Turbopack
+root, or a `RegExp`. Include all decorated declarations in `src/app.ts` and
+`src/posts/` below. Client component SSR is not excluded by the browser condition
+alone. An `@` in a comment or import can match the existing content condition,
+so an explicit boundary matters. `preserveModulePaths: true` avoids renaming
+Babel output to `.js`. The `store.ts.js` SSR import failure reproduced on
+Next 16.3.4 can be compared with the
+[real fixture](../../packages/platform-nextjs/e2e/README.md).
+Omitting the second argument preserves the broad selection and `.js` output
+rule. This opt-in does not add webpack or `.tsx` decorator support.
 
 Put decorated classes in `.ts` files. Expecting the loader to transform UI JSX files with a `.tsx` extension changes the build boundary. The following example writes the React page with `createElement()` specifically to honor this constraint. You can also move actual UI components into separate, undecorated `.tsx` files and call them from a `.ts` router.
 

--- a/docs/CONTEXT.ko.md
+++ b/docs/CONTEXT.ko.md
@@ -118,6 +118,13 @@ Node.js `>=24.0.0 <27`의 Next.js 16.x App Router와 Pages Router에서 Fluo를
 [릴리스 배포 목록](./contracts/release-governance.ko.md#intended-publish-surface)에
 이 어댑터가 포함됩니다.
 
+Compiler scope와 SSR module path 보존의 opt-in 계약은
+[Next package README](../packages/platform-nextjs/README.ko.md#decorator-compiler-연결)가
+소유합니다. `withFluoNextBackend`의 `include`/`exclude`와
+`preserveModulePaths`는 기존 기본 동작을 바꾸지 않습니다. 실행 근거는
+[helper 회귀](../packages/platform-nextjs/src/next-config.test.ts)와
+[실제 Next fixture](../packages/platform-nextjs/e2e/README.ko.md)에서 확인하세요.
+
 ## 라이프사이클 및 multi-provider 순서
 
 [라이프사이클 및 종료 보장](./architecture/lifecycle-and-shutdown.ko.md)은 application 및 testing module bootstrap hook의 SSOT입니다. 적격 singleton `multi: true` contribution은 별도 lifecycle instance로 남으며 singleton provider와 interleave해도 declared provider order로 실행됩니다. Framework integration은 owning DI container를 통해 각 contribution을 resolve하며 internal resolver registrar는 container-private으로 남습니다.

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -118,6 +118,13 @@ The [package surface](./reference/package-surface.md) and
 [release publish list](./contracts/release-governance.md#intended-publish-surface)
 include this adapter.
 
+The opt-in compiler scope and SSR module path preservation contract belongs to
+the [Next package README](../packages/platform-nextjs/README.md#decorator-compiler-wiring).
+`withFluoNextBackend` options `include`/`exclude` and `preserveModulePaths`
+do not change existing defaults. Execution evidence is linked from the
+[helper regressions](../packages/platform-nextjs/src/next-config.test.ts) and
+[real Next fixture](../packages/platform-nextjs/e2e/README.md).
+
 ## Lifecycle & Multi-Provider Ordering
 
 [Lifecycle & Shutdown Guarantees](./architecture/lifecycle-and-shutdown.md) is the source of truth for application and testing module bootstrap hooks. Eligible singleton `multi: true` contributions remain distinct lifecycle instances and run in declared provider order, including when they are interleaved with singleton providers. Framework integrations resolve each contribution through its owning DI container; the internal resolver registrar remains container-private.

--- a/docs/reference/toolchain-contract-matrix.ko.md
+++ b/docs/reference/toolchain-contract-matrix.ko.md
@@ -107,4 +107,10 @@ dependency graph를 평가합니다.
 
 ## 관련 참조
 
+Next compiler의 opt-in `include`/`exclude`와 `preserveModulePaths` 계약은
+[package README](../../packages/platform-nextjs/README.ko.md#decorator-compiler-연결)가
+소유합니다. 기존 기본값을 유지하며 버전별 `type` 옵션을 강제하지 않습니다.
+[실제 fixture](../../packages/platform-nextjs/e2e/README.ko.md)는 server DTO와
+client store SSR을 함께 dev/build/start로 검증합니다.
+
 - [package-surface.ko.md](./package-surface.ko.md)

--- a/docs/reference/toolchain-contract-matrix.md
+++ b/docs/reference/toolchain-contract-matrix.md
@@ -108,4 +108,10 @@ without adding a source scanner or another route discovery path.
 
 ## related reference
 
+The [package README](../../packages/platform-nextjs/README.md#decorator-compiler-wiring)
+owns the Next compiler's opt-in `include`/`exclude` and `preserveModulePaths`
+contract. Existing defaults remain, without forcing a version-specific `type`
+option. The [real fixture](../../packages/platform-nextjs/e2e/README.md) exercises
+server DTOs together with client store SSR through dev/build/start.
+
 - [package-surface.md](./package-surface.md)

--- a/packages/platform-nextjs/README.ko.md
+++ b/packages/platform-nextjs/README.ko.md
@@ -236,6 +236,52 @@ Next 전용 loader와 config object를 제공합니다.
 `*.ts` rule이 이미 있다면 Fluo decorator rule을 뒤에 추가합니다. Helper는
 새 configuration object를 반환하며 input을 변경하지 않습니다.
 
+Backend와 client store가 함께 있는 앱에서는 두 번째 인자로 적용 범위와
+출력 경로 보존을 명시할 수 있습니다. 다음 예제는 decorated 선언과 DTO를
+`src/backend/` 안에 두는 앱을 위한 설정입니다.
+
+```typescript
+import {
+  type FluoNextBackendOptions,
+  withFluoNextBackend,
+} from '@fluojs/platform-nextjs/next-config';
+
+const backend = {
+  include: 'src/backend/**',
+  exclude: '**/*.test.ts',
+  preserveModulePaths: true,
+} satisfies FluoNextBackendOptions;
+
+export default withFluoNextBackend({}, backend);
+```
+
+| 옵션 | 기본값 | 계약 |
+| --- | --- | --- |
+| `include` | 생략 | Turbopack path glob 또는 `RegExp`로 대상 경로를 제한합니다. |
+| `exclude` | 생략 | Turbopack path glob 또는 `RegExp`로 대상 경로를 제외합니다. `include`와 모두 적용됩니다. |
+| `preserveModulePaths` | `false` | `true`이면 `as: '*.js'`를 생략하여 원래 `.ts` 모듈 경로를 보존합니다. |
+
+Path 조건은 Turbopack이 `turbopack.root` 기준의 project-relative 경로에
+적용합니다(기본 root는 Next 프로젝트). Helper는 pattern을 직접 실행하지
+않습니다. `include`/`exclude`는 기존 server/application/content 조건에
+추가되며 browser와 foreign dependency를 다시 포함하지 않습니다.
+기존 content 조건은 `@` 뒤에 word character가 있는 source에 반응하므로
+decorator가 아닌 import나 주석도 일치할 수 있습니다. Client module의 SSR
+처리는 browser가 아니므로 `include` 또는 `exclude`로 별도 경계를 선언하세요.
+기존 사용자 rule의 변환 범위는 helper가 변경하지 않습니다.
+
+옵션을 생략하면 기존의 넓은 `*.ts` 선택과 `as: '*.js'` 출력 규칙을
+그대로 유지합니다. 경로 보존을 선택하면 같은 Babel JavaScript 결과를 원래
+TypeScript filename으로 파싱하며, 버전별 `type: 'ecmascript'` 옵션을
+강제하지 않습니다. Scope 밖의 decorated backend는 별도 compiler 구성이
+없으면 동작하지 않을 수 있으므로 모든 backend 선언과 DTO 경로를 포함하세요.
+Compiler 오류는 Next dev/build에 그대로 전달됩니다.
+
+실제 Next 16.3.4 fixture에서 기존 헬퍼는 client store SSR import를
+`./store.ts.js`로 해석하여 dev의 GET `/`와 production build가 실패했습니다.
+Scope 제한과 경로 보존은 독립적인 opt-in이며, 재현 절차와 지원 범위 내
+버전별 검증 명령은 [실제 Next fixture](./e2e/README.ko.md)에 있습니다.
+
 ## Lifecycle
 
 Backend module은 첫 route request가 import할 때 일반 Fluo bootstrap을 한
@@ -312,7 +358,8 @@ Application이 raw Node.js transport ownership, WebSocket upgrades, independentl
 - `NextAppRouterMethodHandlers`: route module에서 구조분해 export하는 method-keyed App Router record (`createNextAppRouterHandler()` 반환)
 - `createNextPagesRouterHandler(loadAdapter)`: request-lazy streaming Pages Router API handler 생성
 - `NextPagesRouterConfig`: 필수 static `bodyParser: false` literal type-check
-- `withFluoNextBackend(config)`: `@fluojs/platform-nextjs/next-config` export; packaged Turbopack decorator loader 추가
+- `withFluoNextBackend(config, options?)`: `@fluojs/platform-nextjs/next-config` export; packaged Turbopack decorator loader와 opt-in 범위/경로 보존 추가
+- `FluoNextBackendOptions`: 같은 `next-config` subpath의 `include`, `exclude`, `preserveModulePaths` 옵션 타입
 - `decorators-loader`: config helper가 사용하는 packaged loader subpath
 
 ## 개발 검증
@@ -328,4 +375,5 @@ pnpm --filter @fluojs/platform-nextjs test:e2e
 
 Unit suite에는 공통 Web portability 검사와 native Pages transport 회귀
 테스트가 포함됩니다. E2E suite는 package 배포 파일로 실제 Next.js application을
-빌드하고 source alias 없이 두 router를 HTTP로 검증합니다.
+dev/build/start를 거쳐 source alias 없이 두 router와 client store SSR을
+HTTP로 검증합니다. [Fixture 실행 안내](./e2e/README.ko.md)를 참조하세요.

--- a/packages/platform-nextjs/README.md
+++ b/packages/platform-nextjs/README.md
@@ -231,6 +231,53 @@ Existing `turbopack` options, aliases, and rules are preserved. When an
 application already has a `*.ts` rule, the Fluo decorator rule is appended.
 The helper returns a new configuration object and does not mutate its input.
 
+Applications with both a backend and client stores can declare compiler scope
+and output path preservation in the second argument. This example assumes
+decorated declarations and DTOs live under `src/backend/`.
+
+```typescript
+import {
+  type FluoNextBackendOptions,
+  withFluoNextBackend,
+} from '@fluojs/platform-nextjs/next-config';
+
+const backend = {
+  include: 'src/backend/**',
+  exclude: '**/*.test.ts',
+  preserveModulePaths: true,
+} satisfies FluoNextBackendOptions;
+
+export default withFluoNextBackend({}, backend);
+```
+
+| Option | Default | Contract |
+| --- | --- | --- |
+| `include` | Omitted | Restrict eligible paths with a Turbopack path glob or `RegExp`. |
+| `exclude` | Omitted | Exclude paths with a Turbopack path glob or `RegExp`. Both it and `include` apply. |
+| `preserveModulePaths` | `false` | When `true`, omit `as: '*.js'` to retain the original `.ts` module path. |
+
+Turbopack applies path conditions to project-relative paths under
+`turbopack.root` (the Next project by default). The helper does not evaluate
+patterns itself. `include`/`exclude` augment the existing
+server/application/content conditions; they cannot re-include browser or foreign
+dependency files. The existing content condition matches `@` followed by a word
+character, so imports and comments can match without decorators. Client-module
+SSR is not a browser compilation; declare its boundary with `include` or
+`exclude`. The helper does not change the scope of existing user rules.
+
+Omitting the options preserves the existing broad `*.ts` selection and
+`as: '*.js'` output rule. With path preservation, the same Babel JavaScript
+output is parsed under its original TypeScript filename; no version-specific
+`type: 'ecmascript'` option is forced. Include every backend declaration and DTO:
+decorated files outside the scope may not work without their own compiler
+configuration. Compiler errors propagate through Next dev/build.
+
+In the real Next 16.3.4 fixture, the legacy helper resolves the client store SSR
+import as `./store.ts.js`, failing dev GET `/` and the production build.
+Scope restriction and path preservation are independent opt-ins. See the
+[real Next fixture](./e2e/README.md) for reproduction and version-specific
+verification commands within the supported range.
+
 ## Lifecycle
 
 The backend module performs ordinary Fluo bootstrap once when the first route
@@ -307,7 +354,8 @@ Use a Fluo Node or Fastify platform adapter when the application requires raw No
 - `NextAppRouterMethodHandlers`: method-keyed App Router record returned by `createNextAppRouterHandler()`
 - `createNextPagesRouterHandler(loadAdapter)`: creates a request-lazy streaming Pages Router API handler
 - `NextPagesRouterConfig`: type-checks the required static `bodyParser: false` literal
-- `withFluoNextBackend(config)`: exported from `@fluojs/platform-nextjs/next-config`; adds the packaged Turbopack decorator loader
+- `withFluoNextBackend(config, options?)`: exported from `@fluojs/platform-nextjs/next-config`; adds the packaged Turbopack decorator loader with opt-in scope/path preservation
+- `FluoNextBackendOptions`: `include`, `exclude`, and `preserveModulePaths` option type on the same `next-config` subpath
 - `decorators-loader`: packaged loader subpath used by the config helper
 
 ## Development Verification
@@ -323,4 +371,5 @@ pnpm --filter @fluojs/platform-nextjs test:e2e
 
 The unit suite includes shared Web portability checks and native Pages transport
 regressions. The E2E suite stages package distribution files, builds a real
-Next.js application, and verifies both routers over HTTP without source aliases.
+Next.js application through dev/build/start, and verifies both routers and client
+store SSR over HTTP without source aliases. See the [fixture guide](./e2e/README.md).

--- a/packages/platform-nextjs/e2e/README.ko.md
+++ b/packages/platform-nextjs/e2e/README.ko.md
@@ -1,0 +1,72 @@
+# Next compiler 회귀 fixture
+
+<p><a href="./README.md"><kbd>English</kbd></a> <strong><kbd>한국어</kbd></strong></p>
+
+이 fixture는 현재 checkout의 배포 파일과 공개 export만 사용합니다.
+새로 publish한 package의 검증이 아닙니다. Node.js `>=24.0.0 <27`,
+독립적으로 설치한 worktree dependencies와 affected dependency closure build가
+필요합니다. 저장소 root에서 실행하세요.
+
+```bash
+pnpm --filter '@fluojs/platform-nextjs...' build
+pnpm --filter @fluojs/platform-nextjs test:e2e
+```
+
+기본 실행은 worktree에 설치된 Next 16을 사용합니다. 다른 Next 버전은 같은
+worktree의 무시되는 디렉터리에 설치할 수 있습니다. Next와 React renderer가
+서로 다른 React를 로드하지 않도록 세 package를 같은 설치에서 가져옵니다.
+
+```bash
+mkdir -p .omo/next-16.3
+pnpm --dir .omo/next-16.3 add --ignore-workspace next@16.3.4 react@19.2.7 react-dom@19.2.7
+FLUO_E2E_NEXT_ROOT="$PWD/.omo/next-16.3" pnpm --filter @fluojs/platform-nextjs test:e2e
+```
+
+같은 방식으로 `next@16.0.0`을 별도 `.omo/next-16.0`에 설치하여 peer 범위의
+하한을 실행할 수 있습니다. 모든 16.x patch를 검증했다고 해석하지 마세요.
+`FLUO_E2E_NEXT_ROOT`는 worktree 안에 있어야 합니다.
+
+## 자동 회귀
+
+- App Router와 Pages Router의 decorated server controller/field DTO,
+  GET과 JSON POST, cookie conversion, malformed JSON/404를 실제 HTTP로 검증합니다.
+- `'use client'` TypeScript store를 server page에서 import합니다. 주석의
+  `@store`는 기존 content 조건에 의도적으로 일치합니다. HTML의
+  `<output id="store">FLUO_SSR_STORE_OK</output>`을 dev와 build/start에서 확인합니다.
+- Production build가 backend를 시작하지 않는지, 동시 첫 GET이 bundle마다
+  하나의 bootstrap을 공유하는지, SSE와 실패 시 cleanup이 완료되는지 검증합니다.
+- Next build는 `next-config.types.ts`로 배포된 public option 타입을 검사합니다.
+  Rule 순서·비변이·scope 조건은 `src/next-config.test.ts`가 담당합니다.
+
+Consumer config는 helper와 범위 선언만 사용합니다. Custom loader 경로나
+`type: 'ecmascript'` 규칙은 작성하지 않습니다. `preserveModulePaths`는
+`as`를 생략하고 원래 `.ts` 경로를 유지합니다.
+
+## 비교 실험
+
+`FLUO_E2E_COMPILER`는 fixture 전용 선택이며 public package API가 아닙니다.
+
+| 값 | Helper 옵션 | 목적 |
+| --- | --- | --- |
+| 생략 / `scoped` | include + exclude + preserveModulePaths | 권장 scoped 소비자 경로 |
+| `scope-only` | include + exclude | 출력 경로 변경 없이 scope를 독립 검증 |
+| `preserve` | preserveModulePaths | Scope 없이 경로 보존을 독립 검증 |
+| `legacy` | 빈 옵션 | 기존 헬퍼의 SSR import 실패 재현 |
+
+```bash
+FLUO_E2E_NEXT_ROOT="$PWD/.omo/next-16.3" FLUO_E2E_COMPILER=preserve pnpm --filter @fluojs/platform-nextjs test:e2e
+FLUO_E2E_NEXT_ROOT="$PWD/.omo/next-16.3" FLUO_E2E_COMPILER=scope-only pnpm --filter @fluojs/platform-nextjs test:e2e
+FLUO_E2E_NEXT_ROOT="$PWD/.omo/next-16.3" FLUO_E2E_COMPILER=legacy pnpm --filter @fluojs/platform-nextjs test:e2e
+```
+
+Next 16.3.4의 legacy 모드는 의도적으로 실패합니다. Dev GET `/`가 500을
+반환하고 build가 `Can't resolve './store.ts.js'`로 종료됩니다. Scope만
+사용하면 SSR store를 변환하지 않고, 경로 보존만 사용하면 변환된 store도
+원래 import 경로로 해석합니다. 이 오류 재현과 scope 옵션의 필요성은 별개의
+회귀입니다. 기존 기본값은 호환성을 위해 유지합니다.
+
+각 실행은 고유 `.omo/platform-nextjs-e2e-*` 디렉터리와 ephemeral port를
+사용합니다. Readiness/stream 이벤트를 action 전에 구독하고 timeout으로
+실패를 제한합니다. Sleep이나 readiness polling은 사용하지 않습니다.
+`report.json`과 command log는 유지하고 임시 앱과 서버는 종료합니다.
+자동 회귀와 별도의 수동 브라우저/hydration 시연을 혼동하지 마세요.

--- a/packages/platform-nextjs/e2e/README.md
+++ b/packages/platform-nextjs/e2e/README.md
@@ -1,0 +1,74 @@
+# Next compiler regression fixture
+
+<p><strong><kbd>English</kbd></strong> <a href="./README.ko.md"><kbd>한국어</kbd></a></p>
+
+This fixture uses only distribution files and public exports from the current
+checkout, not newly published packages. It requires Node.js `>=24.0.0 <27`,
+independently installed worktree dependencies, and the affected dependency
+closure build. Run from the repository root.
+
+```bash
+pnpm --filter '@fluojs/platform-nextjs...' build
+pnpm --filter @fluojs/platform-nextjs test:e2e
+```
+
+By default, the suite uses the worktree's installed Next 16. Other versions can
+be installed in an ignored directory in the same worktree. Next and the React
+renderer use all three packages from that installation to avoid loading
+different React copies.
+
+```bash
+mkdir -p .omo/next-16.3
+pnpm --dir .omo/next-16.3 add --ignore-workspace next@16.3.4 react@19.2.7 react-dom@19.2.7
+FLUO_E2E_NEXT_ROOT="$PWD/.omo/next-16.3" pnpm --filter @fluojs/platform-nextjs test:e2e
+```
+
+Similarly, install `next@16.0.0` separately in `.omo/next-16.0` to exercise the
+peer range floor. This is not a claim that every 16.x patch was tested.
+`FLUO_E2E_NEXT_ROOT` must stay inside the worktree.
+
+## Automated regressions
+
+- Real HTTP exercises decorated server controllers/field DTOs, GET and JSON POST,
+  cookie conversion, malformed JSON/404 through App Router and Pages Router.
+- A server page imports a `'use client'` TypeScript store. Its `@store` comment
+  deliberately matches the legacy content condition. Dev and build/start must
+  render `<output id="store">FLUO_SSR_STORE_OK</output>` in the HTML.
+- Production builds must not bootstrap the backend; concurrent first GETs share
+  one bootstrap per bundle, and SSE/error cleanup must complete.
+- Next build checks shipped public option types through `next-config.types.ts`.
+  `src/next-config.test.ts` covers rule order, non-mutation, and scope conditions.
+
+Consumer configuration uses only the helper and scope declarations. It does not
+manually resolve loaders or configure `type: 'ecmascript'`.
+`preserveModulePaths` omits `as` and retains the original `.ts` path.
+
+## Comparison experiments
+
+`FLUO_E2E_COMPILER` is a fixture-only switch, not a public package API.
+
+| Value | Helper options | Purpose |
+| --- | --- | --- |
+| Omitted / `scoped` | include + exclude + preserveModulePaths | Recommended scoped consumer path |
+| `scope-only` | include + exclude | Verify scope independently of output path changes |
+| `preserve` | preserveModulePaths | Verify path preservation independently of scope |
+| `legacy` | Empty options | Reproduce the legacy helper's SSR import failure |
+
+```bash
+FLUO_E2E_NEXT_ROOT="$PWD/.omo/next-16.3" FLUO_E2E_COMPILER=preserve pnpm --filter @fluojs/platform-nextjs test:e2e
+FLUO_E2E_NEXT_ROOT="$PWD/.omo/next-16.3" FLUO_E2E_COMPILER=scope-only pnpm --filter @fluojs/platform-nextjs test:e2e
+FLUO_E2E_NEXT_ROOT="$PWD/.omo/next-16.3" FLUO_E2E_COMPILER=legacy pnpm --filter @fluojs/platform-nextjs test:e2e
+```
+
+Legacy mode intentionally fails on Next 16.3.4: dev GET `/` returns 500 and build
+exits with `Can't resolve './store.ts.js'`. Scope alone leaves the SSR store
+untransformed, while path preservation alone lets the transformed store resolve
+at its original import path. The import defect and the need for scope options
+are separate regressions. Existing defaults remain for compatibility.
+
+Each run uses a unique `.omo/platform-nextjs-e2e-*` directory and ephemeral
+ports. Readiness/stream events are subscribed before actions, with bounded
+failure timeouts and no sleeps or readiness polling. `report.json` and command
+logs remain after the temporary app and servers are cleaned up.
+Do not confuse these automated regressions with a separate manual
+browser/hydration demonstration.

--- a/packages/platform-nextjs/e2e/fixture/app/layout.tsx
+++ b/packages/platform-nextjs/e2e/fixture/app/layout.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from 'react';
+
+export default function RootLayout({ children }: { readonly children: ReactNode }) {
+  return <html lang="en"><body>{children}</body></html>;
+}

--- a/packages/platform-nextjs/e2e/fixture/app/page.tsx
+++ b/packages/platform-nextjs/e2e/fixture/app/page.tsx
@@ -1,0 +1,5 @@
+import { StoreView } from '../client/store';
+
+export default function Home() {
+  return <StoreView />;
+}

--- a/packages/platform-nextjs/e2e/fixture/client/store.ts
+++ b/packages/platform-nextjs/e2e/fixture/client/store.ts
@@ -1,0 +1,13 @@
+'use client';
+
+import { createElement, useSyncExternalStore } from 'react';
+
+// @store: this comment intentionally matches the legacy decorator content test.
+const state = { message: 'FLUO_SSR_STORE_OK' };
+const subscribe = () => () => {};
+const snapshot = () => state;
+
+export function StoreView() {
+  const value = useSyncExternalStore(subscribe, snapshot, snapshot);
+  return createElement('output', { id: 'store' }, value.message);
+}

--- a/packages/platform-nextjs/e2e/fixture/next-config.types.ts
+++ b/packages/platform-nextjs/e2e/fixture/next-config.types.ts
@@ -1,0 +1,15 @@
+import {
+  type FluoNextBackendOptions,
+  withFluoNextBackend,
+} from '@fluojs/platform-nextjs/next-config';
+import type { NextConfig } from 'next';
+
+// Next's real build typechecks the shipped declaration and public subpath.
+const options = {
+  include: /(?:^|\/)backend\.ts$/u,
+  exclude: '**/*.test.ts',
+  preserveModulePaths: true,
+} satisfies FluoNextBackendOptions;
+
+export const scopedConfig: NextConfig = withFluoNextBackend({}, options);
+export const legacyConfig: NextConfig = withFluoNextBackend();

--- a/packages/platform-nextjs/e2e/fixture/next.config.mjs
+++ b/packages/platform-nextjs/e2e/fixture/next.config.mjs
@@ -1,6 +1,17 @@
 import { withFluoNextBackend } from '@fluojs/platform-nextjs/next-config';
 
-export default withFluoNextBackend({
+const config = {
   // Installed pnpm dependencies remain inside this root; Fluo is copied as dist.
   turbopack: { root: process.env.FLUO_E2E_WORKTREE },
-});
+};
+
+// The legacy mode reproduces the unscoped SSR import failure. The preserve mode
+// tests output identity independently of scope; normal consumers need no rules.
+export default withFluoNextBackend(config,
+  process.env.FLUO_E2E_COMPILER === 'legacy' ? {}
+    : process.env.FLUO_E2E_COMPILER === 'preserve' ? { preserveModulePaths: true }
+      : {
+        include: /(?:^|\/)backend\.ts$/u,
+        exclude: '**/*.test.ts',
+        preserveModulePaths: process.env.FLUO_E2E_COMPILER !== 'scope-only',
+      });

--- a/packages/platform-nextjs/e2e/next.test.mjs
+++ b/packages/platform-nextjs/e2e/next.test.mjs
@@ -35,6 +35,9 @@ async function json(file) {
 }
 
 async function installed(name, source = packageRoot) {
+  if (['next', 'react', 'react-dom'].includes(name) && process.env.FLUO_E2E_NEXT_ROOT) {
+    return realpath(path.join(process.env.FLUO_E2E_NEXT_ROOT, 'node_modules', name));
+  }
   for (const base of [source, worktree]) {
     try {
       return await realpath(path.join(base, 'node_modules', name));
@@ -106,7 +109,7 @@ async function prepare(app) {
       jsx: 'react-jsx',
       plugins: [{ name: 'next' }],
     },
-    include: ['next-env.d.ts', '**/*.ts', '.next/types/**/*.ts'],
+    include: ['next-env.d.ts', '**/*.ts', '**/*.tsx', '.next/types/**/*.ts'],
     exclude: ['node_modules'],
   }, null, 2));
   return versions;
@@ -274,7 +277,13 @@ test('packaged Fluo serves both routers in a real Next 16 production build', {
   const sentinel = path.join(evidence, 'bootstrap.jsonl');
   await writeFile(sentinel, '');
   const children = [];
-  const report = { node: process.version, commands: [], http: [], evidence };
+  const report = {
+    node: process.version,
+    compiler: process.env.FLUO_E2E_COMPILER ?? 'scoped',
+    commands: [],
+    http: [],
+    evidence,
+  };
   t.diagnostic(`Evidence: ${evidence}`);
   try {
     report.versions = await prepare(app);
@@ -289,6 +298,34 @@ test('packaged Fluo serves both routers in a real Next 16 production build', {
     delete env.FORCE_COLOR;
     delete env.NODE_OPTIONS;
     const nextCli = createRequire(path.join(app, 'package.json')).resolve('next/dist/bin/next');
+
+    await t.test('dev serves client store SSR alongside decorated server DTOs', async () => {
+      const dev = run(process.execPath,
+        [nextCli, 'dev', '--turbopack', '--hostname', '127.0.0.1', '--port', '0'],
+        app, { ...env, NODE_ENV: 'development', FLUO_E2E_PHASE: 'dev' },
+        path.join(evidence, 'dev.log'), children, true);
+      try {
+        const base = await dev.ready();
+        for (const [route, options, status, expected] of [
+          ['/', {}, 200, /<output id="store">FLUO_SSR_STORE_OK<\/output>/],
+          ['/api/app/health', {}, 200, /"status":"ok"/],
+          ['/api/app/binding?count=42', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json', cookie: 'session=hello' },
+            body: '{"message":"dev DTO"}',
+          }, 201, /"message":"dev DTO"/],
+        ]) {
+          const response = await request(base, route, options);
+          report.http.push({ ...response, phase: 'dev' });
+          assert.equal(response.status, status, response.body);
+          assert.match(response.body, expected);
+        }
+      } finally {
+        await stop(dev);
+        report.commands.push({ command: dev.command, ...await dev.exit, phase: 'dev' });
+        await writeFile(sentinel, '');
+      }
+    });
 
     await t.test('resolves only published package exports before building', async () => {
       const preflight = run(process.execPath, ['--input-type=module', '-e', `
@@ -352,6 +389,11 @@ test('packaged Fluo serves both routers in a real Next 16 production build', {
       return response;
     };
     const jsonHeaders = { 'content-type': 'application/json' };
+    await t.test('production renders the client store through its original import', async () => {
+      const response = await capture('/');
+      assert.equal(response.status, 200);
+      assert.match(response.body, /<output id="store">FLUO_SSR_STORE_OK<\/output>/);
+    });
     await t.test('App Router keeps Next.js host method restrictions', async () => {
       const response = await capture('/api/app/health', { method: 'QUERY' });
       assert.equal(response.status, 400);

--- a/packages/platform-nextjs/src/next-config.test.ts
+++ b/packages/platform-nextjs/src/next-config.test.ts
@@ -1,9 +1,28 @@
 import type { NextConfig } from 'next';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 
-import { withFluoNextBackend } from './next-config.js';
+import { type FluoNextBackendOptions, withFluoNextBackend } from './next-config.js';
 
 describe('withFluoNextBackend', () => {
+  it('restricts decorator compilation to the declared backend paths', () => {
+    const result = withFluoNextBackend({}, {
+      include: /(?:^|\/)backend(?:\/|\.ts$)/u,
+      exclude: '**/*.test.ts',
+    });
+
+    expect(result.turbopack?.rules?.['*.ts']).toMatchObject({
+      condition: {
+        all: [
+          { not: 'foreign' },
+          { not: 'browser' },
+          { content: /@\w+/u },
+          { path: /(?:^|\/)backend(?:\/|\.ts$)/u },
+          { not: { path: '**/*.test.ts' } },
+        ],
+      },
+    });
+  });
+
   it('adds the packaged decorator loader while preserving Turbopack config', () => {
     const markdownRule = {
       as: '*.js',
@@ -64,5 +83,90 @@ describe('withFluoNextBackend', () => {
     const result: NextConfig = withFluoNextBackend({});
 
     expect(result.turbopack).toBeDefined();
+  });
+
+  it('preserves module paths only when explicitly requested', () => {
+    const preserved = withFluoNextBackend({}, { preserveModulePaths: true });
+    const legacy = withFluoNextBackend({}, { preserveModulePaths: false });
+
+    expect(preserved.turbopack?.rules?.['*.ts']).not.toHaveProperty('as');
+    expect(preserved.turbopack?.rules?.['*.ts']).not.toHaveProperty('type');
+    expect(legacy.turbopack?.rules?.['*.ts']).toHaveProperty('as', '*.js');
+    expect(withFluoNextBackend()).toEqual(withFluoNextBackend({}, {}));
+  });
+
+  it('appends after every existing rule without mutating frozen input', () => {
+    const first = Object.freeze({ loaders: ['first-loader'] });
+    const second = Object.freeze({ loaders: ['second-loader'], as: '*.js' });
+    const originalRules = [first, second];
+    Object.freeze(originalRules);
+    const input = Object.freeze({
+      turbopack: Object.freeze({
+        rules: Object.freeze({ '*.ts': originalRules, '*.txt': first }),
+      }),
+    });
+    const options = Object.freeze({
+      include: '**/backend/**',
+      exclude: /\.test\.ts$/u,
+      preserveModulePaths: true,
+    });
+
+    const result = withFluoNextBackend(input, options);
+
+    expect(Object.keys(result.turbopack?.rules ?? {})).toEqual(['*.ts', '*.txt']);
+    expect(result.turbopack?.rules?.['*.ts']).toEqual([
+      first,
+      second,
+      {
+        condition: {
+          all: [
+            { not: 'foreign' },
+            { not: 'browser' },
+            { content: /@\w+/u },
+            { path: '**/backend/**' },
+            { not: { path: /\.test\.ts$/u } },
+          ],
+        },
+        loaders: [{ loader: expect.stringMatching(/decorators-loader\.cjs$/u) }],
+      },
+    ]);
+    expect(input.turbopack.rules['*.ts']).toBe(originalRules);
+    expect(originalRules).toEqual([first, second]);
+    expect(result.turbopack?.rules?.['*.txt']).toBe(first);
+  });
+
+  it('allows exclusion without widening browser or foreign guards', () => {
+    const result = withFluoNextBackend({}, { exclude: /client/u });
+
+    expect(result.turbopack?.rules?.['*.ts']).toMatchObject({
+      condition: {
+        all: [
+          { not: 'foreign' },
+          { not: 'browser' },
+          { content: /@\w+/u },
+          { not: { path: /client/u } },
+        ],
+      },
+    });
+  });
+
+  it('does not share generated mutable rule records between calls', () => {
+    const first = withFluoNextBackend();
+    const second = withFluoNextBackend();
+
+    expect(first.turbopack?.rules?.['*.ts']).toEqual(second.turbopack?.rules?.['*.ts']);
+    expect(first.turbopack?.rules?.['*.ts']).not.toBe(second.turbopack?.rules?.['*.ts']);
+  });
+
+  it('exports typed opt-in options without replacing the NextConfig contract', () => {
+    expectTypeOf(withFluoNextBackend).returns.toEqualTypeOf<NextConfig>();
+    expectTypeOf<FluoNextBackendOptions['include']>()
+      .toEqualTypeOf<string | RegExp | undefined>();
+    expectTypeOf<FluoNextBackendOptions['exclude']>()
+      .toEqualTypeOf<string | RegExp | undefined>();
+    expectTypeOf<FluoNextBackendOptions['preserveModulePaths']>()
+      .toEqualTypeOf<boolean | undefined>();
+    expectTypeOf<{ include: string[] }>().not.toExtend<FluoNextBackendOptions>();
+    expectTypeOf<{ preserveModulePaths: string }>().not.toExtend<FluoNextBackendOptions>();
   });
 });

--- a/packages/platform-nextjs/src/next-config.ts
+++ b/packages/platform-nextjs/src/next-config.ts
@@ -10,25 +10,35 @@ type TurbopackRuleCollection = TurbopackRules[string];
 const decoratorsLoaderPath = fileURLToPath(
   new URL('../decorators-loader.cjs', import.meta.url),
 );
-const fluoDecoratorsRule = {
-  as: '*.js',
-  condition: {
-    all: [
-      { not: 'foreign' },
-      { not: 'browser' },
-      { content: /@\w+/u },
-    ],
-  },
-  loaders: [
-    {
-      loader: decoratorsLoaderPath,
-    },
-  ],
-} satisfies TurbopackRuleCollection;
+
+/** Opt-in compiler scope and output identity for the Next.js backend helper. */
+export interface FluoNextBackendOptions {
+  /** Turbopack project-relative path glob or regular expression to include. */
+  readonly include?: string | RegExp;
+  /** Turbopack project-relative path glob or regular expression to exclude. */
+  readonly exclude?: string | RegExp;
+  /** Keep the original `.ts` module path instead of renaming output to `.js`. */
+  readonly preserveModulePaths?: boolean;
+}
 
 function appendDecoratorsRule(
   existingRule: TurbopackRuleCollection | undefined,
+  options: FluoNextBackendOptions,
 ): TurbopackRuleCollection {
+  const fluoDecoratorsRule = {
+    ...(options.preserveModulePaths ? {} : { as: '*.js' }),
+    condition: {
+      all: [
+        { not: 'foreign' },
+        { not: 'browser' },
+        { content: /@\w+/u },
+        ...(options.include === undefined ? [] : [{ path: options.include }]),
+        ...(options.exclude === undefined ? [] : [{ not: { path: options.exclude } }]),
+      ],
+    },
+    loaders: [{ loader: decoratorsLoaderPath }],
+  } satisfies TurbopackRuleCollection;
+
   if (existingRule === undefined) {
     return fluoDecoratorsRule;
   }
@@ -45,12 +55,17 @@ function appendDecoratorsRule(
  *
  * Existing Next options and Turbopack rules are copied into the returned
  * object. The input object is never mutated.
+ * Scope conditions are combined with the existing server/application/content
+ * guards. Path-preserving output remains JavaScript parsed under the original
+ * TypeScript filename; no version-specific Turbopack module type is forced.
  *
  * @param config Existing Next.js configuration.
+ * @param options Optional path scope and module-path preservation; omission keeps legacy output.
  * @returns A Next.js configuration with server TypeScript decorators enabled.
  */
 export function withFluoNextBackend(
   config: NextConfig = {},
+  options: FluoNextBackendOptions = {},
 ): NextConfig {
   const turbopack = config.turbopack ?? {};
   const rules = turbopack.rules ?? {};
@@ -61,7 +76,7 @@ export function withFluoNextBackend(
       ...turbopack,
       rules: {
         ...rules,
-        '*.ts': appendDecoratorsRule(rules['*.ts']),
+        '*.ts': appendDecoratorsRule(rules['*.ts'], options),
       },
     },
   };


### PR DESCRIPTION
## Summary

Closes #3713

Next backend compiler helper에 opt-in 적용 범위와 모듈 경로 보존을 추가합니다. 기존 기본값은 유지하면서 소비 앱의 수동 loader 설정을 공개 helper 옵션으로 대체합니다.

## Changes

- withFluoNextBackend(config, options?)에 include, exclude, preserveModulePaths와 공개 옵션 타입을 추가했습니다.
- 기존 Turbopack rule 순서와 입력 config 비변이를 유지합니다.
- 실제 Next fixture에서 server DTO/decorator와 client store SSR을 함께 검증합니다.
- package README, fixture guide, website, Book, CONTEXT, toolchain reference의 EN/KO companion을 동기화했습니다.

## Testing

Exact reviewed head: `036e861dcd1b7dad4a3101f8f4fc9df56e7ef72a`. Contract, code, verification reviewers 모두 PASS.

- dependency closure build, package typecheck: passed.
- platform-nextjs 전체 테스트: 6 files / 38 tests passed.
- 직접 소비 governance suites: 2 files / 401 tests passed.
- 실제 Next 16.0.0, 16.2.11, 16.3.4: 각 dev/build/start 및 GET/JSON POST/SSR 회귀 통과. Lead가 최종 head에서 Next 16.3.4 scoped suite를 다시 실행해 통과했습니다.
- Next 16.3.4 scope-only / preserve-only 조합도 각각 통과했습니다. 기존 helper 모드에서는 store.ts.js import 오류를 재현했습니다.
- pnpm lint, pnpm verify:platform-consistency-governance, 변경 TS/TSX/MJS 진단: passed.
- Lead의 배포 API 직접 실행: scope 조건, frozen config, 기존 rule 순서, path preservation, legacy defaults 통과.
- Changeset stable gate, docs parity, Book checks: passed.

전체 repository matrix는 CI에서 실행합니다. 모든 Next 16.x patch를 검사한 것은 아니며 위 버전이 실제 검증 범위입니다. 별도 browser/hydration 수동 시연은 수행하지 않았습니다.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

`.changeset/next-backend-compiler-scope.md`: @fluojs/platform-nextjs minor.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching @param / @returns tags where applicable.
- [x] Source examples and README scenario examples serve their respective API and usage roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated.
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] Changed English/Korean companion structure remains synchronized.
- [x] Discoverability/reference companions and executable fixture evidence are included; existing governance checks pass.
- [x] Adapter claims are backed by package portability tests and the real Next fixture.
