### PR TITLE
Resolve #3737: Next.js adapter 생성과 공개 import 소유권 통합

### DIFF
--- a/.changeset/nextjs-canonical-import-ownership.md
+++ b/.changeset/nextjs-canonical-import-ownership.md
@@ -1,0 +1,31 @@
+---
+"@fluojs/platform-nextjs": major
+---
+
+Consolidate Next adapter creation into root `NextHttpApplicationAdapter.create(options)`
+and give each public capability one import owner. Remove `createNextAdapter`
+from source and all package entry points, root App/Pages handler re-exports,
+router-subpath adapter re-exports, and adapter `GET`, `POST`, `PUT`, `PATCH`,
+`DELETE`, `HEAD`, and `OPTIONS` aliases.
+
+Migration: import `NextHttpApplicationAdapter`, `NextAdapterOptions`,
+`NextAdapterLoader`, and `InvalidNextAdapterOptionError` from
+`@fluojs/platform-nextjs`. Replace `createNextAdapter(options)` with
+`NextHttpApplicationAdapter.create(options)`, pass the adapter to
+`FluoFactory.create(AppModule, { adapter })`, and call `app.listen()`.
+Import `createNextAppRouterHandler`, `NextAppRouteHandler`, and
+`NextAppRouterMethodHandlers` only from `/app-router`; import
+`createNextPagesRouterHandler` and `NextPagesRouterConfig` only from `/pages-router`.
+Replace direct adapter method exports with destructured lazy App facade exports.
+Keep Next's required route methods, including `GET`, `POST`, and `HEAD`.
+
+The public constructor, class identity, inheritance, and instance
+`fetch`/`listen`/`close` operations remain supported. Pages still owns the Node
+stream bridge with `bodyParser: false`, backpressure, abort, and post-response
+upload draining; it is not an App Web Request callback. Root
+`defineNextApplication` retains process-local keyed identity and sticky failures,
+distinct from each router facade's closure cache. Compiler configuration remains
+on `/next-config`. There are no permanent compatibility aliases.
+
+See the English and Korean `packages/platform-nextjs/README*.md#api-migration`
+guides for the full removed-surface table and canonical recipes.

--- a/.changeset/nextjs-canonical-import-ownership.md
+++ b/.changeset/nextjs-canonical-import-ownership.md
@@ -1,5 +1,5 @@
 ---
-"@fluojs/platform-nextjs": major
+"@fluojs/platform-nextjs": patch
 ---
 
 Consolidate Next adapter creation into root `NextHttpApplicationAdapter.create(options)`

--- a/apps/docs/content/docs/guides/runtime-adapters.ko.mdx
+++ b/apps/docs/content/docs/guides/runtime-adapters.ko.mdx
@@ -57,13 +57,14 @@ Next.js 16.x의 Node.js host에서 GET-only Fluo route에 HEAD를 연결하려�
 adapter가 제공하는 opt-in을 사용합니다.
 
 ```ts
-import { createNextAdapter } from '@fluojs/platform-nextjs';
+import { NextHttpApplicationAdapter } from '@fluojs/platform-nextjs';
 
-const nextAdapter = createNextAdapter({ headRouting: 'explicit-or-get' });
+const nextAdapter = NextHttpApplicationAdapter.create({ headRouting: 'explicit-or-get' });
 ```
 
-표준 lazy `createNextAppRouterHandler(...)` facade에서 `GET`만 export하면 Next가
-자동 HEAD로 호출하고, `HEAD`도 export하면 직접 호출합니다. 양쪽 모두 Fluo의
+`createNextAppRouterHandler`는 `@fluojs/platform-nextjs/app-router`에서 import합니다.
+이 표준 lazy facade에서 `GET`만 export하면 Next가 자동 HEAD로 호출하고,
+`HEAD`도 export하면 직접 호출합니다. 양쪽 모두 Fluo의
 명시적 HEAD, ALL method wildcard, GET 순서로 route를 한 번 선택하며
 handler가 반환한 404는 재시도하지 않습니다. Status와 header를 보존하면서 body를
 제거하고 stream cancellation과 request cleanup을 기다립니다.

--- a/apps/docs/content/docs/guides/runtime-adapters.mdx
+++ b/apps/docs/content/docs/guides/runtime-adapters.mdx
@@ -57,13 +57,14 @@ On a Next.js 16.x Node.js host, use the adapter's opt-in to connect HEAD to
 GET-only Fluo routes:
 
 ```ts
-import { createNextAdapter } from '@fluojs/platform-nextjs';
+import { NextHttpApplicationAdapter } from '@fluojs/platform-nextjs';
 
-const nextAdapter = createNextAdapter({ headRouting: 'explicit-or-get' });
+const nextAdapter = NextHttpApplicationAdapter.create({ headRouting: 'explicit-or-get' });
 ```
 
-Export only `GET` from the standard lazy `createNextAppRouterHandler(...)`
-facade for Next auto-HEAD, or also export `HEAD` for direct invocation. Both
+Import `createNextAppRouterHandler` from `@fluojs/platform-nextjs/app-router`.
+Export only `GET` from that standard lazy facade for Next auto-HEAD, or also
+export `HEAD` for direct invocation. Both
 select a route once in explicit HEAD, ALL method wildcard, then GET order;
 handler-produced 404s are never retried. Status and headers are preserved while
 the body is removed and stream cancellation and request cleanup are awaited.

--- a/apps/docs/content/docs/packages/http-platform.ko.mdx
+++ b/apps/docs/content/docs/packages/http-platform.ko.mdx
@@ -19,6 +19,14 @@ description: HTTP 의미론, platform adapter, OpenAPI publication을 다룹니�
 
 작업 중심 안내는 [HTTP API](../guides/http-api)와 [런타임 어댑터](../guides/runtime-adapters)를 읽으세요.
 
