### PR TITLE
Resolve #3714: add explicit-first Next HEAD routing

### DIFF
--- a/.changeset/next-explicit-head-routing.md
+++ b/.changeset/next-explicit-head-routing.md
@@ -1,0 +1,18 @@
+---
+"@fluojs/http": minor
+"@fluojs/platform-nextjs": minor
+---
+
+Add opt-in `createNextAdapter({ headRouting: 'explicit-or-get' })` routing for
+Next automatic HEAD and direct HEAD exports. Select explicit HEAD, then ALL,
+then GET before one dispatch, preserve the original HEAD method and response
+metadata, and cancel active response streams before awaiting request cleanup.
+Handler-produced 404 responses never trigger a retry.
+
+The shared HTTP matcher accepts the corresponding adapter-owned
+`FrameworkRequest.headRouting` field. Existing generic routing and adapters
+without the option retain their defaults; no path wildcard grammar is added.
+
+Migration: consumers opting in can remove wrappers that rewrite HEAD to GET and
+discard the body. Middleware, guards, and handlers now observe the original
+HEAD instead of that wrapper's GET, so update method-based application branches.

--- a/apps/docs/content/docs/guides/runtime-adapters.ko.mdx
+++ b/apps/docs/content/docs/guides/runtime-adapters.ko.mdx
@@ -51,6 +51,31 @@ Adapter가 달라도 fluo는 같은 framework-owned semantics를 보존합니다
 
 Adapter는 host-level route matching을 optimize할 수 있지만, matched request는 shared fluo dispatcher로 다시 전달되어 application behavior가 portable하게 유지됩니다.
 
