### PR TITLE
Resolve #3716: 입력 정책과 Standard Schema output binding 제공

### DIFF
--- a/.changeset/explicit-schema-input-binding.md
+++ b/.changeset/explicit-schema-input-binding.md
@@ -1,0 +1,19 @@
+---
+"@fluojs/http": minor
+"@fluojs/validation": minor
+"@fluojs/runtime": minor
+---
+
+Add opt-in DTO and route input policies for unknown body fields and non-object
+bodies while preserving strict defaults, dangerous-key rejection, and original
+request visibility for guards and interceptors.
+
+Add createSchemaDto and StandardSchemaBinder for explicit body/path/query
+mappings, transport aliases, repeated-query policies, and typed Standard Schema
+output binding. Add parseStandardSchema to preserve transformed/defaulted output
+and await asynchronous validators without changing validation-only ValidateClass.
+Schema failures, including empty issues arrays, remain explicit failures.
+
+Add a bootstrap binder factory that composes once with the configured default
+binder, preserving global converters for ordinary DTOs. Pure application contexts,
+native parser behavior, and HEAD policies are unchanged.

--- a/.changeset/explicit-schema-input-binding.md
+++ b/.changeset/explicit-schema-input-binding.md
@@ -2,6 +2,7 @@
 "@fluojs/http": minor
 "@fluojs/validation": minor
 "@fluojs/runtime": minor
+"@fluojs/testing": patch
 ---
 
 Add opt-in DTO and route input policies for unknown body fields and non-object
@@ -17,3 +18,6 @@ Schema failures, including empty issues arrays, remain explicit failures.
 Add a bootstrap binder factory that composes once with the configured default
 binder, preserving global converters for ordinary DTOs. Pure application contexts,
 native parser behavior, and HEAD policies are unchanged.
+
+Declare the validation development dependency used by the testing package's
+input conformance suite so package-local typechecking resolves its public types.

--- a/apps/docs/content/docs/guides/validation-serialization.ko.mdx
+++ b/apps/docs/content/docs/guides/validation-serialization.ko.mdx
@@ -9,12 +9,13 @@ description: 안전한 입력과 출력을 위해 명시적인 request DTO와 re
 
 ```txt
 client input
-  -> HTTP binding
-  -> request DTO materialization
-  -> validation rules
+  -> transport parsing / middleware
+  -> guards / interceptor-before (original parsed input)
+  -> HTTP binding / projection
+  -> schema output OR class DTO conversion + validation
   -> service logic
   -> response DTO
-  -> serialization rules
+  -> interceptor-after / serialization rules
   -> client response
 ```
 
@@ -37,6 +38,8 @@ pnpm add @fluojs/validation @fluojs/serialization
 
 HTTP 애플리케이션에서는 보통 `@fluojs/http`와 함께 사용합니다.
 