+Next adapter는 root `NextHttpApplicationAdapter.create(options)`로 생성합니다.
+App/Pages lazy callback은 `/app-router`와 `/pages-router`에서만 import하며,
+compiler 설정은 `/next-config`가 소유합니다. Next의 일곱 route export는
+adapter의 method 별칭이 아니라 App facade에서 가져옵니다.
+[Package migration 안내](https://github.com/fluojs/fluo/blob/main/packages/platform-nextjs/README.ko.md#api-migration)는
+삭제된 import와 함께 Web Request, Node stream, closure cache,
+process-local keyed cache의 서로 다른 계약을 설명합니다.
+
 Next의 `defineNextApplication({ key, load })`는 같은 JS global의 RSC/auth/route
 bundle에서 하나의 application Promise를 공유하는 opt-in입니다. 실패도 유지하고
 HMR 교체나 자동 retry를 하지 않으며 close/dispose는 application 소유자가
@@ -34,7 +42,7 @@ backend 변환 범위를 선언하고 SSR import의 원래 모듈 경로를 보�
 제약은 package README, 실제 dev/build/start 회귀는
 `packages/platform-nextjs/e2e/README.ko.md`를 참조하세요.
 
-Next의 `createNextAdapter({ bodyParser: 'text' })`는 Content-Type 변경이나 Request
+Next의 `NextHttpApplicationAdapter.create({ bodyParser: 'text' })`는 Content-Type 변경이나 Request
 재구성 없이 bounded text를 opt-in합니다. HTTP가 정책을 소유하고 runtime이 Web 읽기를
 구현하며 Next가 노출합니다. 파싱은 여전히 middleware/guard보다 먼저이며 이후 앱의
 JSON 해석보다 인증을 우선하려면 그 순서를 명시해야 합니다. Adapter capability matrix는

--- a/apps/docs/content/docs/packages/http-platform.mdx
+++ b/apps/docs/content/docs/packages/http-platform.mdx
@@ -19,6 +19,14 @@ description: HTTP semantics, platform adapters, and OpenAPI publication.
 
 Read [HTTP API](../guides/http-api) and [Runtime Adapters](../guides/runtime-adapters) for task-oriented guidance.
 
+Next adapter creation uses root `NextHttpApplicationAdapter.create(options)`.
+Import App/Pages lazy callbacks only from `/app-router` and `/pages-router`;
+`/next-config` owns compiler configuration. Keep the seven Next route exports
+from the App facade, not method aliases on the adapter. The
+[package migration guide](https://github.com/fluojs/fluo/blob/main/packages/platform-nextjs/README.md#api-migration)
+lists removed imports and preserves the distinct Web Request, Node stream,
+closure-cache, and process-local keyed-cache contracts.
+
 Next's `defineNextApplication({ key, load })` optionally shares one application
 Promise across RSC/auth/route bundles in the same JS global. Failure is retained,
 with no HMR replacement or automatic retry; the application owner manages
@@ -35,7 +43,7 @@ behavior. The package README owns exact path conditions and Turbopack-only
 limitations; `packages/platform-nextjs/e2e/README.md` describes the real
 dev/build/start regressions.
 
-Next's `createNextAdapter({ bodyParser: 'text' })` opts into bounded text without
+Next's `NextHttpApplicationAdapter.create({ bodyParser: 'text' })` opts into bounded text without
 changing Content-Type or reconstructing Requests. HTTP owns the policy, runtime
 implements Web reads, and Next exposes it. Parsing still precedes middleware and
 guards; authentication must be explicitly ordered before later application JSON

--- a/book/03-internals/ch15-nextjs-hosting.ko.md
+++ b/book/03-internals/ch15-nextjs-hosting.ko.md
@@ -131,14 +131,23 @@ export class AppModule {}
 
 ## lazy bootstrap이 완료된 adapter만 노출한다
 
+adapter 생성과 accessor의 공개 import는 root, App/Pages host bridge는 각각
+`/app-router`와 `/pages-router`, compiler는 `/next-config`가 소유한다.
+`NextHttpApplicationAdapter.create(options)`가 실제 adapter를 생성한다. 기존
+`createNextAdapter` import와 router subpath의 adapter 재노출은 제거되었다.
+constructor와 상속은 유지하지만 정상 route 연결은 아래 lazy facade를 사용한다.
+`nextAdapter.GET` 등의 instance 별칭을 export하지 않는다. Next가 요구하는
+일곱 route export는 facade에서 계속 제공한다. 이전 표면별 교체 방법은
+[API migration](../../packages/platform-nextjs/README.ko.md#api-migration)에 있다.
+
 다음은 완전한 `src/backend.ts`다. adapter는 application을 생성하지 않는다. runtime이 module graph와 DI를 구성하고 `app.listen()`을 통해 dispatcher를 adapter에 연결한다.
 
 ```typescript
-import { createNextAdapter } from '@fluojs/platform-nextjs';
+import { NextHttpApplicationAdapter } from '@fluojs/platform-nextjs';
 import { FluoFactory } from '@fluojs/runtime';
 import { AppModule } from './app';
 
-export const nextAdapter = createNextAdapter({
+export const nextAdapter = NextHttpApplicationAdapter.create({
   headRouting: 'explicit-or-get',
   maxBodySize: 1_048_576,
   rawBody: true,
@@ -296,7 +305,7 @@ curl -I http://127.0.0.1:3000/api/posts/999
 그 route를 제공한다는 뜻은 아니다.
 
 ```typescript
-export const nextAdapter = createNextAdapter({
+export const nextAdapter = NextHttpApplicationAdapter.create({
   headRouting: 'explicit-or-get',
   maxBodySize: 1_048_576,
   bodyParser(text, context) {
@@ -329,13 +338,14 @@ malformed JSON에서 미인증 401, 인증 후 400을, 큰 입력에서는 413�
 아래 완전한 `src/next-adapter.test.ts`는 앞의 `AppModule`과 현재 Fluo 표준 데코레이터 Vitest 구성을 전제로 한다. 테스트는 Next 서버를 열지 않고 adapter와 lazy facade의 공개 접점을 검증한다. `@fluojs/testing/vitest`의 decorator plugin을 사용하는 기존 테스트 설정이 필요하며 Next용 config helper가 Vitest의 변환을 대신하지는 않는다.
 
 ```typescript
-import { createNextAdapter, createNextAppRouterHandler } from '@fluojs/platform-nextjs';
+import { NextHttpApplicationAdapter } from '@fluojs/platform-nextjs';
+import { createNextAppRouterHandler } from '@fluojs/platform-nextjs/app-router';
 import { FluoFactory } from '@fluojs/runtime';
 import { expect, it } from 'vitest';
 import { AppModule } from './app';
 
 it('shares one loader and keeps explicit close terminal at the facade', async () => {
-  const adapter = createNextAdapter();
+  const adapter = NextHttpApplicationAdapter.create();
   const app = await FluoFactory.create(AppModule, { adapter });
   let loads = 0;
 

--- a/book/03-internals/ch15-nextjs-hosting.md
+++ b/book/03-internals/ch15-nextjs-hosting.md
@@ -132,14 +132,24 @@ This is deliberately a printable SSR document without hydration. Do not put an i
 
 ## Expose the Adapter Only After Lazy Bootstrap Completes
 
+The root owns public adapter creation and accessor imports; `/app-router` and
+`/pages-router` own their respective host bridges, and `/next-config` owns the
+compiler. `NextHttpApplicationAdapter.create(options)` performs adapter creation.
+The former `createNextAdapter` import and adapter re-exports from router subpaths
+are removed. Constructors and inheritance remain supported, but ordinary routes
+use the lazy facade below. Do not export instance aliases such as
+`nextAdapter.GET`. The facade still provides all seven route exports required by
+Next. See [API migration](../../packages/platform-nextjs/README.md#api-migration)
+for each old surface's replacement.
+
 The following is the complete `src/backend.ts`. The adapter does not create the application. The runtime constructs the module graph and DI, then connects the dispatcher to the adapter through `app.listen()`.
 
 ```typescript
-import { createNextAdapter } from '@fluojs/platform-nextjs';
+import { NextHttpApplicationAdapter } from '@fluojs/platform-nextjs';
 import { FluoFactory } from '@fluojs/runtime';
 import { AppModule } from './app';
 
-export const nextAdapter = createNextAdapter({
+export const nextAdapter = NextHttpApplicationAdapter.create({
   headRouting: 'explicit-or-get',
   maxBodySize: 1_048_576,
   rawBody: true,
@@ -304,7 +314,7 @@ assumes you add `/api/posts/draft`; it does not claim the earlier AppModule
 already provides that route.
 
 ```typescript
-export const nextAdapter = createNextAdapter({
+export const nextAdapter = NextHttpApplicationAdapter.create({
   headRouting: 'explicit-or-get',
   maxBodySize: 1_048_576,
   bodyParser(text, context) {
@@ -340,13 +350,14 @@ every Next version or deployment environment.
 The following complete `src/next-adapter.test.ts` assumes the earlier `AppModule` and the current Fluo standard-decorator Vitest configuration. It tests the public interfaces of the adapter and lazy facade without opening a Next server. An existing test configuration using the decorator plugin from `@fluojs/testing/vitest` is required; the Next config helper does not replace Vitest's transformation.
 
 ```typescript
-import { createNextAdapter, createNextAppRouterHandler } from '@fluojs/platform-nextjs';
+import { NextHttpApplicationAdapter } from '@fluojs/platform-nextjs';
+import { createNextAppRouterHandler } from '@fluojs/platform-nextjs/app-router';
 import { FluoFactory } from '@fluojs/runtime';
 import { expect, it } from 'vitest';
 import { AppModule } from './app';
 
 it('shares one loader and keeps explicit close terminal at the facade', async () => {
-  const adapter = createNextAdapter();
+  const adapter = NextHttpApplicationAdapter.create();
   const app = await FluoFactory.create(AppModule, { adapter });
   let loads = 0;
 

--- a/docs/CONTEXT.ko.md
+++ b/docs/CONTEXT.ko.md
@@ -118,6 +118,15 @@ Root와 Node-bound package의 `>=24.0.0 <27` 분류, 8개 portable omission, exa
 
 ## Next.js 호스팅
 
+Canonical import는 [Next 공개 API와 migration 소유 문서](../packages/platform-nextjs/README.ko.md#api-migration)에서 시작하세요.
+Root의 `NextHttpApplicationAdapter.create(options)`와 `defineNextApplication`,
+`/app-router`와 `/pages-router`의 lazy bridge, `/next-config`의 compiler로 나뉩니다.
+Adapter method 별칭은 제거하지만 Next route export는 유지합니다.
+공개 declaration/JavaScript 소유권은
+`packages/platform-nextjs/src/head-routing-public-types.test.ts`, 실제 App/Pages
+build/start/request는 package E2E가 검증합니다. Code fence의 import 검사는
+`tooling/governance/nextjs-public-imports.mjs`와 해당 회귀 suite로 실행합니다.
+
 [`@fluojs/platform-nextjs`](../packages/platform-nextjs/README.ko.md)는
 Node.js `>=24.0.0 <27`의 Next.js 16.x App Router와 Pages Router에서 Fluo를
 호스팅하며 `@fluojs/runtime` 3과 패키지에 포함된 Turbopack 데코레이터 로더를

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -118,6 +118,15 @@ See [Node.js Support](./reference/node-support.md) for root/Node-bound `>=24.0.0
 
 ## Next.js Hosting
 
+For canonical imports, start at the [Next public API and migration owner](../packages/platform-nextjs/README.md#api-migration):
+root `NextHttpApplicationAdapter.create(options)` and `defineNextApplication`,
+App/Pages lazy bridges on `/app-router` and `/pages-router`, compiler on
+`/next-config`. Adapter method aliases are removed; Next route exports remain.
+Public declaration/JavaScript ownership is exercised by
+`packages/platform-nextjs/src/head-routing-public-types.test.ts`; real App/Pages
+build/start/request evidence lives in the package E2E. Code-fence import checks
+run through `tooling/governance/nextjs-public-imports.mjs` and its regression suite.
+
 [`@fluojs/platform-nextjs`](../packages/platform-nextjs/README.md) hosts Fluo in
 Next.js 16.x App Router and Pages Router on Node.js `>=24.0.0 <27`, using
 `@fluojs/runtime` 3 and the packaged Turbopack decorator loader. Backends bootstrap

--- a/packages/platform-nextjs/README.ko.md
+++ b/packages/platform-nextjs/README.ko.md
@@ -21,6 +21,7 @@ Fluo backend를 Next.js App Router Route Handlers와 Pages Router API Routes에
 - [Options](#options)
 - [Runtime contract](#runtime-contract)
 - [Public API](#public-api)
+- [API Migration](#api-migration)
 
 ## 설치
 
@@ -97,12 +98,12 @@ export class AppModule {}
 
 ```typescript
 // src/backend.ts
-import { createNextAdapter } from '@fluojs/platform-nextjs';
+import { NextHttpApplicationAdapter } from '@fluojs/platform-nextjs';
 import { FluoFactory } from '@fluojs/runtime';
 
 import { AppModule } from './app.module';
 
-export const nextAdapter = createNextAdapter();
+export const nextAdapter = NextHttpApplicationAdapter.create();
 export const app = await FluoFactory.create(AppModule, {
   adapter: nextAdapter,
 });
@@ -142,9 +143,9 @@ GET-only Fluo route가 Next의 자동 HEAD와 명시적인 `HEAD` export 모두�
 응답해야 한다면 adapter 생성 시 opt-in합니다.
 
 ```typescript
-import { createNextAdapter } from '@fluojs/platform-nextjs';
+import { NextHttpApplicationAdapter } from '@fluojs/platform-nextjs';
 
-export const nextAdapter = createNextAdapter({
+export const nextAdapter = NextHttpApplicationAdapter.create({
   headRouting: 'explicit-or-get',
 });
 ```
@@ -235,8 +236,8 @@ application과 dispatcher를 만들고
 `NextHttpApplicationAdapter.listen()`으로 dispatcher를 연결합니다.
 
 Next adapter는 application을 만들지 않고 socket도 열지 않습니다.
-Dispatcher 연결 후 bound Web handlers만 제공하며 HTTP server는 계속
-Next.js가 소유합니다.
+Dispatcher 연결 후 instance `fetch(request)`로 dispatch하며 HTTP server는
+계속 Next.js가 소유합니다. 정상 App route 연결은 위 lazy facade를 사용합니다.
 
 Route facade는 첫 request에서 `src/backend.ts`를 dynamic import합니다.
 Import 완료에는 top-level `FluoFactory.create()`와 `app.listen()`이
@@ -350,7 +351,7 @@ Backend module은 첫 route request가 import할 때 일반 Fluo bootstrap을 �
 번 수행합니다.
 
 ```typescript
-const nextAdapter = createNextAdapter();
+const nextAdapter = NextHttpApplicationAdapter.create();
 const app = await FluoFactory.create(AppModule, {
   adapter: nextAdapter,
 });
@@ -408,7 +409,7 @@ Route facade도 같은 graph에서 adapter를 가져옵니다.
 
 ```typescript
 // app/api/[[...path]]/route.ts
-import { createNextAppRouterHandler } from '@fluojs/platform-nextjs';
+import { createNextAppRouterHandler } from '@fluojs/platform-nextjs/app-router';
 import { getApplication } from '../../../src/application';
 
 export const { GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS } =
@@ -472,7 +473,7 @@ production build의 별도 RSC/auth/route 평가, 겹치는 초기화, key/proce
 ## Options
 
 ```typescript
-const nextAdapter = createNextAdapter({
+const nextAdapter = NextHttpApplicationAdapter.create({
   maxBodySize: 1_048_576,
   rawBody: true,
 });
@@ -513,20 +514,56 @@ Application이 raw Node.js transport ownership, WebSocket upgrades, independentl
 
 ## Public API
 
-- `createNextAdapter(options)`: `FluoFactory.create()`에 전달할 HTTP adapter 생성
-- `NextAdapterOptions`: adapter가 소유하는 request parsing 및 opt-in HEAD routing options
-- `NextAdapterLoader`: dynamic canonical backend adapter loader
-- `defineNextApplication(options)`: 명시적 key의 process-local application Promise accessor
-- `NextApplicationOptions<T>`: application 소유 key와 async load 계약
-- `createNextAppRouterHandler(loadAdapter)`: 구조분해 export 가능한 method-keyed App Router handler export record 생성 (`GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, `OPTIONS`)
-- `NextHttpApplicationAdapter`: bound `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, `OPTIONS` handlers를 가진 `HttpApplicationAdapter`
-- `NextAppRouteHandler`: bound methods가 사용하는 Web request handler type
-- `NextAppRouterMethodHandlers`: route module에서 구조분해 export하는 method-keyed App Router record (`createNextAppRouterHandler()` 반환)
-- `createNextPagesRouterHandler(loadAdapter)`: request-lazy streaming Pages Router API handler 생성
-- `NextPagesRouterConfig`: 필수 static `bodyParser: false` literal type-check
-- `withFluoNextBackend(config, options?)`: `@fluojs/platform-nextjs/next-config` export; packaged Turbopack decorator loader와 opt-in 범위/경로 보존 추가
-- `FluoNextBackendOptions`: 같은 `next-config` subpath의 `include`, `exclude`, `preserveModulePaths` 옵션 타입
-- `decorators-loader`: config helper가 사용하는 packaged loader subpath
+| 공개 import 소유자 | Export와 역할 |
+| --- | --- |
+| `@fluojs/platform-nextjs` | `NextHttpApplicationAdapter.create(options)`는 독립된 미연결 adapter를 생성합니다. `NextAdapterOptions`, `NextAdapterLoader`, `InvalidNextAdapterOptionError`도 root 소유입니다. |
+| `@fluojs/platform-nextjs` | `defineNextApplication(options)`와 `NextApplicationOptions<T>`는 명시적인 key의 process-local application Promise를 소유합니다. |
+| `@fluojs/platform-nextjs/app-router` | `createNextAppRouterHandler(loadAdapter)`, `NextAppRouteHandler`, `NextAppRouterMethodHandlers`: Web Request를 받는 lazy callback과 Next가 요구하는 일곱 method export입니다. |
+| `@fluojs/platform-nextjs/pages-router` | `createNextPagesRouterHandler(loadAdapter)`, `NextPagesRouterConfig`: Node stream bridge와 필수 static `bodyParser: false` 타입입니다. |
+| `@fluojs/platform-nextjs/next-config` | `withFluoNextBackend(config, options?)`, `FluoNextBackendOptions`: Turbopack compiler 설정과 opt-in scope/path 보존입니다. |
+| `@fluojs/platform-nextjs/decorators-loader` | Config helper가 사용하는 packaged compiler loader입니다. |
+
+Adapter는 `HttpApplicationAdapter` class identity, public constructor와 상속,
+instance `fetch(request)`, `listen(dispatcher)`, `close()`,
+`getRealtimeCapability()`를 유지합니다. 생성이 dispatcher 연결이나 socket
+생성을 의미하지 않으며, instance 실행 상태를 static으로 공유하지 않습니다.
+Host callback과 compiler helper는 별도의 기능이므로 생성 class로 감싸지 않습니다.
+
+## API Migration
+
+이 변경은 공개 API를 삭제하는 major release입니다. 영구 compatibility alias는 없습니다.
+
+| 제거한 표면 | 교체 방법 |
+| --- | --- |
+| Root/App/Pages의 `createNextAdapter(options)` | Root에서 `NextHttpApplicationAdapter`를 import하고 `.create(options)`를 호출합니다. 같은 options 검증과 class instance를 유지합니다. |
+| App/Pages의 `NextHttpApplicationAdapter`, `NextAdapterOptions`, `NextAdapterLoader` | Root import로 이동합니다. App의 `InvalidNextAdapterOptionError`도 root에서 import합니다. |
+| Root의 `createNextAppRouterHandler`, `NextAppRouteHandler`, `NextAppRouterMethodHandlers` | `/app-router`에서 import합니다. |
+| Root의 `createNextPagesRouterHandler`, `NextPagesRouterConfig` | `/pages-router`에서 import합니다. |
+| Adapter의 `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, `OPTIONS` 필드 | Route module이 `createNextAppRouterHandler(loadAdapter)`의 반환값을 구조분해 export합니다. 위 App Router recipe처럼 backend를 lazy import하세요. |
+
+Next route module의 `GET`/`POST`/`HEAD` 등 export 자체는 삭제하지 않습니다.
+Adapter의 저수준 instance dispatch는 `fetch(request)`로 남지만 route에서 eager
+backend import나 직접 bound handler export로 lazy bootstrap을 대체하지 마세요.
+Pages를 Web Request callback으로 바꾸지 않습니다. `bodyParser: false`, demand-driven
+input, `ServerResponse.write()` backpressure의 `drain` 대기, disconnect abort와
+응답 완료 후 남은 upload drain을 유지하며 socket은 Next 소유입니다.
+
+각 facade의 closure cache는 그 facade의 loader Promise만 보존합니다.
+`defineNextApplication`의 keyed cache는 같은 JS global의 여러 소비자에 걸쳐 첫
+Promise와 실패를 보존합니다. 한 cache를 다른 cache의 보장으로 해석하지 마세요.
+두 cache 모두 실패를 자동 재시도하거나 닫힌 application을 다시 열지 않습니다.
+
+소비자 조사는 package tests/public declarations, 실제 Next fixture, Docs의
+runtime-adapters/http-platform 페이지와 Book 3권 15장의 생성·import 경로를 포함합니다.
+현재 CLI generator와 `examples/`에는 이 Next API 소비자가 없습니다. 실행 가능한
+예제는 [package fixture](./e2e/README.ko.md)입니다. 과거 changelog는 당시 API의
+기록으로 유지합니다. 새 source와 배포 JavaScript/`.d.ts`에는 제거한 export를 남기지 않습니다.
+
+`src/public-api.test.ts`, `src/app-router.test.ts`,
+`src/head-routing-public-types.test.ts`와 실제 Next E2E가 생성, host method,
+cache 구분, import 소유권을 검증합니다. 내부 `createLazyNextAdapterResolver`는
+App/Pages 두 bridge가 공유하는 실제 closure cache 구현이며 공개 package export가 아닙니다.
+문서 code fence의 import 소유권은 `pnpm verify:platform-consistency-governance`로 검사합니다.
 
 ## 개발 검증
 
@@ -548,13 +585,13 @@ HTTP로 검증합니다. [Fixture 실행 안내](./e2e/README.ko.md)를 참조�
 
 Adapter 생성 시 `NextAdapterOptions.bodyParser`를 설정합니다. HTTP 소유
 `BodyParser`인 `'default'`(생략 시 기본값), `'text'`, 동기/비동기 callback을 받습니다.
-애플리케이션 전체 text mode는 `createNextAdapter({ bodyParser: 'text' })`입니다.
+애플리케이션 전체 text mode는 `NextHttpApplicationAdapter.create({ bodyParser: 'text' })`입니다.
 경로별 정책은 Request 재구성 대신 선택하지 않은 경로를 기존 parser에 위임합니다.
 
 ```typescript
-import { createNextAdapter } from '@fluojs/platform-nextjs';
+import { NextHttpApplicationAdapter } from '@fluojs/platform-nextjs';
 
-export const nextAdapter = createNextAdapter({
+export const nextAdapter = NextHttpApplicationAdapter.create({
   headRouting: 'explicit-or-get',
   maxBodySize: 1_048_576,
   rawBody: true,

--- a/packages/platform-nextjs/README.md
+++ b/packages/platform-nextjs/README.md
@@ -21,6 +21,7 @@ dependency injection.
 - [Options](#options)
 - [Runtime Contract](#runtime-contract)
 - [Public API](#public-api)
+- [API Migration](#api-migration)
 
 ## Installation
 
@@ -96,12 +97,12 @@ like every other Fluo HTTP platform:
 
 ```typescript
 // src/backend.ts
-import { createNextAdapter } from '@fluojs/platform-nextjs';
+import { NextHttpApplicationAdapter } from '@fluojs/platform-nextjs';
 import { FluoFactory } from '@fluojs/runtime';
 
 import { AppModule } from './app.module';
 
-export const nextAdapter = createNextAdapter();
+export const nextAdapter = NextHttpApplicationAdapter.create();
 export const app = await FluoFactory.create(AppModule, {
   adapter: nextAdapter,
 });
@@ -141,9 +142,9 @@ Opt in at adapter construction when a GET-only Fluo route should answer Next's
 automatic HEAD as well as an explicit `HEAD` export:
 
 ```typescript
-import { createNextAdapter } from '@fluojs/platform-nextjs';
+import { NextHttpApplicationAdapter } from '@fluojs/platform-nextjs';
 
-export const nextAdapter = createNextAdapter({
+export const nextAdapter = NextHttpApplicationAdapter.create({
   headRouting: 'explicit-or-get',
 });
 ```
@@ -235,8 +236,9 @@ application and dispatcher, then attaches the dispatcher through
 `NextHttpApplicationAdapter.listen()`.
 
 The Next adapter does not create the application and does not open a socket.
-It only exposes bound Web handlers after the dispatcher is attached, while
-Next.js continues to own the HTTP server.
+It dispatches through instance `fetch(request)` after the dispatcher is attached,
+while Next.js continues to own the HTTP server. Use the lazy facade above for
+ordinary App route integration.
 
 Route facades dynamically import `src/backend.ts` on the first request.
 Import completion includes its top-level `FluoFactory.create()` and
@@ -347,7 +349,7 @@ The backend module performs ordinary Fluo bootstrap once when the first route
 request imports it:
 
 ```typescript
-const nextAdapter = createNextAdapter();
+const nextAdapter = NextHttpApplicationAdapter.create();
 const app = await FluoFactory.create(AppModule, {
   adapter: nextAdapter,
 });
@@ -405,7 +407,7 @@ The route facade obtains its adapter from the same graph.
 
 ```typescript
 // app/api/[[...path]]/route.ts
-import { createNextAppRouterHandler } from '@fluojs/platform-nextjs';
+import { createNextAppRouterHandler } from '@fluojs/platform-nextjs/app-router';
 import { getApplication } from '../../../src/application';
 
 export const { GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS } =
@@ -469,7 +471,7 @@ separation, and retained close/failure in an actual Next production build.
 ## Options
 
 ```typescript
-const nextAdapter = createNextAdapter({
+const nextAdapter = NextHttpApplicationAdapter.create({
   maxBodySize: 1_048_576,
   rawBody: true,
 });
@@ -510,20 +512,60 @@ Use a Fluo Node or Fastify platform adapter when the application requires raw No
 
 ## Public API
 
-- `createNextAdapter(options)`: creates the HTTP adapter passed to `FluoFactory.create()`
-- `NextAdapterOptions`: adapter-owned request parsing and opt-in HEAD routing options
-- `NextAdapterLoader`: dynamic canonical backend adapter loader
-- `defineNextApplication(options)`: process-local application Promise accessor for an explicit key
-- `NextApplicationOptions<T>`: application-owned key and async load contract
-- `createNextAppRouterHandler(loadAdapter)`: creates method-keyed App Router handler exports (`GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, `OPTIONS`) ready for destructuring
-- `NextHttpApplicationAdapter`: `HttpApplicationAdapter` with bound `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, and `OPTIONS` handlers
-- `NextAppRouteHandler`: Web request handler type used by those bound methods
-- `NextAppRouterMethodHandlers`: method-keyed App Router record returned by `createNextAppRouterHandler()`
-- `createNextPagesRouterHandler(loadAdapter)`: creates a request-lazy streaming Pages Router API handler
-- `NextPagesRouterConfig`: type-checks the required static `bodyParser: false` literal
-- `withFluoNextBackend(config, options?)`: exported from `@fluojs/platform-nextjs/next-config`; adds the packaged Turbopack decorator loader with opt-in scope/path preservation
-- `FluoNextBackendOptions`: `include`, `exclude`, and `preserveModulePaths` option type on the same `next-config` subpath
-- `decorators-loader`: packaged loader subpath used by the config helper
+| Public import owner | Exports and responsibility |
+| --- | --- |
+| `@fluojs/platform-nextjs` | `NextHttpApplicationAdapter.create(options)` creates an independent, unbound adapter. `NextAdapterOptions`, `NextAdapterLoader`, and `InvalidNextAdapterOptionError` also belong to the root. |
+| `@fluojs/platform-nextjs` | `defineNextApplication(options)` and `NextApplicationOptions<T>` own the process-local application Promise for an explicit key. |
+| `@fluojs/platform-nextjs/app-router` | `createNextAppRouterHandler(loadAdapter)`, `NextAppRouteHandler`, `NextAppRouterMethodHandlers`: lazy Web Request callbacks and the seven method exports required by Next. |
+| `@fluojs/platform-nextjs/pages-router` | `createNextPagesRouterHandler(loadAdapter)`, `NextPagesRouterConfig`: the Node stream bridge and required static `bodyParser: false` type. |
+| `@fluojs/platform-nextjs/next-config` | `withFluoNextBackend(config, options?)`, `FluoNextBackendOptions`: Turbopack compiler configuration and opt-in scope/path preservation. |
+| `@fluojs/platform-nextjs/decorators-loader` | The packaged compiler loader used by the config helper. |
+
+The adapter retains its `HttpApplicationAdapter` class identity, public
+constructor and inheritance, and instance `fetch(request)`, `listen(dispatcher)`,
+`close()`, and `getRealtimeCapability()`. Creation does not bind a dispatcher or
+open a socket; instance execution state is not shared through static fields.
+Host callbacks and the compiler helper remain distinct capabilities rather than
+being wrapped in creation classes.
+
+## API Migration
+
+This is a major release removing public APIs. There are no permanent compatibility aliases.
+
+| Removed surface | Replacement |
+| --- | --- |
+| Root/App/Pages `createNextAdapter(options)` | Import `NextHttpApplicationAdapter` from the root and call `.create(options)`. The same option validation and class instance are preserved. |
+| App/Pages `NextHttpApplicationAdapter`, `NextAdapterOptions`, `NextAdapterLoader` | Move imports to the root. Import App's former `InvalidNextAdapterOptionError` from the root too. |
+| Root `createNextAppRouterHandler`, `NextAppRouteHandler`, `NextAppRouterMethodHandlers` | Import from `/app-router`. |
+| Root `createNextPagesRouterHandler`, `NextPagesRouterConfig` | Import from `/pages-router`. |
+| Adapter `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, `OPTIONS` fields | Destructure the result of `createNextAppRouterHandler(loadAdapter)` into route module exports. Lazily import the backend as in the App Router recipe above. |
+
+Do not delete Next route module exports such as `GET`/`POST`/`HEAD`.
+The adapter's low-level instance dispatch remains `fetch(request)`, but do not
+replace lazy bootstrap with an eager backend import or direct bound handler
+export in a route. Do not convert Pages into a Web Request callback. Preserve
+`bodyParser: false`, demand-driven input, `drain` waits for
+`ServerResponse.write()` backpressure, disconnect abort, and remaining-upload
+drain after the response completes. Next retains socket ownership.
+
+Each facade's closure cache retains only that facade's loader Promise.
+The `defineNextApplication` keyed cache retains the first Promise and failure
+across consumers in the same JS global. Do not attribute one cache's guarantees
+to the other. Neither automatically retries failure or reopens a closed application.
+
+The consumer audit includes package tests/public declarations, the real Next
+fixture, Docs runtime-adapters/http-platform pages, and Book volume 3 chapter 15
+creation/import paths. Current CLI generators and `examples/` have no consumers
+of this Next API. The executable example is the [package fixture](./e2e/README.md).
+Historical changelogs retain the API that existed at the time. New source and
+distributed JavaScript/`.d.ts` do not retain the removed exports.
+
+`src/public-api.test.ts`, `src/app-router.test.ts`,
+`src/head-routing-public-types.test.ts`, and real Next E2E verify creation, host
+methods, cache distinctions, and import ownership. Internal
+`createLazyNextAdapterResolver` is the actual closure-cache implementation shared
+by the App/Pages bridges, not a public package export. Documentation code-fence
+import ownership is checked by `pnpm verify:platform-consistency-governance`.
 
 ## Development Verification
 
@@ -546,13 +588,13 @@ store SSR over HTTP without source aliases. See the [fixture guide](./e2e/README
 Set `NextAdapterOptions.bodyParser` at adapter construction. It accepts the
 HTTP-owned `BodyParser`: `'default'` (also the omitted default), `'text'`, or a
 synchronous/asynchronous callback. Application-wide text mode is
-`createNextAdapter({ bodyParser: 'text' })`. For path-specific policy, delegate
+`NextHttpApplicationAdapter.create({ bodyParser: 'text' })`. For path-specific policy, delegate
 unselected paths to the unchanged parser instead of reconstructing Requests:
 
 ```typescript
-import { createNextAdapter } from '@fluojs/platform-nextjs';
+import { NextHttpApplicationAdapter } from '@fluojs/platform-nextjs';
 
-export const nextAdapter = createNextAdapter({
+export const nextAdapter = NextHttpApplicationAdapter.create({
   headRouting: 'explicit-or-get',
   maxBodySize: 1_048_576,
   rawBody: true,

--- a/packages/platform-nextjs/e2e/README.ko.md
+++ b/packages/platform-nextjs/e2e/README.ko.md
@@ -37,6 +37,12 @@ FLUO_E2E_NEXT_ROOT="$PWD/.omo/next-16.3" pnpm --filter @fluojs/platform-nextjs t
   하나의 bootstrap을 공유하는지, SSE와 실패 시 cleanup이 완료되는지 검증합니다.
 - Next build는 `next-config.types.ts`로 배포된 public option 타입을 검사합니다.
   Rule 순서·비변이·scope 조건은 `src/next-config.test.ts`가 담당합니다.
+- `public-api.types.ts`는 root의 static adapter 생성/accessor와 각 router subpath의
+  callback 타입을 실제 Next build에서 검사합니다. Preflight는 배포 JavaScript의
+  export 이름을 비교하고 adapter method 별칭이 없음을 검증합니다. Backend fixture는
+  `NextHttpApplicationAdapter.create()`와 lazy route facade만 사용합니다.
+  삭제한 import와 instance method의 negative declaration 회귀는
+  `src/head-routing-public-types.test.ts`가 담당합니다.
 
 Consumer config는 helper와 범위 선언만 사용합니다. Custom loader 경로나
 `type: 'ecmascript'` 규칙은 작성하지 않습니다. `preserveModulePaths`는

--- a/packages/platform-nextjs/e2e/README.md
+++ b/packages/platform-nextjs/e2e/README.md
@@ -38,6 +38,12 @@ peer range floor. This is not a claim that every 16.x patch was tested.
   one bootstrap per bundle, and SSE/error cleanup must complete.
 - Next build checks shipped public option types through `next-config.types.ts`.
   `src/next-config.test.ts` covers rule order, non-mutation, and scope conditions.
+- `public-api.types.ts` checks root static adapter creation/accessors and each
+  router subpath's callback types in the actual Next build. Preflight compares
+  distributed JavaScript export names and verifies the absence of adapter method
+  aliases. Backend fixtures use only `NextHttpApplicationAdapter.create()` and
+  lazy route facades. Negative declaration regressions for removed imports and
+  instance methods live in `src/head-routing-public-types.test.ts`.
 
 Consumer configuration uses only the helper and scope declarations. It does not
 manually resolve loaders or configure `type: 'ecmascript'`.

--- a/packages/platform-nextjs/e2e/fixture/app/api/shared-closed/route.ts
+++ b/packages/platform-nextjs/e2e/fixture/app/api/shared-closed/route.ts
@@ -1,4 +1,4 @@
-import { createNextAppRouterHandler } from '@fluojs/platform-nextjs';
+import { createNextAppRouterHandler } from '@fluojs/platform-nextjs/app-router';
 
 import { getApplication } from '../../../shared-application';
 

--- a/packages/platform-nextjs/e2e/fixture/backend.ts
+++ b/packages/platform-nextjs/e2e/fixture/backend.ts
@@ -25,7 +25,7 @@ import {
   UnauthorizedException,
   UseGuards,
 } from '@fluojs/http';
-import { createNextAdapter } from '@fluojs/platform-nextjs';
+import { NextHttpApplicationAdapter } from '@fluojs/platform-nextjs';
 import { FluoFactory } from '@fluojs/runtime';
 
 const sentinel = process.env.FLUO_E2E_BOOTSTRAP;
@@ -278,7 +278,7 @@ class HeadStreamController {
 class BackendModule {}
 
 // No Content-Type rewrite, Request reconstruction, or parser outside the adapter.
-export const nextAdapter = createNextAdapter({
+export const nextAdapter = NextHttpApplicationAdapter.create({
   headRouting: 'explicit-or-get',
   maxBodySize: 128,
   rawBody: true,

--- a/packages/platform-nextjs/e2e/fixture/public-api.types.ts
+++ b/packages/platform-nextjs/e2e/fixture/public-api.types.ts
@@ -1,0 +1,29 @@
+import {
+  defineNextApplication,
+  type NextAdapterLoader,
+  type NextAdapterOptions,
+  NextHttpApplicationAdapter,
+} from '@fluojs/platform-nextjs';
+import {
+  createNextAppRouterHandler,
+  type NextAppRouteHandler,
+  type NextAppRouterMethodHandlers,
+} from '@fluojs/platform-nextjs/app-router';
+import {
+  createNextPagesRouterHandler,
+  type NextPagesRouterConfig,
+} from '@fluojs/platform-nextjs/pages-router';
+
+// Next build typechecks this consumer against staged distribution declarations.
+// It is not a route and is never executed during build or server bootstrap.
+export function publicApiTypes() {
+  const options = { headRouting: 'explicit-or-get', maxBodySize: 128 } satisfies NextAdapterOptions;
+  const adapter = NextHttpApplicationAdapter.create(options);
+  const load: NextAdapterLoader = async () => adapter;
+  const get = defineNextApplication({ key: 'public-types-only', load });
+  const methods: NextAppRouterMethodHandlers = createNextAppRouterHandler(get);
+  const head: NextAppRouteHandler = methods.HEAD;
+  const pages = createNextPagesRouterHandler(get);
+  const config = { api: { bodyParser: false } } satisfies NextPagesRouterConfig;
+  return { adapter, methods, head, pages, config };
+}

--- a/packages/platform-nextjs/e2e/fixture/shared-backend.ts
+++ b/packages/platform-nextjs/e2e/fixture/shared-backend.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto';
 
 import { Inject, Module, publicToken } from '@fluojs/core';
 import { Controller, Get } from '@fluojs/http';
-import { createNextAdapter } from '@fluojs/platform-nextjs';
+import { NextHttpApplicationAdapter } from '@fluojs/platform-nextjs';
 import { FluoFactory } from '@fluojs/runtime';
 
 import type { PublicBlog } from './shared-application';
@@ -44,7 +44,7 @@ export async function loadApplication(key: string) {
   }
   await observe('load', key);
   if (key === 'failed') throw new Error('FLUO_E2E_SHARED_BOOTSTRAP_FAILURE');
-  const adapter = createNextAdapter();
+  const adapter = NextHttpApplicationAdapter.create();
   const app = await FluoFactory.create(AppModule, { adapter });
   try {
     await app.listen();

--- a/packages/platform-nextjs/e2e/next.test.mjs
+++ b/packages/platform-nextjs/e2e/next.test.mjs
@@ -356,6 +356,7 @@ test('packaged Fluo serves both routers in a real Next 16 production build', {
 
     await t.test('resolves only published package exports before building', async () => {
       const preflight = run(process.execPath, ['--input-type=module', '-e', `
+        import assert from 'node:assert/strict';
         import { createRequire } from 'node:module';
         import { access } from 'node:fs/promises';
         import { fileURLToPath } from 'node:url';
@@ -369,7 +370,22 @@ test('packaged Fluo serves both routers in a real Next 16 production build', {
             throw new Error('Not a staged dist export: ' + url);
           }
           await access(fileURLToPath(url));
-          await import(name);
+          const entry = await import(name);
+          const nextExports = {
+            '@fluojs/platform-nextjs': ['InvalidNextAdapterOptionError', 'NextHttpApplicationAdapter', 'defineNextApplication'],
+            '@fluojs/platform-nextjs/app-router': ['createNextAppRouterHandler'],
+            '@fluojs/platform-nextjs/pages-router': ['createNextPagesRouterHandler'],
+            '@fluojs/platform-nextjs/next-config': ['withFluoNextBackend'],
+          };
+          if (nextExports[name]) assert.deepEqual(Object.keys(entry).sort(), nextExports[name]);
+          if (name === '@fluojs/platform-nextjs') {
+            const adapter = entry.NextHttpApplicationAdapter.create();
+            assert.ok(adapter instanceof entry.NextHttpApplicationAdapter);
+            for (const method of ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS']) {
+              assert.equal(method in adapter, false);
+            }
+            await adapter.close();
+          }
           console.log(name + ' -> ' + url);
         }
         const loader = createRequire(import.meta.url).resolve(

--- a/packages/platform-nextjs/package.json
+++ b/packages/platform-nextjs/package.json
@@ -29,8 +29,8 @@
       "import": "./dist/index.js"
     },
     "./app-router": {
-      "types": "./dist/adapter.d.ts",
-      "import": "./dist/adapter.js"
+      "types": "./dist/app-router.d.ts",
+      "import": "./dist/app-router.js"
     },
     "./decorators-loader": "./decorators-loader.cjs",
     "./next-config": {

--- a/packages/platform-nextjs/src/adapter.ts
+++ b/packages/platform-nextjs/src/adapter.ts
@@ -10,11 +10,6 @@ import {
   startWebRequestDispatch,
 } from '@fluojs/runtime/web';
 
-import {
-  createLazyNextAdapterResolver,
-  type NextAdapterLoader,
-} from './lazy-adapter.js';
-
 const NOT_READY_PROBLEM = {
   code: 'next_backend_adapter_not_ready',
   status: 503,
@@ -44,27 +39,6 @@ export interface NextAdapterOptions {
   readonly headRouting?: 'explicit-or-get';
   readonly maxBodySize?: number;
   readonly rawBody?: boolean;
-}
-
-/** Bound Next-compatible Web request handler. */
-export type NextAppRouteHandler = (request: Request) => Promise<Response>;
-
-/** Method-keyed handler exports consumed by one App Router route module. */
-export interface NextAppRouterMethodHandlers {
-  /** Bound handler for Next.js `DELETE` exports. */
-  readonly DELETE: NextAppRouteHandler;
-  /** Bound handler for Next.js `GET` exports. */
-  readonly GET: NextAppRouteHandler;
-  /** Bound handler for Next.js `HEAD` exports. */
-  readonly HEAD: NextAppRouteHandler;
-  /** Bound handler for Next.js `OPTIONS` exports. */
-  readonly OPTIONS: NextAppRouteHandler;
-  /** Bound handler for Next.js `PATCH` exports. */
-  readonly PATCH: NextAppRouteHandler;
-  /** Bound handler for Next.js `POST` exports. */
-  readonly POST: NextAppRouteHandler;
-  /** Bound handler for Next.js `PUT` exports. */
-  readonly PUT: NextAppRouteHandler;
 }
 
 /** Invalid Next adapter setup option. */
@@ -106,6 +80,17 @@ function createProblemResponse(
  * Web-standard Fluo HTTP adapter hosted by a Next.js Route Handler.
  */
 export class NextHttpApplicationAdapter implements HttpApplicationAdapter {
+  /**
+   * Create an independently owned Next-hosted adapter for `FluoFactory.create()`.
+   *
+   * @param options Web request parsing and opt-in HEAD routing options.
+   * @returns A new, unbound adapter instance.
+   * @throws InvalidNextAdapterOptionError When maxBodySize is not a non-negative safe integer.
+   */
+  static create(options: NextAdapterOptions = {}): NextHttpApplicationAdapter {
+    return new NextHttpApplicationAdapter(options);
+  }
+
   private closed = false;
   private dispatcher?: Dispatcher;
   private readonly headRouting;
@@ -149,7 +134,7 @@ export class NextHttpApplicationAdapter implements HttpApplicationAdapter {
    * @param request Native Web request created by Next.js.
    * @returns Native Web response produced by the Fluo dispatcher.
    */
-  readonly fetch: NextAppRouteHandler = async (request) => {
+  readonly fetch = async (request: Request): Promise<Response> => {
     const isHead = request.method === 'HEAD' && this.headRouting === 'explicit-or-get';
     if (this.closed) {
       return createProblemResponse(SHUTDOWN_PROBLEM, isHead);
@@ -181,21 +166,6 @@ export class NextHttpApplicationAdapter implements HttpApplicationAdapter {
     });
   };
 
-  /** Bound handler for Next.js `DELETE` exports. */
-  readonly DELETE = this.fetch;
-  /** Bound handler for Next.js `GET` exports. */
-  readonly GET = this.fetch;
-  /** Bound handler for Next.js `HEAD` exports. */
-  readonly HEAD = this.fetch;
-  /** Bound handler for Next.js `OPTIONS` exports. */
-  readonly OPTIONS = this.fetch;
-  /** Bound handler for Next.js `PATCH` exports. */
-  readonly PATCH = this.fetch;
-  /** Bound handler for Next.js `POST` exports. */
-  readonly POST = this.fetch;
-  /** Bound handler for Next.js `PUT` exports. */
-  readonly PUT = this.fetch;
-
   /**
    * Declare that App Router handlers do not own raw WebSocket upgrades.
    *
@@ -217,45 +187,3 @@ export class NextHttpApplicationAdapter implements HttpApplicationAdapter {
     this.dispatcher = dispatcher;
   }
 }
-
-/**
- * Create a Next-hosted Fluo HTTP adapter.
- *
- * @param options Web request parsing and opt-in HEAD routing options.
- * @returns A new adapter instance.
- */
-export function createNextAdapter(
-  options: NextAdapterOptions = {},
-): NextHttpApplicationAdapter {
-  return new NextHttpApplicationAdapter(options);
-}
-
-/**
- * Create App Router method exports that lazily import a bootstrapped adapter.
- *
- * @param loadAdapter Dynamic backend module loader.
- * @returns Method-keyed handlers shared by every supported App Router method,
- * ready for destructuring into named route module exports.
- */
-export function createNextAppRouterHandler(
-  loadAdapter: NextAdapterLoader,
-): NextAppRouterMethodHandlers {
-  const resolveAdapter = createLazyNextAdapterResolver(loadAdapter);
-
-  const handler: NextAppRouteHandler = async (request) => {
-    const adapter = await resolveAdapter();
-    return adapter.fetch(request);
-  };
-
-  return {
-    DELETE: handler,
-    GET: handler,
-    HEAD: handler,
-    OPTIONS: handler,
-    PATCH: handler,
-    POST: handler,
-    PUT: handler,
-  };
-}
-
-export type { NextAdapterLoader } from './lazy-adapter.js';

--- a/packages/platform-nextjs/src/app-router.test.ts
+++ b/packages/platform-nextjs/src/app-router.test.ts
@@ -1,0 +1,94 @@
+import { randomUUID } from 'node:crypto';
+
+import { Module } from '@fluojs/core';
+import { All, Controller, type RequestContext } from '@fluojs/http';
+import { FluoFactory } from '@fluojs/runtime';
+import { describe, expect, it } from 'vitest';
+
+import { createNextAppRouterHandler } from './app-router.js';
+import { defineNextApplication, NextHttpApplicationAdapter } from './index.js';
+
+@Controller('/api')
+class MethodsController {
+  @All('/methods')
+  method(_input: undefined, context: RequestContext) {
+    context.response.setHeader('x-original-method', context.request.method);
+    return { method: context.request.method };
+  }
+}
+
+@Module({ controllers: [MethodsController] })
+class AppModule {}
+
+describe('App Router callback facade', () => {
+  it.each(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'] as const)(
+    'dispatches Next %s exports with the original Web request',
+    async (method) => {
+      // Given the lazy facade and an ordinary, application-owned adapter.
+      const adapter = NextHttpApplicationAdapter.create({ headRouting: 'explicit-or-get' });
+      const app = await FluoFactory.create(AppModule, { adapter });
+      let loads = 0;
+      const handlers = createNextAppRouterHandler(async () => {
+        loads += 1;
+        await app.listen();
+        return adapter;
+      });
+      try {
+        expect(loads).toBe(0);
+        // When Next invokes its named method export.
+        const response = await handlers[method](new Request('https://next.test/api/methods', { method }));
+        // Then routing observes the original method, including bodyless HEAD.
+        expect(response.status).toBe(200);
+        expect(response.headers.get('x-original-method')).toBe(method);
+        if (method === 'HEAD') expect(response.body).toBeNull();
+        else await expect(response.json()).resolves.toEqual({ method });
+        expect(loads).toBe(1);
+      } finally {
+        await app.close();
+      }
+    },
+  );
+
+  it('keeps independent closure caches unless loaders opt into one application key', async () => {
+    // Given one loader used by separate facade definitions.
+    const adapter = NextHttpApplicationAdapter.create();
+    let loads = 0;
+    const load = async () => { loads += 1; return adapter; };
+    const left = createNextAppRouterHandler(load);
+    const right = createNextAppRouterHandler(load);
+    const get = defineNextApplication({ key: randomUUID(), load });
+    const sharedLeft = createNextAppRouterHandler(get);
+    const sharedRight = createNextAppRouterHandler(get);
+    try {
+      // When each closure receives overlapping requests.
+      await Promise.all([left, left, right, sharedLeft, sharedRight].map((handler) =>
+        handler.GET(new Request('https://next.test/api/methods'))));
+      // Then two ordinary closures load twice, while the keyed pair loads once.
+      expect(loads).toBe(3);
+    } finally {
+      await adapter.close();
+    }
+  });
+
+  it.each(['synchronous', 'asynchronous'])('retains %s loader failure per closure', async (mode) => {
+    // Given a loader whose first bootstrap fails.
+    const failure = new Error('bootstrap failed');
+    let loads = 0;
+    const handlers = createNextAppRouterHandler(() => {
+      loads += 1;
+      if (mode === 'synchronous') throw failure;
+      return Promise.reject(failure);
+    });
+    // When multiple method callbacks request the same facade.
+    const outcomes = await Promise.allSettled([
+      handlers.GET(new Request('https://next.test/')),
+      handlers.POST(new Request('https://next.test/', { method: 'POST' })),
+    ]);
+    // Then neither callback retries or replaces the cached error.
+    expect(outcomes).toEqual([
+      { status: 'rejected', reason: failure },
+      { status: 'rejected', reason: failure },
+    ]);
+    expect(loads).toBe(1);
+  });
+});

--- a/packages/platform-nextjs/src/app-router.ts
+++ b/packages/platform-nextjs/src/app-router.ts
@@ -1,0 +1,52 @@
+import {
+  createLazyNextAdapterResolver,
+  type NextAdapterLoader,
+} from './lazy-adapter.js';
+
+/** Next-compatible Web request callback owned by the App Router bridge. */
+export type NextAppRouteHandler = (request: Request) => Promise<Response>;
+
+/** Method-keyed handler exports consumed by one App Router route module. */
+export interface NextAppRouterMethodHandlers {
+  /** Lazy handler for Next.js `DELETE` exports. */
+  readonly DELETE: NextAppRouteHandler;
+  /** Lazy handler for Next.js `GET` exports. */
+  readonly GET: NextAppRouteHandler;
+  /** Lazy handler for Next.js `HEAD` exports. */
+  readonly HEAD: NextAppRouteHandler;
+  /** Lazy handler for Next.js `OPTIONS` exports. */
+  readonly OPTIONS: NextAppRouteHandler;
+  /** Lazy handler for Next.js `PATCH` exports. */
+  readonly PATCH: NextAppRouteHandler;
+  /** Lazy handler for Next.js `POST` exports. */
+  readonly POST: NextAppRouteHandler;
+  /** Lazy handler for Next.js `PUT` exports. */
+  readonly PUT: NextAppRouteHandler;
+}
+
+/**
+ * Create App Router method exports that lazily import a bootstrapped adapter.
+ *
+ * @param loadAdapter Dynamic backend module loader.
+ * @returns Method-keyed callbacks sharing one closure-local loader promise,
+ * ready for destructuring into named route module exports.
+ */
+export function createNextAppRouterHandler(
+  loadAdapter: NextAdapterLoader,
+): NextAppRouterMethodHandlers {
+  const resolveAdapter = createLazyNextAdapterResolver(loadAdapter);
+  const handler: NextAppRouteHandler = async (request) => {
+    const adapter = await resolveAdapter();
+    return adapter.fetch(request);
+  };
+
+  return {
+    DELETE: handler,
+    GET: handler,
+    HEAD: handler,
+    OPTIONS: handler,
+    PATCH: handler,
+    POST: handler,
+    PUT: handler,
+  };
+}

--- a/packages/platform-nextjs/src/application-accessor.test.ts
+++ b/packages/platform-nextjs/src/application-accessor.test.ts
@@ -153,7 +153,7 @@ describe('defineNextApplication', () => {
       key,
       load: async () => {
         loads += 1;
-        const adapter = next.createNextAdapter();
+        const adapter = next.NextHttpApplicationAdapter.create();
         const app = await FluoFactory.create(AppModule, { adapter });
         await app.listen();
         await app.container.resolve(Resource);
@@ -178,7 +178,7 @@ describe('defineNextApplication', () => {
       expect(destroys).toBe(2);
       expect(loads).toBe(1);
       expect(graph.app.state).toBe('closed');
-      await expect(graph.adapter.GET(new Request('http://next.test/'))).resolves.toMatchObject({
+      await expect(graph.adapter.fetch(new Request('http://next.test/'))).resolves.toMatchObject({
         status: 503,
       });
       await expect(graph.app.container.resolve(Resource)).rejects.toThrow();

--- a/packages/platform-nextjs/src/body-parser.test.ts
+++ b/packages/platform-nextjs/src/body-parser.test.ts
@@ -1,12 +1,13 @@
 import { Module } from '@fluojs/core';
 import {
-  BadRequestException, Controller, type BodyParser, type BodyParserContext,
+  BadRequestException, type BodyParser, type BodyParserContext, Controller,
   type GuardContext, Post, type RequestContext, UnauthorizedException, UseGuards,
 } from '@fluojs/http';
 import { FluoFactory } from '@fluojs/runtime';
 import { describe, expect, it, vi } from 'vitest';
 import bodyParserCases from '../../../tooling/testing/body-parser-cases.json';
-import { createNextAdapter, createNextAppRouterHandler } from './adapter.js';
+import { createNextAppRouterHandler } from './app-router.js';
+import { NextHttpApplicationAdapter } from './index.js';
 
 class AuthGuard {
   canActivate({ requestContext }: GuardContext) {
@@ -36,7 +37,7 @@ class PostsModule {}
 
 describe('Next bounded body parser conformance', () => {
   it.each(bodyParserCases)('preserves %j and %s through the App Router facade', async (body, mime) => {
-    const adapter = createNextAdapter({ bodyParser: 'text', rawBody: true });
+    const adapter = NextHttpApplicationAdapter.create({ bodyParser: 'text', rawBody: true });
     const app = await FluoFactory.create(PostsModule, { adapter });
     try {
       await app.listen();
@@ -58,11 +59,11 @@ describe('Next bounded body parser conformance', () => {
   it.each([
     [undefined, undefined, 400], ['text', undefined, 401], ['text', 'Bearer test', 400],
   ] as const)('makes the auth/JSON boundary explicit for %s and %s', async (bodyParser, authorization, status) => {
-    const adapter = createNextAdapter({ bodyParser });
+    const adapter = NextHttpApplicationAdapter.create({ bodyParser });
     const app = await FluoFactory.create(PostsModule, { adapter });
     try {
       await app.listen();
-      const response = await adapter.POST(new Request('https://next.test/posts/auth', {
+      const response = await adapter.fetch(new Request('https://next.test/posts/auth', {
         method: 'POST', body: '{',
         headers: { 'content-type': 'application/json', ...(authorization ? { authorization } : {}) },
       }));
@@ -76,12 +77,12 @@ describe('Next bounded body parser conformance', () => {
       if (context.path === '/posts/auth') throw new BadRequestException('Parser precedes auth');
       return { custom: text };
     });
-    const adapter = createNextAdapter({ bodyParser, maxBodySize: 3 });
+    const adapter = NextHttpApplicationAdapter.create({ bodyParser, maxBodySize: 3 });
     const app = await FluoFactory.create(PostsModule, { adapter });
     try {
       await app.listen();
       for (const [path, body, status] of [['text', '한', 201], ['text', '한a', 413], ['auth', '{', 400]] as const) {
-        const response = await adapter.POST(new Request(`https://next.test/posts/${path}`, {
+        const response = await adapter.fetch(new Request(`https://next.test/posts/${path}`, {
           method: 'POST', body, headers: { 'content-type': 'application/json' },
         }));
         expect(response.status).toBe(status);

--- a/packages/platform-nextjs/src/head-routing-public-types.test.ts
+++ b/packages/platform-nextjs/src/head-routing-public-types.test.ts
@@ -17,8 +17,8 @@ const require = createRequire(import.meta.url);
 const nextManifest = require.resolve('next/package.json');
 const nextRequire = createRequire(nextManifest);
 const imports = `
-import { createNextAdapter, type NextAdapterOptions } from '@fluojs/platform-nextjs';
-import type { NextAdapterOptions as AppOptions } from '@fluojs/platform-nextjs/app-router';
+import { NextHttpApplicationAdapter, type NextAdapterOptions } from '@fluojs/platform-nextjs';
+import { createNextAppRouterHandler, type NextAppRouteHandler, type NextAppRouterMethodHandlers } from '@fluojs/platform-nextjs/app-router';
 import type { FrameworkRequest } from '@fluojs/http';
 import type { FrameworkRequest as PortableRequest } from '@fluojs/http/portable';
 `;
@@ -86,15 +86,16 @@ function compile(source: string): readonly ts.Diagnostic[] {
   return ts.getPreEmitDiagnostics(ts.createProgram([fixture], options, host));
 }
 
-it('accepts the opt-in through built package root, App Router, and HTTP declarations', () => {
+it('accepts root adapter options through built App Router and HTTP declarations', () => {
   // Given real public export-map resolution, without source aliases.
   const source = `${imports}
 const options = { headRouting: 'explicit-or-get' } satisfies NextAdapterOptions;
-const appOptions: AppOptions = options;
 const policy: FrameworkRequest['headRouting'] = options.headRouting;
 const portable: PortableRequest['headRouting'] = policy;
-createNextAdapter(appOptions);
-createNextAdapter();
+const adapter = NextHttpApplicationAdapter.create(options);
+const handlers: NextAppRouterMethodHandlers = createNextAppRouterHandler(async () => adapter);
+const head: NextAppRouteHandler = handlers.HEAD;
+NextHttpApplicationAdapter.create();
 `;
   // When TypeScript consumes the built declarations.
   const diagnostics = compile(source);
@@ -105,8 +106,8 @@ createNextAdapter();
 it('rejects unsupported policy values at each published entry point', () => {
   // Given independently invalid callers, not suppressed type errors.
   const invalid = [
-    "createNextAdapter({ headRouting: 'retry-on-404' });",
-    "const app: AppOptions = { headRouting: true };",
+    "NextHttpApplicationAdapter.create({ headRouting: 'retry-on-404' });",
+    "const app: NextAdapterOptions = { headRouting: true };",
     "const http: FrameworkRequest['headRouting'] = 'get';",
     "const portable: PortableRequest['headRouting'] = false;",
   ];
@@ -137,11 +138,11 @@ const parser: BodyParser = async (text, context: BodyParserContext) => ({
 });
 const portable: PortableParser = parser;
 const next: NextAdapterOptions = { bodyParser: portable, headRouting: 'explicit-or-get' };
-const app: AppOptions = { bodyParser: 'text' };
+const app: NextAdapterOptions = { bodyParser: 'text' };
 const factory: CreateWebRequestResponseFactoryOptions = { bodyParser: 'default' };
 const dispatch: DispatchWebRequestOptions = { bodyParser: parser, request: new Request('https://test/') };
-createNextAdapter(next);
-createNextAdapter(app);
+NextHttpApplicationAdapter.create(next);
+NextHttpApplicationAdapter.create(app);
 createWebRequestResponseFactory(factory);
 dispatchWebRequest(dispatch);
 createWebFrameworkRequest(dispatch.request, dispatch.request.signal, undefined, 100, true, parser);
@@ -154,12 +155,78 @@ it('rejects invalid parser modes and callback signatures without type suppressio
 import type { BodyParser } from '@fluojs/http';
 import type { BodyParser as PortableParser } from '@fluojs/http/portable';
 import { createWebRequestResponseFactory } from '@fluojs/runtime/web';
-createNextAdapter({ bodyParser: false });
-const app: AppOptions = { bodyParser: 'json-or-null' };
+NextHttpApplicationAdapter.create({ bodyParser: false });
+const app: NextAdapterOptions = { bodyParser: 'json-or-null' };
 const parser: BodyParser = (text: number) => text;
 const portable: PortableParser = true;
 createWebRequestResponseFactory({ bodyParser: 'unlimited' });
 `);
   expect(diagnostics).toHaveLength(5);
   expect(diagnostics.every((entry) => entry.file?.fileName === fixture && entry.code === 2322)).toBe(true);
+});
+
+it('compiles canonical public imports and constructor subclasses without source aliases', () => {
+  const diagnostics = compile(`${imports}
+import { defineNextApplication, type NextAdapterLoader } from '@fluojs/platform-nextjs';
+import { createNextPagesRouterHandler, type NextPagesRouterConfig } from '@fluojs/platform-nextjs/pages-router';
+import { withFluoNextBackend } from '@fluojs/platform-nextjs/next-config';
+class CustomAdapter extends NextHttpApplicationAdapter {}
+const adapter: NextHttpApplicationAdapter = new CustomAdapter({ maxBodySize: 0 });
+const load: NextAdapterLoader = async () => adapter;
+const get = defineNextApplication({ key: 'declarations/app', load });
+const { GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS } = createNextAppRouterHandler(get);
+const pages = createNextPagesRouterHandler(get);
+const config = { api: { bodyParser: false } } satisfies NextPagesRouterConfig;
+withFluoNextBackend({});
+adapter.fetch(new Request('https://next.test/'));
+adapter.close();
+`);
+  expect(diagnostics.map((entry) => ts.flattenDiagnosticMessageText(entry.messageText, '\n'))).toEqual([]);
+});
+
+it('rejects removed exports and adapter method aliases at every public entry point', () => {
+  const removed = {
+    '': ['createNextAdapter', 'createNextAppRouterHandler', 'createNextPagesRouterHandler',
+      'NextAppRouteHandler', 'NextAppRouterMethodHandlers', 'NextPagesRouterConfig'],
+    '/app-router': ['createNextAdapter', 'NextHttpApplicationAdapter', 'InvalidNextAdapterOptionError',
+      'NextAdapterOptions', 'NextAdapterLoader', 'defineNextApplication', 'createNextPagesRouterHandler'],
+    '/pages-router': ['createNextAdapter', 'NextHttpApplicationAdapter', 'NextAdapterOptions',
+      'NextAdapterLoader', 'defineNextApplication', 'createNextAppRouterHandler'],
+    '/next-config': ['createNextAdapter', 'NextHttpApplicationAdapter', 'defineNextApplication'],
+  };
+  const invalid = Object.entries(removed).flatMap(([subpath, names]) =>
+    names.map((name, index) =>
+      `import { ${name} as removed${subpath.replaceAll(/\W/g, '')}${index} } from '@fluojs/platform-nextjs${subpath}';`));
+  const methods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS']
+    .map((method) => `NextHttpApplicationAdapter.create().${method};`);
+  const diagnostics = compile(`${imports}${[...invalid, ...methods].join('\n')}`);
+  expect(diagnostics).toHaveLength(invalid.length + methods.length);
+  expect(diagnostics.filter((entry) =>
+    entry.file?.fileName !== fixture || ![2305, 2724, 2339, 2459].includes(entry.code))
+    .map((entry) => ({
+      code: entry.code,
+      message: ts.flattenDiagnosticMessageText(entry.messageText, '\n'),
+    }))).toEqual([]);
+  const lines = diagnostics.map((entry) =>
+    entry.file && entry.start !== undefined
+      ? entry.file.getLineAndCharacterOfPosition(entry.start).line
+      : -1);
+  expect(lines).toEqual([...invalid, ...methods].map((_, index) => imports.split('\n').length - 1 + index));
+});
+
+it('exposes only canonical runtime names from emitted public entry points', async () => {
+  const result = await execFileAsync(process.execPath, ['--input-type=module', '-e', `
+    const surface = {};
+    for (const path of ['', '/app-router', '/pages-router', '/next-config']) {
+      const entry = await import('@fluojs/platform-nextjs' + path);
+      surface[path] = Object.keys(entry).sort();
+    }
+    console.log(JSON.stringify(surface));
+  `], { cwd: join(root, 'packages/platform-nextjs') });
+  expect(JSON.parse(result.stdout)).toEqual({
+    '': ['InvalidNextAdapterOptionError', 'NextHttpApplicationAdapter', 'defineNextApplication'],
+    '/app-router': ['createNextAppRouterHandler'],
+    '/pages-router': ['createNextPagesRouterHandler'],
+    '/next-config': ['withFluoNextBackend'],
+  });
 });

--- a/packages/platform-nextjs/src/head-routing.test.ts
+++ b/packages/platform-nextjs/src/head-routing.test.ts
@@ -17,10 +17,10 @@ import {
 import { FluoFactory } from '@fluojs/runtime';
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
+import { createNextAppRouterHandler } from './app-router.js';
 import {
-  createNextAdapter,
-  createNextAppRouterHandler,
   type NextAdapterOptions,
+  NextHttpApplicationAdapter,
 } from './index.js';
 
 function deferred() {
@@ -43,12 +43,12 @@ it('selects GET once for an opted-in HEAD request without rewriting its method',
   }
   @Module({ controllers: [ArticlesController] })
   class AppModule {}
-  const adapter = createNextAdapter({ headRouting: 'explicit-or-get' });
+  const adapter = NextHttpApplicationAdapter.create({ headRouting: 'explicit-or-get' });
   const app = await FluoFactory.create(AppModule, { adapter });
   try {
     await app.listen();
     // When Next invokes GET with the original HEAD request.
-    const response = await adapter.GET(new Request('https://next.test/articles/42', {
+    const response = await createNextAppRouterHandler(async () => adapter).GET(new Request('https://next.test/articles/42', {
       method: 'HEAD',
     }));
     // Then one GET handler supplies metadata without a response body.
@@ -115,7 +115,7 @@ describe('HEAD route selection and single execution', () => {
     }
     @Module({ controllers: [Routes], middleware: [ModuleMiddleware], providers: [Guard] })
     class AppModule {}
-    const adapter = createNextAdapter({ headRouting: 'explicit-or-get' });
+    const adapter = NextHttpApplicationAdapter.create({ headRouting: 'explicit-or-get' });
     const app = await FluoFactory.create(AppModule, {
       adapter,
       middleware: [{
@@ -130,7 +130,7 @@ describe('HEAD route selection and single execution', () => {
     try {
       await app.listen();
       // When a direct HEAD export receives the request.
-      const response = await adapter.HEAD(request);
+      const response = await createNextAppRouterHandler(async () => adapter).HEAD(request);
       // Then the complete pipeline runs at most once, including handler-produced 404s.
       expect(response.status).toBe(status);
       expect(response.body).toBeNull();
@@ -154,12 +154,12 @@ describe('HEAD route selection and single execution', () => {
     }
     @Module({ controllers: [Routes] })
     class AppModule {}
-    const adapter = createNextAdapter();
+    const adapter = NextHttpApplicationAdapter.create();
     const app = await FluoFactory.create(AppModule, { adapter });
     try {
       await app.listen();
       // When HEAD has no explicit handler.
-      const response = await adapter.HEAD(new Request('https://next.test/default', { method: 'HEAD' }));
+      const response = await createNextAppRouterHandler(async () => adapter).HEAD(new Request('https://next.test/default', { method: 'HEAD' }));
       // Then the ordinary route miss is preserved.
       expect(response.status).toBe(404);
     } finally {
@@ -185,7 +185,7 @@ describe('HEAD route selection and single execution', () => {
     }
     @Module({ controllers: [Routes] })
     class AppModule {}
-    const adapter = createNextAdapter({ headRouting: 'explicit-or-get' });
+    const adapter = NextHttpApplicationAdapter.create({ headRouting: 'explicit-or-get' });
     const app = await FluoFactory.create(AppModule, { adapter });
     let loads = 0;
     const handlers = createNextAppRouterHandler(async () => { loads += 1; return adapter; });
@@ -243,7 +243,7 @@ describe('HEAD metadata and resource ownership', () => {
     }
     @Module({ controllers: [Routes] })
     class AppModule {}
-    const adapter = createNextAdapter({ headRouting: 'explicit-or-get' });
+    const adapter = NextHttpApplicationAdapter.create({ headRouting: 'explicit-or-get' });
     const app = await FluoFactory.create(AppModule, {
       adapter,
       conditionalRequest: {
@@ -257,7 +257,7 @@ describe('HEAD metadata and resource ownership', () => {
     try {
       await app.listen();
       // When HEAD falls back to the GET representation.
-      const response = await adapter.HEAD(new Request('https://next.test/bytes', {
+      const response = await createNextAppRouterHandler(async () => adapter).HEAD(new Request('https://next.test/bytes', {
         method: 'HEAD', headers,
       }));
       // Then conditional evaluation and range metadata remain HTTP-owned.
@@ -322,7 +322,7 @@ describe('HEAD metadata and resource ownership', () => {
       }
       @Module({ controllers: [Routes] })
       class AppModule {}
-      const adapter = createNextAdapter({ headRouting: 'explicit-or-get' });
+      const adapter = NextHttpApplicationAdapter.create({ headRouting: 'explicit-or-get' });
       const app = await FluoFactory.create(AppModule, {
         adapter,
         observers: [{
@@ -333,7 +333,7 @@ describe('HEAD metadata and resource ownership', () => {
       try {
         await app.listen();
         // When HEAD cancellation closes the real stream and awaits iterator cleanup.
-        const pending = adapter.HEAD(new Request('https://next.test/lifecycle', { method: 'HEAD' }));
+        const pending = createNextAppRouterHandler(async () => adapter).HEAD(new Request('https://next.test/lifecycle', { method: 'HEAD' }));
         if (kind === 'managed' || kind === 'cleanup-error') {
           await cleanupStarted.promise;
           expect(events).toEqual(['handler', 'iterator-return']);
@@ -372,7 +372,7 @@ describe('HEAD metadata and resource ownership', () => {
     }
     @Module({ controllers: [Routes] })
     class AppModule {}
-    const adapter = createNextAdapter({ headRouting: 'explicit-or-get' });
+    const adapter = NextHttpApplicationAdapter.create({ headRouting: 'explicit-or-get' });
     const app = await FluoFactory.create(AppModule, {
       adapter,
       observers: [{
@@ -384,7 +384,7 @@ describe('HEAD metadata and resource ownership', () => {
     try {
       await app.listen();
       // When cancellation occurs after handler entry, before its result.
-      const pending = adapter.HEAD(new Request('https://next.test/abort', {
+      const pending = createNextAppRouterHandler(async () => adapter).HEAD(new Request('https://next.test/abort', {
         method: 'HEAD', signal: abort.signal,
       }));
       await entered.promise;
@@ -402,10 +402,10 @@ describe('HEAD metadata and resource ownership', () => {
 
   it.each(['not-ready', 'closed'] as const)('returns bodyless 503 when %s', async (state) => {
     // Given an unavailable opt-in adapter.
-    const adapter = createNextAdapter({ headRouting: 'explicit-or-get' });
+    const adapter = NextHttpApplicationAdapter.create({ headRouting: 'explicit-or-get' });
     if (state === 'closed') await adapter.close();
     // When HEAD reaches the adapter boundary.
-    const response = await adapter.HEAD(new Request('https://next.test/unavailable', { method: 'HEAD' }));
+    const response = await createNextAppRouterHandler(async () => adapter).HEAD(new Request('https://next.test/unavailable', { method: 'HEAD' }));
     // Then failure metadata is preserved without its JSON body.
     expect(response.status).toBe(503);
     expect(response.headers.get('content-type')).toBe('application/problem+json');

--- a/packages/platform-nextjs/src/index.test.ts
+++ b/packages/platform-nextjs/src/index.test.ts
@@ -17,11 +17,8 @@ import {
 } from '@fluojs/runtime';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import {
-  createNextAdapter,
-  createNextAppRouterHandler,
-  type NextHttpApplicationAdapter,
-} from './index.js';
+import { createNextAppRouterHandler } from './app-router.js';
+import { NextHttpApplicationAdapter } from './index.js';
 
 interface TestBackend {
   readonly adapter: NextHttpApplicationAdapter;
@@ -95,7 +92,7 @@ class ApiController {
 class AppModule {}
 
 async function createTestBackend(): Promise<TestBackend> {
-  const adapter = createNextAdapter();
+  const adapter = NextHttpApplicationAdapter.create();
   const app = await FluoFactory.create(AppModule, { adapter });
   await app.listen();
   activeApplications.push(app);
@@ -111,15 +108,16 @@ afterEach(async () => {
 
 describe('@fluojs/platform-nextjs', () => {
   it('exports one Next handler across every supported HTTP method', async () => {
-    const adapter = createNextAdapter();
+    const adapter = NextHttpApplicationAdapter.create();
+    const handlers = createNextAppRouterHandler(async () => adapter);
     const exportedHandlers = [
-      adapter.GET,
-      adapter.POST,
-      adapter.PUT,
-      adapter.PATCH,
-      adapter.DELETE,
-      adapter.HEAD,
-      adapter.OPTIONS,
+      handlers.GET,
+      handlers.POST,
+      handlers.PUT,
+      handlers.PATCH,
+      handlers.DELETE,
+      handlers.HEAD,
+      handlers.OPTIONS,
     ];
 
     expect(new Set(exportedHandlers)).toHaveLength(1);
@@ -129,7 +127,7 @@ describe('@fluojs/platform-nextjs', () => {
   it('dispatches a decorated module through FluoFactory', async () => {
     const { adapter } = await createTestBackend();
 
-    const response = await adapter.GET(
+    const response = await adapter.fetch(
       new Request('https://next.test/api/health'),
     );
 
@@ -140,17 +138,17 @@ describe('@fluojs/platform-nextjs', () => {
   it('materializes JSON bodies and preserves malformed-body and not-found errors', async () => {
     const { adapter } = await createTestBackend();
 
-    const created = await adapter.POST(new Request('https://next.test/api/echo', {
+    const created = await adapter.fetch(new Request('https://next.test/api/echo', {
       body: JSON.stringify({ message: 'hello' }),
       headers: { 'content-type': 'application/json' },
       method: 'POST',
     }));
-    const malformed = await adapter.POST(new Request('https://next.test/api/echo', {
+    const malformed = await adapter.fetch(new Request('https://next.test/api/echo', {
       body: '{',
       headers: { 'content-type': 'application/json' },
       method: 'POST',
     }));
-    const missing = await adapter.GET(new Request('https://next.test/api/missing'));
+    const missing = await adapter.fetch(new Request('https://next.test/api/missing'));
 
     expect(created.status).toBe(201);
     await expect(created.json()).resolves.toEqual({ message: 'hello' });
@@ -171,7 +169,7 @@ describe('@fluojs/platform-nextjs', () => {
   it('preserves cookies, middleware, converters, and multiple Set-Cookie headers', async () => {
     const { adapter } = await createTestBackend();
 
-    const response = await adapter.GET(
+    const response = await adapter.fetch(
       new Request('https://next.test/api/pipeline', {
         headers: {
           cookie: 'session=hello%20next; theme=light',
@@ -191,7 +189,7 @@ describe('@fluojs/platform-nextjs', () => {
   });
 
   it('lets FluoFactory own idempotent application startup', async () => {
-    const adapter = createNextAdapter();
+    const adapter = NextHttpApplicationAdapter.create();
     const app = await FluoFactory.create(AppModule, { adapter });
     activeApplications.push(app);
 
@@ -203,7 +201,7 @@ describe('@fluojs/platform-nextjs', () => {
 
     expect(app.state).toBe('ready');
     await expect(
-      adapter.GET(new Request('https://next.test/api/health')),
+      adapter.fetch(new Request('https://next.test/api/health')),
     ).resolves.toMatchObject({ status: 200 });
   });
 
@@ -272,7 +270,7 @@ describe('@fluojs/platform-nextjs', () => {
 
     await app.close('test shutdown');
 
-    const response = await adapter.GET(
+    const response = await adapter.fetch(
       new Request('https://next.test/api/health'),
     );
 

--- a/packages/platform-nextjs/src/index.ts
+++ b/packages/platform-nextjs/src/index.ts
@@ -1,17 +1,7 @@
-export type {
-  NextAdapterLoader,
-  NextAdapterOptions,
-  NextAppRouteHandler,
-  NextAppRouterMethodHandlers,
-} from './adapter.js';
+export type { NextAdapterOptions } from './adapter.js';
 export {
-  createNextAdapter,
-  createNextAppRouterHandler,
   InvalidNextAdapterOptionError,
   NextHttpApplicationAdapter,
 } from './adapter.js';
 export { defineNextApplication, type NextApplicationOptions } from './application-accessor.js';
-export type { NextPagesRouterConfig } from './pages-router.js';
-export {
-  createNextPagesRouterHandler,
-} from './pages-router.js';
+export type { NextAdapterLoader } from './lazy-adapter.js';

--- a/packages/platform-nextjs/src/pages-bridge.test.ts
+++ b/packages/platform-nextjs/src/pages-bridge.test.ts
@@ -11,7 +11,7 @@ import { Readable, Writable } from 'node:stream';
 import type { FrameworkRequest } from '@fluojs/http';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { createNextAdapter, type NextHttpApplicationAdapter } from './adapter.js';
+import { NextHttpApplicationAdapter } from './index.js';
 import { dispatchNextPagesRequest } from './pages-bridge.js';
 import { createNextPagesRouterHandler } from './pages-router.js';
 
@@ -136,7 +136,7 @@ describe('Pages transport cancellation and input ownership', () => {
     const entered = deferred<AbortSignal>();
     const release = deferred<void>();
     cleanups.push(() => { release.resolve(); });
-    const adapter = createNextAdapter();
+    const adapter = NextHttpApplicationAdapter.create();
     await adapter.listen({
       async dispatch(request, response) {
         if (!request.signal) {
@@ -170,7 +170,7 @@ describe('Pages transport cancellation and input ownership', () => {
     // Given
     const entered = deferred<FrameworkRequest>();
     const cancelled = deferred<void>();
-    const adapter = createNextAdapter();
+    const adapter = NextHttpApplicationAdapter.create();
     await adapter.listen({
       async dispatch(request, response) {
         entered.resolve(request);
@@ -209,7 +209,7 @@ describe('Pages transport cancellation and input ownership', () => {
     // Given
     const bootstrap = deferred<NextHttpApplicationAdapter>();
     const loaded = deferred<void>();
-    const adapter = createNextAdapter();
+    const adapter = NextHttpApplicationAdapter.create();
     const dispatch = vi.fn(async () => undefined);
     await adapter.listen({ dispatch });
     const loader = vi.fn(() => {
@@ -255,7 +255,7 @@ describe('Pages transport cancellation and input ownership', () => {
     const consumed = deferred<void>();
     const release = deferred<void>();
     cleanups.push(() => { release.resolve(); });
-    const adapter = createNextAdapter();
+    const adapter = NextHttpApplicationAdapter.create();
     vi.spyOn(adapter, 'fetch').mockImplementation(async (request) => {
       const reader = request.body?.getReader();
       if (!reader) {
@@ -285,7 +285,7 @@ describe('Pages transport cancellation and input ownership', () => {
 
   it('returns real HTTP 413 for chunked oversized input before the client finishes uploading', async () => {
     // Given
-    const adapter = createNextAdapter({ maxBodySize: 8 });
+    const adapter = NextHttpApplicationAdapter.create({ maxBodySize: 8 });
     const dispatch = vi.fn(async () => undefined);
     await adapter.listen({ dispatch });
     const server = await serve((request, response) =>
@@ -320,7 +320,7 @@ describe('Pages transport cancellation and input ownership', () => {
   it('consumes the original body and preserves exact bytes without treating completion as abort', async () => {
     // Given
     const bytes = Buffer.from([0, 0xff, 0xc3, 0x28, 13, 10, 0xe2, 0x82, 0xac]);
-    const adapter = createNextAdapter({ rawBody: true });
+    const adapter = NextHttpApplicationAdapter.create({ rawBody: true });
     const dispatched = deferred<FrameworkRequest>();
     await adapter.listen({
       async dispatch(request, response) {

--- a/packages/platform-nextjs/src/pages-bridge.ts
+++ b/packages/platform-nextjs/src/pages-bridge.ts
@@ -6,7 +6,8 @@ import type {
 } from 'node:stream';
 import { finished } from 'node:stream/promises';
 
-import type { NextAdapterLoader, NextHttpApplicationAdapter } from './adapter.js';
+import type { NextHttpApplicationAdapter } from './adapter.js';
+import type { NextAdapterLoader } from './lazy-adapter.js';
 
 interface NextPagesRequestSource extends Readable {
   readonly aborted?: boolean;

--- a/packages/platform-nextjs/src/pages-router.test.ts
+++ b/packages/platform-nextjs/src/pages-router.test.ts
@@ -24,7 +24,7 @@ import {
 import type { NextApiHandler } from 'next';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { createNextAdapter } from './adapter.js';
+import { NextHttpApplicationAdapter } from './index.js';
 import { dispatchNextPagesRequest } from './pages-bridge.js';
 import {
   createNextPagesRouterHandler,
@@ -163,7 +163,7 @@ class PagesAppModule {}
 const activeApplications: Application[] = [];
 
 async function createTestAdapter() {
-  const adapter = createNextAdapter();
+  const adapter = NextHttpApplicationAdapter.create();
   const app = await FluoFactory.create(PagesAppModule, { adapter });
   await app.listen();
   activeApplications.push(app);

--- a/packages/platform-nextjs/src/pages-router.ts
+++ b/packages/platform-nextjs/src/pages-router.ts
@@ -2,13 +2,7 @@ import type {
   NextApiHandler,
 } from 'next';
 
-import {
-  createNextAdapter,
-  type NextAdapterLoader,
-  type NextAdapterOptions,
-  NextHttpApplicationAdapter,
-} from './adapter.js';
-import { createLazyNextAdapterResolver } from './lazy-adapter.js';
+import { createLazyNextAdapterResolver, type NextAdapterLoader } from './lazy-adapter.js';
 import { dispatchNextPagesRequest } from './pages-bridge.js';
 
 /** Static Pages Router config shape required for Fluo request parsing. */
@@ -33,10 +27,3 @@ export function createNextPagesRouterHandler(
     await dispatchNextPagesRequest(resolveAdapter, request, response);
   };
 }
-
-export {
-  createNextAdapter,
-  type NextAdapterLoader,
-  type NextAdapterOptions,
-  NextHttpApplicationAdapter,
-};

--- a/packages/platform-nextjs/src/portability.test.ts
+++ b/packages/platform-nextjs/src/portability.test.ts
@@ -2,13 +2,13 @@ import { type CreateApplicationOptions, FluoFactory } from '@fluojs/runtime';
 import { createWebRuntimeHttpAdapterPortabilityHarness } from '@fluojs/testing/web-runtime-adapter-portability';
 import { describe, it } from 'vitest';
 
-import { createNextAdapter, type NextAdapterOptions } from './adapter.js';
+import { type NextAdapterOptions, NextHttpApplicationAdapter } from './index.js';
 
 type BootstrapOptions = Omit<CreateApplicationOptions, 'adapter'> & NextAdapterOptions;
 
 const portability = createWebRuntimeHttpAdapterPortabilityHarness<BootstrapOptions>({
   async bootstrap(rootModule, { maxBodySize, rawBody, ...options }) {
-    const adapter = createNextAdapter({ maxBodySize, rawBody });
+    const adapter = NextHttpApplicationAdapter.create({ maxBodySize, rawBody });
     const app = await FluoFactory.create(rootModule, { ...options, adapter });
     await app.listen();
 

--- a/packages/platform-nextjs/src/public-api.test.ts
+++ b/packages/platform-nextjs/src/public-api.test.ts
@@ -1,0 +1,78 @@
+import { Module } from '@fluojs/core';
+import { Controller, Get } from '@fluojs/http';
+import { FluoFactory } from '@fluojs/runtime';
+import { describe, expect, it } from 'vitest';
+
+import {
+  InvalidNextAdapterOptionError,
+  NextHttpApplicationAdapter,
+} from './index.js';
+
+@Controller('/api')
+class HealthController {
+  @Get('/health')
+  health() {
+    return { status: 'ok' };
+  }
+}
+
+@Module({ controllers: [HealthController] })
+class AppModule {}
+
+describe('canonical Next adapter creation', () => {
+  it('creates independent class instances usable by FluoFactory', async () => {
+    // Given the public class token and explicit parser/routing options.
+    const adapter = NextHttpApplicationAdapter.create({
+      headRouting: 'explicit-or-get',
+      maxBodySize: 32,
+      rawBody: true,
+    });
+    const other = NextHttpApplicationAdapter.create();
+    const app = await FluoFactory.create(AppModule, { adapter });
+    try {
+      // When the ordinary application lifecycle binds the adapter.
+      await app.listen();
+      const response = await adapter.fetch(new Request('https://next.test/api/health'));
+      // Then creation preserves the class and isolates each adapter's state.
+      expect(adapter).toBeInstanceOf(NextHttpApplicationAdapter);
+      expect(other).not.toBe(adapter);
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({ status: 'ok' });
+      expect((await other.fetch(new Request('https://next.test/api/health'))).status).toBe(503);
+    } finally {
+      await app.close();
+      await other.close();
+    }
+    expect((await adapter.fetch(new Request('https://next.test/api/health'))).status).toBe(503);
+  });
+
+  it.each([-1, 0.5, Number.NaN, Number.POSITIVE_INFINITY, Number.MAX_SAFE_INTEGER + 1])(
+    'rejects invalid maxBodySize %s through static and constructor creation',
+    (maxBodySize) => {
+      // Given an invalid public option.
+      // When either supported construction mechanism receives it.
+      // Then both preserve the existing error class.
+      expect(() => NextHttpApplicationAdapter.create({ maxBodySize }))
+        .toThrow(InvalidNextAdapterOptionError);
+      expect(() => new NextHttpApplicationAdapter({ maxBodySize }))
+        .toThrow(InvalidNextAdapterOptionError);
+    },
+  );
+
+  it('retains constructor inheritance without adapter method aliases', async () => {
+    // Given a consumer subclass using the existing public constructor.
+    class CustomAdapter extends NextHttpApplicationAdapter {}
+    const adapter = new CustomAdapter({ maxBodySize: 0 });
+    try {
+      // When inspecting the constructed adapter, not a router facade.
+      const methods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'];
+      // Then class identity and the one instance dispatch operation remain.
+      expect(adapter).toBeInstanceOf(CustomAdapter);
+      expect(adapter).toBeInstanceOf(NextHttpApplicationAdapter);
+      expect(adapter.fetch).toBeTypeOf('function');
+      for (const method of methods) expect(method in adapter).toBe(false);
+    } finally {
+      await adapter.close();
+    }
+  });
+});

--- a/packages/platform-nextjs/src/schema-input-materialization.test.ts
+++ b/packages/platform-nextjs/src/schema-input-materialization.test.ts
@@ -3,18 +3,19 @@ import {
   Controller,
   createSchemaDto,
   Get,
+  type GuardContext,
   Head,
   Post,
   RequestDto,
   StandardSchemaBinder,
   UnauthorizedException,
   UseGuards,
-  type GuardContext,
 } from '@fluojs/http';
 import { FluoFactory } from '@fluojs/runtime';
 import { describe, expect, it, vi } from 'vitest';
 
-import { createNextAdapter, createNextAppRouterHandler } from './index.js';
+import { createNextAppRouterHandler } from './app-router.js';
+import { NextHttpApplicationAdapter } from './index.js';
 
 describe('schema input through the public Next App Router adapter', () => {
   it('preserves bounded parsing, raw guards, native query arrays and original HEAD semantics', async () => {
@@ -101,7 +102,7 @@ describe('schema input through the public Next App Router adapter', () => {
     }
     @Module({ controllers: [Posts], providers: [Inspect] })
     class App {}
-    const adapter = createNextAdapter({
+    const adapter = NextHttpApplicationAdapter.create({
       headRouting: 'explicit-or-get',
       rawBody: true,
       maxBodySize: 128,

--- a/tooling/governance/nextjs-public-imports.d.mts
+++ b/tooling/governance/nextjs-public-imports.d.mts
@@ -1,0 +1,2 @@
+export const nextjsRecipePaths: readonly string[];
+export function enforceNextjsPublicImports(readText?: (path: string) => string): void;

--- a/tooling/governance/nextjs-public-imports.mjs
+++ b/tooling/governance/nextjs-public-imports.mjs
@@ -1,0 +1,70 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import ts from 'typescript';
+
+export const nextjsRecipePaths = [
+  'packages/platform-nextjs/README.md',
+  'packages/platform-nextjs/README.ko.md',
+  'book/03-internals/ch15-nextjs-hosting.md',
+  'book/03-internals/ch15-nextjs-hosting.ko.md',
+  'apps/docs/content/docs/guides/runtime-adapters.mdx',
+  'apps/docs/content/docs/guides/runtime-adapters.ko.mdx',
+  'apps/docs/content/docs/packages/http-platform.mdx',
+  'apps/docs/content/docs/packages/http-platform.ko.mdx',
+];
+
+const root = '@fluojs/platform-nextjs';
+const exportsByPath = new Map([
+  [root, new Set(['NextHttpApplicationAdapter', 'InvalidNextAdapterOptionError',
+    'NextAdapterOptions', 'NextAdapterLoader', 'defineNextApplication', 'NextApplicationOptions'])],
+  [`${root}/app-router`, new Set(['createNextAppRouterHandler', 'NextAppRouteHandler', 'NextAppRouterMethodHandlers'])],
+  [`${root}/pages-router`, new Set(['createNextPagesRouterHandler', 'NextPagesRouterConfig'])],
+  [`${root}/next-config`, new Set(['withFluoNextBackend', 'FluoNextBackendOptions'])],
+]);
+
+/**
+ * Check machine-consumed imports in canonical Next recipe code fences.
+ * Migration prose may name removed APIs; runnable snippets must use their owners.
+ */
+export function enforceNextjsPublicImports(
+  readText = (path) => readFileSync(fileURLToPath(new URL(`../../${path}`, import.meta.url)), 'utf8'),
+) {
+  for (const path of nextjsRecipePaths) {
+    for (const match of readText(path).matchAll(/^```(?:ts|typescript|tsx|js|javascript)\s*\n([\s\S]*?)^```\s*$/gm)) {
+      const source = ts.createSourceFile(path, match[1], ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+      const namespaces = new Map();
+      const reject = (name, owner) => {
+        throw new Error(`NEXTJS_PUBLIC_IMPORT: ${path}: ${name} is not exported by ${owner}.`);
+      };
+      for (const statement of source.statements) {
+        if (!ts.isImportDeclaration(statement) || !ts.isStringLiteral(statement.moduleSpecifier)) continue;
+        const owner = statement.moduleSpecifier.text;
+        if (owner !== root && !owner.startsWith(`${root}/`)) continue;
+        const allowed = exportsByPath.get(owner);
+        if (!allowed) reject('*', owner);
+        const clause = statement.importClause;
+        if (clause?.name) reject('default', owner);
+        const bindings = clause?.namedBindings;
+        if (bindings && ts.isNamespaceImport(bindings)) {
+          namespaces.set(bindings.name.text, { allowed, owner });
+        } else if (bindings && ts.isNamedImports(bindings)) {
+          for (const entry of bindings.elements) {
+            const name = (entry.propertyName ?? entry.name).text;
+            if (!allowed.has(name)) reject(name, owner);
+          }
+        }
+      }
+      const visit = (node) => {
+        if (ts.isPropertyAccessExpression(node) && ts.isIdentifier(node.expression)) {
+          const namespace = namespaces.get(node.expression.text);
+          if (namespace && !namespace.allowed.has(node.name.text)) reject(node.name.text, namespace.owner);
+        }
+        if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)
+          && node.expression.text === 'createNextAdapter') reject('createNextAdapter', root);
+        ts.forEachChild(node, visit);
+      };
+      visit(source);
+    }
+  }
+}

--- a/tooling/governance/nextjs-public-imports.test.ts
+++ b/tooling/governance/nextjs-public-imports.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import { enforceNextjsPublicImports, nextjsRecipePaths } from './nextjs-public-imports.mjs';
+import { enforceContractCompanionUpdates } from './verify-platform-consistency-governance.mjs';
+
+describe('Next.js public import contract companions', () => {
+  it.each([
+    'packages/platform-nextjs/README.md',
+    'packages/platform-nextjs/README.ko.md',
+    'book/03-internals/ch15-nextjs-hosting.md',
+    'book/03-internals/ch15-nextjs-hosting.ko.md',
+    'apps/docs/content/docs/packages/http-platform.mdx',
+    'apps/docs/content/docs/packages/http-platform.ko.mdx',
+  ])('requires discoverability and enforcement when %s changes', (path) => {
+    // Given a governed recipe changed without its companion evidence.
+    // When the existing changed-path gate evaluates the increment.
+    // Then the package API contract cannot silently bypass that gate.
+    expect(() => enforceContractCompanionUpdates([path])).toThrow(/docs\/CONTEXT\.md/);
+  });
+});
+
+describe('Next.js executable recipe import ownership', () => {
+  it('accepts current EN/KO recipes', () => {
+    expect(() => enforceNextjsPublicImports()).not.toThrow();
+  });
+
+  it.each(nextjsRecipePaths)('rejects a removed adapter factory import in %s', (path) => {
+    const read = (requested: string) => requested === path
+      ? "```ts\nimport { createNextAdapter as make } from '@fluojs/platform-nextjs';\nmake();\n```"
+      : '';
+    expect(() => enforceNextjsPublicImports(read)).toThrow(/NEXTJS_PUBLIC_IMPORT/);
+  });
+
+  it.each([
+    "import { NextHttpApplicationAdapter } from '@fluojs/platform-nextjs/app-router';",
+    "import type { NextAdapterOptions } from '@fluojs/platform-nextjs/pages-router';",
+    "import { createNextAppRouterHandler } from '@fluojs/platform-nextjs';",
+    "import { createNextPagesRouterHandler } from '@fluojs/platform-nextjs';",
+    "import { withFluoNextBackend } from '@fluojs/platform-nextjs';",
+    "import * as next from '@fluojs/platform-nextjs'; next.createNextAdapter();",
+    "import Next from '@fluojs/platform-nextjs';",
+    'const adapter = createNextAdapter();',
+  ])('rejects noncanonical runnable code: %s', (source) => {
+    expect(() => enforceNextjsPublicImports(() => `\`\`\`typescript\n${source}\n\`\`\``))
+      .toThrow(/NEXTJS_PUBLIC_IMPORT/);
+  });
+
+  it('accepts aliased static creation, router callbacks, compiler config, and migration prose', () => {
+    const source = `Removed: createNextAdapter
+\`\`\`typescript
+import { NextHttpApplicationAdapter as Adapter, defineNextApplication } from '@fluojs/platform-nextjs';
+import { createNextAppRouterHandler } from '@fluojs/platform-nextjs/app-router';
+import { createNextPagesRouterHandler, type NextPagesRouterConfig } from '@fluojs/platform-nextjs/pages-router';
+import { withFluoNextBackend } from '@fluojs/platform-nextjs/next-config';
+const adapter = Adapter.create();
+const get = defineNextApplication({ key: 'fixture', load: async () => adapter });
+const { GET, POST, HEAD } = createNextAppRouterHandler(get);
+const pages = createNextPagesRouterHandler(get);
+withFluoNextBackend({});
+\`\`\``;
+    expect(() => enforceNextjsPublicImports(() => source)).not.toThrow();
+  });
+});

--- a/tooling/governance/verify-platform-consistency-governance.mjs
+++ b/tooling/governance/verify-platform-consistency-governance.mjs
@@ -29,6 +29,7 @@ import {
 } from './microservices-safety-guidance.mjs';
 import { enforceMicroservicesNestjsMigrationDocs } from './microservices-nestjs-migration-docs.mjs';
 import { enforceMongooseNestjsMigrationDocs } from './mongoose-nestjs-migration-docs.mjs';
+import { enforceNextjsPublicImports, nextjsRecipePaths } from './nextjs-public-imports.mjs';
 import { enforcePassportJsBridgeNestjsMigration } from './passport-js-bridge-nestjs-migration.mjs';
 import { enforcePlatformShellLifecycleContract } from './platform-shell-lifecycle-contract.mjs';
 import { enforcePrismaNestjsMigrationDocs } from './prisma-nestjs-migration-docs.mjs';
@@ -722,6 +723,7 @@ const ssotPairs = [
 ];
 
 const contractGateTriggers = new Set([
+  ...nextjsRecipePaths,
   'docs/architecture/auth-and-jwt.md',
   'docs/architecture/auth-and-jwt.ko.md',
   'docs/architecture/http-catch-all-route-grammar.md',
@@ -4459,6 +4461,7 @@ export async function main() {
   enforceGraphqlRuntimeBoundaryDiscoverability();
   enforceGraphqlNestjsMigrationBoundaries();
   enforceRequestPipelineImportBoundary();
+  enforceNextjsPublicImports();
   enforcePersistenceTransactionInterceptorCompatibility();
   enforceDrizzleNamedClientContract();
   enforceQueueWorkerOwnershipContract();


### PR DESCRIPTION
## Summary

Next.js adapter 생성과 App/Pages Router의 공개 import 소유권을 하나의 canonical 경로로 통합합니다.

Linked context: https://github.com/fluojs/fluo/issues/3737
Closes #3737

## Changes

- root의 `NextHttpApplicationAdapter.create(options)`가 생성 경로를 소유하며 중복 `createNextAdapter`와 adapter method alias를 제거합니다.
- App/Pages handler는 각각 `/app-router`, `/pages-router`, compiler는 `/next-config`에서 제공합니다.
- 공개 constructor, class identity, instance lifecycle, Next route method export, Pages stream 동작과 두 cache의 의미를 보존합니다.
- EN/KO README, Docs, Book, migration과 executable import governance를 함께 갱신합니다.

## Testing

검증 head: `9d087e0aae2de037c8a5c0cb21d5f87e726def58`

- `pnpm --filter '@fluojs/platform-nextjs...' build`: exit 0.
- `pnpm --filter @fluojs/platform-nextjs typecheck`: exit 0.
- `pnpm --filter '...@fluojs/platform-nextjs' test`: 14 files, 104 tests passed. 해당 패키지의 workspace 역의존 패키지는 없습니다.
- `pnpm exec vitest run --project tooling tooling/governance/nextjs-public-imports.test.ts tooling/governance/verify-platform-consistency-governance.test.ts`: 451 tests passed.
- `pnpm verify:docs`: exit 0; EN/KO 50 pairs, Book 72 chapters, site build passed.
- `pnpm --filter @fluojs/platform-nextjs test:e2e`: 실제 Next dev/build/start에서 54 passed, 0 failed, 0 skipped.
- `pnpm lint`, `pnpm verify:platform-consistency-governance`: exit 0. 깨끗한 main의 동일 lint도 41 warnings / 136 infos이며 공유 governance 파일의 기존 warning 3개를 별도로 대조했습니다.
- 직접 실행한 배포 public API smoke: static instance와 제거 export, GET 200, POST 201, malformed JSON 400, body limit 413, 미시작/종료 후 503, lazy loader 1회를 확인했습니다. 이 수동 증거는 자동 회귀와 별도입니다.
- exact-head contract/code/verification 리뷰 모두 PASS.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

`.changeset/nextjs-canonical-import-ownership.md`는 maintainer의 명시적 요청에 따라 `@fluojs/platform-nextjs` patch 변경을 선언합니다. 공개 API 제거와 EN/KO migration 안내는 유지합니다.

Changeset 분류만 바꾼 head는 `682eef9fb858c029c8052c5a758ae5a1a469db83`입니다. 위 구현 검증과 세 축 리뷰는 `9d087e0aae2de037c8a5c0cb21d5f87e726def58`에서 수행했으며 두 head 사이의 변경은 Changeset frontmatter 한 줄뿐입니다. Maintainer가 PR #3766에 한해 새 CI를 확인하거나 기다리지 않고 즉시 squash merge하도록 명시적으로 승인했습니다.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by applicable platform harness tests.