+## Next.js HEAD 라우팅
+
+Next.js 16.x의 Node.js host에서 GET-only Fluo route에 HEAD를 연결하려면
+adapter가 제공하는 opt-in을 사용합니다.
+
+```ts
+import { createNextAdapter } from '@fluojs/platform-nextjs';
+
+const nextAdapter = createNextAdapter({ headRouting: 'explicit-or-get' });
+```
+
+표준 lazy `createNextAppRouterHandler(...)` facade에서 `GET`만 export하면 Next가
+자동 HEAD로 호출하고, `HEAD`도 export하면 직접 호출합니다. 양쪽 모두 Fluo의
+명시적 HEAD, ALL method wildcard, GET 순서로 route를 한 번 선택하며
+handler가 반환한 404는 재시도하지 않습니다. Status와 header를 보존하면서 body를
+제거하고 stream cancellation과 request cleanup을 기다립니다.
+Pages Router에도 같은 adapter option을 적용합니다.
+
+HEAD를 GET으로 재구성하던 wrapper는 제거할 수 있습니다. 이제 guard와 handler는
+원래 HEAD를 보므로 기존 method 기반 분기도 수정하세요. Option 생략 시 generic
+HTTP routing과 기존 adapter 기본값은 바뀌지 않습니다. Path wildcard 지원을
+추가하는 기능은 아닙니다.
+[Next package README](https://github.com/fluojs/fluo/blob/main/packages/platform-nextjs/README.ko.md#head-routing)가
+기본값, 자원 소유권, migration 및 실제 Next E2E 검증의 소유 문서입니다.
+
 ## Fastify
 
 Fastify는 권장 high-throughput Node.js adapter입니다.

--- a/apps/docs/content/docs/guides/runtime-adapters.mdx
+++ b/apps/docs/content/docs/guides/runtime-adapters.mdx
@@ -51,6 +51,31 @@ Across adapters, fluo preserves the same framework-owned semantics:
 
 Adapters may optimize host-level route matching, but matched requests still hand back to the shared fluo dispatcher so application behavior stays portable.
 
+## Next.js HEAD routing
+
+On a Next.js 16.x Node.js host, use the adapter's opt-in to connect HEAD to
+GET-only Fluo routes:
+
+```ts
+import { createNextAdapter } from '@fluojs/platform-nextjs';
+
+const nextAdapter = createNextAdapter({ headRouting: 'explicit-or-get' });
+```
+
+Export only `GET` from the standard lazy `createNextAppRouterHandler(...)`
+facade for Next auto-HEAD, or also export `HEAD` for direct invocation. Both
+select a route once in explicit HEAD, ALL method wildcard, then GET order;
+handler-produced 404s are never retried. Status and headers are preserved while
+the body is removed and stream cancellation and request cleanup are awaited.
+Pages Router uses the same adapter option.
+
+Remove the wrapper that reconstructed HEAD as GET. Guards and handlers now
+observe the original HEAD, so update method-based application branches too.
+Omitting the option preserves generic HTTP routing and existing adapter
+defaults. This does not add path wildcard support.
+The [Next package README](https://github.com/fluojs/fluo/blob/main/packages/platform-nextjs/README.md#head-routing)
+owns defaults, resource ownership, migration, and actual Next E2E evidence.
+
 ## Fastify
 
 Fastify is the recommended high-throughput Node.js adapter.

--- a/book/03-internals/ch15-nextjs-hosting.ko.md
+++ b/book/03-internals/ch15-nextjs-hosting.ko.md
@@ -124,6 +124,7 @@ import { FluoFactory } from '@fluojs/runtime';
 import { AppModule } from './app';
 
 export const nextAdapter = createNextAdapter({
+  headRouting: 'explicit-or-get',
   maxBodySize: 1_048_576,
   rawBody: true,
 });
@@ -185,6 +186,43 @@ export default function Home() {
 ```
 
 인쇄 링크는 Next layout 안에 HTML 문서를 끼워 넣는 컴포넌트 호출이 아니라 독립 HTTP 탐색이다. full-document 응답의 소유권을 분리했으므로 Next의 layout과 Fluo의 `<html>`이 중첩되지 않는다. 이 구분을 유지하면 기존 Fluo 페이지 일부를 남겨 놓는 점진적 이전도 설명할 수 있다.
+
+## 블로그 링크 검사기의 HEAD를 GET으로 위장하지 않는다
+
+블로그의 링크 검사기는 본문을 내려받지 않고 글의 상태와 header만 확인하려고
+HEAD를 보낸다. Next는 `HEAD` export가 없으면 `GET` export를 호출하지만
+request method는 HEAD로 유지한다. 위 backend의 `headRouting: 'explicit-or-get'`은
+이 요청을 Fluo의 GET-only `/api/posts/:id`에 연결하는 명시적 선택이다.
+Option을 빼면 기존 generic routing을 유지하므로 GET-only route는 HEAD에
+자동으로 매칭되지 않는다.
+
+이 정책은 명시적 `@Head`를 가장 먼저 찾고, 없으면 `@All`, 그다음 `@Get`을
+선택한다. 선택한 handler가 글 없음으로 404를 반환해도 GET을 다시 실행하지
+않는다. 따라서 인증 guard, 조회, audit middleware를 두 번 실행하는 우회
+wrapper가 필요 없다. `ALL`은 method wildcard이며 Next의 파일 catch-all이
+Fluo의 path wildcard 문법을 추가하는 것은 아니다.
+
+기존 앱에서 HEAD request를 GET으로 재구성한 뒤 body를 버리고 있었다면 그
+wrapper를 제거하고 위 표준 facade를 사용한다. Guard와 handler가 관찰하는
+method는 이제 원래 HEAD다. GET만 허용하던 읽기 분기가 있다면 HEAD도 읽기
+요청으로 다루되, 인증이나 공개 글 판정 자체를 생략하지 않는다.
+`GET`과 `HEAD`를 모두 export하든 `GET`만 export해 Next auto-HEAD를 사용하든
+상태와 관련 header는 보존되고 response body는 비어 있다.
+
+열린 response stream은 취소하고 iterator cleanup과 request scope 정리가
+끝나기를 기다린다. 끝나지 않는 iterator `return()`을 framework가 강제로
+완료해 주지는 않는다. 파일 본문이 필요 없는 HEAD에서 파일 stream 자체를
+열지 않으려면 `createByteRangeResponse(...)`에 stream factory를 전달한다.
+다음은 앱을 실행한 뒤 비교하는 재현 명령이지 실행 완료 기록이 아니다.
+
+```bash
+curl -I http://127.0.0.1:3000/api/posts/1
+curl -I http://127.0.0.1:3000/api/posts/999
+```
+
+[HEAD 계약](../../packages/platform-nextjs/README.ko.md#head-routing)과
+[Next production E2E](../../packages/platform-nextjs/e2e/next.test.mjs)가
+자동 HEAD, 직접 HEAD, handler 404, stream 정리의 근거다.
 
 ## 동시에 들어온 첫 요청과 닫힌 뒤의 요청을 시험한다
 

--- a/book/03-internals/ch15-nextjs-hosting.md
+++ b/book/03-internals/ch15-nextjs-hosting.md
@@ -124,6 +124,7 @@ import { FluoFactory } from '@fluojs/runtime';
 import { AppModule } from './app';
 
 export const nextAdapter = createNextAdapter({
+  headRouting: 'explicit-or-get',
   maxBodySize: 1_048_576,
   rawBody: true,
 });
@@ -185,6 +186,45 @@ export default function Home() {
 ```
 
 The print link is an independent HTTP navigation, not a component call that inserts an HTML document into the Next layout. Because ownership of the full-document response is separate, Next's layout and Fluo's `<html>` do not become nested. Preserving this distinction also makes it possible to describe a gradual migration that retains some existing Fluo pages.
+
+## Do Not Disguise the Blog Link Checker's HEAD as GET
+
+The blog link checker sends HEAD to inspect a post's status and headers without
+downloading its body. Next calls the `GET` export when no `HEAD` export exists,
+but preserves the HEAD request method. The backend's
+`headRouting: 'explicit-or-get'` explicitly connects this request to Fluo's
+GET-only `/api/posts/:id`. Omitting the option retains generic routing, where
+GET-only routes do not automatically match HEAD.
+
+This policy first looks for an explicit `@Head`, then `@All`, then `@Get`.
+A selected handler's missing-post 404 does not execute GET again. There is no
+need for a wrapper that repeats the authorization guard, lookup, or audit
+middleware. `ALL` is a method wildcard; Next's filesystem catch-all does not
+introduce Fluo path wildcard grammar.
+
+If the existing application reconstructed HEAD as GET and discarded its body,
+remove that wrapper and use the standard facade above. Guards and handlers
+now observe the original HEAD. Update GET-only read branches to recognize
+HEAD as a read request without skipping authorization or published-post checks.
+Whether both `GET` and `HEAD` are exported or only `GET` is exported for Next
+auto-HEAD, status and relevant headers are preserved and the response body is
+empty.
+
+Open response streams are cancelled, and iterator cleanup and request-scope
+disposal are awaited. The framework cannot force an iterator's non-settling
+`return()` to complete. Pass a stream factory to `createByteRangeResponse(...)`
+to avoid opening a file stream when HEAD needs no body.
+These commands compare the running application; they are reproduction steps,
+not a record of completed execution:
+
+```bash
+curl -I http://127.0.0.1:3000/api/posts/1
+curl -I http://127.0.0.1:3000/api/posts/999
+```
+
+The [HEAD contract](../../packages/platform-nextjs/README.md#head-routing) and
+[Next production E2E](../../packages/platform-nextjs/e2e/next.test.mjs) provide
+evidence for auto-HEAD, direct HEAD, handler 404s, and stream cleanup.
 
 ## Test Concurrent First Requests and Requests After Close
 

--- a/docs/CONTEXT.ko.md
+++ b/docs/CONTEXT.ko.md
@@ -118,6 +118,15 @@ Node.js `>=24.0.0 <27`의 Next.js 16.x App Router와 Pages Router에서 Fluo를
 [릴리스 배포 목록](./contracts/release-governance.ko.md#intended-publish-surface)에
 이 어댑터가 포함됩니다.
 
+GET-only Fluo route에서 application wrapper 없이 Next auto-HEAD와 직접 HEAD를
+지원하려면 [`headRouting: 'explicit-or-get'`](../packages/platform-nextjs/README.ko.md#head-routing)을
+명시적으로 선택합니다.
+[공통 HTTP 매칭 계약](./architecture/http-runtime.ko.md#opt-in-head-route-selection)은
+HEAD method를 유지하며 handler가 반환한 404를 재시도하지 않습니다.
+검증 근거는 `packages/http/src/head-routing.test.ts`,
+`packages/platform-nextjs/src/head-routing.test.ts`, packaged
+`packages/platform-nextjs/e2e/next.test.mjs`에 있습니다.
+
 ## 라이프사이클 및 multi-provider 순서
 
 [라이프사이클 및 종료 보장](./architecture/lifecycle-and-shutdown.ko.md)은 application 및 testing module bootstrap hook의 SSOT입니다. 적격 singleton `multi: true` contribution은 별도 lifecycle instance로 남으며 singleton provider와 interleave해도 declared provider order로 실행됩니다. Framework integration은 owning DI container를 통해 각 contribution을 resolve하며 internal resolver registrar는 container-private으로 남습니다.

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -118,6 +118,15 @@ The [package surface](./reference/package-surface.md) and
 [release publish list](./contracts/release-governance.md#intended-publish-surface)
 include this adapter.
 
+For GET-only Fluo routes, explicitly select
+[`headRouting: 'explicit-or-get'`](../packages/platform-nextjs/README.md#head-routing)
+to support Next auto-HEAD and direct HEAD without an application wrapper.
+The [shared HTTP matching contract](./architecture/http-runtime.md#opt-in-head-route-selection)
+keeps HEAD visible and never retries a handler-produced 404.
+Evidence lives in `packages/http/src/head-routing.test.ts`,
+`packages/platform-nextjs/src/head-routing.test.ts`, and the packaged
+`packages/platform-nextjs/e2e/next.test.mjs`.
+
 ## Lifecycle & Multi-Provider Ordering
 
 [Lifecycle & Shutdown Guarantees](./architecture/lifecycle-and-shutdown.md) is the source of truth for application and testing module bootstrap hooks. Eligible singleton `multi: true` contributions remain distinct lifecycle instances and run in declared provider order, including when they are interleaved with singleton providers. Framework integrations resolve each contribution through its owning DI container; the internal resolver registrar remains container-private.

--- a/docs/architecture/http-runtime.ko.md
+++ b/docs/architecture/http-runtime.ko.md
@@ -16,6 +16,25 @@ conditional-request 평가가 handler 실행을 허용한 뒤 response policy는
 
 `createByteRangeResponse(...)`는 application-owned byte 또는 정확한 representation size를 가진 stream factory를 받는다. 이 API는 filesystem resource를 열거나, stat, seek, size 계산, 소유하지 않는다. application이 정확한 size와 source를 제공하며 multi-range response construction은 의도적으로 지원하지 않는다.
 
+## Opt-in HEAD Route Selection
+
+공통 matcher는 adapter-owned `FrameworkRequest.headRouting:
+'explicit-or-get'`을 받습니다. HEAD request만 명시적 HEAD → ALL → GET 순서로
+선택하며 생략하면 generic matching을 변경하지 않습니다. Version extraction은
+원래 HEAD request에서 한 번 실행하고 각 method 그룹 안에서는 기존 path/version
+규칙을 유지합니다. 선택한 descriptor는 response 기반 재시도가 아닌 하나의
+dispatch lifecycle에 진입합니다. 없는 route와 handler가 반환한 404는 서로
+다른 결과로 유지됩니다. Middleware와 guard도 HEAD를 관찰하므로 conditional
+request 및 byte-range metadata의 기존 정책을 보존합니다.
+
+[HTTP README](../../packages/http/README.ko.md#opt-in-head-selection)가 matching
+seam을 소유하고 [Next README](../../packages/platform-nextjs/README.ko.md#head-routing)가
+opt-in transport API, body suppression, stream cleanup, wrapper migration을
+소유합니다. Path wildcard는 계속 보류 상태입니다. 검증 근거:
+`packages/http/src/head-routing.test.ts`,
+`packages/platform-nextjs/src/head-routing.test.ts`,
+실제 Next `packages/platform-nextjs/e2e/next.test.mjs`.
+
 ## Request Lifecycle
 
 1. 어댑터는 정규화된 `FrameworkRequest`와 `FrameworkResponse`를 `Dispatcher.dispatch(...)`에 전달하며, host가 요청 취소를 노출한다면 `signal` 또는 `isAborted()`를 포함한다.

--- a/docs/architecture/http-runtime.md
+++ b/docs/architecture/http-runtime.md
@@ -16,6 +16,25 @@ After conditional-request evaluation permits handler execution, the response pol
 
 `createByteRangeResponse(...)` accepts application-owned bytes or a stream factory with an exact representation size. It never opens, stats, seeks, sizes, or owns filesystem resources: the application supplies the exact size and source. Multi-range response construction is intentionally unsupported.
 
+## Opt-in HEAD Route Selection
+
+The shared matcher accepts adapter-owned `FrameworkRequest.headRouting:
+'explicit-or-get'`. Only HEAD requests use the explicit HEAD → ALL → GET
+selection order; omission keeps generic matching unchanged. Version extraction
+uses the original HEAD request once, and the existing path/version rules apply
+within each method group. The selected descriptor enters one dispatch lifecycle,
+not a response-based retry. Missing routes and handler-produced 404s remain
+distinct outcomes. Middleware and guards still observe HEAD, so conditional
+requests and byte-range metadata retain their current policy.
+
+The [HTTP README](../../packages/http/README.md#opt-in-head-selection) owns the
+matching seam; the [Next README](../../packages/platform-nextjs/README.md#head-routing)
+owns its opt-in transport API, body suppression, stream cleanup, and wrapper
+migration. Path wildcards remain deferred. Evidence:
+`packages/http/src/head-routing.test.ts`,
+`packages/platform-nextjs/src/head-routing.test.ts`, and the real Next
+`packages/platform-nextjs/e2e/next.test.mjs`.
+
 ## Request Lifecycle
 
 1. The adapter supplies a normalized `FrameworkRequest` and `FrameworkResponse` to `Dispatcher.dispatch(...)`, including `signal` or `isAborted()` when the host exposes request cancellation.

--- a/packages/http/README.ko.md
+++ b/packages/http/README.ko.md
@@ -585,6 +585,28 @@ Node `AsyncLocalStorage` bootstrap을 eager 초기화하지 않고 HTTP authorin
 - `FRAMEWORK_RESPONSE_WRITER` / `registerFrameworkResponseWriter(...)`: first-party response integration을 위한 typed response-entry branding seam.
 - `FRAMEWORK_RESPONSE_VALUE_FINALIZER` / `registerFrameworkResponseValueFinalizer(...)`: typed request-local response finalization seam. Finalizer는 registration 순서대로 compose되고 각각 이전에 resolve된 값을 받으며, dispatcher가 await하므로 throw와 rejection은 기존 error policy를 따릅니다.
 
+## Opt-in HEAD Selection
+
+`FrameworkRequest.headRouting?: 'explicit-or-get'`은 공통
+`createHandlerMapping(...)` matcher에 전달하는 adapter-owned 입력입니다.
+생략하면 기존 method matching을 유지합니다. HEAD에만 opt-in을 적용해 유효한
+명시적 HEAD route, `ALL` method wildcard, GET 순서로 하나를 선택한 뒤
+pipeline을 한 번 dispatch합니다. 각 method 그룹은 기존 static/parameter 및
+version 규칙을 유지합니다. Version extraction은 원래 HEAD request에서 한 번
+실행하며 native request나 middleware, guard, handler가 관찰하는 method를
+재작성하지 않습니다. 404를 포함한 handler 결과는 route selection을 다시
+실행하지 않습니다.
+
+이 field는 path wildcard를 추가하거나 다른 adapter의 기본값을 바꾸지 않습니다.
+Custom `HandlerMapping` 구현은 자신의 matching 정책을 소유합니다. Native route
+handoff는 이미 선택한 route를 사용하므로 이 공통 matcher를 호출하지 않습니다.
+이 field는 route를 선택할 뿐 transport response writer가 아니며 기존 custom
+writer는 계속 HEAD body emission을 소유합니다.
+[Next adapter option](../platform-nextjs/README.ko.md#head-routing)은 Next 소비자에게
+transport body suppression과 stream cleanup을 추가합니다.
+회귀 근거는 [`head-routing.test.ts`](./src/head-routing.test.ts)와
+[Next pipeline tests](../platform-nextjs/src/head-routing.test.ts)에 있습니다.
+
 ## Conditional Requests
 
 runtime bootstrap에서 `conditionalRequest`를 구성해 representation 존재 여부와 optional validator를 분리하여 해석합니다.

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -594,6 +594,27 @@ The `./internal` subpath exports only the low-level utilities used by platform a
 - `FRAMEWORK_RESPONSE_WRITER` / `registerFrameworkResponseWriter(...)`: Typed response-entry branding seam for first-party response integrations.
 - `FRAMEWORK_RESPONSE_VALUE_FINALIZER` / `registerFrameworkResponseValueFinalizer(...)`: Typed request-local response finalization seam. Finalizers compose in registration order, each receives the prior resolved value, and the dispatcher awaits them so throws and rejections follow its normal error policy.
 
+## Opt-in HEAD Selection
+
+`FrameworkRequest.headRouting?: 'explicit-or-get'` is an adapter-owned input to
+the shared `createHandlerMapping(...)` matcher. Omission retains ordinary method
+matching. For HEAD only, opt-in selects an eligible explicit HEAD route, then
+the `ALL` method wildcard, then GET, before dispatching a single pipeline.
+Each method group retains its existing static/parameter and version rules.
+Version extraction runs once against the original HEAD request, and neither
+the native request nor the method seen by middleware, guards, and handlers is
+rewritten. Handler results, including 404, never re-enter route selection.
+
+This field does not add path wildcards or change other adapters' defaults.
+Custom `HandlerMapping` implementations own their matching policy; native route
+handoffs remain preselected routes and do not invoke this shared matcher.
+The field selects a route, not a transport response writer: existing custom
+writers still own HEAD body emission. The
+[Next adapter option](../platform-nextjs/README.md#head-routing) adds transport
+body suppression and stream cleanup for Next consumers.
+Regression evidence is in [`head-routing.test.ts`](./src/head-routing.test.ts)
+and the [Next pipeline tests](../platform-nextjs/src/head-routing.test.ts).
+
 ## Conditional Requests
 
 Configure `conditionalRequest` during runtime bootstrap to resolve representation existence separately from optional validators:

--- a/packages/http/src/dispatch/dispatcher.ts
+++ b/packages/http/src/dispatch/dispatcher.ts
@@ -190,6 +190,7 @@ function createDispatchRequest(request: FrameworkRequest): FrameworkRequest {
     },
     body: request.body,
     connection: request.connection,
+    headRouting: request.headRouting,
     method: request.method,
     params: { ...request.params },
     path: request.path,

--- a/packages/http/src/head-routing.test.ts
+++ b/packages/http/src/head-routing.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  All,
+  Controller,
+  createHandlerMapping,
+  type FrameworkRequest,
+  Get,
+  Head,
+  InvalidRoutePathError,
+  Version,
+  VersioningType,
+} from './index.js';
+
+function request(path: string, headRouting?: FrameworkRequest['headRouting']): FrameworkRequest {
+  return {
+    method: 'HEAD',
+    headRouting,
+    path,
+    url: path,
+    headers: {},
+    cookies: {},
+    query: {},
+    params: {},
+    raw: undefined,
+  };
+}
+
+describe('opt-in HEAD mapping', () => {
+  it.each([
+    { path: '/articles/42', selected: 'head', params: { id: '42' } },
+    { path: '/all/42', selected: 'all', params: { id: '42' } },
+    { path: '//get/42/', selected: 'get', params: { id: '42' } },
+    { path: '/missing', selected: undefined, params: undefined },
+  ])('resolves $path before dispatch', ({ path, selected, params }) => {
+    // Given explicit HEAD, method-wildcard ALL, and GET candidates.
+    @Controller()
+    class Routes {
+      @Get('/articles/42')
+      articleGet() {}
+      @All('/articles/42')
+      articleAll() {}
+      @Head('/articles/:id')
+      head() {}
+      @Get('/all/42')
+      allGet() {}
+      @All('/all/:id')
+      all() {}
+      @Get('/get/:id')
+      get() {}
+    }
+    const mapping = createHandlerMapping([{ controllerToken: Routes }]);
+    const incoming = request(path, 'explicit-or-get');
+    // When the opt-in lookup chooses a single descriptor.
+    const match = mapping.match(incoming);
+    // Then method priority applies before the existing within-method path rules.
+    expect(match?.descriptor.methodName).toBe(selected);
+    expect(match?.params).toEqual(params);
+    expect(incoming.method).toBe('HEAD');
+    expect(incoming.params).toEqual({});
+  });
+
+  it('extracts a version once from the original HEAD request before GET selection', () => {
+    // Given a custom extractor that would select a different version for GET.
+    const methods: string[] = [];
+    @Controller('/versioned')
+    class Routes {
+      @Get()
+      @Version('2')
+      get() {}
+      @Head()
+      @Version('1')
+      head() {}
+    }
+    const mapping = createHandlerMapping([{ controllerToken: Routes }], {
+      versioning: {
+        type: VersioningType.CUSTOM,
+        extractor(incoming) {
+          methods.push(incoming.method);
+          return incoming.method === 'HEAD' ? '2' : '1';
+        },
+      },
+    });
+    // When HEAD has no eligible explicit version.
+    const match = mapping.match(request('/versioned', 'explicit-or-get'));
+    // Then GET supplies the same selected version without another extraction.
+    expect(match?.descriptor.methodName).toBe('get');
+    expect(methods).toEqual(['HEAD']);
+  });
+
+  it('preserves default matching and GET method semantics', () => {
+    // Given ordinary method-specific routes.
+    @Controller('/default')
+    class Routes {
+      @Get()
+      get() {}
+    }
+    const mapping = createHandlerMapping([{ controllerToken: Routes }]);
+    // When no HEAD policy is selected or the request is GET.
+    const head = mapping.match(request('/default'));
+    const get = mapping.match({ ...request('/default', 'explicit-or-get'), method: 'GET' });
+    // Then the generic HEAD miss and ordinary GET hit remain unchanged.
+    expect(head).toBeUndefined();
+    expect(get?.descriptor.methodName).toBe('get');
+  });
+
+  it('does not turn ALL method matching into wildcard path grammar', () => {
+    // Given an unsupported path wildcard.
+    // When a route attempts to register it.
+    const defineWildcard = () => {
+      @Controller()
+      class Routes {
+        @All('/articles/*')
+        all() {}
+      }
+      return createHandlerMapping([{ controllerToken: Routes }]);
+    };
+    // Then the existing route-grammar error remains authoritative.
+    expect(defineWildcard).toThrow(InvalidRoutePathError);
+  });
+});

--- a/packages/http/src/mapping.ts
+++ b/packages/http/src/mapping.ts
@@ -501,70 +501,86 @@ export function createHandlerMapping(sources: HandlerSource[], options?: CreateH
   const descriptors = freezeDescriptorSnapshot(buildDescriptorList(sources, versioning));
   const descriptorIndex = buildDescriptorIndex(descriptors);
 
+  const matchMethod = (
+    method: string,
+    requestVersion: string | undefined,
+    normalizedPath: string,
+    includeAll: boolean,
+  ): HandlerMatch | undefined => {
+    const methodStaticDescriptors = descriptorIndex.static.get(method)?.get(normalizedPath);
+    const allStaticDescriptors = includeAll ? descriptorIndex.static.get('ALL')?.get(normalizedPath) : undefined;
+    const directStaticMatch = findStaticMatch(
+      [methodStaticDescriptors, allStaticDescriptors],
+      requestVersion,
+      versioning,
+    );
+
+    if (directStaticMatch) {
+      return directStaticMatch;
+    }
+
+    const incomingSegments = normalizedPath.split('/').filter(Boolean);
+    const candidates = [
+      ...(descriptorIndex.param.get(method)?.get(incomingSegments.length) ?? []),
+      ...(includeAll ? descriptorIndex.param.get('ALL')?.get(incomingSegments.length) ?? [] : []),
+    ];
+    let firstUnversionedMatch: HandlerMatch | undefined;
+
+    for (const candidate of candidates) {
+      const params = matchParameterizedRoute(candidate, incomingSegments);
+
+      if (!params) {
+        continue;
+      }
+
+      if (versioning.type === VersioningType.URI) {
+        return {
+          descriptor: candidate.descriptor,
+          params,
+        };
+      }
+
+      if (matchesRouteVersion(candidate.descriptor, requestVersion)) {
+        return {
+          descriptor: candidate.descriptor,
+          params,
+        };
+      }
+
+      if (candidate.descriptor.route.version === undefined && !firstUnversionedMatch) {
+        firstUnversionedMatch = {
+          descriptor: candidate.descriptor,
+          params,
+        };
+      }
+    }
+
+    if (versioning.type !== VersioningType.URI) {
+      if (firstUnversionedMatch) {
+        return {
+          descriptor: firstUnversionedMatch.descriptor,
+          params: firstUnversionedMatch.params,
+        };
+      }
+    }
+
+    return undefined;
+  };
+
   const mapping = {
     descriptors,
     match(request: FrameworkRequest): HandlerMatch | undefined {
       const method = request.method.toUpperCase();
       const requestVersion = versioning.type === VersioningType.URI ? undefined : resolveRequestVersion(request, versioning);
       const normalizedPath = normalizeRoutePath(request.path);
-      const methodStaticDescriptors = descriptorIndex.static.get(method)?.get(normalizedPath);
-      const allStaticDescriptors = descriptorIndex.static.get('ALL')?.get(normalizedPath);
-      const directStaticMatch = findStaticMatch(
-        [methodStaticDescriptors, allStaticDescriptors],
-        requestVersion,
-        versioning,
-      );
 
-      if (directStaticMatch) {
-        return directStaticMatch;
+      if (method === 'HEAD' && request.headRouting === 'explicit-or-get') {
+        return matchMethod('HEAD', requestVersion, normalizedPath, false)
+          ?? matchMethod('ALL', requestVersion, normalizedPath, false)
+          ?? matchMethod('GET', requestVersion, normalizedPath, false);
       }
 
-      const incomingSegments = normalizedPath.split('/').filter(Boolean);
-      const candidates = [
-        ...(descriptorIndex.param.get(method)?.get(incomingSegments.length) ?? []),
-        ...(descriptorIndex.param.get('ALL')?.get(incomingSegments.length) ?? []),
-      ];
-      let firstUnversionedMatch: HandlerMatch | undefined;
-
-      for (const candidate of candidates) {
-        const params = matchParameterizedRoute(candidate, incomingSegments);
-
-        if (!params) {
-          continue;
-        }
-
-        if (versioning.type === VersioningType.URI) {
-          return {
-            descriptor: candidate.descriptor,
-            params,
-          };
-        }
-
-        if (matchesRouteVersion(candidate.descriptor, requestVersion)) {
-          return {
-            descriptor: candidate.descriptor,
-            params,
-          };
-        }
-
-        if (candidate.descriptor.route.version === undefined && !firstUnversionedMatch) {
-          firstUnversionedMatch = {
-            descriptor: candidate.descriptor,
-            params,
-          };
-        }
-      }
-
-      if (versioning.type !== VersioningType.URI) {
-        if (firstUnversionedMatch) {
-          return {
-            descriptor: firstUnversionedMatch.descriptor,
-            params: firstUnversionedMatch.params,
-          };
-        }
-      }
-
-      return undefined;
+      return matchMethod(method, requestVersion, normalizedPath, true);
     },
   };
 

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -24,6 +24,12 @@ export enum VersioningType {
  */
 export interface FrameworkRequest {
   method: HttpMethod | string;
+  /**
+   * Opt-in route selection for HEAD: explicit HEAD, then ALL, then GET.
+   * Only matching changes; middleware, guards, handlers, and response policies
+   * retain the original method. Omission preserves ordinary method matching.
+   */
+  readonly headRouting?: 'explicit-or-get';
   path: string;
   url: string;
   headers: Readonly<Record<string, string | string[] | undefined>>;

--- a/packages/platform-nextjs/README.ko.md
+++ b/packages/platform-nextjs/README.ko.md
@@ -11,6 +11,7 @@ Fluo backend를 Next.js App Router Route Handlers와 Pages Router API Routes에
 - [설치](#설치)
 - [공통 설정](#공통-설정)
 - [App Router](#app-router)
+- [HEAD Routing](#head-routing)
 - [Pages Router](#pages-router)
 - [FluoFactory 연결](#fluofactory-연결)
 - [Pipeline compatibility](#pipeline-compatibility)
@@ -133,6 +134,61 @@ Fluo가 decorator metadata, route matching, module bootstrap, dependency
 injection, request scope, body parsing, error, controller dispatch를
 담당합니다. Route Handler는 Fluo backend가 요구하는 Node.js runtime을
 기본으로 사용하므로 `runtime` override는 필요하지 않습니다.
+
+## HEAD Routing
+
+GET-only Fluo route가 Next의 자동 HEAD와 명시적인 `HEAD` export 모두에
+응답해야 한다면 adapter 생성 시 opt-in합니다.
+
+```typescript
+import { createNextAdapter } from '@fluojs/platform-nextjs';
+
+export const nextAdapter = createNextAdapter({
+  headRouting: 'explicit-or-get',
+});
+```
+
+생략하면 기존 method matching을 유지하므로 GET-only Fluo route는 HEAD에
+암묵적으로 매칭되지 않습니다. 이 option에서는 공통 HTTP matcher가 유효한
+명시적 `@Head`, 없으면 `@All`, 없으면 `@Get` route 하나를 선택합니다.
+그룹 간에는 method 우선순위가 path specificity보다 앞서고, 각 그룹 안에서는
+기존 static/parameter 및 version 규칙을 적용합니다. `ALL`은 method wildcard이지
+path wildcard가 아니므로 Fluo catch-all path grammar는 계속 지원하지 않습니다.
+
+선택은 module middleware, guard, controller 이전에 한 번 결정합니다.
+Route miss는 404를 반환합니다. 선택한 handler가 반환한 404는 최종 결과이며
+다시 dispatch하지 않습니다. 기존 short-circuit 동작에 따라 application middleware,
+module middleware, guard, controller는 각각 최대 한 번 실행합니다.
+
+정규화된 request와 native `Request`는 middleware, guard, version extractor,
+conditional resolver, handler 안에서도 원래 **HEAD**를 유지합니다. 선택한
+descriptor에는 GET 등 선언한 method가 그대로 남습니다. 따라서 기존
+conditional-request 및 byte-range status/header 규칙을 유지합니다.
+Adapter는 direct send, route miss, error, 미준비/종료 후 503을 포함한
+모든 opted-in HEAD 응답을 null body로 반환하면서 status, status text,
+representation header, 독립적인 cookie를 보존합니다. 선택된 응답에 없는
+content length를 임의로 만들지는 않습니다.
+
+활성 response stream을 취소한 뒤 dispatch lifecycle, iterator cleanup,
+request-scope disposal 완료를 기다립니다. Stream source는 cancellation에 협력하고
+iterator `return()`을 완료해야 합니다. Cleanup failure는 기존 dispatcher의
+observer/logging 정책으로 처리하며 GET 재시도나 이미 commit한 metadata 교체를
+하지 않습니다. Response stream에 들어오지 않은 application-owned resource는
+계속 application이 소유합니다. HEAD에서 byte source 자체를 열지 않으려면
+`createByteRangeResponse`에 stream factory를 전달하세요.
+
+**Migration:** HEAD request를 GET으로 재구성하고 body를 버리는 application
+wrapper를 제거하고 표준 `createNextAppRouterHandler(loadAdapter)` facade를
+사용합니다. `GET`만 export하여 Next가 auto-HEAD로 호출하게 하거나 `GET`과
+`HEAD`를 함께 export해도 같은 정책을 적용합니다. Pages Router도 같은 adapter
+option을 사용합니다. 기존 wrapper 때문에 GET을 관찰하던 method 기반 application
+분기는 원래 HEAD를 인식하도록 수정하세요. Option을 생략하는 기존 소비자는
+configuration이나 동작을 변경할 필요가 없습니다.
+
+검증 근거: [`head-routing.test.ts`](./src/head-routing.test.ts),
+[`head-routing-public-types.test.ts`](./src/head-routing-public-types.test.ts),
+실제 HTTP로 auto-HEAD, 직접 App Router HEAD, Pages Router HEAD를 비교하는
+packaged [Next 16 production E2E](./e2e/next.test.mjs).
 
 ## Pages Router
 
@@ -279,6 +335,7 @@ await app.listen();
 
 - `maxBodySize`: bytes 단위의 non-negative maximum request body size
 - `rawBody`: parsed request bytes를 `context.request.rawBody`에 보존
+- `headRouting`: 선택적인 `'explicit-or-get'` 라우팅과 body 없는 HEAD lifecycle; [HEAD Routing](#head-routing) 참조
 - Fluo runtime options는 일반 `FluoFactory.create()` options에 유지
 
 ## Runtime contract
@@ -304,7 +361,7 @@ Application이 raw Node.js transport ownership, WebSocket upgrades, independentl
 ## Public API
 
 - `createNextAdapter(options)`: `FluoFactory.create()`에 전달할 HTTP adapter 생성
-- `NextAdapterOptions`: adapter가 소유하는 request parsing options
+- `NextAdapterOptions`: adapter가 소유하는 request parsing 및 opt-in HEAD routing options
 - `NextAdapterLoader`: dynamic canonical backend adapter loader
 - `createNextAppRouterHandler(loadAdapter)`: 구조분해 export 가능한 method-keyed App Router handler export record 생성 (`GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, `OPTIONS`)
 - `NextHttpApplicationAdapter`: bound `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, `OPTIONS` handlers를 가진 `HttpApplicationAdapter`

--- a/packages/platform-nextjs/README.md
+++ b/packages/platform-nextjs/README.md
@@ -11,6 +11,7 @@ dependency injection.
 - [Installation](#installation)
 - [Shared Setup](#shared-setup)
 - [App Router](#app-router)
+- [HEAD Routing](#head-routing)
 - [Pages Router](#pages-router)
 - [FluoFactory Integration](#fluofactory-integration)
 - [Pipeline Compatibility](#pipeline-compatibility)
@@ -132,6 +133,62 @@ route matching, module bootstrap, dependency injection, request scope, body
 parsing, errors, and controller dispatch behind that facade. Route Handlers
 default to the Node.js runtime that Fluo backends require, so no `runtime`
 override is needed.
+
+## HEAD Routing
+
+Opt in at adapter construction when a GET-only Fluo route should answer Next's
+automatic HEAD as well as an explicit `HEAD` export:
+
+```typescript
+import { createNextAdapter } from '@fluojs/platform-nextjs';
+
+export const nextAdapter = createNextAdapter({
+  headRouting: 'explicit-or-get',
+});
+```
+
+Omission preserves existing method matching: a GET-only Fluo route does not
+implicitly match HEAD. With this option, the shared HTTP matcher selects one
+eligible explicit `@Head` route, otherwise `@All`, otherwise `@Get`. Method
+priority precedes path specificity across those groups; normal static/parameter
+and version rules apply within each group. `ALL` is a method wildcard, not a
+path wildcard: Fluo catch-all path grammar remains unsupported.
+
+Selection happens once before module middleware, guards, and the controller.
+A route miss returns 404. A selected handler's 404 is final and never triggers
+another dispatch. Application middleware, module middleware, guards, and
+controller each run at most once, subject to normal short-circuit behavior.
+
+The normalized request and native `Request` retain **HEAD**, including inside
+middleware, guards, version extraction, conditional resolvers, and handlers.
+The selected descriptor still identifies its declared method, such as GET.
+Existing conditional-request and byte-range status/header rules therefore
+remain active. The adapter returns a null body for every opted-in HEAD response,
+including direct sends, route misses, errors, and unavailable/closed 503s,
+preserving status, status text, representation headers, and independent cookies.
+It does not invent a content length when the selected response did not supply one.
+
+Active response streams are cancelled, then the dispatch lifecycle, iterator
+cleanup, and request-scope disposal are awaited. Stream sources must cooperate
+with cancellation and settle their iterator `return()`; cleanup failures retain
+the dispatcher's observer/logging policy without a GET retry or replacement of
+already committed metadata. Application-owned resources that never enter a
+response stream remain application-owned. Prefer a `createByteRangeResponse`
+stream factory when HEAD must avoid opening a byte source altogether.
+
+**Migration:** remove the application wrapper that reconstructs a HEAD request
+as GET and discards its body. Keep the standard
+`createNextAppRouterHandler(loadAdapter)` facade. Export only `GET` to let Next
+auto-HEAD call it, or export both `GET` and `HEAD`; both use the same policy.
+Pages Router uses the same adapter option. Update method-based application
+branches that previously observed GET to recognize the original HEAD. No
+configuration or behavior change is required for consumers that leave this
+option unset.
+
+Evidence: [`head-routing.test.ts`](./src/head-routing.test.ts),
+[`head-routing-public-types.test.ts`](./src/head-routing-public-types.test.ts),
+and the packaged [Next 16 production E2E](./e2e/next.test.mjs), which compares
+auto-HEAD, direct App Router HEAD, and Pages Router HEAD over real HTTP.
 
 ## Pages Router
 
@@ -274,6 +331,7 @@ await app.listen();
 
 - `maxBodySize`: non-negative maximum request body size in bytes
 - `rawBody`: preserve parsed request bytes on `context.request.rawBody`
+- `headRouting`: optional `'explicit-or-get'` selection and bodyless HEAD lifecycle; see [HEAD Routing](#head-routing)
 - Fluo runtime options remain ordinary `FluoFactory.create()` options
 
 ## Runtime Contract
@@ -299,7 +357,7 @@ Use a Fluo Node or Fastify platform adapter when the application requires raw No
 ## Public API
 
 - `createNextAdapter(options)`: creates the HTTP adapter passed to `FluoFactory.create()`
-- `NextAdapterOptions`: adapter-owned request parsing options
+- `NextAdapterOptions`: adapter-owned request parsing and opt-in HEAD routing options
 - `NextAdapterLoader`: dynamic canonical backend adapter loader
 - `createNextAppRouterHandler(loadAdapter)`: creates method-keyed App Router handler exports (`GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, `OPTIONS`) ready for destructuring
 - `NextHttpApplicationAdapter`: `HttpApplicationAdapter` with bound `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, and `OPTIONS` handlers

--- a/packages/platform-nextjs/e2e/fixture/app/api/auto/[[...path]]/route.ts
+++ b/packages/platform-nextjs/e2e/fixture/app/api/auto/[[...path]]/route.ts
@@ -1,0 +1,6 @@
+import { createNextAppRouterHandler } from '@fluojs/platform-nextjs/app-router';
+
+// No HEAD export: Next itself calls GET while preserving request.method === HEAD.
+export const { GET } = createNextAppRouterHandler(() =>
+  import('../../../../backend').then(({ nextAdapter }) => nextAdapter),
+);

--- a/packages/platform-nextjs/e2e/fixture/backend.ts
+++ b/packages/platform-nextjs/e2e/fixture/backend.ts
@@ -1,21 +1,27 @@
 import { randomUUID } from 'node:crypto';
 import { appendFileSync } from 'node:fs';
 
-import { Module } from '@fluojs/core';
+import { Module, Scope } from '@fluojs/core';
 import {
+  All,
   Controller,
   Convert,
+  createByteRangeResponse,
   FromBody,
   FromCookie,
   FromPath,
   FromQuery,
   Get,
+  type GuardContext,
   Head,
   HttpCode,
+  type MiddlewareContext,
+  type Next,
   Post,
   type RequestContext,
   RequestDto,
   Sse,
+  UseGuards,
 } from '@fluojs/http';
 import { createNextAdapter } from '@fluojs/platform-nextjs';
 import { FluoFactory } from '@fluojs/runtime';
@@ -68,9 +74,73 @@ class BoundRequest {
 }
 
 const streams = new Map<string, () => void>();
+const headCounts = new Map<string, number>();
+
+function countHead(context: RequestContext, stage: string) {
+  const id = context.request.headers['x-head-id'];
+  if (typeof id !== 'string') return;
+  const key = `${id}:${stage}`;
+  const count = (headCounts.get(key) ?? 0) + 1;
+  headCounts.set(key, count);
+  context.response.setHeader(`x-${stage}-count`, String(count));
+}
+
+class HeadGuard {
+  canActivate({ requestContext }: GuardContext) {
+    countHead(requestContext, 'guard');
+    requestContext.response.setHeader('x-guard-method', requestContext.request.method);
+    return true;
+  }
+}
+
+class HeadMiddleware {
+  async handle({ requestContext }: MiddlewareContext, next: Next) {
+    countHead(requestContext, 'middleware');
+    await next();
+  }
+}
+
+function headResult(context: RequestContext, selected: string, status = 200) {
+  countHead(context, 'controller');
+  context.response.setHeader('x-selected', selected);
+  context.response.setHeader('x-handler-method', context.request.method);
+  context.response.setHeader('set-cookie', ['head-first=1; Path=/', 'head-second=2; Path=/']);
+  context.response.setStatus(status);
+  return { selected };
+}
 
 @Controller('/api/:facade')
+@UseGuards(HeadGuard)
 class BackendController {
+  @Get('/head-get')
+  headGet(_input: undefined, context: RequestContext) { return headResult(context, 'get'); }
+
+  @Get('/head-explicit')
+  explicitGet(_input: undefined, context: RequestContext) { return headResult(context, 'wrong-get'); }
+
+  @Head('/head-explicit')
+  explicitHead(_input: undefined, context: RequestContext) { return headResult(context, 'head', 202); }
+
+  @Get('/head-all')
+  allGet(_input: undefined, context: RequestContext) { return headResult(context, 'wrong-all-get'); }
+
+  @All('/head-all')
+  allHead(_input: undefined, context: RequestContext) { return headResult(context, 'all', 203); }
+
+  @Get('/head-get-404')
+  get404(_input: undefined, context: RequestContext) { return headResult(context, 'get-404', 404); }
+
+  @Get('/head-explicit-404')
+  wrongRetry(_input: undefined, context: RequestContext) { return headResult(context, 'wrong-retry'); }
+
+  @Head('/head-explicit-404')
+  explicit404(_input: undefined, context: RequestContext) { return headResult(context, 'head-404', 404); }
+
+  @Get('/head-bytes')
+  bytes() {
+    return createByteRangeResponse(new TextEncoder().encode('hello'), { contentType: 'text/plain' });
+  }
+
   @Get('/health')
   health() {
     return { status: 'ok', instance };
@@ -140,13 +210,43 @@ class BackendController {
   }
 }
 
+@Scope('request')
+@Controller('/api/:facade')
+class HeadStreamController {
+  private id = '';
+
+  @Sse('/head-stream/:id')
+  stream(_input: undefined, context: RequestContext): AsyncIterable<string> {
+    this.id = context.request.params.id;
+    const id = this.id;
+    return {
+      [Symbol.asyncIterator]() {
+        return {
+          next: () => new Promise<IteratorResult<string>>(() => undefined),
+          async return() {
+            console.log(`FLUO_E2E_HEAD_STREAM_RETURN ${id}`);
+            return { done: true, value: undefined };
+          },
+        };
+      },
+    };
+  }
+
+  onDestroy() {
+    console.log(`FLUO_E2E_HEAD_SCOPE_DISPOSED ${this.id}`);
+  }
+}
+
 @Module({
-  controllers: [BackendController],
-  providers: [NumberConverter, SessionConverter],
+  controllers: [BackendController, HeadStreamController],
+  providers: [NumberConverter, SessionConverter, HeadGuard, HeadMiddleware],
 })
 class BackendModule {}
 
-export const nextAdapter = createNextAdapter();
-const app = await FluoFactory.create(BackendModule, { adapter: nextAdapter });
+export const nextAdapter = createNextAdapter({ headRouting: 'explicit-or-get' });
+const app = await FluoFactory.create(BackendModule, {
+  adapter: nextAdapter,
+  middleware: [HeadMiddleware],
+});
 await app.listen();
 record('ready');

--- a/packages/platform-nextjs/e2e/next.test.mjs
+++ b/packages/platform-nextjs/e2e/next.test.mjs
@@ -329,6 +329,7 @@ test('packaged Fluo serves both routers in a real Next 16 production build', {
       const appPaths = await json(path.join(app, '.next/server/app-paths-manifest.json'));
       const pagesPaths = await json(path.join(app, '.next/server/pages-manifest.json'));
       assert.ok(appPaths['/api/app/[[...path]]/route']);
+      assert.ok(appPaths['/api/auto/[[...path]]/route']);
       assert.ok(pagesPaths['/api/pages/[[...path]]']);
     });
 
@@ -471,6 +472,58 @@ test('packaged Fluo serves both routers in a real Next 16 production build', {
           method: 'GET', route, status: stream.snapshot().status,
           closedBeforeRelease: true,
         });
+      });
+    }
+    for (const facade of ['auto', 'app', 'pages']) {
+      for (const [route, status, selected] of [
+        ['head-get', 200, 'get'],
+        ['head-explicit', 202, 'head'],
+        ['head-all', 203, 'all'],
+        ['head-get-404', 404, 'get-404'],
+        ['head-explicit-404', 404, 'head-404'],
+        ['head-missing', 404, undefined],
+      ]) {
+        await t.test(`${facade}: HEAD selects ${route} exactly once with no body`, async () => {
+          const response = await capture(`/api/${facade}/${route}`, {
+            method: 'HEAD', headers: { 'x-head-id': randomUUID() },
+          });
+          assert.equal(response.status, status);
+          assert.equal(response.body, '');
+          assert.equal(response.headers['x-middleware-count'], '1');
+          assert.equal(response.headers['x-selected'], selected);
+          assert.equal(response.headers['x-controller-count'], selected ? '1' : undefined);
+          assert.equal(response.headers['x-guard-count'], selected ? '1' : undefined);
+          if (selected) {
+            assert.equal(response.headers['x-guard-method'], 'HEAD');
+            assert.equal(response.headers['x-handler-method'], 'HEAD');
+            assert.deepEqual(response.headers['set-cookie'], [
+              'head-first=1; Path=/', 'head-second=2; Path=/',
+            ]);
+          }
+        });
+      }
+      await t.test(`${facade}: HEAD preserves byte-range metadata`, async () => {
+        const response = await capture(`/api/${facade}/head-bytes`, {
+          method: 'HEAD', headers: { range: 'bytes=1-3' },
+        });
+        assert.equal(response.status, 206);
+        assert.equal(response.headers['content-range'], 'bytes 1-3/5');
+        assert.equal(response.headers['content-length'], '3');
+        assert.equal(response.body, '');
+      });
+      await t.test(`${facade}: HEAD cancels the stream and disposes its request scope`, async () => {
+        const id = randomUUID();
+        // Subscribe to actual server cleanup before triggering HEAD.
+        const returned = server.onLine((line) => line === `FLUO_E2E_HEAD_STREAM_RETURN ${id}`);
+        const disposed = server.onLine((line) => line === `FLUO_E2E_HEAD_SCOPE_DISPOSED ${id}`);
+        const [response] = await Promise.all([
+          capture(`/api/${facade}/head-stream/${id}`, { method: 'HEAD' }),
+          returned,
+          disposed,
+        ]);
+        assert.equal(response.status, 200);
+        assert.equal(response.body, '');
+        assert.match(response.headers['content-type'], /^text\/event-stream/);
       });
     }
     report.bootstrap = await records();

--- a/packages/platform-nextjs/src/adapter.ts
+++ b/packages/platform-nextjs/src/adapter.ts
@@ -6,6 +6,7 @@ import {
 import {
   createWebRequestResponseFactory,
   dispatchWebRequest,
+  startWebRequestDispatch,
 } from '@fluojs/runtime/web';
 
 import {
@@ -26,8 +27,14 @@ const SHUTDOWN_PROBLEM = {
   type: 'https://fluo.dev/problems/next-backend-adapter-closed',
 } as const;
 
-/** Adapter-owned Web request parsing options. */
+/** Adapter-owned Web request parsing and opt-in HEAD routing options. */
 export interface NextAdapterOptions {
+  /**
+   * Select explicit HEAD, then ALL, then GET without changing the request method.
+   * Omit to preserve ordinary routing. Opted-in HEAD responses are bodyless and
+   * active streams are cancelled before request lifecycle completion is awaited.
+   */
+  readonly headRouting?: 'explicit-or-get';
   readonly maxBodySize?: number;
   readonly rawBody?: boolean;
 }
@@ -78,8 +85,11 @@ function validateMaxBodySize(maxBodySize: number | undefined): void {
   }
 }
 
-function createProblemResponse(problem: typeof NOT_READY_PROBLEM | typeof SHUTDOWN_PROBLEM) {
-  return Response.json(problem, {
+function createProblemResponse(
+  problem: typeof NOT_READY_PROBLEM | typeof SHUTDOWN_PROBLEM,
+  bodyless = false,
+) {
+  return new Response(bodyless ? null : JSON.stringify(problem), {
     headers: { 'content-type': 'application/problem+json' },
     status: problem.status,
   });
@@ -91,20 +101,30 @@ function createProblemResponse(problem: typeof NOT_READY_PROBLEM | typeof SHUTDO
 export class NextHttpApplicationAdapter implements HttpApplicationAdapter {
   private closed = false;
   private dispatcher?: Dispatcher;
+  private readonly headRouting;
   private readonly requestResponseFactory;
 
   /**
    * Create a Next-hosted Fluo adapter.
    *
-   * @param options Web request parsing options.
+   * @param options Web request parsing and opt-in HEAD routing options.
    */
   constructor(options: NextAdapterOptions = {}) {
     validateMaxBodySize(options.maxBodySize);
-    this.requestResponseFactory = createWebRequestResponseFactory({
+    const headRouting = options.headRouting;
+    this.headRouting = headRouting;
+    const factory = createWebRequestResponseFactory({
       consumeOriginalBody: true,
       maxBodySize: options.maxBodySize,
       rawBody: options.rawBody,
     });
+    this.requestResponseFactory = {
+      ...factory,
+      async createRequest(request: Request, signal: AbortSignal) {
+        const normalized = await factory.createRequest(request, signal);
+        return Object.assign(normalized, { headRouting });
+      },
+    };
   }
 
   /**
@@ -122,11 +142,27 @@ export class NextHttpApplicationAdapter implements HttpApplicationAdapter {
    * @returns Native Web response produced by the Fluo dispatcher.
    */
   readonly fetch: NextAppRouteHandler = async (request) => {
+    const isHead = request.method === 'HEAD' && this.headRouting === 'explicit-or-get';
     if (this.closed) {
-      return createProblemResponse(SHUTDOWN_PROBLEM);
+      return createProblemResponse(SHUTDOWN_PROBLEM, isHead);
     }
     if (!this.dispatcher) {
-      return createProblemResponse(NOT_READY_PROBLEM);
+      return createProblemResponse(NOT_READY_PROBLEM, isHead);
+    }
+
+    if (isHead) {
+      const dispatch = startWebRequestDispatch({
+        dispatcher: this.dispatcher,
+        factory: this.requestResponseFactory,
+        request,
+      });
+      try {
+        const response = await dispatch.response;
+        await response.body?.cancel();
+        return new Response(null, response);
+      } finally {
+        await dispatch.completion;
+      }
     }
 
     return dispatchWebRequest({
@@ -177,7 +213,7 @@ export class NextHttpApplicationAdapter implements HttpApplicationAdapter {
 /**
  * Create a Next-hosted Fluo HTTP adapter.
  *
- * @param options Web request parsing options.
+ * @param options Web request parsing and opt-in HEAD routing options.
  * @returns A new adapter instance.
  */
 export function createNextAdapter(

--- a/packages/platform-nextjs/src/head-routing-public-types.test.ts
+++ b/packages/platform-nextjs/src/head-routing-public-types.test.ts
@@ -1,10 +1,18 @@
+import { execFile } from 'node:child_process';
+import { access, cp, mkdtemp, realpath, rm, symlink } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { dirname, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
 import ts from 'typescript';
-import { expect, it } from 'vitest';
+import { afterAll, beforeAll, expect, it } from 'vitest';
+import { resolveWorkspaceBuildOrder } from '../../../tooling/scripts/run-workspace-build-closure.mjs';
 
-const fixture = fileURLToPath(new URL('../head-policy-consumer.mts', import.meta.url));
+const repositoryRoot = fileURLToPath(new URL('../../../', import.meta.url));
+const execFileAsync = promisify(execFile);
+let root: string;
+let fixture: string;
 const require = createRequire(import.meta.url);
 const nextManifest = require.resolve('next/package.json');
 const nextRequire = createRequire(nextManifest);
@@ -14,6 +22,42 @@ import type { NextAdapterOptions as AppOptions } from '@fluojs/platform-nextjs/a
 import type { FrameworkRequest } from '@fluojs/http';
 import type { FrameworkRequest as PortableRequest } from '@fluojs/http/portable';
 `;
+
+afterAll(async () => {
+  if (root) await rm(root, { force: true, recursive: true });
+});
+
+beforeAll(async () => {
+  root = await mkdtemp(join(tmpdir(), 'fluo-next-head-declarations-'));
+  // Canonicalize macOS /var so the copied closure CLI matches its import.meta URL.
+  root = await realpath(root);
+  fixture = join(root, 'packages/platform-nextjs/head-policy-consumer.mts');
+  const packages = resolveWorkspaceBuildOrder('@fluojs/platform-nextjs', repositoryRoot);
+  const buildClosureScript = 'tooling/scripts/run-workspace-build-closure.mjs';
+  for (const entry of [
+    'package.json', 'pnpm-workspace.yaml', 'tsconfig.base.json',
+    'tooling/babel', 'tooling/tsconfig', 'tooling/vite',
+    'tooling/scripts/clean-dist.mjs', buildClosureScript,
+    'packages/testing/src/babel-decorators-plugin.ts',
+    ...packages.map((name) => `packages/${name.slice('@fluojs/'.length)}`),
+  ]) {
+    await cp(join(repositoryRoot, entry), join(root, entry), {
+      recursive: true,
+      verbatimSymlinks: true,
+      filter: (source) => !['dist', '.vite', '.vite-temp'].includes(basename(source)),
+    });
+  }
+  // Share only installed external tools; copied relative workspace links stay cold.
+  await symlink(join(repositoryRoot, 'node_modules'), join(root, 'node_modules'), 'dir');
+  for (const name of packages) {
+    await expect(access(join(root, 'packages', name.slice('@fluojs/'.length), 'dist')))
+      .rejects.toMatchObject({ code: 'ENOENT' });
+  }
+  await execFileAsync(process.execPath, [join(root, buildClosureScript), '@fluojs/platform-nextjs'], {
+    cwd: root,
+    env: process.env,
+  });
+}, 300_000);
 
 function compile(source: string): readonly ts.Diagnostic[] {
   const options: ts.CompilerOptions = {

--- a/packages/platform-nextjs/src/head-routing-public-types.test.ts
+++ b/packages/platform-nextjs/src/head-routing-public-types.test.ts
@@ -1,0 +1,79 @@
+import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+import { expect, it } from 'vitest';
+
+const fixture = fileURLToPath(new URL('../head-policy-consumer.mts', import.meta.url));
+const require = createRequire(import.meta.url);
+const nextManifest = require.resolve('next/package.json');
+const nextRequire = createRequire(nextManifest);
+const imports = `
+import { createNextAdapter, type NextAdapterOptions } from '@fluojs/platform-nextjs';
+import type { NextAdapterOptions as AppOptions } from '@fluojs/platform-nextjs/app-router';
+import type { FrameworkRequest } from '@fluojs/http';
+import type { FrameworkRequest as PortableRequest } from '@fluojs/http/portable';
+`;
+
+function compile(source: string): readonly ts.Diagnostic[] {
+  const options: ts.CompilerOptions = {
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    target: ts.ScriptTarget.ESNext,
+    noEmit: true,
+    strict: true,
+    types: [],
+    // Next's bundled Satori directory and sharp 0.35 omit type export entries.
+    // Use their shipped declarations, not stubs or skipLibCheck. Fluo imports
+    // still resolve exclusively through the actual published export maps.
+    paths: {
+      'next/dist/compiled/@vercel/og/satori': [
+        resolve(dirname(nextManifest), 'dist/compiled/@vercel/og/satori/index.d.ts'),
+      ],
+      sharp: [resolve(dirname(nextRequire.resolve('sharp')), '../lib/index.d.ts')],
+    },
+  };
+  const host = ts.createCompilerHost(options);
+  const getSourceFile = host.getSourceFile;
+  host.getSourceFile = (path, languageVersion, onError, shouldCreateNewSourceFile) =>
+    path === fixture
+      ? ts.createSourceFile(path, source, languageVersion, true)
+      : getSourceFile(path, languageVersion, onError, shouldCreateNewSourceFile);
+  return ts.getPreEmitDiagnostics(ts.createProgram([fixture], options, host));
+}
+
+it('accepts the opt-in through built package root, App Router, and HTTP declarations', () => {
+  // Given real public export-map resolution, without source aliases.
+  const source = `${imports}
+const options = { headRouting: 'explicit-or-get' } satisfies NextAdapterOptions;
+const appOptions: AppOptions = options;
+const policy: FrameworkRequest['headRouting'] = options.headRouting;
+const portable: PortableRequest['headRouting'] = policy;
+createNextAdapter(appOptions);
+createNextAdapter();
+`;
+  // When TypeScript consumes the built declarations.
+  const diagnostics = compile(source);
+  // Then the new and existing caller paths both compile.
+  expect(diagnostics.map((entry) => ts.flattenDiagnosticMessageText(entry.messageText, '\n'))).toEqual([]);
+});
+
+it('rejects unsupported policy values at each published entry point', () => {
+  // Given independently invalid callers, not suppressed type errors.
+  const invalid = [
+    "createNextAdapter({ headRouting: 'retry-on-404' });",
+    "const app: AppOptions = { headRouting: true };",
+    "const http: FrameworkRequest['headRouting'] = 'get';",
+    "const portable: PortableRequest['headRouting'] = false;",
+  ];
+  // When TypeScript checks those caller lines.
+  const diagnostics = compile(`${imports}${invalid.join('\n')}`);
+  // Then each caller fails, while imports and dependency declarations remain valid.
+  expect(diagnostics).toHaveLength(invalid.length);
+  expect(diagnostics.every((entry) => entry.file?.fileName === fixture && entry.code === 2322)).toBe(true);
+  const lines = diagnostics.map((entry) =>
+    entry.file && entry.start !== undefined
+      ? entry.file.getLineAndCharacterOfPosition(entry.start).line
+      : -1);
+  expect(lines).toEqual(invalid.map((_, index) => imports.split('\n').length - 1 + index));
+});

--- a/packages/platform-nextjs/src/head-routing.test.ts
+++ b/packages/platform-nextjs/src/head-routing.test.ts
@@ -1,0 +1,423 @@
+import { Module, Scope } from '@fluojs/core';
+import {
+  All,
+  Controller,
+  createByteRangeResponse,
+  Get,
+  type GuardContext,
+  Head,
+  type MiddlewareContext,
+  type Next,
+  NotFoundException,
+  type RequestContext,
+  Sse,
+  SseResponse,
+  UseGuards,
+} from '@fluojs/http';
+import { FluoFactory } from '@fluojs/runtime';
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import {
+  createNextAdapter,
+  createNextAppRouterHandler,
+  type NextAdapterOptions,
+} from './index.js';
+
+function deferred() {
+  let resolve: () => void = () => undefined;
+  const promise = new Promise<void>((complete) => { resolve = complete; });
+  return { promise, resolve };
+}
+
+it('selects GET once for an opted-in HEAD request without rewriting its method', async () => {
+  // Given a real GET-only Fluo application.
+  const methods: string[] = [];
+  @Controller('/articles')
+  class ArticlesController {
+    @Get('/:id')
+    get(_input: undefined, context: RequestContext) {
+      methods.push(context.request.method);
+      context.response.setHeader('x-article', context.request.params.id);
+      return { title: 'Fluo' };
+    }
+  }
+  @Module({ controllers: [ArticlesController] })
+  class AppModule {}
+  const adapter = createNextAdapter({ headRouting: 'explicit-or-get' });
+  const app = await FluoFactory.create(AppModule, { adapter });
+  try {
+    await app.listen();
+    // When Next invokes GET with the original HEAD request.
+    const response = await adapter.GET(new Request('https://next.test/articles/42', {
+      method: 'HEAD',
+    }));
+    // Then one GET handler supplies metadata without a response body.
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-article')).toBe('42');
+    expect(methods).toEqual(['HEAD']);
+    expect(response.body).toBeNull();
+  } finally {
+    await app.close();
+  }
+});
+
+describe('HEAD route selection and single execution', () => {
+  it.each([
+    { path: 'get', status: 200, selected: 'get' },
+    { path: 'explicit', status: 202, selected: 'head' },
+    { path: 'head-not-found', status: 404, selected: 'head-404' },
+    { path: 'get-not-found', status: 404, selected: 'get-404' },
+    { path: 'all', status: 203, selected: 'all' },
+    { path: 'missing', status: 404, selected: undefined },
+  ])('selects $selected for $path without retrying a response', async ({ path, status, selected }) => {
+    // Given real middleware, guards, observers, and controller dispatch.
+    const events: string[] = [];
+    function handle(name: string, context: RequestContext, code = 200) {
+      events.push(name);
+      expect(context.request.method).toBe('HEAD');
+      expect(context.request.raw).toBe(request);
+      context.response.setStatus(code);
+      context.response.setHeader('x-selected', name);
+      context.response.setHeader('set-cookie', ['first=1', 'second=2']);
+      return { selected: name };
+    }
+    class Guard {
+      canActivate({ requestContext }: GuardContext) {
+        events.push(`guard:${requestContext.request.method}`);
+        return true;
+      }
+    }
+    class ModuleMiddleware {
+      async handle(context: MiddlewareContext, next: Next) {
+        events.push(`module:${context.request.method}`);
+        await next();
+      }
+    }
+    @Controller('/routes')
+    @UseGuards(Guard)
+    class Routes {
+      @Get('/get')
+      get(_input: undefined, context: RequestContext) { return handle('get', context); }
+      @Get('/explicit')
+      explicitGet(_input: undefined, context: RequestContext) { return handle('wrong-get', context); }
+      @Head('/explicit')
+      head(_input: undefined, context: RequestContext) { return handle('head', context, 202); }
+      @Get('/head-not-found')
+      notFoundGet(_input: undefined, context: RequestContext) { return handle('wrong-retry', context); }
+      @Head('/head-not-found')
+      head404(_input: undefined, context: RequestContext) { return handle('head-404', context, 404); }
+      @Get('/get-not-found')
+      get404(_input: undefined, context: RequestContext) { return handle('get-404', context, 404); }
+      @Get('/all')
+      allGet(_input: undefined, context: RequestContext) { return handle('wrong-all-get', context); }
+      @All('/all')
+      all(_input: undefined, context: RequestContext) { return handle('all', context, 203); }
+    }
+    @Module({ controllers: [Routes], middleware: [ModuleMiddleware], providers: [Guard] })
+    class AppModule {}
+    const adapter = createNextAdapter({ headRouting: 'explicit-or-get' });
+    const app = await FluoFactory.create(AppModule, {
+      adapter,
+      middleware: [{
+        async handle(context, next) {
+          events.push(`app:${context.request.method}`);
+          await next();
+        },
+      }],
+      observers: [{ onRequestFinish() { events.push('finish'); } }],
+    });
+    const request = new Request(`https://next.test/routes/${path}`, { method: 'HEAD' });
+    try {
+      await app.listen();
+      // When a direct HEAD export receives the request.
+      const response = await adapter.HEAD(request);
+      // Then the complete pipeline runs at most once, including handler-produced 404s.
+      expect(response.status).toBe(status);
+      expect(response.body).toBeNull();
+      expect(await response.text()).toBe('');
+      expect(response.headers.get('x-selected')).toBe(selected ?? null);
+      expect(events).toEqual(selected
+        ? ['app:HEAD', 'module:HEAD', 'guard:HEAD', selected, 'finish']
+        : ['app:HEAD', 'finish']);
+      if (selected) expect(response.headers.getSetCookie()).toEqual(['first=1', 'second=2']);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('keeps GET-only routes unmatched when the policy is omitted', async () => {
+    // Given the existing default adapter.
+    @Controller('/default')
+    class Routes {
+      @Get()
+      get() { throw new Error('HEAD must not invoke GET by default'); }
+    }
+    @Module({ controllers: [Routes] })
+    class AppModule {}
+    const adapter = createNextAdapter();
+    const app = await FluoFactory.create(AppModule, { adapter });
+    try {
+      await app.listen();
+      // When HEAD has no explicit handler.
+      const response = await adapter.HEAD(new Request('https://next.test/default', { method: 'HEAD' }));
+      // Then the ordinary route miss is preserved.
+      expect(response.status).toBe(404);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('keeps concurrent HEAD fallback and GET requests isolated behind one lazy loader', async () => {
+    // Given two requests held inside the same handler until both arrive.
+    const arrived = deferred();
+    const release = deferred();
+    const methods: string[] = [];
+    @Controller('/concurrent')
+    class Routes {
+      @Get()
+      async get(_input: undefined, context: RequestContext) {
+        methods.push(context.request.method);
+        if (methods.length === 2) arrived.resolve();
+        await release.promise;
+        context.response.setHeader('x-method', context.request.method);
+        return context.request.method;
+      }
+    }
+    @Module({ controllers: [Routes] })
+    class AppModule {}
+    const adapter = createNextAdapter({ headRouting: 'explicit-or-get' });
+    const app = await FluoFactory.create(AppModule, { adapter });
+    let loads = 0;
+    const handlers = createNextAppRouterHandler(async () => { loads += 1; return adapter; });
+    try {
+      await app.listen();
+      // When both requests overlap at the exact handler-entry event.
+      const pending = Promise.all([
+        handlers.GET(new Request('https://next.test/concurrent', { method: 'HEAD' })),
+        handlers.GET(new Request('https://next.test/concurrent')),
+      ]);
+      await arrived.promise;
+      release.resolve();
+      const [head, get] = await pending;
+      // Then neither method nor body policy leaks to the other request.
+      expect(loads).toBe(1);
+      expect(methods.sort()).toEqual(['GET', 'HEAD']);
+      expect(head.headers.get('x-method')).toBe('HEAD');
+      expect(head.body).toBeNull();
+      expect(get.headers.get('x-method')).toBe('GET');
+      expect(await get.text()).toBe('GET');
+    } finally {
+      release.resolve();
+      await app.close();
+    }
+  });
+});
+
+describe('HEAD metadata and resource ownership', () => {
+  it.each<{
+    headers: Record<string, string>;
+    status: number;
+    length: string | null;
+    calls: number;
+  }>([
+    { headers: {}, status: 200, length: '5', calls: 1 },
+    { headers: { range: 'bytes=1-3' }, status: 206, length: '3', calls: 1 },
+    { headers: { range: 'bytes=9-' }, status: 416, length: '0', calls: 1 },
+    { headers: { 'if-none-match': '"v1"' }, status: 304, length: null, calls: 0 },
+    { headers: { 'if-match': '"other"' }, status: 412, length: null, calls: 0 },
+  ])('preserves conditional/range status $status without opening a stream', async ({ headers, status, length, calls }) => {
+    // Given a representation with exact size and validators.
+    let handlerCalls = 0;
+    let opened = 0;
+    let resolutions = 0;
+    @Controller('/bytes')
+    class Routes {
+      @Get()
+      get() {
+        handlerCalls += 1;
+        return createByteRangeResponse(() => {
+          opened += 1;
+          return new ReadableStream<Uint8Array>();
+        }, { contentType: 'application/octet-stream', size: 5 });
+      }
+    }
+    @Module({ controllers: [Routes] })
+    class AppModule {}
+    const adapter = createNextAdapter({ headRouting: 'explicit-or-get' });
+    const app = await FluoFactory.create(AppModule, {
+      adapter,
+      conditionalRequest: {
+        resolve({ request }) {
+          resolutions += 1;
+          expect(request.method).toBe('HEAD');
+          return { exists: true, validators: { etag: { opaqueValue: 'v1', strength: 'strong' } } };
+        },
+      },
+    });
+    try {
+      await app.listen();
+      // When HEAD falls back to the GET representation.
+      const response = await adapter.HEAD(new Request('https://next.test/bytes', {
+        method: 'HEAD', headers,
+      }));
+      // Then conditional evaluation and range metadata remain HTTP-owned.
+      expect(response.status).toBe(status);
+      expect(response.headers.get('etag')).toBe('"v1"');
+      expect(response.headers.get('content-length')).toBe(length);
+      if (status === 206) expect(response.headers.get('content-range')).toBe('bytes 1-3/5');
+      if (status === 416) expect(response.headers.get('content-range')).toBe('bytes */5');
+      expect(response.body).toBeNull();
+      expect(handlerCalls).toBe(calls);
+      expect(resolutions).toBe(1);
+      expect(opened).toBe(0);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it.each(['manual', 'managed', 'handler-error', 'cleanup-error', 'send'] as const)(
+    'cleans request resources for %s before returning an empty HEAD response',
+    async (kind) => {
+      // Given a request-scoped controller and real Web response stream.
+      const events: string[] = [];
+      const cleanupStarted = deferred();
+      const releaseCleanup = deferred();
+      const failure = new Error('iterator cleanup failed');
+      const errors: unknown[] = [];
+      let stream: SseResponse | undefined;
+      let returned = 0;
+      @Scope('request')
+      @Controller('/lifecycle')
+      class Routes {
+        @Sse()
+        async get(_input: undefined, context: RequestContext) {
+          events.push('handler');
+          if (kind === 'handler-error') throw new NotFoundException('article missing');
+          if (kind === 'send') {
+            context.response.setStatus(404);
+            await context.response.send('owned body');
+            return;
+          }
+          if (kind === 'manual') {
+            stream = new SseResponse(context);
+            return stream;
+          }
+          return {
+            [Symbol.asyncIterator](): AsyncIterator<string> {
+              return {
+                next: () => new Promise(() => undefined),
+                async return() {
+                  returned += 1;
+                  events.push('iterator-return');
+                  cleanupStarted.resolve();
+                  await releaseCleanup.promise;
+                  if (kind === 'cleanup-error') throw failure;
+                  return { done: true, value: undefined };
+                },
+              };
+            },
+          };
+        }
+        async onDestroy() { events.push('dispose'); }
+      }
+      @Module({ controllers: [Routes] })
+      class AppModule {}
+      const adapter = createNextAdapter({ headRouting: 'explicit-or-get' });
+      const app = await FluoFactory.create(AppModule, {
+        adapter,
+        observers: [{
+          onRequestError(_context, error) { errors.push(error); },
+          onRequestFinish() { events.push('finish'); },
+        }],
+      });
+      try {
+        await app.listen();
+        // When HEAD cancellation closes the real stream and awaits iterator cleanup.
+        const pending = adapter.HEAD(new Request('https://next.test/lifecycle', { method: 'HEAD' }));
+        if (kind === 'managed' || kind === 'cleanup-error') {
+          await cleanupStarted.promise;
+          expect(events).toEqual(['handler', 'iterator-return']);
+          releaseCleanup.resolve();
+        }
+        const response = await pending;
+        // Then neither direct sends nor error bodies escape, and the scope is disposed.
+        expect(response.status).toBe(kind === 'handler-error' || kind === 'send' ? 404 : 200);
+        expect(response.body).toBeNull();
+        expect(events.slice(-2)).toEqual(['finish', 'dispose']);
+        expect(returned).toBe(kind === 'managed' || kind === 'cleanup-error' ? 1 : 0);
+        if (stream) await expect(stream.completion).resolves.toBeUndefined();
+        if (kind === 'cleanup-error') expect(errors).toContain(failure);
+      } finally {
+        releaseCleanup.resolve();
+        await app.close();
+      }
+    },
+  );
+
+  it('finishes an aborted HEAD without late success or leaked request scope', async () => {
+    // Given a controller paused at an exact entry event.
+    const entered = deferred();
+    const release = deferred();
+    const events: string[] = [];
+    @Scope('request')
+    @Controller('/abort')
+    class Routes {
+      @Get()
+      async get() {
+        entered.resolve();
+        await release.promise;
+        return 'late body';
+      }
+      onDestroy() { events.push('dispose'); }
+    }
+    @Module({ controllers: [Routes] })
+    class AppModule {}
+    const adapter = createNextAdapter({ headRouting: 'explicit-or-get' });
+    const app = await FluoFactory.create(AppModule, {
+      adapter,
+      observers: [{
+        onRequestSuccess() { events.push('success'); },
+        onRequestFinish() { events.push('finish'); },
+      }],
+    });
+    const abort = new AbortController();
+    try {
+      await app.listen();
+      // When cancellation occurs after handler entry, before its result.
+      const pending = adapter.HEAD(new Request('https://next.test/abort', {
+        method: 'HEAD', signal: abort.signal,
+      }));
+      await entered.promise;
+      abort.abort();
+      release.resolve();
+      const response = await pending;
+      // Then cleanup completes and no success event or body is committed.
+      expect(response.body).toBeNull();
+      expect(events).toEqual(['finish', 'dispose']);
+    } finally {
+      release.resolve();
+      await app.close();
+    }
+  });
+
+  it.each(['not-ready', 'closed'] as const)('returns bodyless 503 when %s', async (state) => {
+    // Given an unavailable opt-in adapter.
+    const adapter = createNextAdapter({ headRouting: 'explicit-or-get' });
+    if (state === 'closed') await adapter.close();
+    // When HEAD reaches the adapter boundary.
+    const response = await adapter.HEAD(new Request('https://next.test/unavailable', { method: 'HEAD' }));
+    // Then failure metadata is preserved without its JSON body.
+    expect(response.status).toBe(503);
+    expect(response.headers.get('content-type')).toBe('application/problem+json');
+    expect(response.body).toBeNull();
+  });
+
+  it('exposes the additive option through public types', () => {
+    // Given the public option and normalized request contracts.
+    type Policy = 'explicit-or-get' | undefined;
+    // When comparing their caller-visible fields.
+    expectTypeOf<NextAdapterOptions['headRouting']>().toEqualTypeOf<Policy>();
+    // Then adapters and the HTTP matcher share one opt-in shape.
+    expectTypeOf<RequestContext['request']['headRouting']>().toEqualTypeOf<Policy>();
+  });
+});

--- a/tooling/governance/verify-platform-consistency-governance.mjs
+++ b/tooling/governance/verify-platform-consistency-governance.mjs
@@ -55,6 +55,16 @@ const manualSseLifecycleRegressionTest =
   'packages/http/src/dispatch/dispatcher-manual-sse-lifecycle.test.ts';
 const httpConnectionIdentityRegressionTest = 'packages/http/src/connection.test.ts';
 const accessLogObserverLifecycleRegressionTest = 'packages/http/src/access-log-observer.test.ts';
+const nextHeadRoutingRegressionEvidence = [
+  'packages/http/src/head-routing.test.ts',
+  'packages/platform-nextjs/src/head-routing.test.ts',
+  'packages/platform-nextjs/src/head-routing-public-types.test.ts',
+  'packages/platform-nextjs/e2e/next.test.mjs',
+  'packages/http/README.md',
+  'packages/http/README.ko.md',
+  'packages/platform-nextjs/README.md',
+  'packages/platform-nextjs/README.ko.md',
+];
 const httpByteRangeRuntimeSourcePaths = new Set([
   'packages/http/src/byte-range-response.ts',
   'packages/http/src/dispatch/byte-range-response.ts',
@@ -1692,6 +1702,16 @@ export function enforceContractCompanionUpdates(changedFiles, migrationGuideSnap
       assert(
         httpByteRangeRegressionEvidence.every((path) => hasChanged(changedFiles, path)),
         `HTTP byte-range runtime contract changes must include ${httpByteRangeRegressionEvidence.join(', ')}.`,
+      );
+      return;
+    }
+    if (
+      hasChanged(changedFiles, 'packages/http/src/mapping.ts')
+      && hasChanged(changedFiles, 'packages/platform-nextjs/src/adapter.ts')
+    ) {
+      assert(
+        nextHeadRoutingRegressionEvidence.every((path) => hasChanged(changedFiles, path)),
+        `Next HEAD routing contract changes must include ${nextHeadRoutingRegressionEvidence.join(', ')}.`,
       );
       return;
     }

--- a/tooling/governance/verify-platform-consistency-governance.test.ts
+++ b/tooling/governance/verify-platform-consistency-governance.test.ts
@@ -145,6 +145,52 @@ function enforceContractCompanionUpdates(
   );
 }
 
+describe('Next HEAD routing contract companions', () => {
+  const companions = [
+    'docs/architecture/http-runtime.md',
+    'docs/architecture/http-runtime.ko.md',
+    'docs/CONTEXT.md',
+    'docs/CONTEXT.ko.md',
+    'tooling/governance/verify-platform-consistency-governance.mjs',
+    'tooling/governance/verify-platform-consistency-governance.test.ts',
+    'packages/http/src/mapping.ts',
+    'packages/platform-nextjs/src/adapter.ts',
+    'packages/http/src/head-routing.test.ts',
+    'packages/platform-nextjs/src/head-routing.test.ts',
+    'packages/platform-nextjs/src/head-routing-public-types.test.ts',
+    'packages/platform-nextjs/e2e/next.test.mjs',
+    'packages/http/README.md',
+    'packages/http/README.ko.md',
+    'packages/platform-nextjs/README.md',
+    'packages/platform-nextjs/README.ko.md',
+  ];
+
+  it('accepts HEAD selection with its matcher, transport, declarations, native and bilingual evidence', () => {
+    // Given the complete HEAD-specific changed-file evidence.
+    // When the HTTP contract companion gate classifies the change.
+    // Then it uses the focused HEAD regressions rather than unrelated lifecycle tests.
+    expect(() => enforceContractCompanionUpdates(companions)).not.toThrow();
+  });
+
+  it.each(companions.slice(8))('rejects missing HEAD evidence %s', (missing) => {
+    // Given an otherwise complete HEAD contract change.
+    const incomplete = companions.filter((path) => path !== missing);
+    // When one required evidence file is absent.
+    // Then the changed-file gate rejects the incomplete contract.
+    expect(() => enforceContractCompanionUpdates(incomplete)).toThrow();
+  });
+
+  it('does not replace generic HTTP lifecycle evidence without both HEAD source seams', () => {
+    // Given HEAD evidence without the Next adapter change.
+    const incomplete = companions.filter((path) => path !== 'packages/platform-nextjs/src/adapter.ts');
+    // When classifying an ordinary HTTP contract change.
+    // Then the existing lifecycle companion requirement still applies.
+    expect(() => enforceContractCompanionUpdates(incomplete)).toThrow(
+      /http-runtime-isolation\.test\.ts/,
+    );
+  });
+});
+
 describe('Fastify raw-context README companion classification', () => {
   const readmePaths = [
     'packages/platform-fastify/README.md',

--- a/tooling/governance/verify-platform-consistency-governance.test.ts
+++ b/tooling/governance/verify-platform-consistency-governance.test.ts
@@ -165,6 +165,10 @@ describe('Next HEAD routing contract companions', () => {
     'packages/platform-nextjs/README.ko.md',
   ];
 
+  function expectHeadFailure(run: () => void): void {
+    expect(run).toThrow(/Next HEAD routing contract changes must include/u);
+  }
+
   it('accepts HEAD selection with its matcher, transport, declarations, native and bilingual evidence', () => {
     // Given the complete HEAD-specific changed-file evidence.
     // When the HTTP contract companion gate classifies the change.
@@ -177,7 +181,39 @@ describe('Next HEAD routing contract companions', () => {
     const incomplete = companions.filter((path) => path !== missing);
     // When one required evidence file is absent.
     // Then the changed-file gate rejects the incomplete contract.
-    expect(() => enforceContractCompanionUpdates(incomplete)).toThrow();
+    expectHeadFailure(() => enforceContractCompanionUpdates(incomplete));
+  });
+
+  it.each([
+    ['comparison', 'nextHeadRoutingRegressionEvidence.every((path) => hasChanged(changedFiles, path))', 'true'],
+    ['branch', "hasChanged(changedFiles, 'packages/platform-nextjs/src/adapter.ts')", 'false'],
+  ])('rejects a disabled HEAD %s even with generic lifecycle enforcement intact', async (label, target, replacement) => {
+    // Given the real verifier with only the HEAD comparison or branch disabled.
+    const sourceUrl = new URL('./verify-platform-consistency-governance.mjs', import.meta.url);
+    const source = readFileSync(sourceUrl, 'utf8');
+    expect(source.split(target)).toHaveLength(2);
+    const mutated = source.replace(target, replacement)
+      .replace(/from '(\.[^']+)'/gu, (_match, specifier: string) =>
+        `from '${new URL(specifier, sourceUrl).href}'`)
+      .replaceAll('import.meta.url', JSON.stringify(sourceUrl.href));
+    const governance: Pick<typeof import('./verify-platform-consistency-governance.mjs'), 'enforceContractCompanionUpdates'> =
+      await import(`data:text/javascript;base64,${Buffer.from(mutated).toString('base64')}`);
+
+    // When each missing-companion regression evaluates the mutated verifier.
+    // Then the same negative assertion must fail, not accept another guard's error.
+    for (const missing of companions.slice(8)) {
+      const incomplete = companions.filter((path) => path !== missing);
+      const run = () => governance.enforceContractCompanionUpdates(
+        incomplete,
+        withUnchangedEmailMigrationSections(unchangedEmailMigrationGuideSnapshots),
+      );
+      if (label === 'branch') {
+        expect(run).toThrow(/http-runtime-isolation\.test\.ts/u);
+      } else {
+        expect(run).not.toThrow();
+      }
+      expect(() => expectHeadFailure(run)).toThrowError(expect.objectContaining({ name: 'AssertionError' }));
+    }
   });
 
   it('does not replace generic HTTP lifecycle evidence without both HEAD source seams', () => {


### PR DESCRIPTION
## Summary

Closes #3714

Next 통합에 headRouting: 'explicit-or-get' opt-in을 추가합니다. 명시적 HEAD, ALL, GET 순서로 한 번 선택하고 원래 HEAD method를 보존합니다.

## Changes

- 응답 404를 보고 GET을 재시도하지 않으며 middleware/guard/controller를 한 번만 실행합니다.
- Opt-in HEAD의 body 제거, status/header 보존, stream cancellation과 request-scope cleanup을 처리합니다.
- 실제 Next auto-HEAD와 직접 App/Pages HEAD를 같은 backend 정책으로 검증합니다.
- HTTP/Next README, architecture, website, Book, CONTEXT EN/KO와 Changeset을 포함합니다.
- HEAD companion governance는 정확한 실패를 검사하고 실제 비교/분기 mutation을 거부하는 회귀를 포함합니다.

## Testing

Reviewed head: `7127dc3c1b0cedbc3df418cd14a957ac72ed9267`. 세 리뷰 축 모두 PASS.

- dependency closure build와 HTTP/Next typecheck 통과.
- 변경 패키지와 직접 역의존성을 포함한 25개 package suite 통과. 공유 dist 재빌드 충돌을 피하도록 같은 checkout의 package test process는 순차 실행했습니다. OpenAPI 단독 검사도 통과했습니다.
- 직접 관련 governance, 실제 Next production E2E, pnpm lint, pnpm verify:platform-consistency-governance, pnpm verify:docs 통과.
- Native fixture는 auto/App/Pages HEAD, explicit HEAD, ALL, route miss, handler 404, byte/conditional headers와 cleanup을 검사합니다.
- Governance 전체 테스트는 기존 404개 + 새 mutation 회귀 2개 = 406개입니다. 수동 mutation 실행 증거는 자동 회귀와 별도로 기록했습니다.

이전 병렬 package 검증에서 core/dist 파일 누락이 한 번 관찰됐습니다. 소스 변경 없이 단독/순차 검증이 통과했으며 해당 실패도 증거에 보존했습니다.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

`.changeset/next-explicit-head-routing.md`: HTTP와 Next adapter minor.

## Public export documentation

- [x] Changed public exports have source summaries and applicable parameter/return documentation.
- [x] Public declaration tests cover the opt-in.
- [x] README migration explains HEAD-to-GET wrapper removal and preserved HEAD visibility.

## Behavioral contract

- [x] Generic routing defaults and path-wildcard rejection remain unchanged.
- [x] New routing, bodyless-response and resource ownership contracts are documented.
- [x] Runtime and lifecycle invariants have deterministic regression coverage.

## Platform consistency governance (SSOT)

- [x] EN/KO contract and companion documents remain aligned.
- [x] Matcher, adapter, type and real Next evidence are enforced by the companion gate.
- [x] Governance checks and canonical website verification pass.