+입력 정책과 schema mapping의 owner는 [HTTP package README](https://github.com/fluojs/fluo/blob/main/packages/http/README.ko.md#명시적-입력-정책), schema output parsing의 owner는 [validation README](https://github.com/fluojs/fluo/blob/main/packages/validation/README.ko.md#standard-schema-output-parsing), application binder 조합의 owner는 [runtime README](https://github.com/fluojs/fluo/blob/main/packages/runtime/README.ko.md#http-binder-composition)입니다. 아래는 이 계약을 적용하는 사용 예입니다.
+
 ## Request validation
 
 Request validation이 답하는 질문은 하나입니다. **어떤 데이터가 애플리케이션 안으로 들어와도 되는가?**
@@ -48,17 +51,22 @@ Request validation이 답하는 질문은 하나입니다. **어떤 데이터가
 전송 경계에서는 익명 객체 타입보다 DTO class를 선호하세요.
 
 ```ts
+import { FromBody, Optional } from '@fluojs/http';
 import { IsBoolean, IsOptional, IsString, MinLength } from '@fluojs/validation';
 
 export class CreatePostDto {
+  @FromBody()
   @IsString()
   @MinLength(3)
   title = '';
 
+  @FromBody()
   @IsString()
   @MinLength(10)
   body = '';
 
+  @FromBody()
+  @Optional()
   @IsOptional()
   @IsBoolean()
   published?: boolean;
@@ -96,6 +104,18 @@ export class PostsController {
 ```
 
 이 route로 request가 들어오면 HTTP pipeline은 request data를 bind하고, `CreatePostDto` instance를 만들고, validation rule을 적용한 뒤 handler를 호출합니다.
+
+`FromBody`는 출처를 선언합니다. Validation decorator만으로 출처를 추론하지 않습니다. HTTP `Optional`은 source가 없을 때 binding 실패를 생략하며 validation의 `IsOptional`은 `null`/`undefined`일 때 field rule을 건너뜁니다. 명시적 `null`도 거부할 필수 field에는 `IsDefined`를 추가하세요.
+
+### 원본을 보존하는 입력 정책
+
+기본 body policy는 `{ unknownFields: 'reject', nonObjects: 'reject' }`입니다. DTO 클래스나 route method에 `@InputPolicy({ unknownFields: 'strip' })`를 선언하면 알려진 body source key만 binding에 전달합니다. Alias도 허용 목록에 반영됩니다. 일반 클래스 DTO에는 schema binder를 설치할 필요가 없습니다.
+
+Route가 명시한 policy field만 DTO field보다 우선합니다. `strip`만으로 배열이나 원시 body를 허용하지 않습니다. 필요한 소비자만 `nonObjects: 'empty'`를 별도로 선택하며, 그 경우에도 필수 class binding은 `MISSING_FIELD`로 실패할 수 있습니다. `null`과 absent body의 기존 누락 동작은 유지합니다. 위험한 own enumerable body key인 `__proto__`, `constructor`, `prototype`은 policy와 무관하게 계속 차단합니다.
+
+Projection은 shallow binding-local view를 사용하며 `RequestContext.request.body`를 교체하지 않습니다. Guard와 interceptor-before는 원래 parsed input을 보고, 이후 binding/projection, schema parsing 또는 converter와 클래스 검증, handler/service, interceptor-after 순서로 진행합니다. 이후 context reader도 원래 body를 봅니다. 검증된 handler 인수를 얻기 위해 context getter로 돌아가지 마세요.
+
+Guard에서 원본으로 인증하고, 검증된 입력이 필요한 업무 인가는 handler/service에서 서버가 확인한 identity와 함께 수행합니다. Projection 자체는 authorization이 아닙니다. Conditional request는 guard 이후 interceptor 이전에 완료될 수 있고, parser 오류와 byte limit은 여전히 guard보다 먼저 적용됩니다. Native parser와 HEAD policy는 바뀌지 않습니다. 표준·legacy 선언 및 조합 decorator의 정확한 계약은 HTTP owner를 참고하세요.
 
 ### `materialize()` vs `validate()`
 
@@ -173,10 +193,12 @@ fluo validation은 의도적으로 엄격합니다. Transport layer가 `'42'`를
 변환은 변환 책임이 있는 경계에서 명시적으로 수행하세요.
 
 ```ts
-import { Controller, Get, RequestDto } from '@fluojs/http';
+import { Controller, FromQuery, Get, Optional, RequestDto } from '@fluojs/http';
 import { IsOptional, IsString } from '@fluojs/validation';
 
 class ListPostsQueryDto {
+  @FromQuery()
+  @Optional()
   @IsOptional()
   @IsString()
   page = '1';
@@ -244,11 +266,76 @@ class RestrictedUserDto {
 }
 ```
 
+`ValidateClass`는 검증 전용입니다. Schema의 trim, coercion, default가 성공해도 기존 DTO의 field를 그 output으로 교체하지 않으며 기존 `issues: []` 성공 동작도 유지합니다.
+
+### Standard Schema output을 handler에 전달하기
+
+이미 schema를 소유한 앱은 `createSchemaDto`와 `StandardSchemaBinder`를 선택할 수 있습니다. 별도의 projection interceptor, `safeParse` guard, context 저장/getter 대신 성공 output을 handler 인수로 받습니다. 다음은 기존 controller를 교체하지 않는 독립 preview application 예제입니다. Fluo decorator build 설정과 `@fluojs/core`, `@fluojs/http`, `@fluojs/runtime`, `@fluojs/platform-nodejs`, Zod 4가 필요합니다. Zod는 예시 vendor이며 다른 Standard Schema v1 구현도 지원합니다.
+
+```ts
+import { Module } from '@fluojs/core';
+import {
+  Controller, createSchemaDto, Post, RequestDto, StandardSchemaBinder,
+} from '@fluojs/http';
+import { createNodejsAdapter } from '@fluojs/platform-nodejs';
+import { FluoFactory } from '@fluojs/runtime';
+import { z } from 'zod';
+
+const PreviewRequest = createSchemaDto(z.object({
+  title: z.string().trim().min(1),
+  count: z.coerce.number().int().positive().default(1),
+  id: z.string().regex(/^[1-9][0-9]*$/)
+    .transform(Number).refine(Number.isSafeInteger),
+  tags: z.union([z.string(), z.array(z.string())])
+    .transform((value) => typeof value === 'string' ? [value] : value)
+    .default([]),
+}), {
+  fields: {
+    title: { source: 'body', key: 'post_title' },
+    count: { source: 'body' },
+    id: { source: 'path', key: 'postId' },
+    tags: { source: 'query', key: 'tag' },
+  },
+  policy: { unknownFields: 'strip' },
+});
+
+@Controller('/previews')
+class PreviewController {
+  @Post('/:postId')
+  @RequestDto(PreviewRequest)
+  preview(input: InstanceType<typeof PreviewRequest>) {
+    return input;
+  }
+}
+
+@Module({ controllers: [PreviewController] })
+class PreviewModule {}
+
+const app = await FluoFactory.create(PreviewModule, {
+  adapter: createNodejsAdapter({ host: '127.0.0.1', port: 3000 }),
+  binder: (defaultBinder) => new StandardSchemaBinder(defaultBinder),
+});
+await app.listen();
+```
+
+`POST /previews/7?tag=a&tag=b`에 `{ "post_title": "  Draft  ", "authorId": "untrusted" }`를 보내면 예상 handler input은 `{ title: 'Draft', count: 1, id: 7, tags: ['a', 'b'] }`이며 기본 POST 성공 상태는 `201`입니다. 이 preview는 저장하거나 인증하지 않습니다. 공개 쓰기 API에서는 서버 identity와 별도 response contract를 연결해야 합니다. Host는 종료 시 `app.close()`를 호출해야 하며 위 bootstrap은 process signal을 자동 등록하지 않습니다.
+
+`fields`의 property는 logical schema input name이고 `key`는 선택적 transport alias입니다. Source는 `body`, `path`, `query`를 명시합니다. 누락된 mapped value는 schema default가 적용되도록 생략하고 명시적 `null`은 전달합니다. 매핑하지 않은 query/path key는 무시하지만 body unknown-field policy는 독립적으로 유지합니다. Schema 자체의 strip 설정은 HTTP가 먼저 거부한 body key를 처리할 수 없습니다.
+
+Query의 `repeatedQuery` 기본값은 `preserve`입니다. Scalar는 scalar로 유지하고 배열은 복사합니다. 위 예제는 그 이후 schema가 두 형태를 배열로 통일합니다. `first`, `last`는 배열의 첫/마지막 값을 선택하고, `reject`는 둘 이상이면 HTTP 400 / `REPEATED_QUERY`를 만듭니다. `reject`의 원소 하나인 배열은 scalar로 바뀌지 않습니다.
+
+`InstanceType<typeof PreviewRequest>`는 변환·기본값을 반영한 schema **output** 타입입니다. 이 opaque `RequestDto` token을 생성자로 호출하면 `InvariantError`가 발생합니다. 상속하거나 mapped-class DTO helper에 넘기지 마세요. Runtime reflected class-field metadata나 자동 OpenAPI schema conversion이 아니므로 기존 클래스 계약이 필요하면 클래스 DTO를 유지하고, schema-token route의 OpenAPI는 명시적으로 작성합니다.
+
+`bootstrapApplication`도 같은 binder factory를 받습니다. Factory는 bootstrap마다 한 번 호출되고 설정된 global converter를 가진 default binder를 받습니다. `StandardSchemaBinder`는 일반 DTO를 그 fallback으로 위임하므로 기존 converter/class-validation 경로가 유지됩니다. Schema token에는 schema conversion을 사용합니다. Pure application context에는 `binder` option이 없습니다.
+
+HTTP 밖에서는 `@fluojs/validation`의 `parseStandardSchema(schema, value)`로 같은 성공 output을 얻습니다. Async validator도 await하며 output을 그대로 반환합니다. `issues: []`를 포함한 failure는 `DtoValidationError`이고 schema binder는 이를 HTTP 400으로 매핑합니다. Malformed result는 `TypeError`, schema 구현 예외는 그대로 전파됩니다. `ValidateClass`의 검증 전용 동작이나 `materialize(..., { undeclaredProperties: 'reject' })`의 클래스 실체화 정책을 바꾸는 API가 아닙니다.
+
 ### Validation API summary
 
 | 영역 | Public API |
 | --- | --- |
 | Engine | `DefaultValidator`, `Validator`, `DtoValidationError`, `ValidationIssue` |
+| Schema output | `parseStandardSchema`; HTTP의 `createSchemaDto`, `StandardSchemaBinder` |
 | Core type decorators | `IsString`, `IsNumber`, `IsBoolean`, `IsDate`, `IsArray`, `IsObject`, `IsEnum`, `IsInt` |
 | Presence and comparison | `IsDefined`, `IsOptional`, `IsEmpty`, `IsNotEmpty`, `Equals`, `NotEquals`, `IsIn`, `IsNotIn` |
 | Strings and network values | `IsEmail`, `IsUrl`, `IsUUID`, `IsIP`, `Matches`, `Length`, `MinLength`, `MaxLength`, `Contains`, `NotContains` |
@@ -443,6 +530,9 @@ Service는 더 풍부한 internal record를 사용할 수 있습니다. Controll
 
 ## Testing checklist
 
+- Strict 기본값, route/DTO policy 우선순위, alias, 위험 key, 배열·원시 body와 `null`/누락을 구분합니다.
+- Guard와 interceptor-before가 원본을 보고 handler가 변환된 output을 받는지 확인합니다. Async schema 완료는 명시적 signal로 기다리고 고정 sleep에 의존하지 않습니다.
+- Repeated query의 네 정책, schema default, HTTP 400과 schema 구현 오류, 일반 DTO fallback을 확인합니다.
 - Invalid request body를 보내 deterministic validation failure를 확인합니다.
 - Optional field, nested DTO path, array, mapped DTO variant를 테스트합니다.
 - Response DTO가 민감한 field를 노출하지 않는지 확인합니다.
@@ -452,6 +542,8 @@ Service는 더 풍부한 internal record를 사용할 수 있습니다. Controll
 
 ## 관련 문서
 
+- [Book: 외부 입력을 내부 데이터로 바꾸기](https://github.com/fluojs/fluo/blob/main/book/01-fluoblog/ch06-request-boundaries.ko.md)
+- [Application 입력 conformance](https://github.com/fluojs/fluo/blob/main/packages/testing/src/input-materialization.e2e.test.ts), [native Next App Router 요청](https://github.com/fluojs/fluo/blob/main/packages/platform-nextjs/src/schema-input-materialization.test.ts), [cold public declaration](https://github.com/fluojs/fluo/blob/main/packages/runtime/src/input-materialization-public-types.test.ts): 회귀 근거 위치이며 위 preview 예제의 실행 결과를 대신하지 않습니다.
 - [HTTP API](./http-api)
 - [Testing](./testing)
 - [Package Selection](./package-selection)

--- a/apps/docs/content/docs/guides/validation-serialization.mdx
+++ b/apps/docs/content/docs/guides/validation-serialization.mdx
@@ -9,12 +9,13 @@ Validation protects the **input** side: unknown request data becomes a named, va
 
 ```txt
 client input
-  -> HTTP binding
-  -> request DTO materialization
-  -> validation rules
+  -> transport parsing / middleware
+  -> guards / interceptor-before (original parsed input)
+  -> HTTP binding / projection
+  -> schema output OR class DTO conversion + validation
   -> service logic
   -> response DTO
-  -> serialization rules
+  -> interceptor-after / serialization rules
   -> client response
 ```
 
@@ -37,6 +38,8 @@ pnpm add @fluojs/validation @fluojs/serialization
 
 HTTP applications usually use these together with `@fluojs/http`.
 
+The [HTTP package README](https://github.com/fluojs/fluo/blob/main/packages/http/README.md#explicit-input-policies) owns input policies and schema mappings, the [validation README](https://github.com/fluojs/fluo/blob/main/packages/validation/README.md#standard-schema-output-parsing) owns schema output parsing, and the [runtime README](https://github.com/fluojs/fluo/blob/main/packages/runtime/README.md#http-binder-composition) owns application binder composition. The examples below apply those contracts.
+
 ## Request validation
 
 Request validation answers one question: **what data is allowed to enter the application?**
@@ -48,17 +51,22 @@ Network input is untrusted. A route body, query string, path parameter, header, 
 Prefer DTO classes at transport boundaries instead of anonymous object types.
 
 ```ts
+import { FromBody, Optional } from '@fluojs/http';
 import { IsBoolean, IsOptional, IsString, MinLength } from '@fluojs/validation';
 
 export class CreatePostDto {
+  @FromBody()
   @IsString()
   @MinLength(3)
   title = '';
 
+  @FromBody()
   @IsString()
   @MinLength(10)
   body = '';
 
+  @FromBody()
+  @Optional()
   @IsOptional()
   @IsBoolean()
   published?: boolean;
@@ -96,6 +104,18 @@ export class PostsController {
 ```
 
 When a request reaches this route, the HTTP pipeline binds request data, creates a `CreatePostDto` instance, applies validation rules, and only then calls the handler.
+
+`FromBody` declares the source; validation decorators alone do not infer it. HTTP `Optional` skips a binding failure when the source is absent, while validation's `IsOptional` skips field rules for `null`/`undefined`. Add `IsDefined` to required fields that must also reject explicit `null`.
+
+### Input policies that preserve the original
+
+The default body policy is `{ unknownFields: 'reject', nonObjects: 'reject' }`. Declare `@InputPolicy({ unknownFields: 'strip' })` on a DTO class or route method to pass only known body source keys into binding. The allowlist includes aliases. Ordinary class DTOs do not require a schema binder.
+
+Only policy fields explicitly declared on a route override DTO fields. `strip` alone does not accept array or primitive bodies. Consumers that need it must separately select `nonObjects: 'empty'`; required class bindings can still fail with `MISSING_FIELD`. Existing missing-value behavior for `null` and absent bodies is preserved. Dangerous own enumerable body keys `__proto__`, `constructor`, and `prototype` remain blocked regardless of policy.
+
+Projection uses a shallow binding-local view and does not replace `RequestContext.request.body`. Guards and interceptor-before code see original parsed input, followed by binding/projection, schema parsing or converters and class validation, handler/service, and interceptor-after. Later context readers also see the original body. Do not route back through a context getter to obtain the validated handler argument.
+
+Authenticate in a guard using the original input, and perform business authorization that needs validated input in the handler/service together with server-verified identity. Projection itself is not authorization. Conditional requests may finish after guards and before interceptors; parser errors and byte limits still apply before guards. Native parser and HEAD policies do not change. See the HTTP owner for the precise standard/legacy declaration and composed-decorator contracts.
 
 ### `materialize()` vs `validate()`
 
@@ -173,10 +193,12 @@ fluo validation is intentionally strict. If the transport layer provides `'42'` 
 Convert values deliberately at the boundary where conversion belongs.
 
 ```ts
-import { Controller, Get, RequestDto } from '@fluojs/http';
+import { Controller, FromQuery, Get, Optional, RequestDto } from '@fluojs/http';
 import { IsOptional, IsString } from '@fluojs/validation';
 
 class ListPostsQueryDto {
+  @FromQuery()
+  @Optional()
   @IsOptional()
   @IsString()
   page = '1';
@@ -244,11 +266,76 @@ class RestrictedUserDto {
 }
 ```
 
+`ValidateClass` is validation-only. Even when schema trimming, coercion, or defaults succeed, it does not replace existing DTO fields with that output, and its existing `issues: []` success behavior remains unchanged.
+
+### Pass Standard Schema output to the handler
+
+Applications that already own a schema can choose `createSchemaDto` and `StandardSchemaBinder`. Receive successful output as the handler argument instead of maintaining a separate projection interceptor, `safeParse` guard, and context storage/getter. The following is an independent preview application, not a replacement for the existing controllers. It requires Fluo's decorator build configuration, `@fluojs/core`, `@fluojs/http`, `@fluojs/runtime`, `@fluojs/platform-nodejs`, and Zod 4. Zod is an example vendor; other Standard Schema v1 implementations are supported.
+
+```ts
+import { Module } from '@fluojs/core';
+import {
+  Controller, createSchemaDto, Post, RequestDto, StandardSchemaBinder,
+} from '@fluojs/http';
+import { createNodejsAdapter } from '@fluojs/platform-nodejs';
+import { FluoFactory } from '@fluojs/runtime';
+import { z } from 'zod';
+
+const PreviewRequest = createSchemaDto(z.object({
+  title: z.string().trim().min(1),
+  count: z.coerce.number().int().positive().default(1),
+  id: z.string().regex(/^[1-9][0-9]*$/)
+    .transform(Number).refine(Number.isSafeInteger),
+  tags: z.union([z.string(), z.array(z.string())])
+    .transform((value) => typeof value === 'string' ? [value] : value)
+    .default([]),
+}), {
+  fields: {
+    title: { source: 'body', key: 'post_title' },
+    count: { source: 'body' },
+    id: { source: 'path', key: 'postId' },
+    tags: { source: 'query', key: 'tag' },
+  },
+  policy: { unknownFields: 'strip' },
+});
+
+@Controller('/previews')
+class PreviewController {
+  @Post('/:postId')
+  @RequestDto(PreviewRequest)
+  preview(input: InstanceType<typeof PreviewRequest>) {
+    return input;
+  }
+}
+
+@Module({ controllers: [PreviewController] })
+class PreviewModule {}
+
+const app = await FluoFactory.create(PreviewModule, {
+  adapter: createNodejsAdapter({ host: '127.0.0.1', port: 3000 }),
+  binder: (defaultBinder) => new StandardSchemaBinder(defaultBinder),
+});
+await app.listen();
+```
+
+For `POST /previews/7?tag=a&tag=b` with `{ "post_title": "  Draft  ", "authorId": "untrusted" }`, the expected handler input is `{ title: 'Draft', count: 1, id: 7, tags: ['a', 'b'] }`, with the default POST success status `201`. This preview neither persists data nor authenticates requests. A public write API must connect server identity and a separate response contract. The host must call `app.close()` during shutdown; this bootstrap does not automatically register process signals.
+
+Each `fields` property is a logical schema input name, and `key` is an optional transport alias. Explicitly select `body`, `path`, or `query` as the source. Missing mapped values are omitted to allow schema defaults; explicit `null` is passed through. Unmapped query/path keys are ignored, but body unknown-field policy remains independent. A schema's own strip setting cannot process body keys that HTTP rejects first.
+
+Query `repeatedQuery` defaults to `preserve`: scalars remain scalars and arrays are copied. The example subsequently uses its schema to normalize both shapes into an array. `first` and `last` select the first/last array value; `reject` produces HTTP 400 / `REPEATED_QUERY` for more than one value. A one-element array under `reject` does not become a scalar.
+
+`InstanceType<typeof PreviewRequest>` is the schema **output** type, including transformations and defaults. Constructing this opaque `RequestDto` token throws `InvariantError`. Do not subclass it or pass it to mapped-class DTO helpers. It is neither runtime reflected class-field metadata nor automatic OpenAPI schema conversion: retain class DTOs when those class contracts are needed, and explicitly document OpenAPI for schema-token routes.
+
+`bootstrapApplication` accepts the same binder factory. It runs once per bootstrap and receives a default binder with configured global converters. `StandardSchemaBinder` delegates ordinary DTOs to that fallback, preserving existing converter/class-validation paths. Schema tokens use schema conversion instead. Pure application contexts have no `binder` option.
+
+Outside HTTP, obtain the same successful output with `parseStandardSchema(schema, value)` from `@fluojs/validation`. It awaits async validators and returns output unchanged. Failures, including `issues: []`, become `DtoValidationError`, which the schema binder maps to HTTP 400. Malformed results throw `TypeError`; schema implementation exceptions propagate unchanged. This API changes neither validation-only `ValidateClass` nor the class materialization policy of `materialize(..., { undeclaredProperties: 'reject' })`.
+
 ### Validation API summary
 
 | Area | Public API |
 | --- | --- |
 | Engine | `DefaultValidator`, `Validator`, `DtoValidationError`, `ValidationIssue` |
+| Schema output | `parseStandardSchema`; HTTP's `createSchemaDto`, `StandardSchemaBinder` |
 | Core type decorators | `IsString`, `IsNumber`, `IsBoolean`, `IsDate`, `IsArray`, `IsObject`, `IsEnum`, `IsInt` |
 | Presence and comparison | `IsDefined`, `IsOptional`, `IsEmpty`, `IsNotEmpty`, `Equals`, `NotEquals`, `IsIn`, `IsNotIn` |
 | Strings and network values | `IsEmail`, `IsUrl`, `IsUUID`, `IsIP`, `Matches`, `Length`, `MinLength`, `MaxLength`, `Contains`, `NotContains` |
@@ -443,6 +530,9 @@ The service can use richer internal records. The public response remains stable 
 
 ## Testing checklist
 
+- Distinguish strict defaults, route/DTO policy precedence, aliases, dangerous keys, array/primitive bodies, and `null`/missing values.
+- Verify that guards and interceptor-before see original input while handlers receive transformed output. Await async schema completion through an explicit signal rather than fixed sleeps.
+- Cover all four repeated-query policies, schema defaults, HTTP 400 versus schema implementation errors, and ordinary DTO fallback.
 - Send invalid request bodies and assert deterministic validation failures.
 - Test optional fields, nested DTO paths, arrays, and mapped DTO variants.
 - Assert that response DTOs do not expose sensitive fields.
@@ -452,6 +542,8 @@ The service can use richer internal records. The public response remains stable 
 
 ## Related reading
 
+- [Book: Turning External Input into Internal Data](https://github.com/fluojs/fluo/blob/main/book/01-fluoblog/ch06-request-boundaries.md)
+- [Application input conformance](https://github.com/fluojs/fluo/blob/main/packages/testing/src/input-materialization.e2e.test.ts), [native Next App Router requests](https://github.com/fluojs/fluo/blob/main/packages/platform-nextjs/src/schema-input-materialization.test.ts), [cold public declarations](https://github.com/fluojs/fluo/blob/main/packages/runtime/src/input-materialization-public-types.test.ts): regression evidence locations, not substitutes for executing the preview example above.
 - [HTTP API](./http-api)
 - [Testing](./testing)
 - [Package Selection](./package-selection)

--- a/book/01-fluoblog/ch06-request-boundaries.ko.md
+++ b/book/01-fluoblog/ch06-request-boundaries.ko.md
@@ -342,6 +342,104 @@ console.log('Request boundary checks passed.');
 
 단, 문자열 길이 검증은 파싱 후의 값 제한이다. 수십 MB의 요청을 먼저 메모리에 읽는 비용까지 이 DTO가 막아 주지는 않는다. 그런 제한은 Fastify의 `maxBodySize` 같은 transport 경계에서 별도로 설정해야 한다. 파일 업로드와 과도한 요청을 다루는 장에서 바이트 제한과 사용 정책을 더한다. 지금의 상한을 전체 서비스 보호 기능으로 과장하지 않는다.
 
+## 선택 실험: 원본을 보존하면서 입력을 투영한다
+
+여기까지의 클래스 DTO 실습과 확인 스크립트는 그대로 유지한다. `/posts`는 계속 알 수 없는 본문 필드를 거부하고, 뒤의 OpenAPI 장도 이 클래스의 바인딩·검증 메타데이터를 사용한다. 다음은 기존 입력 schema가 있는 소비 앱을 위한 **선택적 비교 실험**이지 본문의 최종 구현을 교체하는 지시가 아니다.
+
+### 거부와 제거는 서로 다른 앱 정책이다
+
+추가 필드를 실수로 보내는 클라이언트와 호환해야 한다면 `@fluojs/http`의 `@InputPolicy({ unknownFields: 'strip' })`를 별도 DTO 클래스나 route method에 선언할 수 있다. 기본값은 여전히 `unknownFields: 'reject'`, `nonObjects: 'reject'`다. Route는 명시한 policy field만 DTO 설정보다 우선하며, 생략한 field는 DTO 설정을 유지한다. `@FromBody('post_title')`를 사용했다면 허용 목록의 key는 `title`이 아니라 transport alias `post_title`이다. 일반 클래스 DTO에 이 정책만 적용할 때는 schema binder가 필요하지 않다.
+
+`strip`은 비객체 입력을 숨기는 옵션이 아니다. 배열·원시 값을 빈 binding body로 취급하려는 소비자만 `nonObjects: 'empty'`를 별도로 선택한다. 그 경우에도 필수 클래스 field는 `MISSING_FIELD`로 실패할 수 있다. `null`과 body 부재의 기존 누락 동작은 바뀌지 않는다. 위험한 own enumerable key인 `__proto__`, `constructor`, `prototype`은 `strip`과 `empty`에서도 차단된다. 이는 최상위 입력 경계이며 재귀 sanitizer가 아니다.
+
+본문 전체를 교체하는 projection interceptor와도 구별해야 한다. Framework projection은 binding-local request view만 만들고 `RequestContext.request.body`를 교체하지 않는다. Transport parsing과 middleware 이후, 요청을 계속 처리하는 경로의 순서는 다음과 같다.
+
+```text
+guard: original parsed input
+  -> interceptor-before: original parsed input
+  -> binding / projection
+  -> schema parsing OR converters + class validation
+  -> handler / service
+  -> interceptor-after
+```
+
+설정된 conditional request는 guard 이후, interceptor 이전에 완료될 수 있다. Parser 실패와 byte limit은 여전히 guard보다 먼저 적용된다. 이 기능은 native parser나 HEAD 정책을 바꾸지 않는다. 인증 guard가 확인할 원본과 서비스에 전달할 검증된 인수는 다른 값이며, 이후 context reader도 원래 body를 본다. `strip`은 인증이나 소유자 확인을 대신하지 않는다. 아래 실험도 작성자를 `author-1`로 고정하는 로컬 실습일 뿐이다.
+
+### 기존 schema의 성공 값을 서비스 인수로 받는다
+
+Zod 4를 선택한다면 실습 앱에서 `pnpm add zod@^4`로 설치한다. 다른 Standard Schema v1 vendor도 사용할 수 있다. 다음은 별도로 추가하는 **`src/schema-boundary-app.ts` 전체**다. 기존 `PostsModule`과 서비스를 재사용하지만 새 route는 `/schema-drafts`에만 등록한다.
+
+```ts
+import { Inject, Module } from '@fluojs/core';
+import { Controller, createSchemaDto, HttpCode, Post, RequestDto } from '@fluojs/http';
+import { z } from 'zod';
+import { runPostCommand } from './posts/post-http-error.js';
+import { PostsModule } from './posts/posts.module.js';
+import { PostsService } from './posts/posts.service.js';
+
+const SchemaDraftRequest = createSchemaDto(z.object({
+  title: z.string().max(120).trim(),
+  content: z.string().max(50_000).default(''),
+  slug: z.string().max(80).trim().default(''),
+}), {
+  fields: {
+    title: { source: 'body', key: 'post_title' },
+    content: { source: 'body' },
+    slug: { source: 'body' },
+  },
+  policy: { unknownFields: 'strip' },
+});
+
+@Controller('/schema-drafts')
+@Inject(PostsService)
+class SchemaDraftController {
+  constructor(private readonly posts: PostsService) {}
+
+  @Post()
+  @HttpCode(201)
+  @RequestDto(SchemaDraftRequest)
+  create(input: InstanceType<typeof SchemaDraftRequest>) {
+    return runPostCommand(() => this.posts.create('author-1', {
+      title: input.title, content: input.content, slug: input.slug,
+    }));
+  }
+}
+
+@Module({
+  imports: [PostsModule],
+  controllers: [SchemaDraftController],
+})
+export class SchemaBoundaryModule {}
+```
+
+Title은 기존 실습처럼 원문 길이를 먼저 제한하고 그다음 trim한다. 반면 `content`, `slug` 누락에 빈 문자열을 주는 것은 이 실험에서 선택한 별도 앱 계약이다. Binder가 누락된 mapping을 schema input에서 생략하므로 schema default가 동작한다. 명시적 `null`은 누락으로 바꾸지 않고 schema에 전달하므로 위 문자열 schema에서는 실패한다.
+
+다음은 선택 실험용 **`src/schema-boundary-main.ts` 전체**다. 기존 CLI/Vite 실행 설정의 entry를 이 파일로 선택하고 기존 서버와 동시에 같은 port에서 실행하지 않는다. 본문의 `src/main.ts`는 수정하지 않는다.
+
+```ts
+import { ensureMetadataSymbol } from '@fluojs/core';
+import { StandardSchemaBinder } from '@fluojs/http';
+import { createFastifyAdapter } from '@fluojs/platform-fastify';
+import { bootstrapApplication } from '@fluojs/runtime';
+
+ensureMetadataSymbol();
+const { SchemaBoundaryModule } = await import('./schema-boundary-app.js');
+const app = await bootstrapApplication({
+  rootModule: SchemaBoundaryModule,
+  adapter: createFastifyAdapter({ host: '127.0.0.1', port: 3000 }),
+  binder: (defaultBinder) => new StandardSchemaBinder(defaultBinder),
+});
+await app.listen();
+```
+
+이 adapter-first 예제는 종료 signal을 자동 등록하지 않는다. 실행 host가 종료 시 `await app.close()`를 호출하거나 Node shutdown registration을 연결해야 한다. `FluoFactory.create(SchemaBoundaryModule, options)`도 같은 `binder` option을 받는다. Factory는 bootstrap마다 한 번 조합되며, 제공받은 default binder에는 설정된 global converter가 포함된다. 일반 DTO는 이 fallback으로 위임되므로 기존 `/posts/:id`의 `PostIdConverter`와 클래스 검증은 유지된다. 순수 application context에는 이 HTTP option이 없다.
+
+Listen 완료 후 `POST /schema-drafts`에 `{ "post_title": "  Draft  ", "authorId": "other-author" }`를 보내면 예상 결과는 `201`이다. Service는 `{ title: 'Draft', content: '', slug: '' }`를 받고 작성자는 계속 서버의 `author-1`이다. 별도 projection interceptor, `safeParse` guard, context 저장/getter 없이 handler 인수가 성공한 schema output이 된다. 동일한 추가 필드를 기존 `/posts`에 보내면 여전히 `UNKNOWN_FIELD`로 실패한다. 새 route에 배열 body를 보내면 `INVALID_BODY`, 제목을 생략하면 schema 검증 실패로 `400`이 된다. 이 원고는 이 선택 실험을 실행했다고 주장하지 않는다.
+
+`InstanceType<typeof SchemaDraftRequest>`는 schema input이 아니라 **output** 타입이다. Token을 `new`로 호출하면 `InvariantError`가 발생한다. 상속하거나 `PickType`, `OmitType`, `PartialType`, `IntersectionType`에 넘기지 않는다. Token은 reflected class-field metadata나 자동 OpenAPI schema conversion이 아니므로, 이 실험을 공개 API로 채택할 때는 요청 schema도 별도로 문서화해야 한다. 본문의 클래스 DTO를 유지하는 이유다.
+
+`@ValidateClass(schema)`는 계속 검증 전용이며 trim/default 결과로 기존 DTO를 교체하지 않는다. HTTP 밖에서 성공 값을 얻으려면 `@fluojs/validation`의 `parseStandardSchema(schema, value)`를 await한다. Schema binder도 이 parser로 async validator를 기다린 뒤 handler를 호출한다. `issues: []`를 포함한 schema failure는 `DtoValidationError`이고 HTTP에서는 `400`으로 바뀐다. 기존 `ValidateClass`의 empty-issues 성공 동작은 유지된다. Malformed schema result는 `TypeError`, schema 구현이 던진 예외는 그대로 전파되므로 서버 결함을 정상적인 입력 거부로 숨기지 않는다.
+
 ## 명령을 작게 만들면 다음 경계가 보인다
 
 완성된 입력 경계는 클라이언트에게 서버 상태를 고를 권한을 주지 않는다. 변환기는 URL 표기를 정규화하고, DTO는 필요한 데이터의 모양을 검증하며, 서비스는 초안·발행 규칙을 지킨다. 각 계층의 오류를 한곳에서 HTTP로 번역하므로 프레임워크를 바꿔도 도메인의 의미를 유지할 수 있다.
@@ -352,6 +450,9 @@ console.log('Request boundary checks passed.');
 
 ## 근거와 이어 읽기
 
+- [HTTP 입력 정책과 schema binding 계약](../../packages/http/README.ko.md#명시적-입력-정책), [schema output parser 계약](../../packages/validation/README.ko.md#standard-schema-output-parsing), [runtime binder 조합 계약](../../packages/runtime/README.ko.md#http-binder-composition): 선택 실험의 API owner다.
+- [입력 정책·mapping 테스트](../../packages/http/src/input-materialization.test.ts), [schema output 테스트](../../packages/validation/src/standard-schema-output.test.ts), [application 경계 테스트](../../packages/testing/src/input-materialization.e2e.test.ts): projection, 원본 guard, 변환 결과, fallback의 회귀 확인 위치다.
+- [Next App Router native 요청 테스트](../../packages/platform-nextjs/src/schema-input-materialization.test.ts), [cold public declaration 테스트](../../packages/runtime/src/input-materialization-public-types.test.ts): 실제 adapter와 공개 타입의 근거 위치이며, 위 Book 실습을 실행했다는 뜻은 아니다.
 - [`@fluojs/http` README](../../packages/http/README.ko.md), [공개 export](../../packages/http/src/index.portable.ts): `RequestDto`, `FromBody`, `FromPath`, `Convert`, `HttpCode`의 공개 경로다.
 - [기본 바인더](../../packages/http/src/adapters/binding.ts)와 [바인딩 테스트](../../packages/http/src/adapters/binding.test.ts): 알 수 없는 본문 key, 필수 출처, 변환기 해석의 근거다.
 - [핸들러 호출 정책](../../packages/http/src/dispatch/dispatch-handler-policy.ts), [HTTP 검증 어댑터](../../packages/http/src/adapters/dto-validation-adapter.ts): 바인딩 뒤 검증과 `400` 번역을 확인할 수 있다.

--- a/book/01-fluoblog/ch06-request-boundaries.md
+++ b/book/01-fluoblog/ch06-request-boundaries.md
@@ -342,6 +342,104 @@ Sending an array as the body makes the default binder reject a violation of the 
 
 String length validation, however, limits values after parsing. This DTO does not prevent the cost of first reading a request of tens of MB into memory. Such limits must be configured separately at the transport boundary, using an option such as Fastify's `maxBodySize`. The chapters on file uploads and excessive requests will add byte limits and usage policies. Do not overstate the current limits as protection for the entire service.
 
+## Optional Experiment: Project Input While Preserving the Original
+
+Keep the class DTO exercise and check script above unchanged. `/posts` still rejects unknown body fields, and the later OpenAPI chapter still uses these classes' binding and validation metadata. The following is an **optional comparison experiment** for a consumer app with an existing input schema, not an instruction to replace the chapter's final implementation.
+
+### Rejection and Removal Are Different Application Policies
+
+When compatibility with clients that send extra fields is intentional, declare `@InputPolicy({ unknownFields: 'strip' })` from `@fluojs/http` on a separate DTO class or route method. The defaults remain `unknownFields: 'reject'` and `nonObjects: 'reject'`. A route overrides only explicitly declared policy fields; omitted fields retain the DTO settings. With `@FromBody('post_title')`, the allowlist key is the transport alias `post_title`, not `title`. Applying this policy alone to an ordinary class DTO does not require a schema binder.
+
+`strip` does not hide non-object input. Only consumers that intend to treat arrays or primitives as an empty binding body should separately select `nonObjects: 'empty'`. Required class fields can still fail with `MISSING_FIELD`. Existing missing-value behavior for `null` and absent bodies is unchanged. Dangerous own enumerable keys `__proto__`, `constructor`, and `prototype` remain blocked with both `strip` and `empty`. This is a top-level input boundary, not a recursive sanitizer.
+
+Distinguish this from a projection interceptor that replaces the entire body. Framework projection creates only a binding-local request view and does not replace `RequestContext.request.body`. After transport parsing and middleware, the path that continues processing follows this order:
+
+```text
+guard: original parsed input
+  -> interceptor-before: original parsed input
+  -> binding / projection
+  -> schema parsing OR converters + class validation
+  -> handler / service
+  -> interceptor-after
+```
+
+Configured conditional requests may finish after guards and before interceptors. Parser failures and byte limits still apply before guards. This feature changes neither native parser nor HEAD policies. The original input inspected by an authentication guard and the validated argument passed to a service are different values; later context readers also see the original body. `strip` does not replace authentication or ownership checks. The experiment below is still only a local exercise with the author fixed to `author-1`.
+
+### Receive an Existing Schema's Successful Value as a Service Argument
+
+If you choose Zod 4, install it in the exercise app with `pnpm add zod@^4`. Other Standard Schema v1 vendors are also supported. The following is the complete additional **`src/schema-boundary-app.ts` file**. It reuses the existing `PostsModule` and service but registers the new route only at `/schema-drafts`.
+
+```ts
+import { Inject, Module } from '@fluojs/core';
+import { Controller, createSchemaDto, HttpCode, Post, RequestDto } from '@fluojs/http';
+import { z } from 'zod';
+import { runPostCommand } from './posts/post-http-error.js';
+import { PostsModule } from './posts/posts.module.js';
+import { PostsService } from './posts/posts.service.js';
+
+const SchemaDraftRequest = createSchemaDto(z.object({
+  title: z.string().max(120).trim(),
+  content: z.string().max(50_000).default(''),
+  slug: z.string().max(80).trim().default(''),
+}), {
+  fields: {
+    title: { source: 'body', key: 'post_title' },
+    content: { source: 'body' },
+    slug: { source: 'body' },
+  },
+  policy: { unknownFields: 'strip' },
+});
+
+@Controller('/schema-drafts')
+@Inject(PostsService)
+class SchemaDraftController {
+  constructor(private readonly posts: PostsService) {}
+
+  @Post()
+  @HttpCode(201)
+  @RequestDto(SchemaDraftRequest)
+  create(input: InstanceType<typeof SchemaDraftRequest>) {
+    return runPostCommand(() => this.posts.create('author-1', {
+      title: input.title, content: input.content, slug: input.slug,
+    }));
+  }
+}
+
+@Module({
+  imports: [PostsModule],
+  controllers: [SchemaDraftController],
+})
+export class SchemaBoundaryModule {}
+```
+
+As in the existing exercise, the title's raw length is limited before trimming. Supplying empty strings for missing `content` and `slug`, however, is a separate application contract chosen for this experiment. The binder omits missing mappings from schema input, allowing schema defaults to run. Explicit `null` is passed to the schema rather than treated as missing, so it fails the string schemas above.
+
+The following is the complete optional **`src/schema-boundary-main.ts` file**. Select this file as the entry in the existing CLI/Vite execution configuration, and do not run it on the same port alongside the existing server. Leave the chapter's `src/main.ts` unchanged.
+
+```ts
+import { ensureMetadataSymbol } from '@fluojs/core';
+import { StandardSchemaBinder } from '@fluojs/http';
+import { createFastifyAdapter } from '@fluojs/platform-fastify';
+import { bootstrapApplication } from '@fluojs/runtime';
+
+ensureMetadataSymbol();
+const { SchemaBoundaryModule } = await import('./schema-boundary-app.js');
+const app = await bootstrapApplication({
+  rootModule: SchemaBoundaryModule,
+  adapter: createFastifyAdapter({ host: '127.0.0.1', port: 3000 }),
+  binder: (defaultBinder) => new StandardSchemaBinder(defaultBinder),
+});
+await app.listen();
+```
+
+This adapter-first example does not automatically register shutdown signals. The execution host must call `await app.close()` during shutdown or install Node shutdown registration. `FluoFactory.create(SchemaBoundaryModule, options)` accepts the same `binder` option. The factory composes once per bootstrap, and the supplied default binder includes configured global converters. Ordinary DTOs delegate to that fallback, preserving the existing `/posts/:id` route's `PostIdConverter` and class validation. Pure application contexts do not expose this HTTP option.
+
+After listening completes, send `{ "post_title": "  Draft  ", "authorId": "other-author" }` to `POST /schema-drafts`; the expected status is `201`. The service receives `{ title: 'Draft', content: '', slug: '' }`, and the author remains the server's `author-1`. The handler argument becomes successful schema output without a separate projection interceptor, `safeParse` guard, or context storage/getter. Sending the same extra field to the existing `/posts` route still fails with `UNKNOWN_FIELD`. An array body on the new route fails with `INVALID_BODY`; omitting the title produces a schema validation failure and `400`. This manuscript does not claim that this optional experiment was executed.
+
+`InstanceType<typeof SchemaDraftRequest>` is the schema **output** type, not its input type. Calling the token with `new` throws `InvariantError`. Do not subclass it or pass it to `PickType`, `OmitType`, `PartialType`, or `IntersectionType`. The token is neither reflected class-field metadata nor automatic OpenAPI schema conversion, so adopting this experiment as a public API also requires explicitly documenting its request schema. This is why the chapter retains its class DTOs.
+
+`@ValidateClass(schema)` remains validation-only and does not replace the existing DTO with trim/default results. Outside HTTP, await `parseStandardSchema(schema, value)` from `@fluojs/validation` to obtain the successful value. The schema binder also uses this parser to await async validators before calling the handler. Schema failures, including `issues: []`, become `DtoValidationError` and map to `400` in HTTP. The existing empty-issues success behavior of `ValidateClass` remains unchanged. Malformed schema results throw `TypeError`, and schema implementation exceptions propagate unchanged so server defects are not disguised as ordinary input rejection.
+
 ## Small Commands Reveal the Next Boundary
 
 The finished input boundary does not give the client authority to choose server state. The converter normalizes URL notation, DTOs validate the shape of the required data, and the service enforces the draft and publication rules. Translating errors from each layer into HTTP at one place lets us preserve the domain's meaning even if the framework changes.
@@ -352,6 +450,9 @@ The request's `authorId` is no longer stored, but the object returned by the con
 
 ## Sources and Further Reading
 
+- [HTTP input policy and schema binding contract](../../packages/http/README.md#explicit-input-policies), [schema output parser contract](../../packages/validation/README.md#standard-schema-output-parsing), [runtime binder composition contract](../../packages/runtime/README.md#http-binder-composition): the API owners for the optional experiment.
+- [Input policy and mapping tests](../../packages/http/src/input-materialization.test.ts), [schema output tests](../../packages/validation/src/standard-schema-output.test.ts), [application-boundary tests](../../packages/testing/src/input-materialization.e2e.test.ts): regression locations for projection, original-input guards, transformed output, and fallback behavior.
+- [Next App Router native request tests](../../packages/platform-nextjs/src/schema-input-materialization.test.ts), [cold public declaration tests](../../packages/runtime/src/input-materialization-public-types.test.ts): evidence locations for the real adapter and public types, not a claim that the Book exercise above was executed.
 - [`@fluojs/http` README](../../packages/http/README.md), [public exports](../../packages/http/src/index.portable.ts): the public paths for `RequestDto`, `FromBody`, `FromPath`, `Convert`, and `HttpCode`.
 - [Default binder](../../packages/http/src/adapters/binding.ts) and [binding tests](../../packages/http/src/adapters/binding.test.ts): evidence for unknown body keys, required sources, and converter resolution.
 - [Handler invocation policy](../../packages/http/src/dispatch/dispatch-handler-policy.ts), [HTTP validation adapter](../../packages/http/src/adapters/dto-validation-adapter.ts): where to confirm validation after binding and translation to `400`.

--- a/book/advanced/ch09-app-context.ko.md
+++ b/book/advanced/ch09-app-context.ko.md
@@ -548,11 +548,11 @@ cleanup failure를 `ApplicationLogger`로 보고합니다.
 
 이 guard를 통과한 뒤에야 `listen()`은 `await this.ready()`를 호출하고, 그 다음 `await this.adapter.listen(this.dispatcher)`를 실행합니다. 성공하면 state를 `'ready'`로 바꾸고 startup log를 남깁니다. 즉 transport adapter가 application state transition을 단독으로 소유하지 않습니다. 더 큰 runtime shell policy의 일부로 참여합니다.
 
-dispatcher 조립은 그보다 앞서 `path:packages/runtime/src/bootstrap.ts:1548-1568`의 `createRuntimeDispatcher()`에서 일어납니다. runtime은 compiled module controller로부터 handler mapping을 만들고, route mapping을 로그로 남기며, middleware, converters, interceptors, observers, optional exception filter로 dispatcher를 생성합니다.
+dispatcher 조립은 그보다 앞서 `path:packages/runtime/src/bootstrap.ts:1553-1573`의 `createRuntimeDispatcher()`에서 일어납니다. runtime은 compiled module controller로부터 handler mapping을 만들고, route mapping을 로그로 남기며, middleware, converters, interceptors, observers, optional exception filter로 dispatcher를 생성합니다.
 
 dispatcher 생성은 full application branch에만 필요한 request-facing 단계입니다. compiled module baseline에서 handler source를 만들고, HTTP pipeline 옵션을 묶은 뒤 dispatcher를 반환합니다.
 
-`path:packages/runtime/src/bootstrap.ts:1548-1568`
+`path:packages/runtime/src/bootstrap.ts:1553-1573`
 ```typescript
 function createRuntimeDispatcher(
   bootstrapped: BootstrapResult,

--- a/book/advanced/ch09-app-context.md
+++ b/book/advanced/ch09-app-context.md
@@ -548,11 +548,11 @@ That exact error string is verified in `path:packages/runtime/src/application.te
 
 Only after this guard passes does `listen()` call `await this.ready()`, then `await this.adapter.listen(this.dispatcher)`. On success, it changes state to `'ready'` and writes the startup log. The transport adapter does not own the application state transition by itself. It participates as part of the larger runtime shell policy.
 
-Dispatcher assembly happens earlier, in `createRuntimeDispatcher()` at `path:packages/runtime/src/bootstrap.ts:1548-1568`. The runtime builds handler mapping from compiled Module controllers, logs route mappings, then creates a dispatcher with middleware, converters, interceptors, observers, and an optional exception filter.
+Dispatcher assembly happens earlier, in `createRuntimeDispatcher()` at `path:packages/runtime/src/bootstrap.ts:1553-1573`. The runtime builds handler mapping from compiled Module controllers, logs route mappings, then creates a dispatcher with middleware, converters, interceptors, observers, and an optional exception filter.
 
 Dispatcher creation is the request-facing step needed only by the full application branch. It creates handler sources from the compiled Module baseline, groups HTTP pipeline options, and returns the dispatcher.
 
-`path:packages/runtime/src/bootstrap.ts:1548-1568`
+`path:packages/runtime/src/bootstrap.ts:1553-1573`
 ```typescript
 function createRuntimeDispatcher(
   bootstrapped: BootstrapResult,

--- a/book/advanced/ch10-runtime-branching.ko.md
+++ b/book/advanced/ch10-runtime-branching.ko.md
@@ -27,11 +27,11 @@
 ## 10.1 Fluo branches by package surface and adapter seams more than by giant runtime conditionals
 Chapter 10에서 가장 먼저 볼 사실은 Fluo의 runtime portability가 하나의 거대한 `if (isNode) ... else if (isEdge) ...` 블록으로 구현되지 않는다는 점입니다. branch point는 훨씬 좁고, 더 아키텍처적인 위치에 있습니다.
 
-`path:packages/runtime/src/bootstrap.ts:1578-1602`의 핵심 bootstrap logic 대부분은 transport-neutral합니다. module graph를 compile하고, DI container를 만들고, runtime token을 등록하고, lifecycle instance를 resolve하고, hook을 실행하고, application/context shell을 조립합니다. 이 코드 어디에도 Node인지, Web platform인지, edge runtime인지 묻는 거대한 분기문은 없습니다.
+`path:packages/runtime/src/bootstrap.ts:1583-1607`의 핵심 bootstrap logic 대부분은 transport-neutral합니다. module graph를 compile하고, DI container를 만들고, runtime token을 등록하고, lifecycle instance를 resolve하고, hook을 실행하고, application/context shell을 조립합니다. 이 코드 어디에도 Node인지, Web platform인지, edge runtime인지 묻는 거대한 분기문은 없습니다.
 
 그 중심부는 host 이름을 판별하는 대신 이미 준비된 adapter와 platform shell을 받아 조립합니다. 아래 발췌에서 runtime은 module graph, provider, token, lifecycle 순서를 다루고, Node나 Web이라는 이름을 조건으로 삼지 않습니다.
 
-`path:packages/runtime/src/bootstrap.ts:1578-1602`
+`path:packages/runtime/src/bootstrap.ts:1583-1607`
 ```typescript
 export async function bootstrapApplication(options: BootstrapApplicationOptions): Promise<Application> {
   const studioDevtools = options.studioDevtools ?? createStudioDevtoolsRuntimeFromConfig();

--- a/book/advanced/ch10-runtime-branching.md
+++ b/book/advanced/ch10-runtime-branching.md
@@ -27,11 +27,11 @@ This chapter explains how Fluo branches only at package surfaces and adapter sea
 ## 10.1 Fluo branches by package surface and adapter seams more than by giant runtime conditionals
 The first fact to notice in Chapter 10 is that Fluo's runtime portability is not implemented as one giant `if (isNode) ... else if (isEdge) ...` block. The branch points are much narrower and sit in more architectural locations.
 
-Most of the core bootstrap logic in `path:packages/runtime/src/bootstrap.ts:1578-1602` is transport-neutral. It compiles the Module Graph, creates the DI container, registers runtime Tokens, resolves lifecycle instances, runs hooks, and assembles the application/context shell. Nowhere in this code is there a giant conditional asking whether the host is Node, the Web platform, or an Edge runtime.
+Most of the core bootstrap logic in `path:packages/runtime/src/bootstrap.ts:1583-1607` is transport-neutral. It compiles the Module Graph, creates the DI container, registers runtime Tokens, resolves lifecycle instances, runs hooks, and assembles the application/context shell. Nowhere in this code is there a giant conditional asking whether the host is Node, the Web platform, or an Edge runtime.
 
 Instead of detecting the host name, that center assembles already prepared adapters and a platform shell. In the excerpt below, the runtime deals with the Module Graph, Providers, Tokens, and lifecycle order. It does not use Node or Web as conditions.
 
-`path:packages/runtime/src/bootstrap.ts:1578-1602`
+`path:packages/runtime/src/bootstrap.ts:1583-1607`
 ```typescript
 export async function bootstrapApplication(options: BootstrapApplicationOptions): Promise<Application> {
   const studioDevtools = options.studioDevtools ?? createStudioDevtoolsRuntimeFromConfig();

--- a/packages/http/README.ko.md
+++ b/packages/http/README.ko.md
@@ -240,6 +240,215 @@ canonical `406 Not Acceptable` response를 반환합니다. 성공한 모든 for
 
 ## 주요 패턴
 
+### 명시적 입력 정책
+
+**범위와 import:** `@fluojs/http` 또는 `@fluojs/http/portable`의 `InputPolicy`,
+`InputPolicyOptions`는 클래스 DTO나 route method의 최상위 body binding을
+설정합니다. 일반 클래스 DTO에는 schema binder가 필요하지 않습니다.
+`RequestDto`와 `FromBody` 같은 명시적 source decorator는 여전히 필요합니다.
+
+| Option | 기본값 | Opt-in 동작 |
+| --- | --- | --- |
+| `unknownFields` | `'reject'` | `'strip'`은 alias를 포함한 선언된 body source key만 투영합니다. |
+| `nonObjects` | `'reject'` | `'empty'`는 배열, 원시 값 및 다른 non-plain 값을 binding용 빈 body로 취급합니다. |
+
+생략한 field는 엄격한 기본값을 유지합니다. Route는 명시한 policy field만
+덮어쓰고 나머지는 상속된 DTO policy를 포함한 DTO 설정에서 가져옵니다.
+`null`과 body 부재는 기존 missing-field 동작을 유지합니다.
+`nonObjects: 'empty'`가 필수 클래스 field를 optional로 만들지는 않습니다.
+`Optional`로 누락을 허용하지 않으면 `FromBody`는 계속 `MISSING_FIELD`를
+보고합니다. Field initializer는 필수 transport field를 대신하지 않습니다.
+
+```ts
+import {
+  Controller, FromBody, InputPolicy, Post, RequestDto,
+} from '@fluojs/http';
+import { IsDefined, IsString } from '@fluojs/validation';
+
+@InputPolicy({ unknownFields: 'strip' })
+class DraftInput {
+  @FromBody('post_title')
+  @IsDefined()
+  @IsString()
+  title = '';
+}
+
+@Controller('/drafts')
+class DraftController {
+  @Post()
+  @RequestDto(DraftInput)
+  create(input: DraftInput) {
+    return { title: input.title };
+  }
+
+  @Post('/strict')
+  @RequestDto(DraftInput)
+  @InputPolicy({ unknownFields: 'reject' })
+  strict(input: DraftInput) {
+    return { title: input.title };
+  }
+}
+```
+
+`{ post_title: 'Draft', authorId: 'untrusted' }`는 `/drafts`에서
+`{ title: 'Draft' }`로 bind되지만 `/drafts/strict`에서는 실패합니다.
+허용 목록은 logical field `title`이 아니라 transport alias `post_title`을
+사용합니다. 알 수 없는 key는 HTTP 400 / `UNKNOWN_FIELD`, 잘못된 body shape은
+HTTP 400 / `INVALID_BODY`로 실패합니다. 위험한 own enumerable body key인
+`__proto__`, `constructor`, `prototype`은 `strip`이나 `empty`에서도 계속
+차단되며 projection으로 허용된 입력이 되지 않습니다. 지원하지 않는
+JavaScript policy 값은 선언 시 `TypeError`를 던집니다.
+
+**순서와 소유권:** transport parsing과 middleware 이후 guard와
+interceptor-before 코드는 원래 parsed input을 봅니다. 실행을 계속하면
+binding의 검사·투영, converter와 일반 클래스 검증, handler/service,
+결과를 받는 interceptor-after 순서로 진행합니다. 설정된 conditional request는
+guard 이후, interceptor 이전에 완료될 수 있습니다. Projection은 binding-local
+request view를 사용하며 `RequestContext.request.body`를 교체하지 않습니다.
+이후 context reader도 원래 body를 볼 수 있습니다. Projection은 shallow하며
+deep clone이나 재귀 sanitizer가 아닙니다. 서버 소유 identity와 authorization
+결정은 client input과 분리하세요. Guard는 앞으로 만들어질 검증된 handler
+인수를 받지 않습니다. Parser 실패는 여전히 guard보다 먼저 발생합니다.
+Parser와 HEAD policy는 모두 바뀌지 않습니다.
+
+**Decorator 조합:** 표준 class/method 선언과 기존 legacy 선언 경로를 지원합니다.
+표준 조합 method decorator는 같은 value와 context를 각 선언에 전달하고
+`RequestDto`와 route 선언을 유지해야 합니다.
+
+```ts
+function StrictDraft(value: Function, context: ClassMethodDecoratorContext) {
+  InputPolicy({ unknownFields: 'reject' })(value, context);
+  RequestDto(DraftInput)(value, context);
+  Post('/composed')(value, context);
+}
+```
+
+Controller method에 `@StrictDraft`를 사용합니다. Legacy integration의 동등한
+policy 호출은 `InputPolicy(options)(DtoClass)`와
+`InputPolicy(options)(ControllerClass.prototype, methodName, descriptor)`입니다.
+이 선언은 DTO token을 교체하거나 sibling route policy를 바꾸지 않습니다.
+Application source는 `emitDecoratorMetadata`를 켜는 대신 표준 decorator
+설정을 유지해야 합니다.
+
+### Standard Schema output binding
+
+**범위와 사전 조건:** `createSchemaDto`, `StandardSchemaBinder`,
+`SchemaDtoOptions`, `SchemaBindingField`는 `@fluojs/http`와
+`@fluojs/http/portable`의 공개 export입니다. Standard Schema v1 구현을
+제공하고 application bootstrap에서 binder를 설치하세요. Schema library는
+application dependency이며 특정 vendor를 요구하지 않습니다.
+
+`createSchemaDto(schema, { fields, policy? })`는 `RequestDto`용 opaque token을
+반환합니다. `InstanceType<typeof Token>`은 input type이 아니라 변환과 기본값을
+포함한 schema의 **output** type입니다. Binder는 클래스 instance를 생성하는
+대신 성공한 schema output을 직접 반환합니다.
+
+| Mapping 입력 | 계약 |
+| --- | --- |
+| `fields` record property | Logical schema input name입니다. |
+| `source` | 명시적 `'body'`, `'path'`, `'query'`이며 출처를 추론하지 않습니다. |
+| `key` | 선택적 transport alias이며 기본값은 logical input name입니다. |
+| 누락된 mapped value | Schema input에서 생략하여 required value와 default를 schema가 소유하게 합니다. 명시적 `null`은 그대로 전달합니다. |
+| 매핑하지 않은 query/path key | 무시합니다. 독립적인 body unknown-field policy를 완화하지는 않습니다. |
+| `policy` | `InputPolicy`와 같은 body option이며 명시적 route field가 우선합니다. |
+
+Query mapping에는 `repeatedQuery`도 지정할 수 있습니다.
+
+| 값 | 동작 |
+| --- | --- |
+| 생략 또는 `'preserve'` | Scalar는 scalar로 유지하고 배열은 값과 순서를 바꾸지 않고 복사합니다. |
+| `'first'` / `'last'` | 배열의 첫/마지막 원소를 선택하며 scalar는 scalar로 유지합니다. |
+| `'reject'` | 배열 원소가 둘 이상이면 HTTP 400 / `REPEATED_QUERY`로 실패합니다. 원소 하나인 배열은 여전히 배열입니다. |
+
+Schema는 매핑된 logical name을 담은 투영 객체 하나를 받습니다. Schema 자체의
+unknown-key option으로는 그 객체를 parse하기 전에 HTTP가 거부하는 transport
+body key를 제거할 수 없습니다. 그런 body boundary가 필요하면
+`policy: { unknownFields: 'strip' }`을 명시하세요.
+
+다음 독립 application fragment는 Standard Schema vendor의 한 예로 Zod 4를
+사용합니다. Fluo가 지원하는 decorator build 설정이 있는 application에
+`@fluojs/core`, `@fluojs/http`, `@fluojs/runtime`, `@fluojs/platform-nodejs`,
+`zod`를 설치하세요.
+
+```ts
+import { Module } from '@fluojs/core';
+import {
+  Controller, createSchemaDto, Post, RequestDto, StandardSchemaBinder,
+} from '@fluojs/http';
+import { createNodejsAdapter } from '@fluojs/platform-nodejs';
+import { bootstrapApplication } from '@fluojs/runtime';
+import { z } from 'zod';
+
+const DraftRequest = createSchemaDto(z.object({
+  title: z.string().trim().min(1),
+  count: z.coerce.number().int().min(1).default(1),
+  id: z.coerce.number().int().positive(),
+  tag: z.string().optional(),
+}), {
+  fields: {
+    title: { source: 'body', key: 'post_title' },
+    count: { source: 'body' },
+    id: { source: 'path', key: 'postId' },
+    tag: { source: 'query', repeatedQuery: 'first' },
+  },
+  policy: { unknownFields: 'strip' },
+});
+
+@Controller('/drafts')
+class DraftController {
+  @Post('/:postId')
+  @RequestDto(DraftRequest)
+  create(input: InstanceType<typeof DraftRequest>) {
+    return input;
+  }
+}
+
+@Module({ controllers: [DraftController] })
+class AppModule {}
+
+const app = await bootstrapApplication({
+  rootModule: AppModule,
+  adapter: createNodejsAdapter({ host: '127.0.0.1', port: 3000 }),
+  binder: (defaultBinder) => new StandardSchemaBinder(defaultBinder),
+});
+await app.listen();
+```
+
+`POST /drafts/7?tag=a&tag=b`에
+`{ "post_title": "  Draft  ", "authorId": "untrusted" }`를 보내면 예상되는
+handler input과 JSON 결과는 `{ title: 'Draft', count: 1, id: 7, tag: 'a' }`입니다.
+배열 body는 `nonObjects: 'empty'`를 명시하지 않으면 여전히 실패합니다.
+종료는 application이 소유하며 host boundary에서 `app.close()`를 호출해야
+합니다. 이 fragment는 process-signal handler를 설치하지 않습니다.
+
+**호환성과 실패:** `StandardSchemaBinder`는 일반 DTO를 fallback으로 위임하여
+기존 converter/class-validation 경로를 유지합니다. 설정된 global converter를
+보존하려면 bootstrap이 제공한 default binder를 전달하세요.
+`new StandardSchemaBinder()`를 직접 만들면 해당 application 설정이 없는
+default binder를 사용합니다. Schema token은 class-field converter가 아니라
+schema conversion을 사용합니다. Async schema validator는 handler 전에
+await됩니다. `issues: []`인 실패를 포함한 `DtoValidationError`는 HTTP 400이
+됩니다. Malformed result는 `TypeError`를 던지고 schema 구현의 예외는
+validation failure로 위장되지 않고 일반 server-error 경로로 전파됩니다.
+[Output parser 계약](../validation/README.ko.md#standard-schema-output-parsing)을
+참고하세요.
+
+Schema token을 생성자로 호출하거나 상속하거나 `PickType`, `OmitType`,
+`PartialType`, `IntersectionType` 같은 mapped-class DTO helper에 넘기지 마세요.
+생성자 호출은 `InvariantError`를 던집니다. 이 token은 runtime reflected
+class-field metadata가 아니며 자동 OpenAPI schema conversion도 제공하지
+않습니다. 해당 클래스 계약이 필요하면 일반 클래스 DTO를 유지하고, schema-token
+route를 문서화할 때는 application-owned OpenAPI schema를 명시하세요.
+잘못된 mapping source, repeated-query option, 위험한 logical/source key는
+token 생성 시 `TypeError`를 던집니다.
+
+**근거:** 구현은 `src/input-policy.ts`, `src/adapters/binding.ts`,
+`src/schema-binding.ts`, `src/dispatch/dispatch-handler-policy.ts`에 있고
+export는 `src/index.portable.ts`에 있습니다. 회귀 확인 위치는
+`src/adapters/binding.test.ts`, `src/input-materialization.test.ts`,
+`../testing/src/input-materialization.e2e.test.ts`입니다. Bootstrap 조합은
+[runtime 계약](../runtime/README.ko.md#http-binder-composition)이 소유합니다.
+
 ### 가드와 인터셉터
 
 ```ts
@@ -549,7 +758,8 @@ export class UploadController {
 ## 공개 API
 
 - **라우팅 데코레이터**: `Controller`, `Get`, `Sse`, `Query`, `Route`, `Post`, `Put`, `Patch`, `Delete`, `All`, `Options`, `Head`
-- **바인딩 데코레이터**: `FromBody`, `FromQuery`, `FromPath`, `FromHeader`, `FromCookie`, `FromFiles`, `RequestDto`, `Optional`, `Convert`
+- **바인딩 데코레이터**: `FromBody`, `FromQuery`, `FromPath`, `FromHeader`, `FromCookie`, `FromFiles`, `RequestDto`, `Optional`, `Convert`, `InputPolicy`
+- **명시적 입력 materialization**: `InputPolicyOptions`, `createSchemaDto`, `StandardSchemaBinder`, `SchemaDtoOptions`, `SchemaBindingField`
 - **실행 데코레이터**: `UseGuards`, `UseInterceptors`, `HttpCode`, `Version`, `Header`, `Redirect`, `Produces`
 - **응답 쿠키 helper**: `setCookie`, `clearCookie`, `CookieOptions`, `ClearCookieOptions`, `CookieSameSite`
 - **Conditional request 타입**: `EntityTagStrength`, `EntityTag`, `ResponseValidators`, `ConditionalRequestContext`, `ConditionalRequestResolution`, `ConditionalRequestResolver`, `ConditionalRequestOptions`

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -244,6 +244,217 @@ any existing `Vary` fields.
 
 ## Common Patterns
 
+### Explicit input policies
+
+**Scope and imports:** `InputPolicy` and `InputPolicyOptions` from `@fluojs/http`
+or `@fluojs/http/portable` configure top-level body binding for a class DTO or a
+route method. Ordinary class DTOs need no schema binder. They still require
+`RequestDto` and explicit source decorators such as `FromBody`.
+
+| Option | Default | Opt-in behavior |
+| --- | --- | --- |
+| `unknownFields` | `'reject'` | `'strip'` projects only declared body source keys, including aliases. |
+| `nonObjects` | `'reject'` | `'empty'` supplies an empty body to binding for arrays, primitives, and other non-plain values. |
+
+Omitted fields retain strict defaults. A route overrides only the policy fields
+it explicitly declares; other fields come from the DTO, including inherited DTO
+policy. `null` and absent bodies retain existing missing-field behavior.
+`nonObjects: 'empty'` does not make required class fields optional:
+`FromBody` still reports `MISSING_FIELD` unless `Optional` permits omission.
+Field initializers do not satisfy required transport fields.
+
+```ts
+import {
+  Controller, FromBody, InputPolicy, Post, RequestDto,
+} from '@fluojs/http';
+import { IsDefined, IsString } from '@fluojs/validation';
+
+@InputPolicy({ unknownFields: 'strip' })
+class DraftInput {
+  @FromBody('post_title')
+  @IsDefined()
+  @IsString()
+  title = '';
+}
+
+@Controller('/drafts')
+class DraftController {
+  @Post()
+  @RequestDto(DraftInput)
+  create(input: DraftInput) {
+    return { title: input.title };
+  }
+
+  @Post('/strict')
+  @RequestDto(DraftInput)
+  @InputPolicy({ unknownFields: 'reject' })
+  strict(input: DraftInput) {
+    return { title: input.title };
+  }
+}
+```
+
+Here `{ post_title: 'Draft', authorId: 'untrusted' }` binds to
+`{ title: 'Draft' }` on `/drafts`, but fails on `/drafts/strict`.
+The allowlist uses the transport alias `post_title`, not the logical field
+`title`. Unknown keys fail with HTTP 400 / `UNKNOWN_FIELD`; invalid body shapes
+fail with HTTP 400 / `INVALID_BODY`. Dangerous own enumerable body keys
+`__proto__`, `constructor`, and `prototype` remain blocked, including with
+`strip` or `empty`; projection never turns them into accepted input.
+Unsupported JavaScript policy values throw `TypeError` at declaration.
+
+**Order and ownership:** after transport parsing and middleware, guards and
+interceptor-before code see the original parsed input. If they continue, binding
+checks/projects input, converters and ordinary class validation run, the
+handler/service executes, and interceptor-after code receives the result.
+Configured conditional requests may finish after guards and before interceptors.
+Projection uses a binding-local request view; it never replaces
+`RequestContext.request.body`. That original body remains visible to later
+context readers too. Projection is shallow, not a deep clone or recursive
+sanitizer. Keep server-owned identity and authorization decisions outside
+client input; a guard does not receive a future validated handler argument.
+Parser failures still precede guards. Neither parser nor HEAD policy changes.
+
+**Decorator composition:** standard class/method declarations and the existing
+legacy declaration path are supported. A standard composed method decorator
+forwards the same value and context to each declaration; it must retain
+`RequestDto` and the route declaration:
+
+```ts
+function StrictDraft(value: Function, context: ClassMethodDecoratorContext) {
+  InputPolicy({ unknownFields: 'reject' })(value, context);
+  RequestDto(DraftInput)(value, context);
+  Post('/composed')(value, context);
+}
+```
+
+Use `@StrictDraft` on a controller method. For legacy integrations, the equivalent
+policy calls are `InputPolicy(options)(DtoClass)` and
+`InputPolicy(options)(ControllerClass.prototype, methodName, descriptor)`.
+These declarations do not replace the DTO token or alter sibling route policies.
+Application source should retain the standard decorator configuration rather
+than enable `emitDecoratorMetadata`.
+
+### Standard Schema output binding
+
+**Scope and prerequisites:** `createSchemaDto`, `StandardSchemaBinder`,
+`SchemaDtoOptions`, and `SchemaBindingField` are public exports from
+`@fluojs/http` and `@fluojs/http/portable`. Supply a Standard Schema v1
+implementation and install the binder at application bootstrap. Schema libraries
+are application dependencies; no particular vendor is required.
+
+`createSchemaDto(schema, { fields, policy? })` returns an opaque token for
+`RequestDto`. `InstanceType<typeof Token>` is the schema's **output** type,
+including transformations and defaults, not its input type. The binder returns
+the successful schema output directly rather than constructing a class instance.
+
+| Mapping input | Contract |
+| --- | --- |
+| `fields` record property | Logical schema input name. |
+| `source` | Explicit `'body'`, `'path'`, or `'query'`; no source inference. |
+| `key` | Optional transport alias; defaults to the logical input name. |
+| Missing mapped value | Omitted from schema input so the schema owns required values and defaults. Explicit `null` is passed through. |
+| Unmapped query/path keys | Ignored; this does not relax the independent body unknown-field policy. |
+| `policy` | The same body options as `InputPolicy`; explicit route fields override them. |
+
+Query mappings also accept `repeatedQuery`:
+
+| Value | Behavior |
+| --- | --- |
+| Omitted or `'preserve'` | Scalars remain scalars; arrays are copied without changing their values or order. |
+| `'first'` / `'last'` | Select the first/last array element; a scalar remains a scalar. |
+| `'reject'` | More than one array element fails with HTTP 400 / `REPEATED_QUERY`; a one-element array is still an array. |
+
+The schema receives one projected object containing the mapped logical names.
+Its own unknown-key option cannot strip transport body keys that HTTP rejects
+before parsing that object. Configure `policy: { unknownFields: 'strip' }`
+explicitly when that is the intended body boundary.
+
+The following standalone application fragment uses Zod 4 as one Standard Schema
+vendor. Install `@fluojs/core`, `@fluojs/http`, `@fluojs/runtime`,
+`@fluojs/platform-nodejs`, and `zod` in an application with Fluo's supported
+decorator build configuration:
+
+```ts
+import { Module } from '@fluojs/core';
+import {
+  Controller, createSchemaDto, Post, RequestDto, StandardSchemaBinder,
+} from '@fluojs/http';
+import { createNodejsAdapter } from '@fluojs/platform-nodejs';
+import { bootstrapApplication } from '@fluojs/runtime';
+import { z } from 'zod';
+
+const DraftRequest = createSchemaDto(z.object({
+  title: z.string().trim().min(1),
+  count: z.coerce.number().int().min(1).default(1),
+  id: z.coerce.number().int().positive(),
+  tag: z.string().optional(),
+}), {
+  fields: {
+    title: { source: 'body', key: 'post_title' },
+    count: { source: 'body' },
+    id: { source: 'path', key: 'postId' },
+    tag: { source: 'query', repeatedQuery: 'first' },
+  },
+  policy: { unknownFields: 'strip' },
+});
+
+@Controller('/drafts')
+class DraftController {
+  @Post('/:postId')
+  @RequestDto(DraftRequest)
+  create(input: InstanceType<typeof DraftRequest>) {
+    return input;
+  }
+}
+
+@Module({ controllers: [DraftController] })
+class AppModule {}
+
+const app = await bootstrapApplication({
+  rootModule: AppModule,
+  adapter: createNodejsAdapter({ host: '127.0.0.1', port: 3000 }),
+  binder: (defaultBinder) => new StandardSchemaBinder(defaultBinder),
+});
+await app.listen();
+```
+
+For `POST /drafts/7?tag=a&tag=b` with
+`{ "post_title": "  Draft  ", "authorId": "untrusted" }`, the expected handler
+input and JSON result are `{ title: 'Draft', count: 1, id: 7, tag: 'a' }`.
+An array body still fails unless `nonObjects: 'empty'` is explicitly selected.
+The application owns shutdown and must call `app.close()` at its host boundary;
+this fragment does not install process-signal handlers.
+
+**Compatibility and failures:** `StandardSchemaBinder` delegates ordinary DTOs
+to its fallback, preserving the ordinary converter/class-validation path.
+Pass the bootstrap-supplied default binder so configured global converters are
+retained; constructing `new StandardSchemaBinder()` directly uses a default
+binder without those application settings. Schema tokens use schema conversion,
+not class-field converters. Async schema validators are awaited before the
+handler. `DtoValidationError`, including a failure with `issues: []`, becomes
+HTTP 400. Malformed results throw `TypeError`, and schema implementation
+exceptions propagate through the normal server-error path rather than being
+disguised as validation failures. See the
+[output parser contract](../validation/README.md#standard-schema-output-parsing).
+
+Do not construct, subclass, or pass a schema token to mapped-class DTO helpers
+such as `PickType`, `OmitType`, `PartialType`, or `IntersectionType`.
+Construction throws `InvariantError`; the token is not runtime reflected
+class-field metadata and does not provide automatic OpenAPI schema conversion.
+Keep ordinary class DTOs when those class contracts are needed, or document
+schema-token routes with explicit application-owned OpenAPI schemas.
+Invalid mapping sources, repeated-query options, or dangerous logical/source
+keys throw `TypeError` during token creation.
+
+**Evidence:** implementations are `src/input-policy.ts`,
+`src/adapters/binding.ts`, `src/schema-binding.ts`, and
+`src/dispatch/dispatch-handler-policy.ts`; exports are in `src/index.portable.ts`.
+Regression locations are `src/adapters/binding.test.ts`,
+`src/input-materialization.test.ts`, and
+`../testing/src/input-materialization.e2e.test.ts`. Bootstrap composition belongs
+to the [runtime contract](../runtime/README.md#http-binder-composition).
+
 ### Guards and interceptors
 
 ```ts
@@ -557,7 +768,8 @@ Response content negotiation formatters must return `string` or `Uint8Array` fro
 ## Public API
 
 - **Routing decorators**: `Controller`, `Get`, `Sse`, `Query`, `Route`, `Post`, `Put`, `Patch`, `Delete`, `All`, `Options`, `Head`
-- **Binding decorators**: `FromBody`, `FromQuery`, `FromPath`, `FromHeader`, `FromCookie`, `FromFiles`, `RequestDto`, `Optional`, `Convert`
+- **Binding decorators**: `FromBody`, `FromQuery`, `FromPath`, `FromHeader`, `FromCookie`, `FromFiles`, `RequestDto`, `Optional`, `Convert`, `InputPolicy`
+- **Explicit input materialization**: `InputPolicyOptions`, `createSchemaDto`, `StandardSchemaBinder`, `SchemaDtoOptions`, `SchemaBindingField`
 - **Execution decorators**: `UseGuards`, `UseInterceptors`, `HttpCode`, `Version`, `Header`, `Redirect`, `Produces`
 - **Header helpers**: `getRequestHeader`, `getResponseHeader`, `hasResponseHeader`, `appendVaryHeader`, `buildContentDisposition`
 - **Response cookie helpers**: `setCookie`, `clearCookie`, `CookieOptions`, `ClearCookieOptions`, `CookieSameSite`

--- a/packages/http/src/adapters/binding.test.ts
+++ b/packages/http/src/adapters/binding.test.ts
@@ -118,6 +118,26 @@ function createContext(
 }
 
 describe('DefaultBinder', () => {
+  it('honors opt-in body projection without replacing the original request body', async () => {
+    class ProjectedRequest {
+      @FromBody('post_title')
+      title = '';
+    }
+
+    // Seed the HTTP-owned DTO policy record independently of the new decorator.
+    Object.defineProperty(ProjectedRequest, Symbol.for('fluo.http.input-policy'), {
+      value: Object.freeze({ unknownFields: 'strip' }),
+    });
+    const body = Object.freeze({ post_title: 'Draft', authorId: 'client-owned' });
+    const context = createContext(createRequest({ body }));
+
+    await expect(new DefaultBinder().bind(ProjectedRequest, context)).resolves.toEqual({
+      title: 'Draft',
+    });
+    expect(context.requestContext.request.body).toBe(body);
+    expect(body.authorId).toBe('client-owned');
+  });
+
   it('binds explicit path/body fields into a DTO instance', async () => {
     class CreateUserRequest {
       @FromPath('id')

--- a/packages/http/src/adapters/binding.ts
+++ b/packages/http/src/adapters/binding.ts
@@ -2,6 +2,7 @@ import { type Constructor, InvariantError, type Token } from '@fluojs/core';
 
 import { BadRequestException, type HttpExceptionDetail } from '../exceptions.js';
 import { toInputErrorDetail } from '../input-error-detail.js';
+import { getInputPolicy, type InputPolicyOptions } from '../input-policy.js';
 import type { ArgumentResolverContext, Binder, Converter, ConverterLike, ConverterTarget, FrameworkRequest } from '../types.js';
 import { getCompiledDtoBindingPlan } from './dto-binding-plan.js';
 
@@ -18,15 +19,27 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return prototype === Object.prototype || prototype === null;
 }
 
-function validateBodyKeys(
+/**
+ * Validate and optionally project the body into a binding-local request view.
+ *
+ * @param request Original adapter-normalized request.
+ * @param bodyKeys Allowed body source keys, including declared aliases.
+ * @param policy Explicit DTO and route input policies.
+ * @returns The original request or a shallow binding-only view with a projected body.
+ * @throws BadRequestException For invalid bodies, dangerous keys, or rejected unknown keys.
+ * @internal
+ */
+export function prepareBindingRequest(
   request: FrameworkRequest,
   bodyKeys: ReadonlySet<string>,
-): void {
+  policy: InputPolicyOptions,
+): FrameworkRequest {
   if (request.body === undefined || request.body === null) {
-    return;
+    return request;
   }
 
-  if (!isPlainObject(request.body)) {
+  const plain = isPlainObject(request.body);
+  if (!plain && policy.nonObjects !== 'empty') {
     throw new BadRequestException('Request body must be a plain object.', {
       details: [toInputErrorDetail({ code: 'INVALID_BODY', message: 'Request body must be a plain object.', source: 'body' })],
     });
@@ -34,13 +47,13 @@ function validateBodyKeys(
 
   const details: HttpExceptionDetail[] = [];
 
-  for (const key of Object.keys(request.body)) {
+  for (const key of Object.keys(Object(request.body))) {
     if (DANGEROUS_KEYS.has(key)) {
       details.push(toInputErrorDetail({ code: 'DANGEROUS_KEY', field: key, message: `Dangerous body key ${key} is not allowed.`, source: 'body' }));
       continue;
     }
 
-    if (!bodyKeys.has(key)) {
+    if (plain && policy.unknownFields !== 'strip' && !bodyKeys.has(key)) {
       details.push(toInputErrorDetail({ code: 'UNKNOWN_FIELD', field: key, message: `Unknown body field ${key}.`, source: 'body' }));
     }
   }
@@ -50,6 +63,20 @@ function validateBodyKeys(
       details,
     });
   }
+
+  if (!plain) {
+    return { ...request, body: {} };
+  }
+  if (policy.unknownFields === 'strip') {
+    const body: Record<string, unknown> = Object.create(null);
+    for (const key of Object.keys(request.body as Record<string, unknown>)) {
+      if (bodyKeys.has(key)) {
+        body[key] = (request.body as Record<string, unknown>)[key];
+      }
+    }
+    return { ...request, body };
+  }
+  return request;
 }
 
 /**
@@ -136,12 +163,9 @@ export class DefaultBinder implements Binder {
 
   async bind(dto: Constructor, context: ArgumentResolverContext): Promise<unknown> {
     const plan = getCompiledDtoBindingPlan(dto);
-    const request = context.requestContext.request;
+    const originalRequest = context.requestContext.request;
     const value = new dto() as Record<string | symbol, unknown>;
-
-    if (request.body !== undefined && request.body !== null) {
-      validateBodyKeys(request, plan.bodyKeys);
-    }
+    const request = prepareBindingRequest(originalRequest, plan.bodyKeys, getInputPolicy(dto, context.handler));
 
     const details: HttpExceptionDetail[] = [];
 

--- a/packages/http/src/index.portable.ts
+++ b/packages/http/src/index.portable.ts
@@ -25,6 +25,10 @@ export * from './context/request-context.js';
 export * from './context/sse.js';
 export * from './connection.js';
 export * from './cookie-helpers.js';
+export { InputPolicy } from './input-policy.js';
+export type { InputPolicyOptions } from './input-policy.js';
+export { createSchemaDto, StandardSchemaBinder } from './schema-binding.js';
+export type { SchemaBindingField, SchemaDtoOptions } from './schema-binding.js';
 export {
   All,
   Controller,

--- a/packages/http/src/input-materialization.test.ts
+++ b/packages/http/src/input-materialization.test.ts
@@ -1,0 +1,415 @@
+import { type Constructor, InvariantError } from '@fluojs/core';
+import type { StandardSchemaV1Like } from '@fluojs/validation';
+import { describe, expect, it } from 'vitest';
+
+import { DefaultBinder } from './adapters/binding.js';
+import {
+  Controller,
+  createHandlerMapping,
+  createSchemaDto,
+  FromBody,
+  InputPolicy,
+  Optional,
+  Post,
+  RequestDto,
+  StandardSchemaBinder,
+  type ArgumentResolverContext,
+  type FrameworkRequest,
+  type SchemaBindingField,
+} from './index.js';
+import * as portable from './index.portable.js';
+
+function context(
+  body: unknown,
+  overrides: Partial<FrameworkRequest> = {},
+): ArgumentResolverContext {
+  return {
+    handler: {
+      controllerToken: class ControllerToken {},
+      methodName: 'create',
+      metadata: {
+        controllerPath: '/',
+        effectivePath: '/',
+        moduleMiddleware: [],
+        pathParams: [],
+      },
+      route: { method: 'POST', path: '/' },
+    },
+    requestContext: {
+      container: {
+        async dispose() {},
+        async resolve() {
+          throw new Error('Unexpected DI resolution');
+        },
+      },
+      metadata: {},
+      request: {
+        body,
+        cookies: {},
+        headers: {},
+        method: 'POST',
+        params: {},
+        path: '/',
+        query: {},
+        raw: undefined,
+        url: '/',
+        ...overrides,
+      },
+      response: {
+        committed: false,
+        headers: {},
+        statusCode: undefined,
+        statusSet: false,
+        redirect() {},
+        send() {},
+        setHeader() {},
+        setStatus() {},
+      },
+    },
+  };
+}
+
+const echo: StandardSchemaV1Like<unknown, Record<string, unknown>> = {
+  '~standard': {
+    version: 1,
+    vendor: 'fluo-test',
+    validate: (value) => ({ value: value as Record<string, unknown> }),
+  },
+};
+
+describe('independent HTTP input policies', () => {
+  it('exports the same APIs through root and portable entry points', () => {
+    expect(portable.InputPolicy).toBe(InputPolicy);
+    expect(portable.createSchemaDto).toBe(createSchemaDto);
+    expect(portable.StandardSchemaBinder).toBe(StandardSchemaBinder);
+  });
+
+  it('keeps strict defaults and isolates inherited policy overrides', async () => {
+    class Strict {
+      @FromBody('post_title')
+      title = '';
+    }
+    @InputPolicy({ unknownFields: 'strip' })
+    class Projected extends Strict {}
+    @InputPolicy({ unknownFields: 'reject' })
+    class StrictAgain extends Projected {}
+
+    const binder = new DefaultBinder();
+    for (const dto of [Strict, StrictAgain]) {
+      await expect(binder.bind(dto, context({ post_title: 'Draft', extra: true })))
+        .rejects.toMatchObject({
+          status: 400,
+          details: [expect.objectContaining({ code: 'UNKNOWN_FIELD', field: 'extra' })],
+        });
+    }
+    await expect(binder.bind(Projected, context({ post_title: 'Draft', extra: true })))
+      .resolves.toEqual({ title: 'Draft' });
+  });
+
+  it.each([[], ['bad'], 'text', 42, false])(
+    'requires an explicit non-object-to-empty policy for %j',
+    async (body) => {
+      class Strict {
+        @FromBody()
+        @Optional()
+        title = 'default';
+      }
+      @InputPolicy({ nonObjects: 'empty' })
+      class Empty extends Strict {}
+
+      await expect(new DefaultBinder().bind(Strict, context(body)))
+        .rejects.toMatchObject({
+          status: 400,
+          details: [expect.objectContaining({ code: 'INVALID_BODY' })],
+        });
+      const incoming = context(body);
+      await expect(new DefaultBinder().bind(Empty, incoming))
+        .resolves.toEqual({ title: 'default' });
+      expect(incoming.requestContext.request.body).toBe(body);
+    },
+  );
+
+  it('preserves null/absent-body handling and required binding semantics', async () => {
+    class OptionalInput {
+      @FromBody()
+      @Optional()
+      title = 'default';
+    }
+    @InputPolicy({ nonObjects: 'empty' })
+    class Required {
+      @FromBody()
+      title = 'initializer-is-not-a-binding-default';
+    }
+    for (const body of [undefined, null]) {
+      await expect(new DefaultBinder().bind(OptionalInput, context(body)))
+        .resolves.toEqual({ title: 'default' });
+    }
+    for (const body of [undefined, null, []]) {
+      await expect(new DefaultBinder().bind(Required, context(body)))
+        .rejects.toMatchObject({
+          details: [expect.objectContaining({ code: 'MISSING_FIELD', field: 'title' })],
+        });
+    }
+  });
+
+  it.each(['__proto__', 'constructor', 'prototype'])(
+    'never strips or empties dangerous own key %s',
+    async (key) => {
+      @InputPolicy({ unknownFields: 'strip', nonObjects: 'empty' })
+      class Projected {
+        @FromBody()
+        @Optional()
+        title = '';
+      }
+      const SchemaInput = createSchemaDto(echo, {
+        fields: { title: { source: 'body' } },
+        policy: { unknownFields: 'strip', nonObjects: 'empty' },
+      });
+      const array: unknown[] = [];
+      Object.defineProperty(array, key, { enumerable: true, value: 'blocked' });
+      expect(Object.hasOwn(array, key)).toBe(true);
+      expect(Object.getOwnPropertyDescriptor(array, key)).toMatchObject({
+        enumerable: true,
+        value: 'blocked',
+      });
+
+      for (const body of [{ title: 'Draft', [key]: 'blocked' }, array]) {
+        await expect(new DefaultBinder().bind(Projected, context(body)))
+          .rejects.toMatchObject({
+            status: 400,
+            details: [expect.objectContaining({ code: 'DANGEROUS_KEY', field: key })],
+          });
+        await expect(new StandardSchemaBinder().bind(SchemaInput, context(body)))
+          .rejects.toMatchObject({
+            status: 400,
+            details: [expect.objectContaining({ code: 'DANGEROUS_KEY', field: key })],
+          });
+      }
+    },
+  );
+
+  it('composes route decorators in either order without changing DTO identity or sibling policies', async () => {
+    @InputPolicy({ unknownFields: 'strip' })
+    class Input {
+      @FromBody('post_title')
+      title = '';
+    }
+    function StrictPost(value: Function, decoratorContext: ClassMethodDecoratorContext) {
+      InputPolicy({ unknownFields: 'reject' })(value, decoratorContext);
+      RequestDto(Input)(value, decoratorContext);
+      Post('/strict')(value, decoratorContext);
+    }
+    @Controller('/posts')
+    class Routes {
+      @StrictPost
+      strict() {}
+
+      @InputPolicy({ unknownFields: 'strip' })
+      @RequestDto(Input)
+      @Post('/projected')
+      projected() {}
+
+      @Post('/reversed')
+      @RequestDto(Input)
+      @InputPolicy({ unknownFields: 'reject' })
+      reversed() {}
+
+      @Post('/legacy')
+      @RequestDto(Input)
+      legacy() {}
+    }
+    InputPolicy({ unknownFields: 'reject' })(
+      Routes.prototype,
+      'legacy',
+      Object.getOwnPropertyDescriptor(Routes.prototype, 'legacy'),
+    );
+
+    const mapping = createHandlerMapping([{ controllerToken: Routes }]);
+    expect(mapping.descriptors).toHaveLength(4);
+    for (const handler of mapping.descriptors) {
+      expect(handler.route.request).toBe(Input);
+      const incoming = context({ post_title: 'Draft', extra: true });
+      incoming.handler = handler;
+      const bound = new DefaultBinder().bind(Input, incoming);
+      if (handler.methodName === 'projected') {
+        await expect(bound).resolves.toEqual({ title: 'Draft' });
+      } else {
+        await expect(bound).rejects.toMatchObject({ status: 400 });
+      }
+    }
+  });
+
+  it('rejects invalid JavaScript policy values during declaration', () => {
+    expect(() => Reflect.apply(InputPolicy, undefined, [{ unknownFields: 'allow' }]))
+      .toThrow(TypeError);
+    expect(() => Reflect.apply(InputPolicy, undefined, [{ nonObjects: 'ignore' }]))
+      .toThrow(TypeError);
+  });
+});
+
+describe('Standard Schema binding', () => {
+  it.each(['preserve', 'first', 'last', 'reject'] as const)(
+    'defines repeated query policy %s without mutating the query',
+    async (repeatedQuery) => {
+      const Input = createSchemaDto(echo, {
+        fields: { tags: { source: 'query', key: 'tag', repeatedQuery } },
+      });
+      const incoming = context(undefined, { query: { tag: ['a', 'b'] } });
+      const original = incoming.requestContext.request.query.tag;
+      const bound = new StandardSchemaBinder().bind(Input, incoming);
+      if (repeatedQuery === 'reject') {
+        await expect(bound).rejects.toMatchObject({
+          status: 400,
+          details: [expect.objectContaining({
+            code: 'REPEATED_QUERY',
+            field: 'tags',
+            source: 'query',
+          })],
+        });
+      } else {
+        await expect(bound).resolves.toEqual({
+          tags: repeatedQuery === 'preserve' ? ['a', 'b'] : repeatedQuery === 'first' ? 'a' : 'b',
+        });
+      }
+      expect(incoming.requestContext.request.query.tag).toBe(original);
+      expect(original).toEqual(['a', 'b']);
+    },
+  );
+
+  it('preserves default query shapes and omits absent mappings', async () => {
+    const Input = createSchemaDto(echo, {
+      fields: { tags: { source: 'query', key: 'tag' } },
+    });
+    const binder = new StandardSchemaBinder();
+    await expect(binder.bind(Input, context(undefined))).resolves.toEqual({});
+    await expect(binder.bind(Input, context(undefined, { query: { tag: 'a', extra: 'ignored' } })))
+      .resolves.toEqual({ tags: 'a' });
+    const incoming = context(undefined, { query: { tag: ['a', 'b'] } });
+    const output = await binder.bind(Input, incoming);
+    expect(output).toEqual({ tags: ['a', 'b'] });
+    if (typeof output !== 'object' || output === null || !('tags' in output)) {
+      throw new Error('Expected the mapped schema output');
+    }
+    expect(output.tags).not.toBe(incoming.requestContext.request.query.tag);
+  });
+
+  it('snapshots mappings and policies and lets the schema own missing fields and defaults', async () => {
+    const fields: Record<string, SchemaBindingField> = {
+      title: { source: 'body', key: 'post_title' },
+      id: { source: 'path', key: 'postId' },
+    };
+    const policy: {
+      unknownFields: 'strip' | 'reject';
+      nonObjects: 'empty' | 'reject';
+    } = { unknownFields: 'strip', nonObjects: 'empty' };
+    const schema: StandardSchemaV1Like<unknown, { title: string; id: number }> = {
+      '~standard': {
+        version: 1,
+        vendor: 'fluo-test',
+        async validate(value) {
+          const input = value as Record<string, unknown>;
+          return {
+            value: {
+              title: typeof input.title === 'string' ? input.title.trim() : 'Untitled',
+              id: Number(input.id),
+            },
+          };
+        },
+      },
+    };
+    const Input = createSchemaDto(schema, { fields, policy });
+    fields.title = { source: 'query', key: 'changed' };
+    policy.unknownFields = 'reject';
+    policy.nonObjects = 'reject';
+    const binder = new StandardSchemaBinder();
+    await expect(binder.bind(Input, context(
+      { post_title: '  Draft  ', extra: true },
+      { params: { postId: '7' } },
+    ))).resolves.toEqual({ title: 'Draft', id: 7 });
+    await expect(binder.bind(Input, context([], { params: { postId: '8' } })))
+      .resolves.toEqual({ title: 'Untitled', id: 8 });
+    expect(() => new Input()).toThrow(InvariantError);
+  });
+
+  it('retains strict body defaults for schema tokens', async () => {
+    const Input = createSchemaDto(echo, { fields: { title: { source: 'body' } } });
+    const binder = new StandardSchemaBinder();
+    await expect(binder.bind(Input, context({ title: 'Draft', extra: true })))
+      .rejects.toMatchObject({
+        status: 400,
+        details: [expect.objectContaining({ code: 'UNKNOWN_FIELD', field: 'extra' })],
+      });
+    await expect(binder.bind(Input, context([]))).rejects.toMatchObject({
+      status: 400,
+      details: [expect.objectContaining({ code: 'INVALID_BODY' })],
+    });
+  });
+
+  it('normalizes schema issue paths into HTTP 400 and propagates implementation failures', async () => {
+    const failure: StandardSchemaV1Like = {
+      '~standard': {
+        version: 1,
+        vendor: 'fluo-test',
+        validate: () => ({
+          issues: [{ message: 'Invalid title', path: ['posts', { key: 0 }, 'title'] }],
+        }),
+      },
+    };
+    const Input = createSchemaDto(failure, { fields: {} });
+    await expect(new StandardSchemaBinder().bind(Input, context(undefined)))
+      .rejects.toMatchObject({
+        status: 400,
+        details: [expect.objectContaining({ code: 'INVALID_FIELD', field: 'posts[0].title' })],
+      });
+
+    const error = new Error('schema implementation failed');
+    const Throwing = createSchemaDto({
+      '~standard': {
+        version: 1,
+        vendor: 'fluo-test',
+        validate() { throw error; },
+      },
+    }, { fields: {} });
+    await expect(new StandardSchemaBinder().bind(Throwing, context(undefined)))
+      .rejects.toBe(error);
+  });
+
+  it('treats an empty Standard Schema issues array as HTTP 400, not success or a server error', async () => {
+    const Input = createSchemaDto({
+      '~standard': {
+        version: 1,
+        vendor: 'fluo-test',
+        validate: () => ({ issues: [] }),
+      },
+    }, { fields: {} });
+    await expect(new StandardSchemaBinder().bind(Input, context(undefined)))
+      .rejects.toMatchObject({ status: 400, details: [] });
+  });
+
+  it('delegates ordinary DTOs to the supplied Binder with the original context', async () => {
+    class Ordinary {}
+    const incoming = context(undefined);
+    const calls: Array<[Constructor, ArgumentResolverContext]> = [];
+    const result = new Ordinary();
+    const binder = new StandardSchemaBinder({
+      bind(dto, supplied) {
+        calls.push([dto, supplied]);
+        return result;
+      },
+    });
+    await expect(binder.bind(Ordinary, incoming)).resolves.toBe(result);
+    expect(calls).toEqual([[Ordinary, incoming]]);
+  });
+
+  it.each(['__proto__', 'constructor', 'prototype'])(
+    'rejects dangerous mapping key %s before handling requests',
+    (key) => {
+      expect(() => createSchemaDto(echo, {
+        fields: { [key]: { source: 'body', key: 'safe' } },
+      })).toThrow(TypeError);
+      expect(() => createSchemaDto(echo, {
+        fields: { safe: { source: 'body', key } },
+      })).toThrow(TypeError);
+    },
+  );
+});

--- a/packages/http/src/input-policy.ts
+++ b/packages/http/src/input-policy.ts
@@ -1,0 +1,100 @@
+import type { Constructor, MetadataPropertyKey } from '@fluojs/core';
+import {
+  ensureRequestPipelineMetadataSymbol,
+  getRequestPipelineMetadataBag,
+} from '@fluojs/core/request-pipeline';
+
+import type { HandlerDescriptor } from './types.js';
+
+const dtoPolicyKey = Symbol.for('fluo.http.input-policy');
+const routePolicyKey = Symbol.for('fluo.http.route-input-policy');
+
+ensureRequestPipelineMetadataSymbol();
+
+/**
+ * Opt-in policies for the top-level body consumed by HTTP input binding.
+ *
+ * Omission preserves unknown-field rejection and non-object rejection.
+ * Null and absent bodies retain the existing missing-field behavior.
+ */
+export interface InputPolicyOptions {
+  readonly unknownFields?: 'reject' | 'strip';
+  readonly nonObjects?: 'reject' | 'empty';
+}
+
+type StandardClassDecoratorFn = (value: Function, context: ClassDecoratorContext) => void;
+type StandardMethodDecoratorFn = (value: Function, context: ClassMethodDecoratorContext) => void;
+type LegacyClassDecoratorFn = (target: Function) => void;
+type LegacyMethodDecoratorFn = (target: object, propertyKey: MetadataPropertyKey, descriptor?: PropertyDescriptor) => void;
+type InputPolicyDecorator = StandardClassDecoratorFn & StandardMethodDecoratorFn & LegacyClassDecoratorFn & LegacyMethodDecoratorFn;
+
+type PolicyMap = ReadonlyMap<MetadataPropertyKey, Readonly<InputPolicyOptions>>;
+type PolicyOwner = {
+  [dtoPolicyKey]?: Readonly<InputPolicyOptions>;
+  [routePolicyKey]?: PolicyMap;
+};
+
+/**
+ * Declare body input policies on a DTO class or HTTP route method.
+ *
+ * @param options Policies to merge with inherited DTO or existing route policies.
+ * @returns A standard or legacy class/method decorator; explicit route fields override DTO fields.
+ * @throws TypeError When a JavaScript caller supplies an unsupported policy value.
+ * @remarks Projection never assigns to RequestContext.request.body. This decorator does
+ * not change parser, guard, interceptor, converter, or validation execution order.
+ */
+export function InputPolicy(options: InputPolicyOptions): InputPolicyDecorator {
+  if (
+    (options.unknownFields !== undefined && options.unknownFields !== 'reject' && options.unknownFields !== 'strip')
+    || (options.nonObjects !== undefined && options.nonObjects !== 'reject' && options.nonObjects !== 'empty')
+  ) {
+    throw new TypeError('Unsupported HTTP input policy.');
+  }
+  const snapshot: InputPolicyOptions = {
+    ...(options.unknownFields === undefined ? {} : { unknownFields: options.unknownFields }),
+    ...(options.nonObjects === undefined ? {} : { nonObjects: options.nonObjects }),
+  };
+
+  return (
+    value: Function | object,
+    context?: ClassDecoratorContext | ClassMethodDecoratorContext | MetadataPropertyKey,
+    _descriptor?: PropertyDescriptor,
+  ): void => {
+    if (typeof context === 'string' || typeof context === 'symbol') {
+      const owner = value as PolicyOwner;
+      const map = new Map(owner[routePolicyKey]);
+      map.set(context, Object.freeze({ ...map.get(context), ...snapshot }));
+      Object.defineProperty(owner, routePolicyKey, { configurable: true, value: map });
+      return;
+    }
+    if (context?.kind === 'method') {
+      const bag = context.metadata as Record<PropertyKey, unknown>;
+      const map = new Map(bag[routePolicyKey] as PolicyMap | undefined);
+      map.set(context.name, Object.freeze({ ...map.get(context.name), ...snapshot }));
+      bag[routePolicyKey] = map;
+      return;
+    }
+    const owner = value as PolicyOwner;
+    Object.defineProperty(owner, dtoPolicyKey, {
+      configurable: true,
+      value: Object.freeze({ ...owner[dtoPolicyKey], ...snapshot }),
+    });
+  };
+}
+
+/**
+ * Resolve DTO and route input policy records for one binding invocation.
+ *
+ * @param dto DTO constructor selected by the existing RequestDto metadata.
+ * @param handler Matched handler whose explicit policy fields take precedence.
+ * @returns The merged policy without mutating either metadata record.
+ * @internal
+ */
+export function getInputPolicy(dto: Constructor, handler: HandlerDescriptor): InputPolicyOptions {
+  const standard = getRequestPipelineMetadataBag(handler.controllerToken)?.[routePolicyKey] as PolicyMap | undefined;
+  const legacy = (handler.controllerToken.prototype as PolicyOwner)[routePolicyKey];
+  return {
+    ...(dto as PolicyOwner)[dtoPolicyKey],
+    ...(standard?.get(handler.methodName) ?? legacy?.get(handler.methodName)),
+  };
+}

--- a/packages/http/src/schema-binding.ts
+++ b/packages/http/src/schema-binding.ts
@@ -1,0 +1,163 @@
+import { type Constructor, InvariantError } from '@fluojs/core';
+import {
+  DtoValidationError,
+  parseStandardSchema,
+  type StandardSchemaV1Like,
+} from '@fluojs/validation';
+
+import { DefaultBinder, prepareBindingRequest } from './adapters/binding.js';
+import { BadRequestException } from './exceptions.js';
+import { toInputErrorDetail } from './input-error-detail.js';
+import { getInputPolicy, InputPolicy, type InputPolicyOptions } from './input-policy.js';
+import type { ArgumentResolverContext, Binder } from './types.js';
+
+const schemaDefinitionKey = Symbol.for('fluo.http.schema-binding');
+const dangerousKeys = new Set(['__proto__', 'constructor', 'prototype']);
+
+/**
+ * A field projected into Standard Schema input before schema validation.
+ *
+ * The record property is the schema input name; key is its transport alias.
+ * Repeated query values preserve their array by default.
+ */
+export type SchemaBindingField =
+  | { readonly source: 'body' | 'path'; readonly key?: string }
+  | {
+      readonly source: 'query';
+      readonly key?: string;
+      readonly repeatedQuery?: 'preserve' | 'first' | 'last' | 'reject';
+    };
+
+/** Explicit transport mappings and optional body policy for a schema request token. */
+export interface SchemaDtoOptions {
+  readonly fields: Readonly<Record<string, SchemaBindingField>>;
+  readonly policy?: InputPolicyOptions;
+}
+
+interface SchemaDefinition {
+  readonly schema: StandardSchemaV1Like;
+  readonly entries: readonly (readonly [string, SchemaBindingField])[];
+  readonly bodyKeys: ReadonlySet<string>;
+}
+
+type SchemaTokenOwner = Constructor & {
+  readonly [schemaDefinitionKey]: SchemaDefinition;
+};
+
+/**
+ * Create an opaque RequestDto token whose instance type is the schema output.
+ *
+ * @param schema Vendor-independent Standard Schema v1 validator.
+ * @param options Explicit input field mappings and optional body policies.
+ * @returns A token for RequestDto; use InstanceType of this token for handler input.
+ * @throws TypeError For unsupported mappings or dangerous input/source keys.
+ * @remarks Install StandardSchemaBinder through the Binder seam. Do not construct,
+ * subclass, or apply mapped-class DTO helpers to this token. Missing mapped values
+ * are omitted so the schema owns required fields, defaults, and transformations.
+ */
+export function createSchemaDto<Input, Output>(
+  schema: StandardSchemaV1Like<Input, Output>,
+  options: SchemaDtoOptions,
+): Constructor<Output>;
+/**
+ * Store schema binding metadata on an opaque token that cannot be instantiated.
+ *
+ * @param schema Standard Schema validator retained for binding.
+ * @param options Input mappings and body policy to snapshot.
+ * @returns The request token; StandardSchemaBinder produces its handler value.
+ */
+export function createSchemaDto(
+  schema: StandardSchemaV1Like,
+  options: SchemaDtoOptions,
+): Constructor {
+  const entries = Object.entries(options.fields).map(([name, field]) => {
+    const key = field.key ?? name;
+    if (
+      dangerousKeys.has(name)
+      || dangerousKeys.has(key)
+      || typeof key !== 'string'
+      || !['body', 'path', 'query'].includes(field.source)
+      || (field.source === 'query'
+        && field.repeatedQuery !== undefined
+        && !['preserve', 'first', 'last', 'reject'].includes(field.repeatedQuery))
+    ) {
+      throw new TypeError('Invalid Standard Schema input mapping.');
+    }
+    return [name, Object.freeze({ ...field, key })] as const;
+  });
+  class SchemaRequest {
+    constructor() {
+      throw new InvariantError('Schema request tokens require StandardSchemaBinder.');
+    }
+  }
+  InputPolicy(options.policy ?? {})(SchemaRequest);
+  Object.defineProperty(SchemaRequest, schemaDefinitionKey, {
+    value: {
+      schema,
+      entries: Object.freeze(entries),
+      bodyKeys: new Set(entries.filter(([, field]) => field.source === 'body').map(([, field]) => field.key)),
+    } satisfies SchemaDefinition,
+  });
+  return SchemaRequest;
+}
+
+/**
+ * Bind explicit schema request tokens to successful Standard Schema output.
+ *
+ * Ordinary DTOs delegate to the supplied binder, preserving their converter and
+ * validation pipeline. Direct construction defaults to the ordinary DefaultBinder.
+ * Runtime applications should pass the default binder supplied by bootstrap.
+ */
+export class StandardSchemaBinder implements Binder {
+  constructor(private readonly fallback: Binder = new DefaultBinder()) {}
+
+  async bind(dto: Constructor, context: ArgumentResolverContext): Promise<unknown> {
+    if (!Object.hasOwn(dto, schemaDefinitionKey)) {
+      return this.fallback.bind(dto, context);
+    }
+    const definition = (dto as SchemaTokenOwner)[schemaDefinitionKey];
+    const request = prepareBindingRequest(
+      context.requestContext.request,
+      definition.bodyKeys,
+      getInputPolicy(dto, context.handler),
+    );
+    const input: Record<string, unknown> = {};
+    for (const [name, field] of definition.entries) {
+      const key = field.key ?? name;
+      const source = field.source === 'body' ? request.body : field.source === 'path' ? request.params : request.query;
+      let value = source !== undefined && source !== null && Object.hasOwn(source, key)
+        ? (source as Record<string, unknown>)[key]
+        : undefined;
+      if (field.source === 'query' && Array.isArray(value)) {
+        if (field.repeatedQuery === 'reject' && value.length > 1) {
+          throw new BadRequestException('Repeated query values are not allowed.', {
+            details: [toInputErrorDetail({
+              code: 'REPEATED_QUERY',
+              field: name,
+              message: `Repeated query field ${key} is not allowed.`,
+              source: 'query',
+            })],
+          });
+        }
+        value = field.repeatedQuery === 'first'
+          ? value[0]
+          : field.repeatedQuery === 'last'
+            ? value.at(-1)
+            : [...value];
+      }
+      if (value !== undefined) {
+        input[name] = value;
+      }
+    }
+    try {
+      return await parseStandardSchema(definition.schema, input);
+    } catch (error) {
+      if (error instanceof DtoValidationError) {
+        throw new BadRequestException(error.message, {
+          details: error.issues.map((issue) => toInputErrorDetail(issue)),
+        });
+      }
+      throw error;
+    }
+  }
+}

--- a/packages/platform-nextjs/src/schema-input-materialization.test.ts
+++ b/packages/platform-nextjs/src/schema-input-materialization.test.ts
@@ -1,0 +1,238 @@
+import { Module } from '@fluojs/core';
+import {
+  Controller,
+  createSchemaDto,
+  Get,
+  Head,
+  Post,
+  RequestDto,
+  StandardSchemaBinder,
+  UnauthorizedException,
+  UseGuards,
+  type GuardContext,
+} from '@fluojs/http';
+import { FluoFactory } from '@fluojs/runtime';
+import { describe, expect, it, vi } from 'vitest';
+
+import { createNextAdapter, createNextAppRouterHandler } from './index.js';
+
+describe('schema input through the public Next App Router adapter', () => {
+  it('preserves bounded parsing, raw guards, native query arrays and original HEAD semantics', async () => {
+    const events: string[] = [];
+    const seen: Array<{
+      method: string;
+      body: unknown;
+      bytes: number[];
+      raw: unknown;
+    }> = [];
+    const schema = {
+      '~standard': {
+        version: 1 as const,
+        vendor: 'native-input-conformance',
+        async validate(value: unknown) {
+          events.push('schema');
+          const input = value as Record<string, unknown>;
+          if (input.title !== undefined && typeof input.title !== 'string') {
+            return { issues: [{ message: 'Invalid title', path: ['title'] }] };
+          }
+          return {
+            value: {
+              title: typeof input.title === 'string' ? input.title.trim() : 'Untitled',
+              id: Number(input.id),
+              tags: Array.isArray(input.tags) ? input.tags.map(String) : [],
+            },
+          };
+        },
+      },
+    };
+    const Input = createSchemaDto(schema, {
+      fields: {
+        title: { source: 'body', key: 'post_title' },
+        id: { source: 'path', key: 'postId' },
+        tags: { source: 'query', key: 'tag' },
+      },
+      policy: { unknownFields: 'strip', nonObjects: 'empty' },
+    });
+    class Inspect {
+      canActivate({ requestContext }: GuardContext) {
+        events.push('guard');
+        seen.push({
+          method: requestContext.request.method,
+          body: requestContext.request.body,
+          bytes: Array.from(requestContext.request.rawBody ?? []),
+          raw: requestContext.request.raw,
+        });
+        if (requestContext.request.headers.authorization !== 'Bearer test') {
+          throw new UnauthorizedException();
+        }
+        return true;
+      }
+    }
+    @Controller('/posts')
+    @UseGuards(Inspect)
+    class Posts {
+      @Post('/:postId')
+      @RequestDto(Input)
+      create(input: InstanceType<typeof Input>) {
+        events.push('post');
+        return input;
+      }
+
+      @Get('/:postId')
+      @RequestDto(Input)
+      get(input: InstanceType<typeof Input>) {
+        events.push('get');
+        return input;
+      }
+
+      @Get('/explicit/:postId')
+      @RequestDto(Input)
+      explicitGet(input: InstanceType<typeof Input>) {
+        events.push('explicit-get');
+        return input;
+      }
+
+      @Head('/explicit/:postId')
+      @RequestDto(Input)
+      explicitHead(input: InstanceType<typeof Input>) {
+        events.push('explicit-head');
+        return input;
+      }
+    }
+    @Module({ controllers: [Posts], providers: [Inspect] })
+    class App {}
+    const adapter = createNextAdapter({
+      headRouting: 'explicit-or-get',
+      rawBody: true,
+      maxBodySize: 128,
+      bodyParser(_text, parserContext) {
+        events.push('parse');
+        return parserContext.parseDefault();
+      },
+    });
+    const app = await FluoFactory.create(App, {
+      adapter,
+      binder: (fallback) => new StandardSchemaBinder(fallback),
+    });
+    try {
+      await app.listen();
+      const handler = createNextAppRouterHandler(async () => adapter);
+      const wire = '{"post_title":"  Draft  ","extra":true}';
+      const native = new Request('https://schema.test/posts/9?tag=a&tag=b', {
+        method: 'POST',
+        body: wire,
+        headers: {
+          authorization: 'Bearer test',
+          'content-type': 'application/json',
+        },
+      });
+      const clone = vi.spyOn(native, 'clone');
+      const response = await handler.POST(native);
+      expect(response.status).toBe(201);
+      await expect(response.json()).resolves.toEqual({
+        title: 'Draft', id: 9, tags: ['a', 'b'],
+      });
+      expect(events).toEqual(['parse', 'guard', 'schema', 'post']);
+      expect(seen[0]).toMatchObject({
+        method: 'POST',
+        body: { post_title: '  Draft  ', extra: true },
+        bytes: Array.from(new TextEncoder().encode(wire)),
+      });
+      expect(seen[0]?.raw).toBe(native);
+      expect(native.headers.get('content-type')).toBe('application/json');
+      expect(native.bodyUsed).toBe(true);
+      expect(clone).not.toHaveBeenCalled();
+      clone.mockRestore();
+
+      for (const [body, status, expectedEvents] of [
+        ['{', 400, ['parse']],
+        ['x'.repeat(129), 413, []],
+      ] as const) {
+        events.length = 0;
+        const failed = await handler.POST(new Request('https://schema.test/posts/9', {
+          method: 'POST',
+          body,
+          headers: { 'content-type': 'application/json' },
+        }));
+        expect(failed.status).toBe(status);
+        expect(events).toEqual(expectedEvents);
+      }
+
+      events.length = 0;
+      const unauthorized = await handler.POST(new Request('https://schema.test/posts/9', {
+        method: 'POST',
+        body: '{"post_title":"Draft","extra":true}',
+        headers: { 'content-type': 'application/json' },
+      }));
+      expect(unauthorized.status).toBe(401);
+      expect(events).toEqual(['parse', 'guard']);
+
+      events.length = 0;
+      const dangerous = await handler.POST(new Request('https://schema.test/posts/9', {
+        method: 'POST',
+        body: '{"post_title":"Draft","__proto__":"blocked"}',
+        headers: {
+          authorization: 'Bearer test',
+          'content-type': 'application/json',
+        },
+      }));
+      expect(dangerous.status).toBe(400);
+      await expect(dangerous.json()).resolves.toMatchObject({
+        error: {
+          details: [expect.objectContaining({ code: 'DANGEROUS_KEY', field: '__proto__' })],
+        },
+      });
+      expect(events).toEqual(['parse', 'guard']);
+
+      events.length = 0;
+      const invalid = await handler.POST(new Request('https://schema.test/posts/9', {
+        method: 'POST',
+        body: '{"post_title":123}',
+        headers: {
+          authorization: 'Bearer test',
+          'content-type': 'application/json',
+        },
+      }));
+      expect(invalid.status).toBe(400);
+      await expect(invalid.json()).resolves.toMatchObject({
+        error: {
+          details: [expect.objectContaining({ code: 'INVALID_FIELD', field: 'title' })],
+        },
+      });
+      expect(events).toEqual(['parse', 'guard', 'schema']);
+
+      events.length = 0;
+      const empty = await handler.POST(new Request('https://schema.test/posts/9', {
+        method: 'POST',
+        body: '[]',
+        headers: {
+          authorization: 'Bearer test',
+          'content-type': 'application/json',
+        },
+      }));
+      expect(empty.status).toBe(201);
+      await expect(empty.json()).resolves.toEqual({ title: 'Untitled', id: 9, tags: [] });
+      expect(seen.at(-1)?.body).toEqual([]);
+      expect(events).toEqual(['parse', 'guard', 'schema', 'post']);
+
+      for (const [path, selected] of [
+        ['/posts/9', 'get'],
+        ['/posts/explicit/9', 'explicit-head'],
+      ] as const) {
+        events.length = 0;
+        const head = await handler.HEAD(new Request(`https://schema.test${path}`, {
+          method: 'HEAD',
+          headers: { authorization: 'Bearer test' },
+        }));
+        expect(head.status).toBe(200);
+        await expect(head.text()).resolves.toBe('');
+        expect(seen.at(-1)?.method).toBe('HEAD');
+        expect(seen.at(-1)?.body).toBeUndefined();
+        expect(events).toEqual(['guard', 'schema', selected]);
+      }
+    } finally {
+      vi.restoreAllMocks();
+      await app.close();
+    }
+  });
+});

--- a/packages/runtime/README.ko.md
+++ b/packages/runtime/README.ko.md
@@ -168,6 +168,57 @@ Runtime bootstrap은 `@fluojs/http`의 `conditionalRequest` option을 받습니�
 
 `createAccessLogObserver(...)`를 bootstrap `observers` option으로 전달하면 portable request lifecycle record를 애플리케이션 소유 structured logging으로 라우팅할 수 있습니다. Observer는 native adapter에서도 complete fallback path를 선택해 dispatcher lifecycle을 보존합니다. Trusted client identity와 header allowlist 요구사항은 [`@fluojs/http` Access logging 계약](../http/README.ko.md#access-logging)을 참고하세요.
 
+### HTTP binder composition
+
+**범위와 입력:** `BootstrapApplicationOptions`, `CreateApplicationOptions`는
+`binder?: (defaultBinder: Binder) => Binder`를 받습니다. Bootstrap API는
+`@fluojs/runtime`, `Binder` 계약과 `StandardSchemaBinder`는 `@fluojs/http`에서
+import합니다. 생략하면 기존 default HTTP binding pipeline을 유지합니다.
+`CreateApplicationContextOptions`는 `binder`를 제외합니다. 순수 DI context는
+HTTP dispatcher를 생성하지 않습니다.
+
+동기 factory는 request마다가 아니라 runtime이 dispatcher를 조립할 때 HTTP
+application bootstrap마다 한 번 실행됩니다. Global `converters`가 이미
+설정된 default binder를 받습니다. 별개의 default를 만들어 설정을 잃지 말고
+일반 DTO를 제공받은 binder로 위임하세요. 반환한 binder는 application의
+dispatcher가 재사용합니다.
+
+다음 bootstrap fragment는 controller가 등록된 기존 `AppModule`을 전제로 합니다.
+[완전한 schema route 예제](../http/README.ko.md#standard-schema-output-binding)도
+참고하세요.
+
+```typescript
+import { StandardSchemaBinder } from '@fluojs/http';
+import { createNodejsAdapter } from '@fluojs/platform-nodejs';
+import { FluoFactory } from '@fluojs/runtime';
+import { AppModule } from './app.js';
+
+const app = await FluoFactory.create(AppModule, {
+  adapter: createNodejsAdapter({ host: '127.0.0.1', port: 3000 }),
+  binder: (defaultBinder) => new StandardSchemaBinder(defaultBinder),
+});
+await app.listen();
+```
+
+`bootstrapApplication({ rootModule: AppModule, ...options })`도 같은 factory를
+받습니다. 기존 `converters`는 `binder`와 함께 지정할 수 있고 일반 DTO의
+fallback을 통해 계속 실행됩니다. Schema token은 대신 schema의
+conversion/default rule을 사용합니다. 이 callback 자리에 binder instance나
+async factory를 전달하지 마세요.
+
+**실패와 소유권:** 호출 가능한 `bind` method가 없는 결과는 bootstrap을
+`TypeError`로 reject합니다. Factory 예외는 기존 bootstrap-failure cleanup을
+거쳐 전파됩니다. Runtime은 binder를 연결하지만 binder disposal hook을 추가하지
+않습니다. Application-owned 외부 resource에는 기존 lifecycle 등록이 필요합니다.
+종료는 host가 소유하고 `app.close()`를 호출합니다. 위 fragment는 process
+signal을 등록하지 않습니다. 이 option은 native body parsing이나 HEAD 동작을
+바꾸지 않습니다. Projection, validation error, request 순서는 HTTP가 소유합니다.
+HTTP의 [입력 정책 계약](../http/README.ko.md#명시적-입력-정책)을 참고하세요.
+
+**근거:** `src/types.ts`, `src/bootstrap.ts`,
+`../testing/src/input-materialization.e2e.test.ts`는 option, composition,
+application boundary 회귀의 확인 위치입니다.
+
 ### 애플리케이션 컨텍스트 (HTTP 제외)
 
 백그라운드 워커나 스크립트의 경우, `createApplicationContext`를 사용하여 HTTP 설정을 건너뛸 수 있습니다.

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -169,6 +169,57 @@ Runtime bootstrap accepts the `conditionalRequest` option from `@fluojs/http`. I
 
 Pass `createAccessLogObserver(...)` through the bootstrap `observers` option to route portable request lifecycle records to application-owned structured logging. The observer preserves the dispatcher lifecycle for native adapters by selecting the complete fallback path; see the [`@fluojs/http` Access logging contract](../http/README.md#access-logging) for trusted client identity and header allowlist requirements.
 
+
+### HTTP binder composition
+
+**Scope and inputs:** `BootstrapApplicationOptions` and `CreateApplicationOptions`
+accept `binder?: (defaultBinder: Binder) => Binder`. Import bootstrap APIs from
+`@fluojs/runtime` and the `Binder` contract and `StandardSchemaBinder` from
+`@fluojs/http`. Omission preserves the existing default HTTP binding pipeline.
+`CreateApplicationContextOptions` excludes `binder`: pure DI contexts do not
+create an HTTP dispatcher.
+
+The synchronous factory runs once per HTTP application bootstrap, when runtime
+assembles the dispatcher, not once per request. It receives the default binder
+already configured with global `converters`. Delegate ordinary DTOs to that
+binder rather than constructing an unrelated default and losing those settings.
+The returned binder is reused by the application's dispatcher.
+
+This bootstrap fragment assumes an existing `AppModule` with registered
+controllers; see the [complete schema route example](../http/README.md#standard-schema-output-binding).
+
+```typescript
+import { StandardSchemaBinder } from '@fluojs/http';
+import { createNodejsAdapter } from '@fluojs/platform-nodejs';
+import { FluoFactory } from '@fluojs/runtime';
+import { AppModule } from './app.js';
+
+const app = await FluoFactory.create(AppModule, {
+  adapter: createNodejsAdapter({ host: '127.0.0.1', port: 3000 }),
+  binder: (defaultBinder) => new StandardSchemaBinder(defaultBinder),
+});
+await app.listen();
+```
+
+`bootstrapApplication({ rootModule: AppModule, ...options })` accepts the same
+factory. Existing `converters` can be supplied alongside `binder`; they continue
+to run through the fallback for ordinary DTOs. Schema tokens instead use their
+schema's conversion/default rules. Do not pass a binder instance or an async
+factory where this callback is expected.
+
+**Failures and ownership:** a result without a callable `bind` method rejects
+bootstrap with `TypeError`; factory exceptions propagate through existing
+bootstrap-failure cleanup. Runtime wires the binder but does not add a binder
+disposal hook. Application-owned external resources still need their normal
+lifecycle registration. The host owns shutdown and calls `app.close()`; the
+fragment above does not register process signals. This option changes neither
+native body parsing nor HEAD behavior. HTTP owns projection, validation errors,
+and request order; see its [input policy contract](../http/README.md#explicit-input-policies).
+
+**Evidence:** `src/types.ts`, `src/bootstrap.ts`, and
+`../testing/src/input-materialization.e2e.test.ts` are the option, composition,
+and application-boundary regression locations.
+
 ### Application Context (No HTTP)
 
 For background workers or scripts, use `createApplicationContext` to skip HTTP setup.

--- a/packages/runtime/src/bootstrap.ts
+++ b/packages/runtime/src/bootstrap.ts
@@ -1534,8 +1534,13 @@ function createRuntimeDispatcherOptions(
     rootContainer: bootstrapped.container,
   };
 
-  if (converters.length > 0) {
-    dispatcherOptions.binder = new RuntimeDefaultBinder(converters);
+  if (options.binder !== undefined || converters.length > 0) {
+    const defaultBinder = new RuntimeDefaultBinder(converters);
+    const binder = options.binder === undefined ? defaultBinder : options.binder(defaultBinder);
+    if (typeof binder !== 'object' || binder === null || typeof binder.bind !== 'function') {
+      throw new TypeError('The bootstrap binder factory must return a Binder.');
+    }
+    dispatcherOptions.binder = binder;
   }
 
   if (errorHandler) {

--- a/packages/runtime/src/input-materialization-public-types.test.ts
+++ b/packages/runtime/src/input-materialization-public-types.test.ts
@@ -1,0 +1,220 @@
+import { execFile } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { cp, mkdir, mkdtemp, realpath, rm, symlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+import ts from 'typescript';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { resolveWorkspaceBuildOrder } from '../../../tooling/scripts/run-workspace-build-closure.mjs';
+
+const execFileAsync = promisify(execFile);
+const repositoryRoot = fileURLToPath(new URL('../../../', import.meta.url));
+let root: string;
+let fixture: string;
+const imports = `
+import {
+  Controller, createSchemaDto, FromBody, InputPolicy, Post, RequestDto,
+  StandardSchemaBinder,
+} from '@fluojs/http';
+import {
+  createSchemaDto as portableDto,
+  InputPolicy as PortableInputPolicy,
+  type SchemaDtoOptions,
+} from '@fluojs/http/portable';
+import { parseStandardSchema, type StandardSchemaV1Like } from '@fluojs/validation';
+import type { BootstrapApplicationOptions } from '@fluojs/runtime';
+const schema: StandardSchemaV1Like<{ title: string }, { title: string; count: number }> = {
+  '~standard': {
+    version: 1, vendor: 'consumer',
+    validate: () => ({ value: { title: 'Draft', count: 2 } }),
+  },
+};
+const Input = createSchemaDto(schema, { fields: { title: { source: 'body' } } });
+`;
+
+function compile(source: string, experimentalDecorators = false): readonly ts.Diagnostic[] {
+  const options: ts.CompilerOptions = {
+    experimentalDecorators,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    noEmit: true,
+    skipLibCheck: false,
+    strict: true,
+    target: ts.ScriptTarget.ESNext,
+    types: [],
+  };
+  const host = ts.createCompilerHost(options);
+  const getSourceFile = host.getSourceFile;
+  host.getSourceFile = (path, languageVersion, onError, shouldCreateNewSourceFile) =>
+    path === fixture
+      ? ts.createSourceFile(path, source, languageVersion, true)
+      : getSourceFile(path, languageVersion, onError, shouldCreateNewSourceFile);
+  const program = ts.createProgram([fixture], options, host);
+  const declarations = program.getSourceFiles().filter((file) =>
+    file.fileName.includes('/packages/') && file.fileName !== fixture,
+  );
+  expect(declarations.length).toBeGreaterThan(0);
+  for (const declaration of declarations) {
+    expect(declaration.fileName.startsWith(join(root, 'packages/'))).toBe(true);
+    expect(declaration.isDeclarationFile).toBe(true);
+  }
+  return ts.getPreEmitDiagnostics(program);
+}
+
+function messages(diagnostics: readonly ts.Diagnostic[]): string[] {
+  return diagnostics.map((entry) => ts.flattenDiagnosticMessageText(entry.messageText, '\n'));
+}
+
+describe('cold public input materialization declarations', () => {
+  afterAll(async () => {
+    if (root) await rm(root, { recursive: true, force: true });
+  });
+
+  beforeAll(async () => {
+    root = await realpath(await mkdtemp(join(tmpdir(), 'fluo-input-3716-declarations-')));
+    fixture = join(root, 'consumer/input-consumer.mts');
+    const packages = resolveWorkspaceBuildOrder('@fluojs/runtime', repositoryRoot);
+    const script = 'tooling/scripts/run-workspace-build-closure.mjs';
+    for (const entry of [
+      'package.json', 'pnpm-workspace.yaml', 'tsconfig.base.json',
+      'tooling/babel', 'tooling/tsconfig', 'tooling/vite',
+      'tooling/scripts/clean-dist.mjs', script,
+      'packages/testing/src/babel-decorators-plugin.ts',
+      ...packages.map((name) => `packages/${name.slice('@fluojs/'.length)}`),
+    ]) {
+      await cp(join(repositoryRoot, entry), join(root, entry), {
+        recursive: true,
+        verbatimSymlinks: true,
+        filter: (source) => !['dist', '.vite', '.vite-temp'].includes(basename(source)),
+      });
+    }
+    await symlink(join(repositoryRoot, 'node_modules'), join(root, 'node_modules'), 'dir');
+    await mkdir(join(root, 'consumer/node_modules/@fluojs'), { recursive: true });
+    for (const name of packages) {
+      const packageRoot = join(root, 'packages', name.slice('@fluojs/'.length));
+      expect(existsSync(join(packageRoot, 'dist'))).toBe(false);
+      await symlink(packageRoot, join(root, 'consumer/node_modules', name), 'dir');
+    }
+    await execFileAsync(process.execPath, [join(root, script), '@fluojs/runtime'], {
+      cwd: root,
+      env: process.env,
+      timeout: 240_000,
+      killSignal: 'SIGTERM',
+    });
+  }, 300_000);
+
+  it('infers schema output through manifest exports rather than workspace source aliases', () => {
+    const diagnostics = compile(`${imports}
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+type Assert<T extends true> = T;
+type Output = Assert<Equal<InstanceType<typeof Input>, { title: string; count: number }>>;
+const parsed = parseStandardSchema(schema, { title: 'Draft' });
+type Parsed = Assert<Equal<typeof parsed, Promise<{ title: string; count: number }>>>;
+const options = { fields: { title: { source: 'body' } } } satisfies SchemaDtoOptions;
+const Portable = portableDto(schema, options);
+type PortableOutput = Assert<Equal<InstanceType<typeof Portable>, InstanceType<typeof Input>>>;
+const scalarSchema: StandardSchemaV1Like<unknown, number> = {
+  '~standard': { version: 1, vendor: 'consumer', validate: () => ({ value: 42 }) },
+};
+const Scalar = createSchemaDto(scalarSchema, { fields: {} });
+type ScalarOutput = Assert<Equal<InstanceType<typeof Scalar>, number>>;
+class App {}
+const application: BootstrapApplicationOptions = {
+  rootModule: App,
+  binder: (fallback) => new StandardSchemaBinder(fallback),
+};
+InputPolicy({ unknownFields: 'strip', nonObjects: 'empty' });
+`);
+    expect(messages(diagnostics)).toEqual([]);
+  });
+
+  it('compiles standard class/method decorators, composition and body aliases', () => {
+    const diagnostics = compile(`${imports}
+@InputPolicy({ unknownFields: 'strip' })
+class ClassInput {
+  @FromBody('post_title')
+  title = '';
+}
+function BoundPost(value: Function, context: ClassMethodDecoratorContext): void {
+  InputPolicy({ unknownFields: 'strip' })(value, context);
+  RequestDto(Input)(value, context);
+  Post('/composed')(value, context);
+}
+@Controller('/posts')
+class Posts {
+  @InputPolicy({ unknownFields: 'strip' })
+  @Post()
+  @RequestDto(Input)
+  create(input: InstanceType<typeof Input>) {
+    const count: number = input.count;
+    return count;
+  }
+  @Post('/reversed')
+  @RequestDto(ClassInput)
+  @PortableInputPolicy({ nonObjects: 'empty' })
+  reversed(input: ClassInput) { return input.title; }
+  @BoundPost
+  composed(input: InstanceType<typeof Input>) { return input.count; }
+}
+`);
+    expect(messages(diagnostics)).toEqual([]);
+  });
+
+  it('compiles actual legacy class/method decoration and three-argument composition', () => {
+    const diagnostics = compile(`${imports}
+const classDecorator: ClassDecorator = InputPolicy({ unknownFields: 'strip' });
+const methodDecorator: MethodDecorator = InputPolicy({ nonObjects: 'empty' });
+function Projected(): ClassDecorator & MethodDecorator {
+  return PortableInputPolicy({ unknownFields: 'strip' });
+}
+function ComposedPolicy(): MethodDecorator {
+  const policy = InputPolicy({ unknownFields: 'reject' });
+  return (target, propertyKey, descriptor) => {
+    policy(target, propertyKey, descriptor);
+  };
+}
+@InputPolicy({ unknownFields: 'strip' })
+class LegacyInput { title = ''; }
+@Projected()
+class LegacyPosts {
+  @InputPolicy({ nonObjects: 'empty' })
+  create(input: InstanceType<typeof Input>) { return input.count; }
+  @Projected()
+  projected(input: LegacyInput) { return input.title; }
+  @ComposedPolicy()
+  composed(input: InstanceType<typeof Input>) { return input.count; }
+}
+InputPolicy({ unknownFields: 'reject' })(
+  LegacyPosts.prototype,
+  'create',
+  Object.getOwnPropertyDescriptor(LegacyPosts.prototype, 'create'),
+);
+`, true);
+    expect(messages(diagnostics)).toEqual([]);
+  });
+
+  it('rejects input-shaped outputs and unsupported policies at the consumer', () => {
+    const invalid = [
+      "const output: InstanceType<typeof Input> = { title: 'Draft', count: '2' };",
+      "InputPolicy({ unknownFields: 'allow' });",
+      "InputPolicy({ nonObjects: 'ignore' });",
+      "createSchemaDto(schema, { fields: { title: { source: 'cookie' } } });",
+      "createSchemaDto(schema, { fields: { title: { source: 'query', repeatedQuery: 'join' } } });",
+      "const app: BootstrapApplicationOptions = { rootModule: class App {}, binder: async (fallback) => fallback };",
+    ];
+    const diagnostics = compile(`${imports}${invalid.join('\n')}`);
+    expect(diagnostics).toHaveLength(invalid.length);
+    expect(diagnostics.every((entry) => entry.file?.fileName === fixture && entry.code === 2322))
+      .toBe(true);
+    expect(diagnostics.map((entry) =>
+      entry.file && entry.start !== undefined
+        ? entry.file.getLineAndCharacterOfPosition(entry.start).line
+        : -1,
+    )).toEqual(invalid.map((_, index) => imports.split('\n').length - 1 + index));
+  });
+});

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -1,6 +1,7 @@
 import type { Constructor, MaybePromise, Token } from '@fluojs/core';
 import type { Container, Provider } from '@fluojs/di';
 import type {
+  Binder,
   ConditionalRequestOptions,
   ContentNegotiationOptions,
   ConverterLike,
@@ -187,6 +188,12 @@ export interface BootstrapApplicationOptions {
    */
   filters?: ExceptionFilterHandler[];
   converters?: readonly ConverterLike[];
+  /**
+   * Compose an HTTP binder once during bootstrap. The supplied default binder
+   * includes configured global converters; delegate ordinary DTOs to it.
+   * Omission preserves the existing default binding pipeline.
+   */
+  binder?: (defaultBinder: Binder) => Binder;
   interceptors?: InterceptorLike[];
   logger?: ApplicationLogger;
   middleware?: MiddlewareLike[];
@@ -207,7 +214,7 @@ export type CreateApplicationOptions = Omit<BootstrapApplicationOptions, 'logger
 
 /** Options accepted by `FluoFactory.createApplicationContext(...)`. */
 export interface CreateApplicationContextOptions
-  extends Omit<BootstrapApplicationOptions, 'adapter' | 'converters' | 'filters' | 'logger' | 'middleware' | 'observers' | 'rootModule'> {
+  extends Omit<BootstrapApplicationOptions, 'adapter' | 'binder' | 'converters' | 'filters' | 'logger' | 'middleware' | 'observers' | 'rootModule'> {
 }
 
 /** Runtime transport contract used by microservice application shells. */

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -108,6 +108,7 @@
     "@fluojs/platform-nodejs": "workspace:^",
     "@fluojs/platform-express": "workspace:^",
     "@fluojs/platform-fastify": "workspace:^",
+    "@fluojs/validation": "workspace:^",
     "vitest": "^4.1.11"
   }
 }

--- a/packages/testing/src/input-materialization.e2e.test.ts
+++ b/packages/testing/src/input-materialization.e2e.test.ts
@@ -1,0 +1,273 @@
+import { Inject, Module, publicToken } from '@fluojs/core';
+import {
+  Controller,
+  Convert,
+  createSchemaDto,
+  FromBody,
+  FromQuery,
+  Get,
+  InputPolicy,
+  Post,
+  RequestDto,
+  StandardSchemaBinder,
+  UnauthorizedException,
+  UseGuards,
+  UseInterceptors,
+  type CallHandler,
+  type Converter,
+  type GuardContext,
+  type InterceptorContext,
+} from '@fluojs/http';
+import { IsInt, ValidateClass, type StandardSchemaV1Like } from '@fluojs/validation';
+import { describe, expect, it } from 'vitest';
+
+import { createTestApp } from './app.js';
+import type { TestResponse } from './http.js';
+
+function observeSchemaEntry(events: EventTarget): {
+  promise: Promise<void>;
+  cancel(): void;
+} {
+  let cancel: () => void = () => {
+    throw new Error('Schema entry observation was not initialized');
+  };
+  const promise = new Promise<void>((resolve, reject) => {
+    const cleanup = () => {
+      clearTimeout(timer);
+      events.removeEventListener('schema-entry', onEntry);
+    };
+    const onEntry = () => {
+      cleanup();
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error('Timed out waiting for schema entry'));
+    }, 2_000);
+    events.addEventListener('schema-entry', onEntry, { once: true });
+    cancel = () => {
+      cleanup();
+      resolve();
+    };
+  });
+  return { promise, cancel: () => cancel() };
+}
+
+describe('blog input materialization through the application boundary', () => {
+  it('projects class DTOs without installing a schema binder and validates only projected aliases', async () => {
+    const validated: unknown[] = [];
+    @InputPolicy({ unknownFields: 'strip' })
+    @ValidateClass((value: unknown) => { validated.push(value); return true; })
+    class Input {
+      @FromBody('post_title')
+      title = '';
+    }
+    @Controller('/posts')
+    class Posts {
+      @Post()
+      @RequestDto(Input)
+      create(input: Input) {
+        return input;
+      }
+    }
+    @Module({ controllers: [Posts] })
+    class App {}
+    const app = await createTestApp({ rootModule: App });
+    try {
+      const response = await app.request('POST', '/posts')
+        .body({ post_title: 'Draft', authorId: 'untrusted' }).send();
+      expect(response.status).toBe(201);
+      expect(response.body).toEqual({ title: 'Draft' });
+      expect(validated).toEqual([{ title: 'Draft' }]);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('replaces projection/context workarounds while retaining guards, aliases, converters and async order', async () => {
+    const events: string[] = [];
+    const originalBodies: unknown[] = [];
+    const schemaEvents = new EventTarget();
+    let release: () => void = () => {
+      throw new Error('Schema gate was not initialized');
+    };
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    type Command = { title: string; count: number; id: number; tags: string[] };
+    const schema: StandardSchemaV1Like<unknown, Command> = {
+      '~standard': {
+        version: 1,
+        vendor: 'blog-conformance',
+        async validate(value) {
+          events.push('schema');
+          schemaEvents.dispatchEvent(new Event('schema-entry'));
+          await gate;
+          const input = value as Record<string, unknown>;
+          if (typeof input.title !== 'string') {
+            return { issues: [{ message: 'Title is required', path: ['title'] }] };
+          }
+          return {
+            value: {
+              title: input.title.trim(),
+              count: input.count === undefined ? 1 : Number(input.count),
+              id: Number(input.id),
+              tags: Array.isArray(input.tags) ? input.tags.map(String) : [],
+            },
+          };
+        },
+      },
+    };
+    const Input = createSchemaDto(schema, {
+      fields: {
+        title: { source: 'body', key: 'post_title' },
+        count: { source: 'body' },
+        id: { source: 'path', key: 'postId' },
+        tags: { source: 'query', key: 'tag' },
+      },
+      policy: { unknownFields: 'strip' },
+    });
+    class PostsService {
+      save(input: Command) {
+        events.push('service');
+        return { ...input, authorId: 'server-owned' };
+      }
+    }
+    class TwiceConverter implements Converter {
+      convert(value: unknown) {
+        expect(value).toBeTypeOf('number');
+        return Number(value) * 2;
+      }
+    }
+    const postsToken = publicToken<PostsService>(`test/3716/posts/${crypto.randomUUID()}`);
+    const converterToken = publicToken<Converter>(`test/3716/converter/${crypto.randomUUID()}`);
+    class LegacyInput {
+      @FromQuery('page')
+      @Convert(converterToken)
+      @IsInt()
+      page = 0;
+    }
+    class Auth {
+      canActivate({ requestContext }: GuardContext) {
+        events.push('guard');
+        originalBodies.push(requestContext.request.body);
+        if (requestContext.request.headers.authorization !== 'Bearer test') {
+          throw new UnauthorizedException();
+        }
+        return true;
+      }
+    }
+    class Around {
+      async intercept(_context: InterceptorContext, next: CallHandler) {
+        events.push('interceptor:before');
+        const result = await next.handle();
+        events.push('interceptor:after');
+        return result;
+      }
+    }
+    @Controller('/posts')
+    @Inject(postsToken)
+    class Posts {
+      constructor(private readonly posts: PostsService) {}
+
+      @Post('/:postId')
+      @RequestDto(Input)
+      @UseGuards(Auth)
+      @UseInterceptors(Around)
+      create(input: InstanceType<typeof Input>) {
+        events.push('handler');
+        return this.posts.save(input);
+      }
+
+      @Get('/legacy')
+      @RequestDto(LegacyInput)
+      legacy(input: LegacyInput) {
+        return input;
+      }
+    }
+    @Module({
+      controllers: [Posts],
+      providers: [
+        PostsService, TwiceConverter, Auth, Around,
+        { provide: postsToken, useExisting: PostsService },
+        { provide: converterToken, useExisting: TwiceConverter },
+      ],
+    })
+    class App {}
+    let factories = 0;
+    const app = await createTestApp({
+      rootModule: App,
+      converters: [{ convert: (value) => Number(value) }],
+      binder(defaultBinder) {
+        factories += 1;
+        return new StandardSchemaBinder(defaultBinder);
+      },
+    });
+    const entry = observeSchemaEntry(schemaEvents);
+    let pending: Promise<TestResponse> | undefined;
+    try {
+      const body = Object.freeze({ post_title: '  Draft  ', authorId: 'untrusted' });
+      pending = app.request('POST', '/posts/7')
+        .header('authorization', 'Bearer test')
+        .query('tag', ['a', 'b'])
+        .body(body).send();
+      await entry.promise;
+      expect(events).toEqual(['guard', 'interceptor:before', 'schema']);
+      expect(originalBodies).toEqual([body]);
+      expect(originalBodies[0]).toBe(body);
+      release();
+      const response = await pending;
+      expect(response.status).toBe(201);
+      expect(response.body).toEqual({
+        title: 'Draft', count: 1, id: 7, tags: ['a', 'b'], authorId: 'server-owned',
+      });
+      expect(events).toEqual([
+        'guard', 'interceptor:before', 'schema', 'handler', 'service', 'interceptor:after',
+      ]);
+
+      events.length = 0;
+      const unauthorized = await app.request('POST', '/posts/7')
+        .body({ ['constructor']: 'blocked' }).send();
+      expect(unauthorized.status).toBe(401);
+      expect(events).toEqual(['guard']);
+
+      events.length = 0;
+      const dangerous = await app.request('POST', '/posts/7')
+        .header('authorization', 'Bearer test')
+        .body({ post_title: 'Draft', ['__proto__']: 'blocked' }).send();
+      expect(dangerous.status).toBe(400);
+      expect(dangerous.body).toMatchObject({
+        error: { details: [expect.objectContaining({ code: 'DANGEROUS_KEY', field: '__proto__' })] },
+      });
+      expect(events).toEqual(['guard', 'interceptor:before']);
+
+      events.length = 0;
+      const invalid = await app.request('POST', '/posts/7')
+        .header('authorization', 'Bearer test').body({}).send();
+      expect(invalid.status).toBe(400);
+      expect(invalid.body).toMatchObject({
+        error: { details: [expect.objectContaining({ code: 'INVALID_FIELD', field: 'title' })] },
+      });
+      expect(events).toEqual(['guard', 'interceptor:before', 'schema']);
+
+      const coerced = await app.request('POST', '/posts/8')
+        .header('authorization', 'Bearer test')
+        .body({ post_title: '  Next  ', count: '2' }).send();
+      expect(coerced.status).toBe(201);
+      expect(coerced.body).toEqual({
+        title: 'Next', count: 2, id: 8, tags: [], authorId: 'server-owned',
+      });
+
+      const legacy = await app.request('GET', '/posts/legacy').query('page', '3').send();
+      expect(legacy.status).toBe(200);
+      expect(legacy.body).toEqual({ page: 6 });
+      expect(factories).toBe(1);
+    } finally {
+      entry.cancel();
+      release();
+      try {
+        await pending;
+      } finally {
+        await app.close();
+      }
+    }
+  }, 5_000);
+});

--- a/packages/validation/README.ko.md
+++ b/packages/validation/README.ko.md
@@ -154,7 +154,10 @@ target이 해당 value를 독립적으로 실체화하고 검증할 수 있습�
 
 ### Standard Schema 지원
 
-Standard Schema adapter는 유효하지 않은 입력을 명시적인 issue로 보고해야 합니다. issue가 없는 검증 결과는 성공으로 처리합니다.
+`ValidateClass`에서 Standard Schema adapter는 유효하지 않은 입력을 명시적인
+issue로 보고해야 합니다. Issue가 없는 결과와 기존 `issues: []` 경우는 성공으로
+처리합니다. 이는 검증 전용 계약입니다. 성공한 transformed/defaulted output으로
+DTO나 그 field를 교체하지 않습니다.
 
 ```ts
 import { ValidateClass } from '@fluojs/validation';
@@ -169,6 +172,54 @@ class RestrictedUserDto {
 ```
 
 `ValidateClass(...)`는 custom class-level validator도 받을 수 있습니다. `Validate(...)`는 built-in decorator만으로 부족할 때 custom field-level validator를 붙이고, `ValidateIf(...)`는 predicate가 false를 반환하면 dependent validator를 short-circuit합니다.
+
+### Standard Schema output parsing
+
+**범위와 import:** 성공한 schema output 자체가 필요하면 `@fluojs/validation`의
+`parseStandardSchema`, `StandardSchemaV1Like`를 사용하세요. Zod나 Valibot 같은
+Standard Schema v1 구현은 application dependency로 제공합니다. 독립 parsing에는
+HTTP 등록이 필요하지 않습니다.
+
+```ts
+import { parseStandardSchema } from '@fluojs/validation';
+import { z } from 'zod';
+
+const DraftSchema = z.object({
+  title: z.string().trim(),
+  count: z.coerce.number().int().default(1),
+});
+
+const input = await parseStandardSchema(DraftSchema, { title: '  Draft  ' });
+// input: { title: string; count: number }
+// value: { title: 'Draft', count: 1 }
+```
+
+**입력·기본값·출력:** `parseStandardSchema(schema, value)`는 unknown input을 받고
+schema에서 추론한 `Promise<Output>`을 반환합니다. 동기 또는 비동기 검증을
+await하고 transform, default, 유효한 `{ value: undefined }` 결과를 포함한
+성공 `value`를 그대로 반환합니다. Class hydration, HTTP source selection,
+unknown-field policy, implicit coercion을 추가하지 않습니다. 값 수준의 선택은
+schema가 소유합니다.
+
+**실패:** `issues: []`를 포함한 모든 issues array 반환은 `DtoValidationError`로
+reject됩니다. Issue는 message를 유지하며 정규화된 code와 `posts[0].title` 같은
+dot/index path를 사용합니다. Standard Schema issue에 HTTP `source`가 반드시
+있는 것은 아닙니다. Non-object result, 배열이 아닌 issues, issues와 성공
+`value`가 모두 없는 결과는 `TypeError`로 reject됩니다. Schema 구현이 던지거나
+reject한 예외는 그대로 전파됩니다.
+
+**소유권과 대안:** schema와 input은 caller가 소유하며 완료를 await해야 합니다.
+이 helper는 listener나 disposable resource를 생성하지 않고, 사용자 schema
+코드가 수행하는 mutation을 격리하지도 않습니다. `ValidateClass`는 기존
+empty-issues 동작을 포함한 검증 전용 API로 유지됩니다.
+`DefaultValidator.materialize(..., { undeclaredProperties: 'reject' })`는 별도의
+class hydration/rejection 계약이며 schema output parsing이나 HTTP projection이
+아닙니다. Handler output binding에는
+[`createSchemaDto`와 `StandardSchemaBinder`](../http/README.ko.md#standard-schema-output-binding)를
+사용하세요. HTTP는 parser의 `DtoValidationError` 실패를 400으로 바꿉니다.
+
+**근거:** `src/standard-schema.ts`, `src/index.ts`의 export,
+`src/standard-schema-output.test.ts`가 parser와 호환성 경계의 확인 위치입니다.
 
 ### Custom field 검증
 
@@ -209,7 +260,7 @@ reverse-map 멤버 이름은 값이 아니므로 거부됩니다.
 - **배열 데코레이터**: `ArrayContains`, `ArrayNotContains`, `ArrayNotEmpty`, `ArrayMinSize`, `ArrayMaxSize`, `ArrayUnique`
 - **Mapped DTO 헬퍼**: `PickType`, `OmitType`, `PartialType`, `IntersectionType`
 - **Mapped DTO 서브패스**: `@fluojs/validation/mapped-types`
-- **Standard Schema 계약**: `ValidateClass(...)` 스키마를 타입 지정하기 위한 `StandardSchemaV1Like`
+- **Standard Schema 계약**: schema 타입을 위한 `StandardSchemaV1Like`, 성공한 output parsing을 위한 `parseStandardSchema`, 검증 전용 연동을 위한 `ValidateClass(...)`
 - **검증 흐름**: 실체화 및 검증을 위한 `materialize()`, 단순 검증을 위한 `validate()`
 
 ## 관련 패키지

--- a/packages/validation/README.md
+++ b/packages/validation/README.md
@@ -159,7 +159,10 @@ so each nested target can materialize and validate the value independently.
 
 ### Standard Schema support
 
-Standard Schema adapters are expected to report invalid input through explicit issues. Validation results without issues are treated as successful.
+For `ValidateClass`, Standard Schema adapters are expected to report invalid input
+through explicit issues. Results without issues, and the existing empty
+`issues: []` case, are treated as successful. This is a validation-only contract:
+successful transformed/defaulted output does not replace the DTO or its fields.
 
 ```ts
 import { ValidateClass } from '@fluojs/validation';
@@ -174,6 +177,54 @@ class RestrictedUserDto {
 ```
 
 `ValidateClass(...)` also accepts custom class-level validators. `Validate(...)` attaches custom field-level validators when built-in decorators are not enough, and `ValidateIf(...)` short-circuits dependent validators when its predicate returns false.
+
+### Standard Schema output parsing
+
+**Scope and imports:** use `parseStandardSchema` and `StandardSchemaV1Like` from
+`@fluojs/validation` when the successful schema output is the value the caller
+needs. Supply a Standard Schema v1 implementation such as Zod or Valibot as an
+application dependency. No HTTP registration is needed for standalone parsing.
+
+```ts
+import { parseStandardSchema } from '@fluojs/validation';
+import { z } from 'zod';
+
+const DraftSchema = z.object({
+  title: z.string().trim(),
+  count: z.coerce.number().int().default(1),
+});
+
+const input = await parseStandardSchema(DraftSchema, { title: '  Draft  ' });
+// input: { title: string; count: number }
+// value: { title: 'Draft', count: 1 }
+```
+
+**Inputs, defaults, and output:** `parseStandardSchema(schema, value)` accepts
+unknown input and returns `Promise<Output>` inferred from the schema. It awaits
+sync or async validation and returns the successful `value` unchanged, including
+transforms, defaults, and a valid `{ value: undefined }` result. It adds no class
+hydration, HTTP source selection, unknown-field policy, or implicit coercion;
+the schema owns those value-level choices.
+
+**Failures:** any returned issues array, including `issues: []`, rejects with
+`DtoValidationError`. Issues retain messages and use normalized codes and
+dot/index paths such as `posts[0].title`; Standard Schema issues need not carry
+an HTTP `source`. Non-object results, non-array issues, and results with neither
+issues nor a success `value` reject with `TypeError`. Exceptions thrown or
+rejected by the schema implementation propagate unchanged.
+
+**Ownership and alternatives:** the caller owns the schema and input and must
+await completion; this helper creates no listener or disposable resource and
+does not isolate mutations performed by user-supplied schema code.
+`ValidateClass` remains validation-only, including its existing empty-issues
+behavior. `DefaultValidator.materialize(..., { undeclaredProperties: 'reject' })`
+is a separate class hydration/rejection contract, not schema output parsing or
+HTTP projection. For handler output binding, use
+[`createSchemaDto` and `StandardSchemaBinder`](../http/README.md#standard-schema-output-binding);
+HTTP maps parser `DtoValidationError` failures to 400.
+
+**Evidence:** `src/standard-schema.ts`, the export in `src/index.ts`, and
+`src/standard-schema-output.test.ts` cover the parser and compatibility boundary.
 
 ### Custom field validation
 
@@ -214,7 +265,7 @@ reverse-map member names are not values and are rejected.
 - **Array decorators**: `ArrayContains`, `ArrayNotContains`, `ArrayNotEmpty`, `ArrayMinSize`, `ArrayMaxSize`, `ArrayUnique`
 - **Mapped DTO helpers**: `PickType`, `OmitType`, `PartialType`, `IntersectionType`
 - **Mapped DTO subpath**: `@fluojs/validation/mapped-types`
-- **Standard Schema contract**: `StandardSchemaV1Like` for typing `ValidateClass(...)` schemas
+- **Standard Schema contract**: `StandardSchemaV1Like` for typing schemas, `parseStandardSchema` for successful output parsing, and `ValidateClass(...)` for validation-only integration
 - **Validation flow**: `materialize()` for hydration + validation, `validate()` for validation-only checks
 
 ## Related Packages

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -4,3 +4,4 @@ export * from './mapped-types.js';
 export * from './types.js';
 export * from './validation.js';
 export type { StandardSchemaV1Like } from './standard-schema.js';
+export { parseStandardSchema } from './standard-schema.js';

--- a/packages/validation/src/standard-schema-output.test.ts
+++ b/packages/validation/src/standard-schema-output.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import { z } from 'zod';
+import * as v from 'valibot';
+
+import {
+  DefaultValidator,
+  DtoValidationError,
+  parseStandardSchema,
+  ValidateClass,
+  type StandardSchemaV1Like,
+} from './index.js';
+
+describe('explicit Standard Schema output parsing', () => {
+  it('returns inferred transformed output and defaults without changing ValidateClass', async () => {
+    const schema = z.object({
+      title: z.string().trim(),
+      count: z.coerce.number().default(2),
+    });
+    const parsed = parseStandardSchema(schema, { title: '  Draft  ' });
+    expectTypeOf(parsed).toEqualTypeOf<Promise<{ title: string; count: number }>>();
+    await expect(parsed).resolves.toEqual({ title: 'Draft', count: 2 });
+
+    @ValidateClass(schema)
+    class Input {
+      title = '  Draft  ';
+    }
+    const input = new Input();
+    await new DefaultValidator().validate(input, Input);
+    expect(input.title).toBe('  Draft  ');
+    expect(Object.hasOwn(input, 'count')).toBe(false);
+  });
+
+  it('supports another Standard Schema vendor and asynchronous transforms', async () => {
+    const valibot = v.pipe(v.string(), v.trim());
+    await expect(parseStandardSchema(valibot, '  Draft  ')).resolves.toBe('Draft');
+    const asyncSchema = z.string().transform(async (value) => ({ length: value.length }));
+    await expect(parseStandardSchema(asyncSchema, 'post')).resolves.toEqual({ length: 4 });
+  });
+
+  it('returns schema issues, including nested paths, as DtoValidationError', async () => {
+    await expect(parseStandardSchema(
+      z.object({ posts: z.array(z.object({ title: z.string() })) }),
+      { posts: [{ title: 1 }] },
+    )).rejects.toMatchObject({
+      name: 'DtoValidationError',
+      issues: [expect.objectContaining({ field: 'posts[0].title' })],
+    });
+  });
+
+  it('rejects valid empty-issues failures while preserving ValidateClass compatibility', async () => {
+    const schema: StandardSchemaV1Like = {
+      '~standard': {
+        version: 1,
+        vendor: 'fluo-test',
+        validate: () => ({ issues: [] }),
+      },
+    };
+    const failed = parseStandardSchema(schema, {});
+    await expect(failed).rejects.toBeInstanceOf(DtoValidationError);
+    await expect(failed).rejects.toMatchObject({ issues: [] });
+
+    @ValidateClass(schema)
+    class Input {
+      title = 'unchanged';
+    }
+    const input = new Input();
+    await expect(new DefaultValidator().validate(input, Input)).resolves.toBeUndefined();
+    expect(input.title).toBe('unchanged');
+  });
+
+  it.each([undefined, null, {}, { issues: 'invalid' }])(
+    'rejects malformed success/failure result %j instead of fabricating output',
+    async (result) => {
+      const schema = {
+        '~standard': { version: 1, vendor: 'fluo-test', validate: () => result },
+      };
+      await expect(Reflect.apply(parseStandardSchema, undefined, [schema, {}]))
+        .rejects.toBeInstanceOf(TypeError);
+    },
+  );
+
+  it('preserves successful undefined output and thrown schema failures', async () => {
+    const schema: StandardSchemaV1Like<unknown, undefined> = {
+      '~standard': { version: 1, vendor: 'fluo-test', validate: () => ({ value: undefined }) },
+    };
+    await expect(parseStandardSchema(schema, {})).resolves.toBeUndefined();
+    const error = new Error('schema failure');
+    await expect(parseStandardSchema({
+      '~standard': { version: 1, vendor: 'fluo-test', validate() { throw error; } },
+    }, {})).rejects.toBe(error);
+  });
+});

--- a/packages/validation/src/standard-schema.ts
+++ b/packages/validation/src/standard-schema.ts
@@ -1,6 +1,7 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec';
 import type { CustomClassValidator } from '@fluojs/core/request-pipeline';
 
+import { DtoValidationError } from './errors.js';
 import type { ValidationIssue } from './types.js';
 
 /**
@@ -111,6 +112,40 @@ function toStandardValidationIssue(issue: StandardSchemaIssueLike): ValidationIs
     field: toFieldPath(toStandardSchemaPath(issue.path)) ?? issue.propString,
     message: issue.message,
   };
+}
+
+/**
+ * Parse unknown input and return the successful Standard Schema output.
+ *
+ * @param schema Standard Schema v1 validator, including asynchronous validators.
+ * @param value Unknown input to validate and transform.
+ * @returns The exact successful output, including schema defaults and transformations.
+ * @throws DtoValidationError When the schema returns a failure, including an empty issues array.
+ * @throws TypeError When the schema returns neither a success value nor an issues array.
+ * @remarks This opt-in materialization API does not change ValidateClass, which
+ * remains validation-only. Exceptions thrown by schema implementations propagate.
+ */
+export async function parseStandardSchema<Input, Output>(
+  schema: StandardSchemaV1Like<Input, Output>,
+  value: unknown,
+): Promise<Output> {
+  const result = await schema['~standard'].validate(value);
+  if (typeof result !== 'object' || result === null) {
+    throw new TypeError('Standard Schema returned an invalid result.');
+  }
+  if (result.issues !== undefined) {
+    if (!Array.isArray(result.issues)) {
+      throw new TypeError('Standard Schema failure must contain an issues array.');
+    }
+    throw new DtoValidationError(
+      'Standard Schema validation failed.',
+      result.issues.map((issue) => toStandardValidationIssue(issue)),
+    );
+  }
+  if (!('value' in result)) {
+    throw new TypeError('Standard Schema success must contain a value.');
+  }
+  return result.value;
 }
 
 function isStandardSchemaFailureResult(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1286,6 +1286,9 @@ importers:
       '@fluojs/platform-nodejs':
         specifier: workspace:^
         version: link:../platform-nodejs
+      '@fluojs/validation':
+        specifier: workspace:^
+        version: link:../validation
       vitest:
         specifier: ^4.1.11
         version: 4.1.11(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(happy-dom@20.9.0)(vite@8.2.2(@types/node@22.19.15)(esbuild@0.28.1)(tsx@4.23.1))

--- a/tooling/governance/runtime-shutdown-terminality.test.ts
+++ b/tooling/governance/runtime-shutdown-terminality.test.ts
@@ -287,7 +287,7 @@ describe('legacy Book runtime source consumers', () => {
     const contextMarker = 'path:packages/runtime/src/bootstrap.ts:860-900';
     const listenMarker = 'path:packages/runtime/src/bootstrap.ts:741-789';
     const readyMarker = 'path:packages/runtime/src/bootstrap.ts:654-660';
-    const dispatcherMarker = 'path:packages/runtime/src/bootstrap.ts:1548-1568';
+    const dispatcherMarker = 'path:packages/runtime/src/bootstrap.ts:1553-1573';
     const contextGet = sourceExample(content, contextMarker);
     const applicationListen = sourceExample(content, listenMarker);
 

--- a/tooling/governance/verify-platform-consistency-governance.test.ts
+++ b/tooling/governance/verify-platform-consistency-governance.test.ts
@@ -695,8 +695,8 @@ describe('advanced runtime branching source excerpts', () => {
   const excerpts: readonly RuntimeSourceExcerpt[] = [
     {
       sourcePath: 'packages/runtime/src/bootstrap.ts',
-      startLine: 1578,
-      endLine: 1602,
+      startLine: 1583,
+      endLine: 1607,
       fenceLanguage: 'typescript',
     },
     {


### PR DESCRIPTION
## Summary

기본 strict DTO binding을 유지하면서 두 opt-in 표면을 제공합니다. `InputPolicy`는 입력 projection 정책을 선언하고, `StandardSchemaBinder`는 성공한 schema output을 handler 인수로 전달합니다.

Linked context: https://github.com/fluojs/fluo/issues/3716

Closes #3716

## Changes

- DTO·route 단위 `InputPolicy`와 `unknownFields: 'reject' | 'strip'`, `nonObjects: 'reject' | 'empty'`를 추가합니다. 위험한 body key는 차단하고 원래 `request.body`를 보존합니다.
- `createSchemaDto`, `StandardSchemaBinder`, `parseStandardSchema`를 추가합니다. 변환·기본값·async schema output과 TypeScript 추론, body/path/query alias, repeated-query 정책, HTTP validation 오류 경로를 정의합니다.
- Runtime의 `binder(defaultBinder)` 조합 옵션으로 실제 bootstrap에서 schema binder를 설치하며, 일반 DTO와 기존 global Converter 경로는 제공받은 fallback으로 유지합니다.
- 기존 `ValidateClass`는 검증 전용 의미와 empty-issues 호환성을 유지합니다. 새 parser의 empty-issues failure는 명시적인 `DtoValidationError`입니다.
- 세 package README와 Book·website EN/KO를 갱신합니다. Bootstrap 줄 이동에 영향받은 legacy Book 발췌와 소비 테스트의 범위를 함께 정렬합니다.

## Testing

검증 head: `45fd7a80aa55a679a699c1be3a1e4141e061292a`.

- Projection opt-in을 무시하던 기존 binder에서 `UNKNOWN_FIELD authorId` assertion RED를 확인한 후 GREEN으로 전환했습니다.
- 변경·직접 의존 38개 package의 closure build와 전체 suite: 5,742 tests 통과.
- HTTP·validation·runtime·testing·platform-nextjs 및 tooling typecheck 통과.
- Binding 28, 독립 HTTP 26, validation 9 tests 통과. Application·실제 Next App Router adapter·cold public declaration 검증은 4 files, 33 tests 통과했습니다. 이 수치는 package suite와 중복되는 별도 실행 근거입니다.
- Cold declaration은 실제 emitted export map과 `skipLibCheck: false`를 사용하여 output 추론, standard/legacy decorator compilation 및 invalid-value 진단을 확인했습니다.
- 빌드된 공개 parser를 직접 import해 trim/default 결과와 empty-issues 실패를 수동 확인했습니다.
- 관련 governance 127 tests, `pnpm verify:docs`, stable Changeset intent, `pnpm lint`, `pnpm verify:platform-consistency-governance`, `git diff --check` 모두 통과했습니다. Lint의 41 warnings와 136 infos는 기록했으며 억제하지 않았습니다.
- 새 선택적 Book·website application을 독립 서버로 기동하지는 않았습니다. 동등한 실제 bootstrap/native adapter conformance를 실행했고, Book의 module export와 재사용 service/helper 연결을 확인했습니다.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

`.changeset/explicit-schema-input-binding.md`는 `@fluojs/http`, `@fluojs/validation`, `@fluojs/runtime`에 minor, `@fluojs/testing`에 patch를 지정합니다. Testing conformance가 사용하는 validation devDependency와 lockfile을 정식으로 선언했습니다. Frozen install과 모든 package dist 제거·부재 확인 후 `pnpm build`를 통과했습니다. Testing runtime API와 Next production 코드는 변경하지 않습니다.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Schema DTO token은 opaque token이며 직접 생성, 상속, mapped-class helper 또는 자동 OpenAPI schema 변환을 지원하는 클래스 메타데이터로 취급하지 않습니다. Projection은 shallow이고 authorization을 대신하지 않습니다. 기존 parser·HEAD 정책과 순수 application context 범위는 유지합니다.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests, such as `createPlatformConformanceHarness(...)` for platform component contracts or `createHttpAdapterPortabilityHarness(...)` for HTTP adapter portability contracts.

이번 변경으로 이동한 Book dispatcher 발췌만 원본과 재정렬했습니다. Baseline부터 어긋나 있던 Chapter 9의 다른 발췌 13건은 범위 밖으로 남겼으며, 실패한 canonical 검사를 면제하지 않았습니다.
