### PR TITLE
Resolve #3715: add bounded body parser policies

### DIFF
--- a/.changeset/bounded-body-parser-policy.md
+++ b/.changeset/bounded-body-parser-policy.md
@@ -1,0 +1,14 @@
+---
+"@fluojs/http": minor
+"@fluojs/runtime": minor
+"@fluojs/platform-nextjs": minor
+"@fluojs/platform-cloudflare-workers": minor
+---
+
+Add opt-in bounded text and custom body parsing without rewriting Content-Type
+or reconstructing Requests. HTTP owns BodyParser and BodyParserContext; runtime
+Web helpers implement byte-limited materialization, and Next plus the existing
+Workers Web option inheritance expose it. Custom parsers may delegate unchanged
+MIME behavior with context.parseDefault(). Existing default JSON/multipart and
+HEAD policies remain unchanged. Text mode does not guarantee authentication
+order: authenticate explicitly before application-owned JSON interpretation.

--- a/apps/docs/content/docs/packages/http-platform.ko.mdx
+++ b/apps/docs/content/docs/packages/http-platform.ko.mdx
@@ -25,3 +25,10 @@ backend 변환 범위를 선언하고 SSR import의 원래 모듈 경로를 보�
 옵션을 생략하면 기존 동작을 유지합니다. 정확한 path 조건과 Turbopack 전용
 제약은 package README, 실제 dev/build/start 회귀는
 `packages/platform-nextjs/e2e/README.ko.md`를 참조하세요.
+
+Next의 `createNextAdapter({ bodyParser: 'text' })`는 Content-Type 변경이나 Request
+재구성 없이 bounded text를 opt-in합니다. HTTP가 정책을 소유하고 runtime이 Web 읽기를
+구현하며 Next가 노출합니다. 파싱은 여전히 middleware/guard보다 먼저이며 이후 앱의
+JSON 해석보다 인증을 우선하려면 그 순서를 명시해야 합니다. Adapter capability matrix는
+`packages/http/README.ko.md#bounded-body-parser-policy`, 경로별 callback, default 위임,
+wrapper migration은 `packages/platform-nextjs/README.ko.md#bounded-body-parsing`을 참고하세요.

--- a/apps/docs/content/docs/packages/http-platform.mdx
+++ b/apps/docs/content/docs/packages/http-platform.mdx
@@ -26,3 +26,11 @@ from `@fluojs/platform-nextjs/next-config`. Omitting options keeps existing
 behavior. The package README owns exact path conditions and Turbopack-only
 limitations; `packages/platform-nextjs/e2e/README.md` describes the real
 dev/build/start regressions.
+
+Next's `createNextAdapter({ bodyParser: 'text' })` opts into bounded text without
+changing Content-Type or reconstructing Requests. HTTP owns the policy, runtime
+implements Web reads, and Next exposes it. Parsing still precedes middleware and
+guards; authentication must be explicitly ordered before later application JSON
+interpretation. See `packages/http/README.md#bounded-body-parser-policy` for the
+adapter capability matrix and `packages/platform-nextjs/README.md#bounded-body-parsing`
+for per-path callbacks, default delegation, and wrapper migration.

--- a/book/03-internals/ch15-nextjs-hosting.ko.md
+++ b/book/03-internals/ch15-nextjs-hosting.ko.md
@@ -239,6 +239,43 @@ curl -I http://127.0.0.1:3000/api/posts/999
 [Next production E2E](../../packages/platform-nextjs/e2e/next.test.mjs)가
 자동 HEAD, 직접 HEAD, handler 404, stream 정리의 근거다.
 
+## 초안 저장의 Content-Type을 위장하지 않는다
+
+로그인하지 않은 편집기의 잘못된 JSON에 400보다 401을 먼저 보여 주는 것은 블로그의
+정책이지 text parser의 자동 인증 기능이 아니다. 이 장의 앱에 초안 저장 route를
+추가할 때는 Content-Type을 바꾼 대체 Request 대신 adapter의 경로별 정책을 사용한다.
+다음은 `/api/posts/draft`를 추가하는 경우의 설정 조각이며 기존 장의 AppModule이 이미
+그 route를 제공한다는 뜻은 아니다.
+
+```typescript
+export const nextAdapter = createNextAdapter({
+  headRouting: 'explicit-or-get',
+  maxBodySize: 1_048_576,
+  bodyParser(text, context) {
+    if (context.path === '/api/posts/draft') return text;
+    return context.parseDefault();
+  },
+});
+```
+
+인증 guard에서 로그인 여부를 확인한 뒤 handler가 `context.request.body`의 string을
+JSON으로 해석하고 syntax error를 `BadRequestException`으로 바꾼다. 다른 route는
+`parseDefault()`로 기존 MIME parser에 위임하므로 JSON 기본 동작을 복제하지 않는다.
+Body 수집과 byte limit은 guard보다 먼저이며 너무 큰 요청은 인증 여부와 관계없이
+413이다. 사용자 parser 안에서 JSON을 해석하면 그 오류도 guard보다 먼저다.
+
+Content-Type을 `text/plain`으로 바꾸고 Request를 재구성하던 wrapper는 제거하고
+표준 facade에 원래 Request를 전달한다. Next adapter는 원본 body를 한 번 소비하며
+clone하지 않는다. `rawBody: true`는 byte 보존일 뿐 JSON 해석 우회가 아니다.
+Pages Router의 Next `bodyParser: false`는 원본 stream 소유권을 위해 계속 필요하다.
+
+[Parser 계약과 matrix](../../packages/http/README.ko.md#bounded-body-parser-policy),
+[Next 사용법](../../packages/platform-nextjs/README.ko.md#bounded-body-parsing),
+[실행 가능한 production fixture](../../packages/platform-nextjs/e2e/fixture/backend.ts)를
+함께 보자. Fixture의 `/api/app/bounded-auth`와 `/api/pages/bounded-auth`는 작은
+malformed JSON에서 미인증 401, 인증 후 400을, 큰 입력에서는 413을 비교한다.
+현재 checkout에서 재현하는 실험이며 모든 Next 버전이나 배포 환경을 검증했다는 뜻은 아니다.
+
 ## 동시에 들어온 첫 요청과 닫힌 뒤의 요청을 시험한다
 
 아래 완전한 `src/next-adapter.test.ts`는 앞의 `AppModule`과 현재 Fluo 표준 데코레이터 Vitest 구성을 전제로 한다. 테스트는 Next 서버를 열지 않고 adapter와 lazy facade의 공개 접점을 검증한다. `@fluojs/testing/vitest`의 decorator plugin을 사용하는 기존 테스트 설정이 필요하며 Next용 config helper가 Vitest의 변환을 대신하지는 않는다.

--- a/book/03-internals/ch15-nextjs-hosting.md
+++ b/book/03-internals/ch15-nextjs-hosting.md
@@ -242,6 +242,47 @@ The [HEAD contract](../../packages/platform-nextjs/README.md#head-routing) and
 [Next production E2E](../../packages/platform-nextjs/e2e/next.test.mjs) provide
 evidence for auto-HEAD, direct HEAD, handler 404s, and stream cleanup.
 
+## Do Not Disguise the Draft Save Content-Type
+
+Showing 401 before 400 for malformed JSON from an unauthenticated editor is a
+blog policy, not automatic authentication supplied by a text parser. When adding
+a draft-save route to this chapter's app, use the adapter's per-path policy
+instead of a replacement Request with a changed Content-Type. This fragment
+assumes you add `/api/posts/draft`; it does not claim the earlier AppModule
+already provides that route.
+
+```typescript
+export const nextAdapter = createNextAdapter({
+  headRouting: 'explicit-or-get',
+  maxBodySize: 1_048_576,
+  bodyParser(text, context) {
+    if (context.path === '/api/posts/draft') return text;
+    return context.parseDefault();
+  },
+});
+```
+
+Check authentication in the guard, then interpret the string at
+`context.request.body` as JSON in the handler, translating syntax errors to
+`BadRequestException`. Other routes delegate to the original MIME parser through
+`parseDefault()` rather than duplicating JSON defaults. Body collection and byte
+limits still precede guards: oversized requests return 413 regardless of auth.
+JSON errors thrown inside a custom parser also precede guards.
+
+Remove the wrapper that changes Content-Type to `text/plain` and reconstructs
+the Request; pass the original Request to the standard facade. The Next adapter
+consumes that body once without cloning. `rawBody: true` preserves bytes; it is
+not a JSON interpretation bypass. Pages Router still needs Next
+`bodyParser: false` to preserve original stream ownership.
+
+Read the [parser contract and matrix](../../packages/http/README.md#bounded-body-parser-policy),
+[Next usage](../../packages/platform-nextjs/README.md#bounded-body-parsing), and
+[executable production fixture](../../packages/platform-nextjs/e2e/fixture/backend.ts).
+The fixture's `/api/app/bounded-auth` and `/api/pages/bounded-auth` compare
+unauthenticated 401 with authenticated 400 for small malformed JSON, and 413 for
+oversized input. This is a current-checkout reproduction, not verification of
+every Next version or deployment environment.
+
 ## Test Concurrent First Requests and Requests After Close
 
 The following complete `src/next-adapter.test.ts` assumes the earlier `AppModule` and the current Fluo standard-decorator Vitest configuration. It tests the public interfaces of the adapter and lazy facade without opening a Next server. An existing test configuration using the decorator plugin from `@fluojs/testing/vitest` is required; the Next config helper does not replace Vitest's transformation.

--- a/docs/CONTEXT.ko.md
+++ b/docs/CONTEXT.ko.md
@@ -141,6 +141,18 @@ Compiler scope와 SSR module path 보존의 opt-in 계약은
 [helper 회귀](../packages/platform-nextjs/src/next-config.test.ts)와
 [실제 Next fixture](../packages/platform-nextjs/e2e/README.ko.md)에서 확인하세요.
 
+## Bounded Body Parser Policy
+
+Content-Type 변경 없는 text/custom 파싱은
+[HTTP 정책과 adapter matrix](../packages/http/README.ko.md#bounded-body-parser-policy) 및
+[HTTP materialization 경계](./architecture/http-runtime.ko.md#body-parser-boundary)에서 시작하세요.
+Runtime Web helper가 정책을 구현하고 Next와 Workers adapter가 노출합니다.
+[Next 사용 안내](../packages/platform-nextjs/README.ko.md#bounded-body-parsing)는 경로별
+default 위임과 Request 재구성 제거를 설명합니다. 읽기와 byte limit은 여전히
+middleware/guard보다 먼저이며 이후 앱의 JSON 해석보다 인증을 우선하려면 명시적으로
+구성해야 합니다. 근거는 runtime, Next, Workers의 `body-parser.test.ts`
+(runtime은 `web-body-parser.test.ts`), cold Next declaration 테스트, 실제 Next E2E입니다.
+
 ## 라이프사이클 및 multi-provider 순서
 
 [라이프사이클 및 종료 보장](./architecture/lifecycle-and-shutdown.ko.md)은 application 및 testing module bootstrap hook의 SSOT입니다. 적격 singleton `multi: true` contribution은 별도 lifecycle instance로 남으며 singleton provider와 interleave해도 declared provider order로 실행됩니다. Framework integration은 owning DI container를 통해 각 contribution을 resolve하며 internal resolver registrar는 container-private으로 남습니다.

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -141,6 +141,19 @@ do not change existing defaults. Execution evidence is linked from the
 [helper regressions](../packages/platform-nextjs/src/next-config.test.ts) and
 [real Next fixture](../packages/platform-nextjs/e2e/README.md).
 
+## Bounded Body Parser Policy
+
+For text/custom parsing without Content-Type changes, start at the
+[HTTP policy and adapter matrix](../packages/http/README.md#bounded-body-parser-policy)
+and [HTTP materialization boundary](./architecture/http-runtime.md#body-parser-boundary).
+Runtime Web helpers implement the policy; Next and the Workers adapter expose it.
+The [Next usage guide](../packages/platform-nextjs/README.md#bounded-body-parsing)
+explains path-specific default delegation and removal of Request reconstruction.
+Reading and byte limits still precede middleware/guards; authenticate explicitly
+before later application-owned JSON interpretation. Evidence is in the runtime,
+Next, and Workers `body-parser.test.ts` suites (runtime uses
+`web-body-parser.test.ts`), the cold Next declaration test, and real Next E2E.
+
 ## Lifecycle & Multi-Provider Ordering
 
 [Lifecycle & Shutdown Guarantees](./architecture/lifecycle-and-shutdown.md) is the source of truth for application and testing module bootstrap hooks. Eligible singleton `multi: true` contributions remain distinct lifecycle instances and run in declared provider order, including when they are interleaved with singleton providers. Framework integrations resolve each contribution through its owning DI container; the internal resolver registrar remains container-private.

--- a/docs/architecture/http-runtime.ko.md
+++ b/docs/architecture/http-runtime.ko.md
@@ -35,6 +35,21 @@ opt-in transport API, body suppression, stream cleanup, wrapper migration을
 `packages/platform-nextjs/src/head-routing.test.ts`,
 실제 Next `packages/platform-nextjs/e2e/next.test.mjs`.
 
+## Body Parser Boundary
+
+HTTP가 `BodyParser`와 `BodyParserContext`를 소유하고 runtime이 bounded Web
+materialization을 구현하며 adapter가 지원 option을 노출합니다. Materialization은
+아래 dispatcher lifecycle 이전에 유지됩니다. Opt-in text/custom 파싱은 원래 header를
+보존하며 인증을 읽기나 byte limit 앞으로 옮기지 않습니다. 애플리케이션은 이후 자신의
+JSON 해석보다 먼저 인증할 수 있지만 사용자 parser callback 자체는 여전히
+middleware/guard보다 먼저 실행합니다. 이미 파싱된 host body는 기존 adapter가
+소유하며 이 Web 경로가 다시 소비하지 않습니다.
+[HTTP README](../../packages/http/README.ko.md#bounded-body-parser-policy)가 정책과
+adapter matrix를, [Next README](../../packages/platform-nextjs/README.ko.md#bounded-body-parsing)가
+설정과 wrapper migration을 소유합니다. 회귀 근거는
+`packages/runtime/src/web-body-parser.test.ts`,
+`packages/platform-nextjs/src/body-parser.test.ts`, 실제 Next production E2E입니다.
+
 ## Request Lifecycle
 
 1. 어댑터는 정규화된 `FrameworkRequest`와 `FrameworkResponse`를 `Dispatcher.dispatch(...)`에 전달하며, host가 요청 취소를 노출한다면 `signal` 또는 `isAborted()`를 포함한다.

--- a/docs/architecture/http-runtime.md
+++ b/docs/architecture/http-runtime.md
@@ -35,6 +35,22 @@ migration. Path wildcards remain deferred. Evidence:
 `packages/platform-nextjs/src/head-routing.test.ts`, and the real Next
 `packages/platform-nextjs/e2e/next.test.mjs`.
 
+## Body Parser Boundary
+
+HTTP owns `BodyParser` and `BodyParserContext`; runtime owns bounded Web
+materialization, and adapters expose supported options. Materialization remains
+before the dispatcher lifecycle below. Opt-in text/custom parsing preserves
+original headers and does not move authentication ahead of reading or byte limits.
+An application can authenticate before its own later JSON interpretation; custom
+parser callbacks themselves still run before middleware/guards. Host-parsed
+bodies remain with their existing adapter and are not consumed by this Web path.
+The [HTTP README](../../packages/http/README.md#bounded-body-parser-policy) owns
+the policy and adapter matrix; the
+[Next README](../../packages/platform-nextjs/README.md#bounded-body-parsing) owns
+configuration and wrapper migration. Regression evidence is in
+`packages/runtime/src/web-body-parser.test.ts`,
+`packages/platform-nextjs/src/body-parser.test.ts`, and the real Next production E2E.
+
 ## Request Lifecycle
 
 1. The adapter supplies a normalized `FrameworkRequest` and `FrameworkResponse` to `Dispatcher.dispatch(...)`, including `signal` or `isAborted()` when the host exposes request cancellation.

--- a/packages/http/README.ko.md
+++ b/packages/http/README.ko.md
@@ -660,3 +660,54 @@ dispatcher는 먼저 일반 conditional request를 평가합니다. 그 다음 `
 - `examples/realworld-api/src/users/create-user.dto.ts`
 - `examples/auth-jwt-passport/src/auth/auth.controller.ts`
 - `packages/http/src/dispatch/dispatcher.test.ts`
+
+## Bounded Body Parser Policy
+
+`BodyParser`와 `BodyParserContext`는 `@fluojs/http` 및
+`@fluojs/http/portable`에서 export합니다. HTTP가 정책을 소유하고 runtime이
+Web 읽기를 구현하며 platform adapter가 지원 설정을 노출합니다. 생략 또는
+`'default'`는 기존 MIME 기반 파싱을 유지합니다. 잘못된 JSON은 HTTP 400,
+유효한 JSON `null`은 `null`, 비-JSON은 text이며 multipart는 기존 parser를 씁니다.
+
+`'text'`로 opt-in하면 Content-Type, header, native Request를 변경하지 않고
+UTF-8 decoded text를 받습니다. 빈 stream은 `''`, body 부재는 `undefined`입니다.
+사용자 `(text, context) => value | Promise<value>`는 생성 시점의 `contentType`,
+`headers`, `method`, `path`와 framework `signal`을 받습니다.
+`context.parseDefault()`는 이미 제한된 byte에 기존 MIME parser를 적용하며
+request를 다시 소비하지 않습니다. 경로별 정책에서 다른 경로를 위임할 때
+JSON/MIME 로직을 복제할 필요가 없습니다. Body 부재와 multipart에서는 callback을
+호출하지 않습니다. 잘못된 JavaScript option은 setup에서 `TypeError`로 실패하며
+TypeScript도 미지원 mode와 callback signature를 거부합니다.
+
+모든 mode는 decoding/callback 전에 byte limit을 유지합니다. Text/custom 파싱에서
+`rawBody: true`는 별개로 정확한 byte를 보존하며 빈 stream은 0 byte입니다.
+Multipart의 raw-body 제외는 유지합니다. Materialization은 dispatch까지 지연하고
+동시 호출과 실패에서도 memoize합니다. Opt-in stream 읽기는 cancellation을
+관찰하고 reader를 해제합니다. Async callback은 `context.signal`에 협력해야 하며
+abort된 callback 결과는 body에 할당하지 않습니다. 사용자 parser가 소비된 body를
+다시 읽을 수는 없습니다.
+
+**순서:** materialization과 parser 실패는 HTTP middleware, route matching,
+guard, DTO binding, exception filter보다 먼저입니다. Text mode만으로 인증 순서를
+보장하지 않습니다. 잘못된 JSON보다 인증을 우선하려면 middleware/guard에서
+명시적으로 인증하고 handler 또는 그 뒤의 application-owned 단계에서 text를
+해석하여 잘못된 JSON에 `BadRequestException`을 던지세요. Byte-limit 413과
+transport 실패는 여전히 인증보다 먼저입니다. 사용자 parser도 인증 전에 실행합니다.
+초기 HTTP 오류를 선택하려면 `HttpException`을 던지며 알 수 없는 예외는 500입니다.
+전역 malformed-JSON-to-null fallback은 설치하지 않습니다.
+
+### Adapter Capability Matrix
+
+| Surface | Parser policy | Ownership and evidence |
+| --- | --- | --- |
+| `@fluojs/runtime/web` | 지원 | Web factory, dispatch, standalone request helper; `packages/runtime/src/web-body-parser.test.ts` |
+| Next App Router 및 Pages Router | 지원 | `NextAdapterOptions.bodyParser`; Pages는 Next `bodyParser: false` 유지; `packages/platform-nextjs/src/body-parser.test.ts` 및 실제 Next E2E |
+| Cloudflare Workers | 지원 | Adapter/bootstrap이 Web factory option을 상속; `packages/platform-cloudflare-workers/src/body-parser.test.ts`는 실제 fetch adapter를 실행하며 deployed isolate 검증은 아님 |
+| Bun 및 Deno adapter/fetch helper | 미노출 | 기존 adapter option/default parsing 유지; 직접 runtime Web helper 사용은 별도 integration surface |
+| Node.js, Express, Fastify | 미노출 | 기존 host/parser 소유권 유지; Web 정책이 Fastify의 이미 파싱된 host body를 다시 소비하지 않음 |
+
+Runtime, Next, Workers 테스트는 `tooling/testing/body-parser-cases.json`의 동일한
+wire-case fixture를 소비합니다. 기존 Web portability와 Fastify native-body 테스트는
+default/raw-body/multipart 동작을 유지합니다. 공개 declaration 테스트는 cold isolated
+의존성 closure를 build하고 package export map으로 해석합니다.
+[Next 사용법과 migration](../platform-nextjs/README.ko.md#bounded-body-parsing)을 참고하세요.

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -668,3 +668,55 @@ The dispatcher evaluates normal conditional requests first. `If-Range` then perm
 - `examples/realworld-api/src/users/create-user.dto.ts`
 - `examples/auth-jwt-passport/src/auth/auth.controller.ts`
 - `packages/http/src/dispatch/dispatcher.test.ts`
+
+## Bounded Body Parser Policy
+
+`BodyParser` and `BodyParserContext` are exported from `@fluojs/http` and
+`@fluojs/http/portable`. HTTP owns this policy; runtime implements Web reads;
+platform adapters expose the supported configuration. Omission or `'default'`
+keeps existing MIME-based parsing, including malformed JSON as HTTP 400, valid
+JSON `null` as `null`, and non-JSON text. Multipart uses its existing parser.
+
+Opt in with `'text'` to receive UTF-8 decoded text without changing Content-Type,
+headers, or the native Request. An empty stream produces `''`; an absent body
+remains `undefined`. A custom `(text, context) => value | Promise<value>` receives
+creation-time `contentType`, `headers`, `method`, `path`, and the framework `signal`.
+`context.parseDefault()` applies the existing MIME parser to the bounded bytes,
+without consuming the request again, so a per-path policy can delegate other
+paths without duplicating JSON/MIME logic. Custom callbacks are not invoked for
+absent or multipart bodies. Invalid JavaScript option values fail setup with
+`TypeError`; TypeScript rejects unsupported modes and callback signatures.
+
+All modes retain byte limits before decoding or callbacks. With text/custom
+parsing, `rawBody: true` retains exact bytes independently, including zero bytes
+for an empty stream; multipart raw-body exclusion is unchanged. Materialization
+is deferred until dispatch and memoized across concurrent calls and failures.
+Opt-in stream reads observe cancellation and release the reader; async callbacks
+must cooperate with `context.signal`, and an aborted callback result is never
+assigned. A custom parser cannot re-read the consumed body.
+
+**Ordering:** materialization and parser failures precede HTTP middleware,
+route matching, guards, DTO binding, and exception filters. Text mode alone
+never guarantees authentication order. To give authentication precedence over
+malformed JSON, explicitly authenticate in middleware/guards, then interpret
+text in the handler or a later application-owned stage and throw
+`BadRequestException` for invalid JSON. Byte-limit 413 and transport failures
+still precede authentication. A custom parser runs before authentication too;
+throw an `HttpException` to select its early HTTP error, while unknown exceptions
+remain 500. No global malformed-JSON-to-null fallback is installed.
+
+### Adapter Capability Matrix
+
+| Surface | Parser policy | Ownership and evidence |
+| --- | --- | --- |
+| `@fluojs/runtime/web` | Supported | Web factory, dispatch, and standalone request helper; `packages/runtime/src/web-body-parser.test.ts` |
+| Next App Router and Pages Router | Supported | `NextAdapterOptions.bodyParser`; Pages still requires Next `bodyParser: false`; `packages/platform-nextjs/src/body-parser.test.ts` and real Next E2E |
+| Cloudflare Workers | Supported | Inherited Web factory option on adapter/bootstrap; `packages/platform-cloudflare-workers/src/body-parser.test.ts` exercises the actual fetch adapter, not a deployed isolate |
+| Bun and Deno adapter/fetch helpers | Not exposed | Keep existing adapter options/default parsing; direct runtime Web helpers are a separate integration surface |
+| Node.js, Express, Fastify | Not exposed | Their existing host/parser ownership remains unchanged; Fastify's already parsed host body is not re-consumed by the Web policy |
+
+The runtime, Next, and Workers tests consume the same wire-case fixture at
+`tooling/testing/body-parser-cases.json`. Existing Web portability and Fastify
+native-body tests retain default/raw-body/multipart behavior. Public declaration
+tests build a cold isolated dependency closure and resolve package export maps.
+See the [Next usage and migration](../platform-nextjs/README.md#bounded-body-parsing).

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -7,6 +7,40 @@ export type { ValidationIssue, Validator } from '@fluojs/validation';
 /** Canonical uppercase HTTP method token or Fluo's reserved `ALL` wildcard sentinel. */
 export type HttpMethod = string;
 
+/** Creation-time request metadata and default parsing delegate for a bounded body parser. */
+export interface BodyParserContext {
+  /** Original Content-Type, without normalization or rewriting. */
+  readonly contentType: string | undefined;
+  /** Creation-time request headers; parsing never rewrites the native headers. */
+  readonly headers: FrameworkRequest['headers'];
+  /** Original HTTP method. */
+  readonly method: string;
+  /** URL pathname, usable for application-owned per-path parser selection. */
+  readonly path: string;
+  /** Framework cancellation signal; asynchronous parsers must cooperate with it. */
+  readonly signal: AbortSignal;
+  /**
+   * Apply the unchanged MIME-based parser to the already bounded bytes.
+   *
+   * @returns The default parsed value, without consuming the request again.
+   * @throws {BadRequestException} If the original MIME selects JSON and it is invalid.
+   */
+  parseDefault(): unknown;
+}
+
+/**
+ * Opt-in parsing policy for bounded, UTF-8 decoded non-multipart request bodies.
+ *
+ * @remarks
+ * Omission or `default` preserves MIME-based parsing. `text` preserves decoded text,
+ * including an empty stream as `''`; a missing body remains `undefined` without a
+ * callback. Custom parsers run once after byte limits and before HTTP middleware and
+ * guards, may return a promise, and own error classification (throw an HttpException
+ * for an HTTP error). This policy does not order authentication. Multipart and
+ * already host-parsed bodies remain owned by their adapter, not this callback.
+ */
+export type BodyParser = 'default' | 'text' | ((text: string, context: BodyParserContext) => MaybePromise<unknown>);
+
 /** Strategies that decide how versioned HTTP routes are selected for one request. */
 export enum VersioningType {
   URI = 'URI',

--- a/packages/platform-cloudflare-workers/README.ko.md
+++ b/packages/platform-cloudflare-workers/README.ko.md
@@ -219,3 +219,25 @@ Root `@fluojs/platform-cloudflare-workers` export는 application code와 first-p
 
 - `packages/platform-cloudflare-workers/src/adapter.test.ts`
 - `packages/websockets/src/cloudflare-workers/cloudflare-workers.test.ts`
+
+## Bounded Body Parsing
+
+`CloudflareWorkerAdapterOptions`는 runtime Web factory의 HTTP 소유 `bodyParser`
+정책을 상속합니다. Adapter와 bootstrap helper는 `'text'`, `'default'`, 사용자
+callback을 받으며 생략하면 기존 MIME 기반 파싱과 limit을 유지합니다.
+
+```typescript
+import { createCloudflareWorkerAdapter } from '@fluojs/platform-cloudflare-workers';
+
+const adapter = createCloudflareWorkerAdapter({
+  bodyParser: 'text', maxBodySize: 1_048_576, rawBody: true,
+});
+```
+
+Header와 native Request identity를 보존하고 runtime clone 경로는 원본 body를 읽을
+수 있게 남깁니다. Multipart는 독립적으로 유지합니다. 파싱은 HTTP middleware/guard보다
+먼저이므로 text만으로 인증 순서를 보장하지 않습니다. Callback 위임, 오류, 빈 body,
+cancellation 협력은 [HTTP 계약과 matrix](../http/README.ko.md#bounded-body-parser-policy)를
+참고하세요. `src/body-parser.test.ts`는 공통 wire fixture로 실제 adapter를 실행하고
+`waitUntil` lifecycle을 관찰합니다. 로컬 Web conformance이며 deployed Cloudflare isolate
+테스트를 했다는 주장은 아닙니다.

--- a/packages/platform-cloudflare-workers/README.md
+++ b/packages/platform-cloudflare-workers/README.md
@@ -219,3 +219,26 @@ The shared edge portability suite in `packages/testing/src/portability/web-runti
 
 - `packages/platform-cloudflare-workers/src/adapter.test.ts`
 - `packages/websockets/src/cloudflare-workers/cloudflare-workers.test.ts`
+
+## Bounded Body Parsing
+
+`CloudflareWorkerAdapterOptions` inherits the runtime Web factory's HTTP-owned
+`bodyParser` policy. Adapter and bootstrap helpers accept `'text'`, `'default'`,
+or a custom callback. Omission retains MIME-based parsing and existing limits.
+
+```typescript
+import { createCloudflareWorkerAdapter } from '@fluojs/platform-cloudflare-workers';
+
+const adapter = createCloudflareWorkerAdapter({
+  bodyParser: 'text', maxBodySize: 1_048_576, rawBody: true,
+});
+```
+
+Headers and native Request identity are preserved. The runtime clone path keeps
+the original body readable. Multipart remains independent. Parsing happens
+before HTTP middleware/guards, so text alone does not guarantee auth order.
+See the [HTTP contract and matrix](../http/README.md#bounded-body-parser-policy)
+for callback delegation, errors, empty bodies, and cancellation cooperation.
+`src/body-parser.test.ts` runs the actual adapter with the shared wire fixture
+and observes its `waitUntil` lifecycle. This is local Web conformance, not a
+claim of a deployed Cloudflare isolate test.

--- a/packages/platform-cloudflare-workers/src/body-parser.test.ts
+++ b/packages/platform-cloudflare-workers/src/body-parser.test.ts
@@ -1,0 +1,63 @@
+import { Controller, Post, type RequestContext } from '@fluojs/http';
+import { defineModule, FluoFactory } from '@fluojs/runtime';
+import { describe, expect, it } from 'vitest';
+import bodyParserCases from '../../../tooling/testing/body-parser-cases.json';
+import { createCloudflareWorkerAdapter } from './adapter.js';
+
+@Controller('/body')
+class BodyController {
+  @Post('/')
+  echo(_input: undefined, { request }: RequestContext) {
+    return { body: request.body, mime: request.headers['content-type'], raw: Array.from(request.rawBody ?? []) };
+  }
+}
+
+class BodyModule {}
+defineModule(BodyModule, { controllers: [BodyController] });
+
+describe('Workers inherited bounded parser conformance', () => {
+  it.each(bodyParserCases)('preserves %j with %s through the actual fetch adapter', async (body, mime) => {
+    const adapter = createCloudflareWorkerAdapter({ bodyParser: 'text', rawBody: true });
+    const app = await FluoFactory.create(BodyModule, { adapter });
+    const lifecycles: Promise<unknown>[] = [];
+    try {
+      await app.listen();
+      const request = new Request('https://worker.test/body', {
+        method: 'POST', body, headers: { 'content-type': mime },
+      });
+      const response = await adapter.fetch(request, {}, { waitUntil: (pending) => { lifecycles.push(pending); } });
+      expect(response.status).toBe(201);
+      await expect(response.json()).resolves.toEqual({ body, mime, raw: Array.from(new TextEncoder().encode(body)) });
+      expect(request.headers.get('content-type')).toBe(mime);
+      expect(request.bodyUsed).toBe(false);
+      await expect(request.text()).resolves.toBe(body);
+      expect(lifecycles).toHaveLength(1);
+      await Promise.all(lifecycles);
+    } finally { await app.close(); }
+  });
+
+  it('inherits custom parsing and UTF-8 limits before invoking the callback', async () => {
+    let calls = 0;
+    const adapter = createCloudflareWorkerAdapter({
+      maxBodySize: 3,
+      bodyParser(text, context) {
+        calls += 1;
+        return { text, path: context.path };
+      },
+    });
+    const app = await FluoFactory.create(BodyModule, { adapter });
+    const lifecycles: Promise<unknown>[] = [];
+    try {
+      await app.listen();
+      for (const [body, status] of [['한', 201], ['한a', 413]] as const) {
+        const response = await adapter.fetch(new Request('https://worker.test/body', {
+          method: 'POST', body, headers: { 'content-type': 'application/json' },
+        }), {}, { waitUntil: (pending) => { lifecycles.push(pending); } });
+        expect(response.status).toBe(status);
+        if (status === 201) await expect(response.json()).resolves.toMatchObject({ body: { text: '한', path: '/body' } });
+      }
+      expect(calls).toBe(1);
+      await Promise.all(lifecycles);
+    } finally { await app.close(); }
+  });
+});

--- a/packages/platform-nextjs/README.ko.md
+++ b/packages/platform-nextjs/README.ko.md
@@ -434,3 +434,50 @@ Unit suite에는 공통 Web portability 검사와 native Pages transport 회귀
 테스트가 포함됩니다. E2E suite는 package 배포 파일로 실제 Next.js application을
 dev/build/start를 거쳐 source alias 없이 두 router와 client store SSR을
 HTTP로 검증합니다. [Fixture 실행 안내](./e2e/README.ko.md)를 참조하세요.
+
+## Bounded Body Parsing
+
+Adapter 생성 시 `NextAdapterOptions.bodyParser`를 설정합니다. HTTP 소유
+`BodyParser`인 `'default'`(생략 시 기본값), `'text'`, 동기/비동기 callback을 받습니다.
+애플리케이션 전체 text mode는 `createNextAdapter({ bodyParser: 'text' })`입니다.
+경로별 정책은 Request 재구성 대신 선택하지 않은 경로를 기존 parser에 위임합니다.
+
+```typescript
+import { createNextAdapter } from '@fluojs/platform-nextjs';
+
+export const nextAdapter = createNextAdapter({
+  headRouting: 'explicit-or-get',
+  maxBodySize: 1_048_576,
+  rawBody: true,
+  bodyParser(text, context) {
+    if (context.path === '/api/posts/draft') return text;
+    return context.parseDefault();
+  },
+});
+```
+
+이 adapter를 기존 `FluoFactory.create()`에 전달하고 일반 App/Pages facade를
+유지하세요. Path는 Fluo route matching 이전의 원래 URL pathname이며 이 단계에는
+matched params나 route metadata가 없습니다. Multipart는 기존 parser/limit을 유지하고
+callback을 호출하지 않습니다. 기본값, 빈 body/부재, raw byte, 오류, abort 협력은
+[HTTP 계약과 capability matrix](../http/README.ko.md#bounded-body-parser-policy)가 소유합니다.
+
+**인증 경계:** bounded read와 사용자 callback은 Fluo middleware, guard, filter보다
+먼저입니다. 잘못된 JSON의 400보다 401을 우선하려면 text를 받고 middleware/guard에서
+명시적으로 인증한 다음 handler(또는 이후 application 단계)에서 JSON을 파싱하고
+syntax error를 `BadRequestException`으로 변환하세요. 크기 초과 입력은 여전히 인증
+전에 413입니다. Text mode는 인증하거나 pipeline 순서를 바꾸거나 잘못된 JSON을 null로
+만들지 않습니다.
+
+**Migration:** Content-Type을 `text/plain`으로 바꾸고 대체 Request를 만드는 wrapper를
+제거하세요. 원래 header를 유지하고 원래 Request를 표준 facade에 전달합니다.
+Adapter는 이미 clone 없이 원본 body를 소비합니다. 제거한 wrapper의 proxied
+Request.clone 실패는 Next adapter 결함이 아닙니다. `rawBody: true`만으로 JSON 파싱을
+우회할 수도 없습니다. Pages Router는 Fluo가 raw stream을 소유하도록 Next
+`api: { bodyParser: false }` export를 유지합니다. Upstream에서 파싱한 host body로 원래
+byte를 복구할 수는 없습니다.
+
+근거: `src/body-parser.test.ts`, `src/head-routing-public-types.test.ts`의 cold 공개
+declaration 테스트, `e2e/fixture/backend.ts`와 `e2e/next.test.mjs`. Production fixture는
+App/Pages route에서 request/header 재작성 없이 이 공개 callback을 사용하며 default
+위임, UTF-8 limit, raw byte, 빈/잘못된/비-JSON 입력, 인증 우선순위를 검증합니다.

--- a/packages/platform-nextjs/README.md
+++ b/packages/platform-nextjs/README.md
@@ -431,3 +431,53 @@ The unit suite includes shared Web portability checks and native Pages transport
 regressions. The E2E suite stages package distribution files, builds a real
 Next.js application through dev/build/start, and verifies both routers and client
 store SSR over HTTP without source aliases. See the [fixture guide](./e2e/README.md).
+
+## Bounded Body Parsing
+
+Set `NextAdapterOptions.bodyParser` at adapter construction. It accepts the
+HTTP-owned `BodyParser`: `'default'` (also the omitted default), `'text'`, or a
+synchronous/asynchronous callback. Application-wide text mode is
+`createNextAdapter({ bodyParser: 'text' })`. For path-specific policy, delegate
+unselected paths to the unchanged parser instead of reconstructing Requests:
+
+```typescript
+import { createNextAdapter } from '@fluojs/platform-nextjs';
+
+export const nextAdapter = createNextAdapter({
+  headRouting: 'explicit-or-get',
+  maxBodySize: 1_048_576,
+  rawBody: true,
+  bodyParser(text, context) {
+    if (context.path === '/api/posts/draft') return text;
+    return context.parseDefault();
+  },
+});
+```
+
+Pass this adapter to the existing `FluoFactory.create()` and keep the ordinary
+App/Pages facade. Paths are original URL pathnames before Fluo route matching;
+there are no matched params or route metadata at this stage. Multipart keeps its
+existing parser/limits and does not invoke the callback. The
+[HTTP contract and capability matrix](../http/README.md#bounded-body-parser-policy)
+own defaults, empty/absent bodies, raw bytes, errors, and abort cooperation.
+
+**Authentication boundary:** bounded reading and custom callbacks precede Fluo
+middleware, guards, and filters. To return 401 before malformed-JSON 400, receive
+text, authenticate explicitly in middleware/a guard, then parse JSON in the
+handler (or a later application stage), translating syntax errors to
+`BadRequestException`. Oversized input still returns 413 before authentication.
+Text mode does not authenticate, reorder the pipeline, or make invalid JSON null.
+
+**Migration:** remove the wrapper that changes Content-Type to `text/plain` and
+constructs a replacement Request. Keep original headers and pass the original
+Request to the standard facade. The adapter already consumes the original body
+without cloning; a proxied Request.clone failure in that removed wrapper is not
+a Next adapter defect. `rawBody: true` alone is not a JSON parsing bypass.
+Pages Router still exports Next `api: { bodyParser: false }` so Fluo owns the raw
+stream; an upstream parsed host body cannot recover original bytes.
+
+Evidence: `src/body-parser.test.ts`, the cold public declaration tests in
+`src/head-routing-public-types.test.ts`, and `e2e/fixture/backend.ts` plus
+`e2e/next.test.mjs`. The production fixture uses this public callback and no
+request/header rewriting for App and Pages routes, including default delegation,
+UTF-8 limits, raw bytes, empty/malformed/non-JSON inputs, and auth precedence.

--- a/packages/platform-nextjs/e2e/README.ko.md
+++ b/packages/platform-nextjs/e2e/README.ko.md
@@ -70,3 +70,11 @@ Next 16.3.4의 legacy 모드는 의도적으로 실패합니다. Dev GET `/`가 
 실패를 제한합니다. Sleep이나 readiness polling은 사용하지 않습니다.
 `report.json`과 command log는 유지하고 임시 앱과 서버는 종료합니다.
 자동 회귀와 별도의 수동 브라우저/hydration 시연을 혼동하지 마세요.
+
+## Bounded parser regression
+
+같은 fixture는 text/custom route에 공개 `bodyParser` callback을, 기존 JSON/DTO route에는
+`context.parseDefault()`를 사용합니다. App/Pages HTTP case는 원래 MIME, 정확한 raw byte,
+빈/잘못된/비-JSON body, UTF-8 byte-limit 413, 명시적 인증 후 handler가 소유한 JSON 해석을
+비교합니다. Request 재구성이나 header 재작성은 사용하지 않습니다. 기존 HEAD, SSE,
+compiler, lifecycle case도 이 parser 설정에서 계속 실행합니다.

--- a/packages/platform-nextjs/e2e/README.md
+++ b/packages/platform-nextjs/e2e/README.md
@@ -72,3 +72,12 @@ failure timeouts and no sleeps or readiness polling. `report.json` and command
 logs remain after the temporary app and servers are cleaned up.
 Do not confuse these automated regressions with a separate manual
 browser/hydration demonstration.
+
+## Bounded parser regression
+
+The same fixture uses public `bodyParser` callbacks for text/custom routes and
+`context.parseDefault()` for existing JSON/DTO routes. App and Pages HTTP cases
+compare original MIME, exact raw bytes, empty/malformed/non-JSON bodies, UTF-8
+byte-limit 413, and explicitly authenticated handler-owned JSON interpretation.
+No request reconstruction or header rewrite is used. Existing HEAD, SSE, compiler,
+and lifecycle cases continue to run with this parser configuration.

--- a/packages/platform-nextjs/e2e/fixture/backend.ts
+++ b/packages/platform-nextjs/e2e/fixture/backend.ts
@@ -4,6 +4,7 @@ import { appendFileSync } from 'node:fs';
 import { Module, Scope } from '@fluojs/core';
 import {
   All,
+  BadRequestException,
   Controller,
   Convert,
   createByteRangeResponse,
@@ -21,6 +22,7 @@ import {
   type RequestContext,
   RequestDto,
   Sse,
+  UnauthorizedException,
   UseGuards,
 } from '@fluojs/http';
 import { createNextAdapter } from '@fluojs/platform-nextjs';
@@ -83,6 +85,15 @@ function countHead(context: RequestContext, stage: string) {
   const count = (headCounts.get(key) ?? 0) + 1;
   headCounts.set(key, count);
   context.response.setHeader(`x-${stage}-count`, String(count));
+}
+
+class BodyAuthGuard {
+  canActivate({ requestContext }: GuardContext) {
+    if (requestContext.request.headers.authorization !== 'Bearer fixture') {
+      throw new UnauthorizedException();
+    }
+    return true;
+  }
 }
 
 class HeadGuard {
@@ -149,6 +160,29 @@ class BackendController {
   @Head('/health')
   healthHead() {
     return { status: 'ok', instance };
+  }
+
+  @Post('/bounded-text')
+  boundedText(_input: undefined, { request }: RequestContext) {
+    return {
+      body: request.body,
+      mime: request.headers['content-type'],
+      raw: Array.from(request.rawBody ?? []),
+      consumed: (request.raw as Request).bodyUsed,
+    };
+  }
+
+  @Post('/bounded-custom')
+  boundedCustom(_input: undefined, { request }: RequestContext) {
+    return { body: request.body };
+  }
+
+  @Post('/bounded-auth')
+  @UseGuards(BodyAuthGuard)
+  boundedAuth(_input: undefined, { request }: RequestContext) {
+    if (typeof request.body !== 'string') throw new BadRequestException();
+    try { return { body: JSON.parse(request.body) }; }
+    catch { throw new BadRequestException('Invalid post JSON'); }
   }
 
   @Post('/echo')
@@ -239,11 +273,21 @@ class HeadStreamController {
 
 @Module({
   controllers: [BackendController, HeadStreamController],
-  providers: [NumberConverter, SessionConverter, HeadGuard, HeadMiddleware],
+  providers: [NumberConverter, SessionConverter, HeadGuard, HeadMiddleware, BodyAuthGuard],
 })
 class BackendModule {}
 
-export const nextAdapter = createNextAdapter({ headRouting: 'explicit-or-get' });
+// No Content-Type rewrite, Request reconstruction, or parser outside the adapter.
+export const nextAdapter = createNextAdapter({
+  headRouting: 'explicit-or-get',
+  maxBodySize: 128,
+  rawBody: true,
+  bodyParser(text, context) {
+    if (context.path.endsWith('/bounded-custom')) return { custom: text };
+    if (context.path.includes('/bounded-')) return text;
+    return context.parseDefault();
+  },
+});
 const app = await FluoFactory.create(BackendModule, {
   adapter: nextAdapter,
   middleware: [HeadMiddleware],

--- a/packages/platform-nextjs/e2e/fixture/package.json
+++ b/packages/platform-nextjs/e2e/fixture/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@fluo-fixtures/next-production",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/packages/platform-nextjs/e2e/next.test.mjs
+++ b/packages/platform-nextjs/e2e/next.test.mjs
@@ -91,6 +91,7 @@ async function prepare(app) {
   assert.match(versions.next, /^16\./, 'This suite verifies Next 16');
   await writeFile(path.join(app, 'package.json'), JSON.stringify({
     name: 'fluo-next-production-e2e',
+    version: '0.0.0',
     private: true,
     type: 'module',
     dependencies: versions,
@@ -425,6 +426,41 @@ test('packaged Fluo serves both routers in a real Next 16 production build', {
         const response = await capture(`${prefix}/health`, { method: 'HEAD' });
         assert.equal(response.status, 200);
         assert.equal(response.body, '');
+      });
+      await t.test(`${facade}: bounded text keeps MIME, bytes, and native consumption`, async () => {
+        for (const [body, mime] of [
+          ['{', 'application/json'], ['', 'application/json'],
+          ['plain', 'application/octet-stream'], ['한', 'application/problem+json'],
+        ]) {
+          const response = await capture(`${prefix}/bounded-text`, {
+            method: 'POST', headers: { 'content-type': mime }, body,
+          });
+          assert.equal(response.status, 201);
+          assert.deepEqual(JSON.parse(response.body), {
+            body, mime, raw: Array.from(Buffer.from(body)), consumed: true,
+          });
+        }
+        const large = await capture(`${prefix}/bounded-text`, {
+          method: 'POST', headers: jsonHeaders, body: '한'.repeat(43),
+        });
+        assert.equal(large.status, 413);
+        const custom = await capture(`${prefix}/bounded-custom`, {
+          method: 'POST', headers: jsonHeaders, body: '{',
+        });
+        assert.equal(custom.status, 201);
+        assert.deepEqual(JSON.parse(custom.body), { body: { custom: '{' } });
+      });
+      await t.test(`${facade}: authentication precedes route-owned JSON interpretation, not byte limits`, async () => {
+        for (const [body, authorization, status] of [
+          ['{', undefined, 401], ['{', 'Bearer fixture', 400],
+          ['{"ok":true}', 'Bearer fixture', 201], ['x'.repeat(129), undefined, 413],
+        ]) {
+          const response = await capture(`${prefix}/bounded-auth`, {
+            method: 'POST', body,
+            headers: { ...jsonHeaders, ...(authorization ? { authorization } : {}) },
+          });
+          assert.equal(response.status, status);
+        }
       });
       await t.test(`${facade}: ordinary JSON POST`, async () => {
         const response = await capture(`${prefix}/echo`, {

--- a/packages/platform-nextjs/src/adapter.ts
+++ b/packages/platform-nextjs/src/adapter.ts
@@ -1,4 +1,5 @@
 import {
+  type BodyParser,
   createUnsupportedHttpAdapterRealtimeCapability,
   type Dispatcher,
   type HttpApplicationAdapter,
@@ -29,6 +30,12 @@ const SHUTDOWN_PROBLEM = {
 
 /** Adapter-owned Web request parsing and opt-in HEAD routing options. */
 export interface NextAdapterOptions {
+  /**
+   * Bounded non-multipart parser, before HTTP middleware/guards. Omission keeps
+   * MIME-based parsing; text preserves the original Content-Type without JSON
+   * interpretation. Pages Router still requires Next's `bodyParser: false`.
+   */
+  readonly bodyParser?: BodyParser;
   /**
    * Select explicit HEAD, then ALL, then GET without changing the request method.
    * Omit to preserve ordinary routing. Opted-in HEAD responses are bodyless and
@@ -114,6 +121,7 @@ export class NextHttpApplicationAdapter implements HttpApplicationAdapter {
     const headRouting = options.headRouting;
     this.headRouting = headRouting;
     const factory = createWebRequestResponseFactory({
+      bodyParser: options.bodyParser,
       consumeOriginalBody: true,
       maxBodySize: options.maxBodySize,
       rawBody: options.rawBody,

--- a/packages/platform-nextjs/src/body-parser.test.ts
+++ b/packages/platform-nextjs/src/body-parser.test.ts
@@ -1,0 +1,93 @@
+import { Module } from '@fluojs/core';
+import {
+  BadRequestException, Controller, type BodyParser, type BodyParserContext,
+  type GuardContext, Post, type RequestContext, UnauthorizedException, UseGuards,
+} from '@fluojs/http';
+import { FluoFactory } from '@fluojs/runtime';
+import { describe, expect, it, vi } from 'vitest';
+import bodyParserCases from '../../../tooling/testing/body-parser-cases.json';
+import { createNextAdapter, createNextAppRouterHandler } from './adapter.js';
+
+class AuthGuard {
+  canActivate({ requestContext }: GuardContext) {
+    if (requestContext.request.headers.authorization !== 'Bearer test') throw new UnauthorizedException();
+    return true;
+  }
+}
+
+@Controller('/posts')
+class PostsController {
+  @Post('/text')
+  text(_input: undefined, { request }: RequestContext) {
+    return { body: request.body, mime: request.headers['content-type'], raw: Array.from(request.rawBody ?? []) };
+  }
+
+  @Post('/auth')
+  @UseGuards(AuthGuard)
+  authenticated(_input: undefined, { request }: RequestContext) {
+    if (typeof request.body !== 'string') throw new BadRequestException();
+    try { return { parsed: JSON.parse(request.body) }; }
+    catch { throw new BadRequestException('Invalid post JSON'); }
+  }
+}
+
+@Module({ controllers: [PostsController], providers: [AuthGuard] })
+class PostsModule {}
+
+describe('Next bounded body parser conformance', () => {
+  it.each(bodyParserCases)('preserves %j and %s through the App Router facade', async (body, mime) => {
+    const adapter = createNextAdapter({ bodyParser: 'text', rawBody: true });
+    const app = await FluoFactory.create(PostsModule, { adapter });
+    try {
+      await app.listen();
+      const handler = createNextAppRouterHandler(async () => adapter);
+      const request = new Request('https://next.test/posts/text', {
+        method: 'POST', body, headers: { 'content-type': mime },
+      });
+      const clone = vi.spyOn(request, 'clone');
+      const response = await handler.POST(request);
+      expect(response.status).toBe(201);
+      await expect(response.json()).resolves.toEqual({ body, mime, raw: Array.from(new TextEncoder().encode(body)) });
+      expect(request.headers.get('content-type')).toBe(mime);
+      expect(clone).not.toHaveBeenCalled();
+      expect(request.bodyUsed).toBe(true);
+      await expect(request.text()).rejects.toBeInstanceOf(TypeError);
+    } finally { await app.close(); }
+  });
+
+  it.each([
+    [undefined, undefined, 400], ['text', undefined, 401], ['text', 'Bearer test', 400],
+  ] as const)('makes the auth/JSON boundary explicit for %s and %s', async (bodyParser, authorization, status) => {
+    const adapter = createNextAdapter({ bodyParser });
+    const app = await FluoFactory.create(PostsModule, { adapter });
+    try {
+      await app.listen();
+      const response = await adapter.POST(new Request('https://next.test/posts/auth', {
+        method: 'POST', body: '{',
+        headers: { 'content-type': 'application/json', ...(authorization ? { authorization } : {}) },
+      }));
+      expect(response.status).toBe(status);
+      await expect(response.json()).resolves.toMatchObject({ error: { status } });
+    } finally { await app.close(); }
+  });
+
+  it('runs a custom per-path parser before guards, without bypassing byte limits', async () => {
+    const bodyParser: BodyParser = vi.fn((text: string, context: BodyParserContext) => {
+      if (context.path === '/posts/auth') throw new BadRequestException('Parser precedes auth');
+      return { custom: text };
+    });
+    const adapter = createNextAdapter({ bodyParser, maxBodySize: 3 });
+    const app = await FluoFactory.create(PostsModule, { adapter });
+    try {
+      await app.listen();
+      for (const [path, body, status] of [['text', '한', 201], ['text', '한a', 413], ['auth', '{', 400]] as const) {
+        const response = await adapter.POST(new Request(`https://next.test/posts/${path}`, {
+          method: 'POST', body, headers: { 'content-type': 'application/json' },
+        }));
+        expect(response.status).toBe(status);
+        if (status === 201) await expect(response.json()).resolves.toMatchObject({ body: { custom: '한' } });
+      }
+      expect(bodyParser).toHaveBeenCalledTimes(2);
+    } finally { await app.close(); }
+  });
+});

--- a/packages/platform-nextjs/src/head-routing-public-types.test.ts
+++ b/packages/platform-nextjs/src/head-routing-public-types.test.ts
@@ -121,3 +121,45 @@ it('rejects unsupported policy values at each published entry point', () => {
       : -1);
   expect(lines).toEqual(invalid.map((_, index) => imports.split('\n').length - 1 + index));
 });
+
+
+it('exports bounded parser contracts through cold HTTP, Web, and Next declarations', () => {
+  const diagnostics = compile(`${imports}
+import type { BodyParser, BodyParserContext } from '@fluojs/http';
+import type { BodyParser as PortableParser } from '@fluojs/http/portable';
+import {
+  createWebFrameworkRequest, createWebRequestResponseFactory, dispatchWebRequest,
+  type CreateWebRequestResponseFactoryOptions, type DispatchWebRequestOptions,
+} from '@fluojs/runtime/web';
+const parser: BodyParser = async (text, context: BodyParserContext) => ({
+  text, path: context.path, method: context.method,
+  mime: context.contentType, headers: context.headers, signal: context.signal,
+});
+const portable: PortableParser = parser;
+const next: NextAdapterOptions = { bodyParser: portable, headRouting: 'explicit-or-get' };
+const app: AppOptions = { bodyParser: 'text' };
+const factory: CreateWebRequestResponseFactoryOptions = { bodyParser: 'default' };
+const dispatch: DispatchWebRequestOptions = { bodyParser: parser, request: new Request('https://test/') };
+createNextAdapter(next);
+createNextAdapter(app);
+createWebRequestResponseFactory(factory);
+dispatchWebRequest(dispatch);
+createWebFrameworkRequest(dispatch.request, dispatch.request.signal, undefined, 100, true, parser);
+`);
+  expect(diagnostics.map((entry) => ts.flattenDiagnosticMessageText(entry.messageText, '\n'))).toEqual([]);
+});
+
+it('rejects invalid parser modes and callback signatures without type suppression', () => {
+  const diagnostics = compile(`${imports}
+import type { BodyParser } from '@fluojs/http';
+import type { BodyParser as PortableParser } from '@fluojs/http/portable';
+import { createWebRequestResponseFactory } from '@fluojs/runtime/web';
+createNextAdapter({ bodyParser: false });
+const app: AppOptions = { bodyParser: 'json-or-null' };
+const parser: BodyParser = (text: number) => text;
+const portable: PortableParser = true;
+createWebRequestResponseFactory({ bodyParser: 'unlimited' });
+`);
+  expect(diagnostics).toHaveLength(5);
+  expect(diagnostics.every((entry) => entry.file?.fileName === fixture && entry.code === 2322)).toBe(true);
+});

--- a/packages/runtime/README.ko.md
+++ b/packages/runtime/README.ko.md
@@ -512,3 +512,35 @@ phase를 명시적 retry 대상으로 남기며, bootstrap은 원래 failure를 
 - [examples/minimal](../../examples/minimal): 최소한의 부트스트랩 예제.
 - [examples/realworld-api](../../examples/realworld-api): 복잡한 모듈 연결이 포함된 전체 애플리케이션 예제.
 - [packages/runtime/src/bootstrap.test.ts](./src/bootstrap.test.ts): 부트스트랩 단계별 동작 테스트.
+
+## Bounded Body Parsing
+
+HTTP 소유 `BodyParser` 정책은 `@fluojs/runtime/web`의
+`CreateWebRequestResponseFactoryOptions`, `DispatchWebRequestOptions`에서
+`bodyParser`로, 그리고
+`createWebFrameworkRequest(request, signal, multipart, maxBodySize, rawBody, bodyParser)`의
+마지막 optional 인수로 제공합니다. Dispatch에 `factory`를 전달하면 해당 factory의
+파싱 설정이 우선합니다.
+
+```typescript
+import { createWebRequestResponseFactory } from '@fluojs/runtime/web';
+
+const factory = createWebRequestResponseFactory({
+  bodyParser: 'text',
+  maxBodySize: 1_048_576,
+  rawBody: true,
+});
+```
+
+기본값은 1 MiB 제한의 MIME 기반 파싱입니다. Factory는 저비용 metadata snapshot을
+생성하고 HTTP middleware/guard 이전 dispatch 경계에서 body를 한 번 materialize합니다.
+Text/custom 정책도 header 변경 없이 bounded UTF-8 decoding과 정확한 raw byte를
+유지하며 생성 시점의 Content-Length를 사용합니다. 기존 default 동작은 유지합니다.
+Web helper는 기본적으로 clone을 읽어 원본을 읽을 수 있게 남깁니다. Next는 의도적으로
+`consumeOriginalBody: true`를 사용하므로 Request 재구성이나 clone 우회가 필요 없습니다.
+다른 factory/adapter가 제공한 이미 파싱된 host body는 이 Web parser에 전달하지 않습니다.
+
+Callback/default 위임, 빈 body와 부재, abort 협력, 인증 순서, adapter capability는
+[HTTP parser 계약](../http/README.ko.md#bounded-body-parser-policy)을 참고하세요.
+근거: `src/web-body-parser.test.ts`, `src/web-body-limit.test.ts`,
+[Next production 예제](../platform-nextjs/e2e/fixture/backend.ts).

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -512,3 +512,36 @@ failure and reports cleanup failures through `ApplicationLogger`.
 - [examples/minimal](../../examples/minimal): Smallest possible bootstrap.
 - [examples/realworld-api](../../examples/realworld-api): Full application with complex module wiring.
 - [packages/runtime/src/bootstrap.test.ts](./src/bootstrap.test.ts): Behavioral tests for bootstrap phases.
+
+## Bounded Body Parsing
+
+The HTTP-owned `BodyParser` policy is available as `bodyParser` on
+`CreateWebRequestResponseFactoryOptions` and `DispatchWebRequestOptions` from
+`@fluojs/runtime/web`, and as the final optional argument of
+`createWebFrameworkRequest(request, signal, multipart, maxBodySize, rawBody, bodyParser)`.
+A supplied dispatch `factory` owns its parsing configuration and takes precedence.
+
+```typescript
+import { createWebRequestResponseFactory } from '@fluojs/runtime/web';
+
+const factory = createWebRequestResponseFactory({
+  bodyParser: 'text',
+  maxBodySize: 1_048_576,
+  rawBody: true,
+});
+```
+
+The default remains MIME-based parsing with a 1 MiB limit. The factory creates a
+cheap metadata snapshot and materializes the body once at dispatch, before HTTP
+middleware/guards. Text/custom policies retain bounded UTF-8 decoding and exact
+raw bytes without header changes; they use the creation-time Content-Length.
+Default behavior is unchanged. Web helpers read a clone by default, leaving the
+original readable; Next deliberately sets `consumeOriginalBody: true`, avoiding
+any Request reconstruction or clone workaround. Host-parsed bodies supplied by
+other factories/adapters are not routed through this Web parser.
+
+For callback/default delegation, empty/absent bodies, abort cooperation,
+authentication order, and adapter capabilities, see the
+[HTTP parser contract](../http/README.md#bounded-body-parser-policy).
+Evidence: `src/web-body-parser.test.ts`, `src/web-body-limit.test.ts`, and the
+[Next production example](../platform-nextjs/e2e/fixture/backend.ts).

--- a/packages/runtime/src/web-body-parser.test.ts
+++ b/packages/runtime/src/web-body-parser.test.ts
@@ -1,0 +1,190 @@
+import type { BodyParserContext } from '@fluojs/http';
+import bodyParserCases from '../../../tooling/testing/body-parser-cases.json';
+import { describe, expect, it, vi } from 'vitest';
+import { createWebFrameworkRequest, createWebRequestResponseFactory, dispatchWebRequest } from './web.js';
+
+function request(body?: BodyInit, headers: Record<string, string> = {}) {
+  return new Request('https://parser.test/posts?draft=1', {
+    method: 'POST', body, headers: { 'content-type': 'application/json', ...headers }, duplex: 'half',
+  } as RequestInit & { duplex: 'half' });
+}
+
+describe('bounded Web body parser policy', () => {
+  it.each(bodyParserCases)('returns exact text for %j with %s without changing metadata', async (text, mime) => {
+    const raw = request(text, { 'content-type': mime, 'x-original': 'yes' });
+    const factory = createWebRequestResponseFactory({ bodyParser: 'text', rawBody: true });
+    const normalized = await factory.createRequest(raw, raw.signal);
+    expect(raw.bodyUsed).toBe(false);
+    expect(normalized.body).toBeUndefined();
+    await factory.materializeRequest?.(normalized);
+    expect(normalized.body).toBe(text);
+    expect(normalized.rawBody).toEqual(new TextEncoder().encode(text));
+    expect(normalized.raw).toBe(raw);
+    expect(normalized.headers['content-type']).toBe(mime);
+    expect(raw.headers.get('content-type')).toBe(mime);
+    expect(raw.headers.get('x-original')).toBe('yes');
+    await expect(raw.text()).resolves.toBe(text);
+  });
+
+  it('lets a path-specific callback delegate unchanged MIME behavior to the default parser', async () => {
+    const bodyParser = (text: string, context: BodyParserContext) =>
+      context.path === '/posts' ? text : context.parseDefault();
+    for (const [path, body, expected] of [
+      ['/posts', '{', '{'], ['/other', '{"ok":true}', { ok: true }],
+    ] as const) {
+      const raw = new Request(`https://parser.test${path}`, {
+        method: 'POST', body, headers: { 'content-type': 'application/json' },
+      });
+      const normalized = await createWebFrameworkRequest(raw, raw.signal, undefined, 100, false, bodyParser);
+      expect(normalized.body).toEqual(expected);
+    }
+    const malformed = new Request('https://parser.test/other', {
+      method: 'POST', body: '{', headers: { 'content-type': 'application/json' },
+    });
+    await expect(createWebFrameworkRequest(malformed, malformed.signal, undefined, 100, false, bodyParser))
+      .rejects.toMatchObject({ status: 400 });
+  });
+
+  it.each([false, 'json-or-null', {}, 1, null])('rejects invalid JavaScript parser option %j during setup', (bodyParser) => {
+    expect(() => Reflect.apply(createWebRequestResponseFactory, undefined, [{ bodyParser }])).toThrow(TypeError);
+  });
+
+  it('keeps absent bodies undefined and does not call a custom parser', async () => {
+    const bodyParser = vi.fn(() => 'unexpected');
+    const factory = createWebRequestResponseFactory({ bodyParser });
+    const raw = request();
+    const normalized = await factory.createRequest(raw, raw.signal);
+    await factory.materializeRequest?.(normalized);
+    expect(normalized.body).toBeUndefined();
+    expect(bodyParser).not.toHaveBeenCalled();
+  });
+
+  it('invokes an async custom parser once with creation-time metadata, including limits', async () => {
+    const bodyParser = vi.fn(async (text: string, context: BodyParserContext) => ({ text, path: context.path }));
+    const raw = request('abc', { 'content-length': '3' });
+    const factory = createWebRequestResponseFactory({ bodyParser, maxBodySize: 3, rawBody: true });
+    const normalized = await factory.createRequest(raw, raw.signal);
+    expect(bodyParser).not.toHaveBeenCalled();
+    raw.headers.set('content-type', 'text/plain');
+    raw.headers.set('content-length', '999');
+    await Promise.all([factory.materializeRequest?.(normalized), factory.materializeRequest?.(normalized)]);
+    await factory.materializeRequest?.(normalized);
+    expect(bodyParser).toHaveBeenCalledTimes(1);
+    expect(bodyParser).toHaveBeenCalledWith('abc', expect.objectContaining({
+      contentType: 'application/json', path: '/posts', method: 'POST', signal: raw.signal,
+      headers: expect.objectContaining({ 'content-length': '3' }),
+    }));
+    expect(normalized.body).toEqual({ text: 'abc', path: '/posts' });
+    expect(normalized.rawBody).toEqual(new TextEncoder().encode('abc'));
+  });
+
+  it.each(['text', vi.fn(() => 'unreachable')] as const)('enforces UTF-8 bytes before %s parsing', async (bodyParser) => {
+    const response = await dispatchWebRequest({
+      bodyParser, maxBodySize: 2, request: request('한'),
+      dispatcher: { dispatch: vi.fn(() => { throw new Error('must not dispatch'); }) },
+    });
+    expect(response.status).toBe(413);
+    if (typeof bodyParser === 'function') expect(bodyParser).not.toHaveBeenCalled();
+  });
+
+  it('rejects an oversized snapshotted content length before consuming bytes', async () => {
+    const raw = request('a', { 'content-length': '4' });
+    const factory = createWebRequestResponseFactory({ bodyParser: 'text', maxBodySize: 3 });
+    const normalized = await factory.createRequest(raw, raw.signal);
+    raw.headers.delete('content-length');
+    await expect(factory.materializeRequest?.(normalized)).rejects.toMatchObject({ status: 413 });
+    expect(raw.bodyUsed).toBe(false);
+  });
+
+  it('cancels a pending opt-in read on the framework signal without invoking the parser', async () => {
+    let resolveReading!: () => void;
+    const reading = new Promise<void>((resolve) => { resolveReading = resolve; });
+    let resolveCancelled!: (reason: unknown) => void;
+    const cancelled = new Promise<unknown>((resolve) => { resolveCancelled = resolve; });
+    const abort = new AbortController();
+    const raw = request(new ReadableStream<Uint8Array>({
+      pull() { resolveReading(); }, cancel(reason) { resolveCancelled(reason); },
+    }, { highWaterMark: 0 }));
+    const bodyParser = vi.fn(() => 'unexpected');
+    const factory = createWebRequestResponseFactory({ bodyParser, consumeOriginalBody: true });
+    const normalized = await factory.createRequest(raw, abort.signal);
+    const reason = new Error('cancel parser');
+    const rejected = expect(factory.materializeRequest?.(normalized)).rejects.toBe(reason);
+    await reading;
+    abort.abort(reason);
+    await rejected;
+    await expect(cancelled).resolves.toBe(reason);
+    expect(bodyParser).not.toHaveBeenCalled();
+  }, 2_000);
+
+  it('rejects a pre-aborted opt-in body before reading or parsing it', async () => {
+    const abort = new AbortController();
+    const reason = new Error('already aborted');
+    abort.abort(reason);
+    const bodyParser = vi.fn(() => 'unexpected');
+    const factory = createWebRequestResponseFactory({ bodyParser, consumeOriginalBody: true });
+    const raw = request('abc');
+    const normalized = await factory.createRequest(raw, abort.signal);
+    await expect(factory.materializeRequest?.(normalized)).rejects.toBe(reason);
+    expect(raw.bodyUsed).toBe(false);
+    expect(bodyParser).not.toHaveBeenCalled();
+  });
+
+  it('does not assign a custom async result after cancellation', async () => {
+    let started!: () => void;
+    const entered = new Promise<void>((resolve) => { started = resolve; });
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    const abort = new AbortController();
+    const bodyParser = async (_text: string, { signal }: BodyParserContext) => {
+      signal.addEventListener('abort', release, { once: true });
+      started();
+      try { await gate; return 'must not assign'; }
+      finally { signal.removeEventListener('abort', release); }
+    };
+    const factory = createWebRequestResponseFactory({ bodyParser, consumeOriginalBody: true });
+    const raw = request('abc');
+    const normalized = await factory.createRequest(raw, abort.signal);
+    const reason = new Error('cancel callback');
+    const rejected = expect(factory.materializeRequest?.(normalized)).rejects.toBe(reason);
+    await entered;
+    abort.abort(reason);
+    await rejected;
+    expect(normalized.body).toBeUndefined();
+  }, 2_000);
+
+  it('memoizes parser failures instead of consuming again', async () => {
+    const failure = new Error('custom parser failure');
+    const bodyParser = vi.fn(() => { throw failure; });
+    const factory = createWebRequestResponseFactory({ bodyParser, consumeOriginalBody: true });
+    const raw = request('value');
+    const normalized = await factory.createRequest(raw, raw.signal);
+    await expect(factory.materializeRequest?.(normalized)).rejects.toBe(failure);
+    await expect(factory.materializeRequest?.(normalized)).rejects.toBe(failure);
+    expect(bodyParser).toHaveBeenCalledTimes(1);
+    await expect(raw.text()).rejects.toBeInstanceOf(TypeError);
+  });
+
+  it('rejects an already consumed native body without invoking the parser', async () => {
+    const raw = request('value');
+    await raw.text();
+    const bodyParser = vi.fn(() => 'unexpected');
+    const factory = createWebRequestResponseFactory({ bodyParser, consumeOriginalBody: true });
+    const normalized = await factory.createRequest(raw, raw.signal);
+    await expect(factory.materializeRequest?.(normalized)).rejects.toBeInstanceOf(TypeError);
+    expect(bodyParser).not.toHaveBeenCalled();
+  });
+
+  it('does not replace multipart parsing or capture multipart rawBody', async () => {
+    const form = new FormData();
+    form.set('title', 'post');
+    const raw = new Request('https://parser.test/posts', { method: 'POST', body: form });
+    const bodyParser = vi.fn(() => 'unexpected');
+    const factory = createWebRequestResponseFactory({ bodyParser, rawBody: true });
+    const normalized = await factory.createRequest(raw, raw.signal);
+    await factory.materializeRequest?.(normalized);
+    expect(normalized.body).toEqual({ title: 'post' });
+    expect(normalized.rawBody).toBeUndefined();
+    expect(bodyParser).not.toHaveBeenCalled();
+  });
+});

--- a/packages/runtime/src/web.ts
+++ b/packages/runtime/src/web.ts
@@ -1,5 +1,7 @@
 import {
   BadRequestException,
+  type BodyParser,
+  type BodyParserContext,
   createErrorResponse,
   type Dispatcher,
   type FrameworkRequest,
@@ -34,6 +36,8 @@ const REQUEST_BODY_LIMIT_MESSAGE = 'Request body exceeds the size limit.';
  * Configures Web request parsing, multipart handling, and raw body preservation.
  */
 export interface CreateWebRequestResponseFactoryOptions {
+  /** HTTP-owned non-multipart parser policy. Omission preserves MIME-based parsing. */
+  bodyParser?: BodyParser;
   consumeOriginalBody?: boolean;
   maxBodySize?: number;
   multipart?: MultipartOptions;
@@ -54,7 +58,7 @@ export interface DispatchWebRequestOptions extends CreateWebRequestResponseFacto
   /**
    * Factory reused by adapters that share one stable Web parsing configuration across requests.
    *
-   * When provided, the factory owns parsing configuration and `maxBodySize`, `multipart`, and `rawBody` are ignored.
+   * When provided, the factory owns parsing configuration and `bodyParser`, `maxBodySize`, `multipart`, and `rawBody` are ignored.
    */
   factory?: RequestResponseFactory<Request, AbortSignal | undefined, WebFrameworkResponse>;
   request: Request;
@@ -310,6 +314,7 @@ export function createWebRequestResponseFactory(
   options: CreateWebRequestResponseFactoryOptions = {},
 ): RequestResponseFactory<Request, AbortSignal | undefined, WebFrameworkResponse> {
   const maxBodySize = resolveWebMaxBodySize(options.maxBodySize);
+  const bodyParser = resolveWebBodyParser(options.bodyParser);
 
   return {
     async createRequest(request: Request, signal: AbortSignal) {
@@ -320,6 +325,7 @@ export function createWebRequestResponseFactory(
         maxBodySize,
         options.rawBody ?? false,
         options.consumeOriginalBody ?? false,
+        bodyParser,
       );
     },
     materializeRequest(request) {
@@ -406,6 +412,7 @@ export function startWebRequestDispatch({
  * @param multipartOptions - Multipart parser options applied to multipart requests.
  * @param maxBodySize - Maximum allowed non-multipart body size in bytes.
  * @param preserveRawBody - Whether to retain the raw request body bytes.
+ * @param bodyParser - Bounded non-multipart parsing policy; defaults to MIME-based parsing.
  * @returns The normalized framework request used by the dispatcher.
  */
 export async function createWebFrameworkRequest(
@@ -414,6 +421,7 @@ export async function createWebFrameworkRequest(
   multipartOptions?: MultipartOptions,
   maxBodySize = DEFAULT_MAX_BODY_SIZE,
   preserveRawBody = false,
+  bodyParser: BodyParser = 'default',
 ): Promise<FrameworkRequest> {
   const resolvedMaxBodySize = resolveWebMaxBodySize(maxBodySize);
   const frameworkRequest = createDeferredWebFrameworkRequest(
@@ -422,6 +430,8 @@ export async function createWebFrameworkRequest(
     multipartOptions,
     resolvedMaxBodySize,
     preserveRawBody,
+    false,
+    resolveWebBodyParser(bodyParser),
   );
   await materializeWebFrameworkRequestBody(frameworkRequest);
 
@@ -445,6 +455,7 @@ function createDeferredWebFrameworkRequest(
   maxBodySize = DEFAULT_MAX_BODY_SIZE,
   preserveRawBody = false,
   consumeOriginalBody = false,
+  bodyParser: BodyParser = 'default',
 ): FrameworkRequest {
   const url = new URL(request.url);
   const requestHeaders = new Headers(request.headers);
@@ -486,7 +497,10 @@ function createDeferredWebFrameworkRequest(
       return;
     }
 
-    validateWebRequestContentLength(request, maxBodySize);
+    validateWebRequestContentLength(bodyParser === 'default' ? request : { headers: requestHeaders }, maxBodySize);
+    if (bodyParser !== 'default') {
+      signal.throwIfAborted();
+    }
 
     if (!request.body) {
       frameworkRequest.body = undefined;
@@ -499,6 +513,8 @@ function createDeferredWebFrameworkRequest(
       contentType,
       maxBodySize,
       preserveRawBody,
+      bodyParser,
+      { contentType, get headers() { return headers(); }, method, path: url.pathname, signal },
     );
     frameworkRequest.body = bodyResult.body;
 
@@ -558,7 +574,7 @@ function createRequestWithSnapshotMetadata(
   return new Request(url, init);
 }
 
-function validateWebRequestContentLength(request: Request, maxBodySize: number): void {
+function validateWebRequestContentLength(request: Pick<Request, 'headers'>, maxBodySize: number): void {
   const contentLength = request.headers.get('content-length');
 
   if (contentLength === null) {
@@ -570,6 +586,14 @@ function validateWebRequestContentLength(request: Request, maxBodySize: number):
   if (Number.isFinite(parsedContentLength) && parsedContentLength > maxBodySize) {
     throw new PayloadTooLargeException(REQUEST_BODY_LIMIT_MESSAGE);
   }
+}
+
+function resolveWebBodyParser(value: BodyParser | undefined): BodyParser {
+  if (value === undefined) return 'default';
+  if (value !== 'default' && value !== 'text' && typeof value !== 'function') {
+    throw new TypeError('bodyParser must be default, text, or a parser function.');
+  }
+  return value;
 }
 
 function resolveWebMaxBodySize(value: number | undefined): number {
@@ -723,15 +747,35 @@ async function readWebRequestBody(
   request: Request,
   contentType: string | undefined,
   maxBodySize = DEFAULT_MAX_BODY_SIZE,
-  preserveRawBody = false,
+  preserveRawBody: boolean,
+  bodyParser: BodyParser,
+  context: Omit<BodyParserContext, 'parseDefault'>,
 ): Promise<{ body: unknown; rawBody?: Uint8Array }> {
-  validateWebRequestContentLength(request, maxBodySize);
+  if (bodyParser === 'default') {
+    validateWebRequestContentLength(request, maxBodySize);
+  }
 
   if (!request.body) {
     return { body: undefined };
   }
 
-  return parseWebRequestRawBody(await readByteLimitedStream(request.body, maxBodySize), contentType, preserveRawBody);
+  const rawBody = await readByteLimitedStream(
+    request.body, maxBodySize, bodyParser === 'default' ? undefined : context.signal,
+  );
+  if (bodyParser === 'default') {
+    return parseWebRequestRawBody(rawBody, contentType, preserveRawBody);
+  }
+  const text = TEXT_DECODER.decode(rawBody);
+  const body = bodyParser === 'text' ? text : await bodyParser(text, {
+    contentType: context.contentType,
+    get headers() { return context.headers; },
+    method: context.method,
+    path: context.path,
+    signal: context.signal,
+    parseDefault: () => parseWebRequestRawBody(rawBody, contentType, false).body,
+  });
+  context.signal.throwIfAborted();
+  return { body, rawBody: preserveRawBody ? rawBody : undefined };
 }
 
 function parseWebRequestRawBody(
@@ -769,14 +813,22 @@ function parseWebRequestRawBody(
 async function readByteLimitedStream(
   stream: ReadableStream<Uint8Array>,
   maxBodySize: number,
+  signal?: AbortSignal,
 ): Promise<Uint8Array> {
+  signal?.throwIfAborted();
   const reader = stream.getReader();
   const chunks: Uint8Array[] = [];
   let totalSize = 0;
+  const onAbort = () => {
+    // Cancellation must not delay settlement or replace the original failure.
+    void Promise.allSettled([reader.cancel(signal?.reason)]);
+  };
+  signal?.addEventListener('abort', onAbort, { once: true });
 
   try {
     while (true) {
       const { done, value } = await reader.read();
+      signal?.throwIfAborted();
 
       if (done) {
         break;
@@ -795,6 +847,7 @@ async function readByteLimitedStream(
       chunks.push(value);
     }
   } finally {
+    signal?.removeEventListener('abort', onAbort);
     reader.releaseLock();
   }
 

--- a/tooling/governance/verify-platform-consistency-governance.mjs
+++ b/tooling/governance/verify-platform-consistency-governance.mjs
@@ -55,6 +55,27 @@ const manualSseLifecycleRegressionTest =
   'packages/http/src/dispatch/dispatcher-manual-sse-lifecycle.test.ts';
 const httpConnectionIdentityRegressionTest = 'packages/http/src/connection.test.ts';
 const accessLogObserverLifecycleRegressionTest = 'packages/http/src/access-log-observer.test.ts';
+const bodyParserRuntimeSourcePaths = [
+  'packages/http/src/types.ts',
+  'packages/runtime/src/web.ts',
+  'packages/platform-nextjs/src/adapter.ts',
+];
+const bodyParserRegressionEvidence = [
+  'packages/runtime/src/web-body-parser.test.ts',
+  'packages/platform-nextjs/src/body-parser.test.ts',
+  'packages/platform-cloudflare-workers/src/body-parser.test.ts',
+  'packages/platform-nextjs/src/head-routing-public-types.test.ts',
+  'packages/platform-nextjs/e2e/next.test.mjs',
+  'tooling/testing/body-parser-cases.json',
+  'packages/http/README.md',
+  'packages/http/README.ko.md',
+  'packages/runtime/README.md',
+  'packages/runtime/README.ko.md',
+  'packages/platform-nextjs/README.md',
+  'packages/platform-nextjs/README.ko.md',
+  'packages/platform-cloudflare-workers/README.md',
+  'packages/platform-cloudflare-workers/README.ko.md',
+];
 const nextHeadRoutingRegressionEvidence = [
   'packages/http/src/head-routing.test.ts',
   'packages/platform-nextjs/src/head-routing.test.ts',
@@ -1723,6 +1744,13 @@ export function enforceContractCompanionUpdates(changedFiles, migrationGuideSnap
       hasChanged(changedFiles, httpConnectionIdentityRegressionTest)
       || hasChanged(changedFiles, accessLogObserverLifecycleRegressionTest)
     ) {
+      return;
+    }
+    if (bodyParserRuntimeSourcePaths.every((path) => hasChanged(changedFiles, path))) {
+      assert(
+        bodyParserRegressionEvidence.every((path) => hasChanged(changedFiles, path)),
+        `Bounded body parser contract changes must include ${bodyParserRegressionEvidence.join(', ')}.`,
+      );
       return;
     }
     assert(

--- a/tooling/governance/verify-platform-consistency-governance.test.ts
+++ b/tooling/governance/verify-platform-consistency-governance.test.ts
@@ -227,6 +227,89 @@ describe('Next HEAD routing contract companions', () => {
   });
 });
 
+describe('Bounded body parser contract companions', () => {
+  const sources = [
+    'packages/http/src/types.ts',
+    'packages/runtime/src/web.ts',
+    'packages/platform-nextjs/src/adapter.ts',
+  ];
+  const evidence = [
+    'packages/runtime/src/web-body-parser.test.ts',
+    'packages/platform-nextjs/src/body-parser.test.ts',
+    'packages/platform-cloudflare-workers/src/body-parser.test.ts',
+    'packages/platform-nextjs/src/head-routing-public-types.test.ts',
+    'packages/platform-nextjs/e2e/next.test.mjs',
+    'tooling/testing/body-parser-cases.json',
+    'packages/http/README.md',
+    'packages/http/README.ko.md',
+    'packages/runtime/README.md',
+    'packages/runtime/README.ko.md',
+    'packages/platform-nextjs/README.md',
+    'packages/platform-nextjs/README.ko.md',
+    'packages/platform-cloudflare-workers/README.md',
+    'packages/platform-cloudflare-workers/README.ko.md',
+  ];
+  const companions = [
+    'docs/architecture/http-runtime.md',
+    'docs/architecture/http-runtime.ko.md',
+    'docs/CONTEXT.md',
+    'docs/CONTEXT.ko.md',
+    'tooling/governance/verify-platform-consistency-governance.mjs',
+    'tooling/governance/verify-platform-consistency-governance.test.ts',
+    ...sources,
+    ...evidence,
+  ];
+
+  function expectParserFailure(run: () => void): void {
+    expect(run).toThrow(/Bounded body parser contract changes must include/u);
+  }
+
+  it('accepts complete parser-specific runtime, adapter, declaration, and bilingual evidence', () => {
+    expect(() => enforceContractCompanionUpdates(companions)).not.toThrow();
+  });
+
+  it.each(evidence)('rejects missing parser evidence %s', (missing) => {
+    const incomplete = companions.filter((path) => path !== missing);
+    expectParserFailure(() => enforceContractCompanionUpdates(incomplete));
+  });
+
+  it.each(sources)('retains generic lifecycle enforcement without source seam %s', (missing) => {
+    const incomplete = companions.filter((path) => path !== missing);
+    expect(() => enforceContractCompanionUpdates(incomplete)).toThrow(
+      /http-runtime-isolation\.test\.ts/u,
+    );
+  });
+
+  it.each([
+    ['comparison', 'bodyParserRegressionEvidence.every((path) => hasChanged(changedFiles, path))', 'true'],
+    ['branch', 'bodyParserRuntimeSourcePaths.every((path) => hasChanged(changedFiles, path))', 'false'],
+  ])('detects disabled parser %s enforcement', async (label, target, replacement) => {
+    const sourceUrl = new URL('./verify-platform-consistency-governance.mjs', import.meta.url);
+    const source = readFileSync(sourceUrl, 'utf8');
+    expect(source.split(target)).toHaveLength(2);
+    const mutated = source.replace(target, replacement)
+      .replace(/from '(\.[^']+)'/gu, (_match, specifier: string) =>
+        `from '${new URL(specifier, sourceUrl).href}'`)
+      .replaceAll('import.meta.url', JSON.stringify(sourceUrl.href));
+    const governance: Pick<typeof import('./verify-platform-consistency-governance.mjs'), 'enforceContractCompanionUpdates'> =
+      await import(`data:text/javascript;base64,${Buffer.from(mutated).toString('base64')}`);
+
+    for (const missing of evidence) {
+      const incomplete = companions.filter((path) => path !== missing);
+      const run = () => governance.enforceContractCompanionUpdates(
+        incomplete,
+        withUnchangedEmailMigrationSections(unchangedEmailMigrationGuideSnapshots),
+      );
+      if (label === 'branch') {
+        expect(run).toThrow(/http-runtime-isolation\.test\.ts/u);
+      } else {
+        expect(run).not.toThrow();
+      }
+      expect(() => expectParserFailure(run)).toThrowError(expect.objectContaining({ name: 'AssertionError' }));
+    }
+  });
+});
+
 describe('Fastify raw-context README companion classification', () => {
   const readmePaths = [
     'packages/platform-fastify/README.md',

--- a/tooling/testing/body-parser-cases.json
+++ b/tooling/testing/body-parser-cases.json
@@ -1,0 +1,22 @@
+[
+  [
+    "{",
+    "application/json"
+  ],
+  [
+    "{\"ok\":true}",
+    "application/problem+json"
+  ],
+  [
+    "hello",
+    "application/octet-stream"
+  ],
+  [
+    "  ",
+    "application/json"
+  ],
+  [
+    "",
+    "application/json"
+  ]
+]


### PR DESCRIPTION
## Summary

Closes #3715

Content-Type과 native Request를 유지하는 opt-in bounded text/custom body parser를 제공합니다. 기존 기본 JSON/multipart 파싱과 HEAD 정책은 유지합니다.

## Changes

- HTTP가 BodyParser/BodyParserContext를 소유하고 runtime Web helpers가 byte-limited lazy materialization을 구현합니다.
- Next와 기존 Web 옵션을 상속하는 Workers adapter에 정책을 노출합니다.
- context.parseDefault()로 경로별 정책에서 기존 MIME parsing에 위임합니다.
- Raw bytes, 빈/없는 body, metadata snapshot, abort, double consumption과 host-parsed body 소유권을 유지합니다.
- 인증 순서의 실제 경계, adapter capability matrix, wrapper 제거 사용법과 EN/KO companions를 문서화했습니다.
- Parser-specific governance의 positive/negative/mutation 회귀를 포함합니다.

## Testing

Reviewed head: `257275b75753ffe11e73ae1c4f942749a093e2ad`. Contract/code/verification 모두 PASS.

- 네 변경 패키지의 dependency closure build와 typecheck 통과.
- 변경 및 직접 역의존성을 포함한 37개 package suite 통과.
- 관련 HTTP/runtime/website governance, 실제 Next dev/build/start E2E 51개 통과.
- Workers는 실제 fetch adapter와 waitUntil lifecycle을 사용하는 local conformance로 검증했습니다. Deployed isolate 검증이라고 주장하지 않습니다.
- Canonical pnpm verify:docs, pnpm lint, pnpm verify:platform-consistency-governance 통과.
- 최초 runtime/Next/policy RED와 parser governance RED를 보존했습니다.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

`.changeset/bounded-body-parser-policy.md`: HTTP, runtime, platform-nextjs, platform-cloudflare-workers minor. Dependency 필드 변경은 없습니다.

## Public export documentation

- [x] Changed types/functions have TSDoc summaries and applicable parameter/return tags.
- [x] Public declaration regressions use real isolated cold builds/export maps.
- [x] README and native consumer examples explain policy selection and ownership.

## Behavioral contract

- [x] Default MIME/multipart/HEAD behavior is preserved.
- [x] Text mode does not itself authenticate or reorder the pipeline.
- [x] Reading, limits and custom parsing remain before middleware/guards; application-owned later JSON interpretation can follow explicit authentication.
- [x] Cancellation requires custom async parser cooperation; unsupported adapter exposure is explicit.

## Platform consistency governance (SSOT)

- [x] EN/KO READMEs, architecture, CONTEXT, website and Book companions are aligned.
- [x] Shared wire cases cover runtime, Next and Workers.
- [x] Governance checks require parser-specific evidence without removing existing HEAD/generic checks.
